### PR TITLE
example: use standalone nydusd mode

### DIFF
--- a/docs/containerd-env-setup.md
+++ b/docs/containerd-env-setup.md
@@ -49,7 +49,6 @@ Then start `containerd-nydus-grpc` remote snapshotter:
 ```bash
 /usr/local/bin/containerd-nydus-grpc --nydusd-path /usr/local/bin/nydusd \
     --config-path /etc/nydusd-config.json \
-    --shared-daemon \
     --log-level debug \
     --root /var/lib/containerd/io.containerd.snapshotter.v1.nydus \
     --address /run/containerd/containerd-nydus-grpc.sock

--- a/misc/example/containerd-entrypoint.sh
+++ b/misc/example/containerd-entrypoint.sh
@@ -6,7 +6,6 @@ if [ "$#" -eq 0 ]; then
         /opt/bin/containerd -c /opt/etc/containerd/config.toml -l debug &
 	/opt/bin/containerd-nydus-grpc --nydusd-path /opt/bin/nydusd \
 		--config-path /opt/etc/nydusd-config.json \
-		--shared-daemon \
 		--log-level debug \
 		--root /var/lib/containerd-test/io.containerd.snapshotter.v1.nydus \
 		--address /run/containerd-test/containerd-nydus-grpc.sock &


### PR DESCRIPTION
`--shared-daemon` is not working due to API incompatibility.
Let's use standalone mode for now until that is fixed.

issue #44 