### PR TITLE
Nydusify: fix insecure registry endpoint access

### DIFF
--- a/contrib/nydusify/cmd/nydusify.go
+++ b/contrib/nydusify/cmd/nydusify.go
@@ -34,6 +34,9 @@ func main() {
 				&cli.StringFlag{Name: "source", Required: true, Usage: "Source image reference", EnvVars: []string{"SOURCE"}},
 				&cli.StringFlag{Name: "target", Required: true, Usage: "Target image reference", EnvVars: []string{"TARGET"}},
 
+				&cli.BoolFlag{Name: "source-insecure", Required: false, Usage: "Allow http/insecure source registry communication", EnvVars: []string{"SOURCE_INSECURE"}},
+				&cli.BoolFlag{Name: "target-insecure", Required: false, Usage: "Allow http/insecure target registry communication", EnvVars: []string{"TARGET_INSECURE"}},
+
 				&cli.StringFlag{Name: "work-dir", Value: "./tmp", Usage: "Work directory path for image conversion", EnvVars: []string{"WORK_DIR"}},
 				&cli.StringFlag{Name: "prefetch-dir", Value: "/", Usage: "Prefetch directory for nydus image, use absolute path of rootfs", EnvVars: []string{"PREFETCH_DIR"}},
 				&cli.StringFlag{Name: "nydus-image", Value: "./nydus-image", Usage: "The nydus-image binary path", EnvVars: []string{"NYDUS_IMAGE"}},
@@ -43,8 +46,10 @@ func main() {
 			},
 			Action: func(c *cli.Context) error {
 				converter, err := converter.New(converter.Option{
-					Source: c.String("source"),
-					Target: c.String("target"),
+					Source:         c.String("source"),
+					Target:         c.String("target"),
+					SourceInsecure: c.Bool("source-insecure"),
+					TargetInsecure: c.Bool("target-insecure"),
 
 					WorkDir:          c.String("work-dir"),
 					PrefetchDir:      c.String("prefetch-dir"),

--- a/contrib/nydusify/converter/converter.go
+++ b/contrib/nydusify/converter/converter.go
@@ -17,8 +17,10 @@ import (
 )
 
 type Option struct {
-	Source string
-	Target string
+	Source         string
+	Target         string
+	SourceInsecure bool
+	TargetInsecure bool
 
 	WorkDir          string
 	PrefetchDir      string
@@ -66,9 +68,11 @@ func (converter *Converter) Convert() error {
 	}
 
 	reg, err := registry.New(registry.RegistryOption{
-		WorkDir: converter.WorkDir,
-		Source:  converter.Source,
-		Target:  converter.Target,
+		WorkDir:        converter.WorkDir,
+		Source:         converter.Source,
+		Target:         converter.Target,
+		SourceInsecure: converter.SourceInsecure,
+		TargetInsecure: converter.TargetInsecure,
 	})
 	if err != nil {
 		return err

--- a/contrib/nydusify/registry/registry.go
+++ b/contrib/nydusify/registry/registry.go
@@ -44,9 +44,11 @@ type Image struct {
 }
 
 type RegistryOption struct {
-	WorkDir string
-	Source  string
-	Target  string
+	WorkDir        string
+	Source         string
+	Target         string
+	SourceInsecure bool
+	TargetInsecure bool
 }
 
 type Registry struct {
@@ -61,12 +63,19 @@ func withDefaultAuth() authn.Keychain {
 
 func New(option RegistryOption) (*Registry, error) {
 	// Parse source & image reference from provided
-	sourceRef, err := name.ParseReference(option.Source)
+	sourceOpts := []name.Option{}
+	if option.SourceInsecure {
+		sourceOpts = append(sourceOpts, name.Insecure)
+	}
+	sourceRef, err := name.ParseReference(option.Source, sourceOpts...)
 	if err != nil {
 		return nil, errors.Wrap(err, "parse source reference")
 	}
-
-	targetRef, err := name.ParseReference(option.Target)
+	targetOpts := []name.Option{}
+	if option.TargetInsecure {
+		targetOpts = append(targetOpts, name.Insecure)
+	}
+	targetRef, err := name.ParseReference(option.Target, targetOpts...)
 	if err != nil {
 		return nil, errors.Wrap(err, "parse target reference")
 	}


### PR DESCRIPTION
Add `--source-insecure` and `--target-insecure` options for Nydusify,
instead of getting HTTP scheme automatically according to url.

Signed-off-by: Yan Song <imeoer@linux.alibaba.com>