### PR TITLE
travis: drop sudo tag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@
 
 dist: bionic
 os: linux
-sudo: required
 
 language: rust
 cache: cargo


### PR DESCRIPTION
As travis reports, it is deprecated and has no effects.