### PR TITLE
utils: fix push_str clippy warnning

### DIFF
--- a/utils/src/fuse.rs
+++ b/utils/src/fuse.rs
@@ -266,7 +266,7 @@ fn fuse_kern_mount(
     );
     let mut fstype = String::from(FUSE_FSTYPE);
     if !subtype.is_empty() {
-        fstype.push_str(".");
+        fstype.push('.');
         fstype.push_str(subtype);
     }
 


### PR DESCRIPTION
With cargo 1.48.0 (65cbdd2dc 2020-10-14) and rustc 1.48.0 (7eac88abb 2020-11-16):

   --> utils/src/fuse.rs:269:9
    |
269 |         fstype.push_str(".");
    |         ^^^^^^^^^^^^^^^^^^^^ help: consider using `push` with a character literal: `fstype.push('.')`
    |
    = note: `-D clippy::single-char-push-str` implied by `-D clippy::all`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#single_char_push_str

Closes #27