### PR TITLE
Snapshotter: shorten go module name

### DIFF
--- a/contrib/nydus-snapshotter/cmd/containerd-nydus-grpc/app/snapshotter/main.go
+++ b/contrib/nydus-snapshotter/cmd/containerd-nydus-grpc/app/snapshotter/main.go
@@ -11,11 +11,11 @@ import (
 
 	"github.com/pkg/errors"
 
-	"gitlab.alipay-inc.com/antsys/nydus-snapshotter/pkg/filesystem/nydus"
-	"gitlab.alipay-inc.com/antsys/nydus-snapshotter/pkg/filesystem/stargz"
-	"gitlab.alipay-inc.com/antsys/nydus-snapshotter/pkg/signature"
-	"gitlab.alipay-inc.com/antsys/nydus-snapshotter/pkg/utils/signals"
-	"gitlab.alipay-inc.com/antsys/nydus-snapshotter/snapshot"
+	"contrib/nydus-snapshotter/pkg/filesystem/nydus"
+	"contrib/nydus-snapshotter/pkg/filesystem/stargz"
+	"contrib/nydus-snapshotter/pkg/signature"
+	"contrib/nydus-snapshotter/pkg/utils/signals"
+	"contrib/nydus-snapshotter/snapshot"
 )
 
 func Start(ctx context.Context, cfg Config) error {

--- a/contrib/nydus-snapshotter/cmd/containerd-nydus-grpc/app/snapshotter/validate.go
+++ b/contrib/nydus-snapshotter/cmd/containerd-nydus-grpc/app/snapshotter/validate.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/pkg/errors"
 
-	"gitlab.alipay-inc.com/antsys/nydus-snapshotter/cmd/containerd-nydus-grpc/pkg/command"
-	"gitlab.alipay-inc.com/antsys/nydus-snapshotter/pkg/filesystem/nydus"
+	"contrib/nydus-snapshotter/cmd/containerd-nydus-grpc/pkg/command"
+	"contrib/nydus-snapshotter/pkg/filesystem/nydus"
 )
 
 type Config struct {

--- a/contrib/nydus-snapshotter/cmd/containerd-nydus-grpc/app/snapshotter/validate_test.go
+++ b/contrib/nydus-snapshotter/cmd/containerd-nydus-grpc/app/snapshotter/validate_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"gitlab.alipay-inc.com/antsys/nydus-snapshotter/cmd/containerd-nydus-grpc/pkg/command"
+	"contrib/nydus-snapshotter/cmd/containerd-nydus-grpc/pkg/command"
 )
 
 func TestValidate(t *testing.T) {

--- a/contrib/nydus-snapshotter/cmd/containerd-nydus-grpc/main.go
+++ b/contrib/nydus-snapshotter/cmd/containerd-nydus-grpc/main.go
@@ -13,10 +13,10 @@ import (
 	"github.com/pkg/errors"
 	"github.com/urfave/cli/v2"
 
-	"gitlab.alipay-inc.com/antsys/nydus-snapshotter/cmd/containerd-nydus-grpc/app/snapshotter"
-	"gitlab.alipay-inc.com/antsys/nydus-snapshotter/cmd/containerd-nydus-grpc/pkg/command"
-	"gitlab.alipay-inc.com/antsys/nydus-snapshotter/cmd/containerd-nydus-grpc/pkg/logging"
-	"gitlab.alipay-inc.com/antsys/nydus-snapshotter/pkg/errdefs"
+	"contrib/nydus-snapshotter/cmd/containerd-nydus-grpc/app/snapshotter"
+	"contrib/nydus-snapshotter/cmd/containerd-nydus-grpc/pkg/command"
+	"contrib/nydus-snapshotter/cmd/containerd-nydus-grpc/pkg/logging"
+	"contrib/nydus-snapshotter/pkg/errdefs"
 )
 
 func main() {

--- a/contrib/nydus-snapshotter/go.mod
+++ b/contrib/nydus-snapshotter/go.mod
@@ -1,6 +1,6 @@
-module gitlab.alipay-inc.com/antsys/nydus-snapshotter
+module contrib/nydus-snapshotter
 
-go 1.13
+go 1.14
 
 require (
 	github.com/Microsoft/hcsshim v0.8.9 // indirect

--- a/contrib/nydus-snapshotter/pkg/auth/keychain.go
+++ b/contrib/nydus-snapshotter/pkg/auth/keychain.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/google/go-containerregistry/pkg/authn"
 
-	"gitlab.alipay-inc.com/antsys/nydus-snapshotter/pkg/label"
+	"contrib/nydus-snapshotter/pkg/label"
 )
 
 const (

--- a/contrib/nydus-snapshotter/pkg/auth/keychain_test.go
+++ b/contrib/nydus-snapshotter/pkg/auth/keychain_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"gitlab.alipay-inc.com/antsys/nydus-snapshotter/pkg/label"
+	"contrib/nydus-snapshotter/pkg/label"
 )
 
 func TestFromLabels(t *testing.T) {

--- a/contrib/nydus-snapshotter/pkg/daemon/daemon.go
+++ b/contrib/nydus-snapshotter/pkg/daemon/daemon.go
@@ -14,8 +14,8 @@ import (
 
 	"github.com/pkg/errors"
 
-	"gitlab.alipay-inc.com/antsys/nydus-snapshotter/pkg/nydussdk"
-	"gitlab.alipay-inc.com/antsys/nydus-snapshotter/pkg/nydussdk/model"
+	"contrib/nydus-snapshotter/pkg/nydussdk"
+	"contrib/nydus-snapshotter/pkg/nydussdk/model"
 )
 
 type NewDaemonOpt func(d *Daemon) error

--- a/contrib/nydus-snapshotter/pkg/filesystem/nydus/config.go
+++ b/contrib/nydus-snapshotter/pkg/filesystem/nydus/config.go
@@ -9,8 +9,8 @@ package nydus
 import (
 	"errors"
 
-	"gitlab.alipay-inc.com/antsys/nydus-snapshotter/pkg/filesystem/meta"
-	"gitlab.alipay-inc.com/antsys/nydus-snapshotter/pkg/signature"
+	"contrib/nydus-snapshotter/pkg/filesystem/meta"
+	"contrib/nydus-snapshotter/pkg/signature"
 )
 
 type NewFSOpt func(d *filesystem) error

--- a/contrib/nydus-snapshotter/pkg/filesystem/nydus/daemonconfig.go
+++ b/contrib/nydus-snapshotter/pkg/filesystem/nydus/daemonconfig.go
@@ -12,9 +12,9 @@ import (
 
 	"github.com/pkg/errors"
 
-	"gitlab.alipay-inc.com/antsys/nydus-snapshotter/pkg/auth"
-	"gitlab.alipay-inc.com/antsys/nydus-snapshotter/pkg/daemon"
-	"gitlab.alipay-inc.com/antsys/nydus-snapshotter/pkg/utils/registry"
+	"contrib/nydus-snapshotter/pkg/auth"
+	"contrib/nydus-snapshotter/pkg/daemon"
+	"contrib/nydus-snapshotter/pkg/utils/registry"
 )
 
 type DaemonConfig struct {

--- a/contrib/nydus-snapshotter/pkg/filesystem/nydus/fs.go
+++ b/contrib/nydus-snapshotter/pkg/filesystem/nydus/fs.go
@@ -16,14 +16,14 @@ import (
 	"github.com/containerd/containerd/snapshots/storage"
 	"github.com/pkg/errors"
 
-	"gitlab.alipay-inc.com/antsys/nydus-snapshotter/pkg/daemon"
-	"gitlab.alipay-inc.com/antsys/nydus-snapshotter/pkg/errdefs"
-	"gitlab.alipay-inc.com/antsys/nydus-snapshotter/pkg/filesystem/meta"
-	"gitlab.alipay-inc.com/antsys/nydus-snapshotter/pkg/label"
-	"gitlab.alipay-inc.com/antsys/nydus-snapshotter/pkg/process"
-	"gitlab.alipay-inc.com/antsys/nydus-snapshotter/pkg/signature"
-	"gitlab.alipay-inc.com/antsys/nydus-snapshotter/pkg/utils/retry"
-	"gitlab.alipay-inc.com/antsys/nydus-snapshotter/snapshot"
+	"contrib/nydus-snapshotter/pkg/daemon"
+	"contrib/nydus-snapshotter/pkg/errdefs"
+	"contrib/nydus-snapshotter/pkg/filesystem/meta"
+	"contrib/nydus-snapshotter/pkg/label"
+	"contrib/nydus-snapshotter/pkg/process"
+	"contrib/nydus-snapshotter/pkg/signature"
+	"contrib/nydus-snapshotter/pkg/utils/retry"
+	"contrib/nydus-snapshotter/snapshot"
 )
 
 type FSMode int

--- a/contrib/nydus-snapshotter/pkg/filesystem/stargz/config.go
+++ b/contrib/nydus-snapshotter/pkg/filesystem/stargz/config.go
@@ -9,8 +9,8 @@ package stargz
 import (
 	"errors"
 
-	"gitlab.alipay-inc.com/antsys/nydus-snapshotter/pkg/filesystem/meta"
-	"gitlab.alipay-inc.com/antsys/nydus-snapshotter/pkg/filesystem/nydus"
+	"contrib/nydus-snapshotter/pkg/filesystem/meta"
+	"contrib/nydus-snapshotter/pkg/filesystem/nydus"
 )
 
 func WithMeta(root string) NewFSOpt {

--- a/contrib/nydus-snapshotter/pkg/filesystem/stargz/fs.go
+++ b/contrib/nydus-snapshotter/pkg/filesystem/stargz/fs.go
@@ -19,15 +19,15 @@ import (
 	"github.com/containerd/containerd/snapshots/storage"
 	"github.com/pkg/errors"
 
-	"gitlab.alipay-inc.com/antsys/nydus-snapshotter/pkg/auth"
-	"gitlab.alipay-inc.com/antsys/nydus-snapshotter/pkg/daemon"
-	"gitlab.alipay-inc.com/antsys/nydus-snapshotter/pkg/errdefs"
-	"gitlab.alipay-inc.com/antsys/nydus-snapshotter/pkg/filesystem/meta"
-	"gitlab.alipay-inc.com/antsys/nydus-snapshotter/pkg/filesystem/nydus"
-	"gitlab.alipay-inc.com/antsys/nydus-snapshotter/pkg/label"
-	"gitlab.alipay-inc.com/antsys/nydus-snapshotter/pkg/process"
-	"gitlab.alipay-inc.com/antsys/nydus-snapshotter/pkg/utils/retry"
-	"gitlab.alipay-inc.com/antsys/nydus-snapshotter/snapshot"
+	"contrib/nydus-snapshotter/pkg/auth"
+	"contrib/nydus-snapshotter/pkg/daemon"
+	"contrib/nydus-snapshotter/pkg/errdefs"
+	"contrib/nydus-snapshotter/pkg/filesystem/meta"
+	"contrib/nydus-snapshotter/pkg/filesystem/nydus"
+	"contrib/nydus-snapshotter/pkg/label"
+	"contrib/nydus-snapshotter/pkg/process"
+	"contrib/nydus-snapshotter/pkg/utils/retry"
+	"contrib/nydus-snapshotter/snapshot"
 )
 
 type filesystem struct {

--- a/contrib/nydus-snapshotter/pkg/filesystem/stargz/fs_test.go
+++ b/contrib/nydus-snapshotter/pkg/filesystem/stargz/fs_test.go
@@ -17,10 +17,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"gitlab.alipay-inc.com/antsys/nydus-snapshotter/pkg/filesystem/meta"
-	"gitlab.alipay-inc.com/antsys/nydus-snapshotter/pkg/filesystem/nydus"
-	"gitlab.alipay-inc.com/antsys/nydus-snapshotter/pkg/label"
-	"gitlab.alipay-inc.com/antsys/nydus-snapshotter/pkg/process"
+	"contrib/nydus-snapshotter/pkg/filesystem/meta"
+	"contrib/nydus-snapshotter/pkg/filesystem/nydus"
+	"contrib/nydus-snapshotter/pkg/label"
+	"contrib/nydus-snapshotter/pkg/process"
 )
 
 func ensureExists(path string) error {

--- a/contrib/nydus-snapshotter/pkg/filesystem/stargz/resolver_test.go
+++ b/contrib/nydus-snapshotter/pkg/filesystem/stargz/resolver_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"gitlab.alipay-inc.com/antsys/nydus-snapshotter/pkg/auth"
+	"contrib/nydus-snapshotter/pkg/auth"
 )
 
 func TestResolver_resolve(t *testing.T) {

--- a/contrib/nydus-snapshotter/pkg/nydussdk/client.go
+++ b/contrib/nydus-snapshotter/pkg/nydussdk/client.go
@@ -19,8 +19,8 @@ import (
 
 	"github.com/pkg/errors"
 
-	"gitlab.alipay-inc.com/antsys/nydus-snapshotter/pkg/nydussdk/model"
-	"gitlab.alipay-inc.com/antsys/nydus-snapshotter/pkg/utils/retry"
+	"contrib/nydus-snapshotter/pkg/nydussdk/model"
+	"contrib/nydus-snapshotter/pkg/utils/retry"
 )
 
 const (

--- a/contrib/nydus-snapshotter/pkg/nydussdk/client_test.go
+++ b/contrib/nydus-snapshotter/pkg/nydussdk/client_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"gitlab.alipay-inc.com/antsys/nydus-snapshotter/pkg/nydussdk/model"
+	"contrib/nydus-snapshotter/pkg/nydussdk/model"
 )
 
 func prepareNydusServer(t *testing.T) (string, func()) {

--- a/contrib/nydus-snapshotter/pkg/process/manager.go
+++ b/contrib/nydus-snapshotter/pkg/process/manager.go
@@ -17,10 +17,10 @@ import (
 	"github.com/containerd/containerd/log"
 	"github.com/pkg/errors"
 
-	"gitlab.alipay-inc.com/antsys/nydus-snapshotter/pkg/daemon"
-	"gitlab.alipay-inc.com/antsys/nydus-snapshotter/pkg/errdefs"
-	"gitlab.alipay-inc.com/antsys/nydus-snapshotter/pkg/store"
-	"gitlab.alipay-inc.com/antsys/nydus-snapshotter/pkg/utils/mount"
+	"contrib/nydus-snapshotter/pkg/daemon"
+	"contrib/nydus-snapshotter/pkg/errdefs"
+	"contrib/nydus-snapshotter/pkg/store"
+	"contrib/nydus-snapshotter/pkg/utils/mount"
 )
 
 type configGenerator = func(*daemon.Daemon) error

--- a/contrib/nydus-snapshotter/pkg/process/store.go
+++ b/contrib/nydus-snapshotter/pkg/process/store.go
@@ -7,8 +7,8 @@
 package process
 
 import (
-	"gitlab.alipay-inc.com/antsys/nydus-snapshotter/pkg/daemon"
-	"gitlab.alipay-inc.com/antsys/nydus-snapshotter/pkg/store"
+	"contrib/nydus-snapshotter/pkg/daemon"
+	"contrib/nydus-snapshotter/pkg/store"
 )
 
 type Store interface {

--- a/contrib/nydus-snapshotter/pkg/signature/signature.go
+++ b/contrib/nydus-snapshotter/pkg/signature/signature.go
@@ -14,8 +14,8 @@ import (
 
 	"github.com/pkg/errors"
 
-	"gitlab.alipay-inc.com/antsys/nydus-snapshotter/pkg/label"
-	"gitlab.alipay-inc.com/antsys/nydus-snapshotter/pkg/utils/signer"
+	"contrib/nydus-snapshotter/pkg/label"
+	"contrib/nydus-snapshotter/pkg/utils/signer"
 )
 
 type Verifier struct {

--- a/contrib/nydus-snapshotter/pkg/store/store.go
+++ b/contrib/nydus-snapshotter/pkg/store/store.go
@@ -10,7 +10,7 @@ import (
 	"fmt"
 	"sync"
 
-	"gitlab.alipay-inc.com/antsys/nydus-snapshotter/pkg/daemon"
+	"contrib/nydus-snapshotter/pkg/daemon"
 )
 
 

--- a/contrib/nydus-snapshotter/snapshot/snapshot.go
+++ b/contrib/nydus-snapshotter/snapshot/snapshot.go
@@ -23,10 +23,10 @@ import (
 	"github.com/containerd/continuity/fs"
 	"github.com/pkg/errors"
 
-	"gitlab.alipay-inc.com/antsys/nydus-snapshotter/pkg/daemon"
-	"gitlab.alipay-inc.com/antsys/nydus-snapshotter/pkg/label"
-	"gitlab.alipay-inc.com/antsys/nydus-snapshotter/pkg/process"
-	"gitlab.alipay-inc.com/antsys/nydus-snapshotter/pkg/snapshot"
+	"contrib/nydus-snapshotter/pkg/daemon"
+	"contrib/nydus-snapshotter/pkg/label"
+	"contrib/nydus-snapshotter/pkg/process"
+	"contrib/nydus-snapshotter/pkg/snapshot"
 )
 
 var _ snapshots.Snapshotter = &snapshotter{}


### PR DESCRIPTION
Shorten go module name to `contrib/nydus-snapshotter`, it's still compilable.

Signed-off-by: Yan Song <imeoer@linux.alibaba.com>