### PR TITLE
nydus-image: fix rustlang backward compatibility issues

### DIFF
--- a/src/bin/nydus-image/node.rs
+++ b/src/bin/nydus-image/node.rs
@@ -127,7 +127,7 @@ impl Node {
         let mut node = Node {
             index: 0,
             real_ino: 0,
-            dev: u64::MAX,
+            dev: std::u64::MAX,
             source,
             path,
             overlay,

--- a/src/bin/nydus-image/tree.rs
+++ b/src/bin/nydus-image/tree.rs
@@ -110,7 +110,7 @@ impl<'a> MetadataTreeBuilder<'a> {
         Ok(Node {
             index: 0,
             real_ino: ondisk_inode.i_ino,
-            dev: u64::MAX,
+            dev: std::u64::MAX,
             overlay: Overlay::Lower,
             explicit_uidgid: self.rs.meta.explicit_uidgid(),
             source: PathBuf::from_str("/").unwrap(),
@@ -330,7 +330,7 @@ impl StargzIndexTreeBuilder {
         Ok(Node {
             index: 0,
             real_ino: ino,
-            dev: u64::MAX,
+            dev: std::u64::MAX,
             overlay: Overlay::UpperAddition,
             explicit_uidgid,
             source: PathBuf::from_str("/").unwrap(),


### PR DESCRIPTION
When compiling source code with lower version rust, failure may occur with error "u64::MAX associated item not found in u64".
Using full path std::u64::MAX will be OK.

Fixes: #26

Signed-off-by: LiYa'nan <oliverliyn@gmail.com>