### PR TITLE
CI: use rust 1.47.0 environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ os: linux
 language: rust
 cache: cargo
 rust:
-    - stable
+    - 1.47.0
 
 before_install:
     - rustup component add clippy rustfmt


### PR DESCRIPTION
Use a fixed rust version in the CI environment to make testing stable,
we can move forward once decided to upgrade the rust version in project.

Fix CI issue on #36 

Signed-off-by: Yan Song <imeoer@linux.alibaba.com>