### PR TITLE
cargo: change micro-http dependency to Cloud Hypervisor organization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -604,8 +604,8 @@ checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 
 [[package]]
 name = "micro_http"
-version = "0.1.0"
-source = "git+https://github.com/firecracker-microvm/micro-http.git#c9ffb90aebdc77a8fade2e4196f311f9bbfcce82"
+version = "0.2.0"
+source = "git+https://github.com/cloud-hypervisor/micro-http.git?branch=master#af72318b755620f9c1b99b319bc2e4e942b91b2f"
 dependencies = [
  "epoll",
 ]

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -5,12 +5,11 @@ authors = ["The Ant Financial Nydus Developers"]
 edition = "2018"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 lazy_static = "1.4.0"
 log = "0.4"
-micro_http = { git = "https://github.com/firecracker-microvm/micro-http.git", branch = "master" }
-serde = {version = ">=1.0.27", features = ["rc"] }
+micro_http = { git = "https://github.com/cloud-hypervisor/micro-http.git", branch = "master" }
+serde = { version = ">=1.0.27", features = ["rc"] }
 serde_derive = ">=1.0.27"
 serde_json = ">=1.0.9"
 vmm-sys-util = ">=0.3.1"


### PR DESCRIPTION
Mirco-http was forked into Cloud Hypersior. Nydus relies on mirco-http
to implement Api server. After the fork, it now supports more http methods.

Signed-off-by: Changwei Ge <chge@linux.alibaba.com>