### PR TITLE
nydusify: fix conversion for the image included empty platform

### DIFF
--- a/contrib/nydusify/remote/remote.go
+++ b/contrib/nydusify/remote/remote.go
@@ -261,7 +261,7 @@ func (remote *Remote) Pull() error {
 	platform := platforms.Default()
 	var sourceManifestDesc *ocispec.Descriptor
 	for _, desc := range descs {
-		if platform.Match(*desc.Platform) {
+		if desc.Platform == nil || platform.Match(*desc.Platform) {
 			sourceManifestDesc = &desc
 			break
 		}


### PR DESCRIPTION
If the image includes an empty platform manifest, nydusify will panic on
conversion, check this situation to avoid.

Signed-off-by: Yan Song <imeoer@linux.alibaba.com>