### PR TITLE
Fix clippy error of using sort_unstable instead of sort

### DIFF
--- a/rafs/src/metadata/layout.rs
+++ b/rafs/src/metadata/layout.rs
@@ -483,7 +483,7 @@ impl PrefetchTable {
     pub fn store(&mut self, w: &mut RafsIoWriter) -> Result<usize> {
         // Sort prefetch table by inode index, hopefully, it can save time when mounting rafs
         // Because file data is dumped in the order of inode index.
-        self.inode_indexes.sort();
+        self.inode_indexes.sort_unstable();
 
         let (_, data, _) = unsafe { self.inode_indexes.align_to::<u8>() };
 

--- a/rafs/src/storage/backend/localfs.rs
+++ b/rafs/src/storage/backend/localfs.rs
@@ -239,7 +239,7 @@ impl LocalFsAccessLog {
             }
             return;
         }
-        r.sort();
+        r.sort_unstable();
         r.dedup();
 
         // record is valid as long as LocalFsAccessLog is not dropped


### PR DESCRIPTION
Using sort_unstable instead of sort for primitive type will get better performance.