### PR TITLE
rafs: backend related fixes

### DIFF
--- a/rafs/src/storage/backend/localfs.rs
+++ b/rafs/src/storage/backend/localfs.rs
@@ -88,12 +88,14 @@ pub fn new(config: serde_json::value::Value, id: Option<&str>) -> Result<LocalFs
         return Err(einval!("blob file or dir is required"));
     }
 
+    let metrics = id.map(|i| BackendMetrics::new(i, "localfs"));
     if !config.blob_file.is_empty() {
         return Ok(LocalFs {
             blob_file: config.blob_file,
             readahead: config.readahead,
             readahead_sec: config.readahead_sec,
             file_table: RwLock::new(HashMap::new()),
+            metrics,
             ..Default::default()
         });
     }
@@ -103,7 +105,7 @@ pub fn new(config: serde_json::value::Value, id: Option<&str>) -> Result<LocalFs
         readahead: config.readahead,
         readahead_sec: config.readahead_sec,
         file_table: RwLock::new(HashMap::new()),
-        metrics: id.map(|i| BackendMetrics::new(i, "localfs")),
+        metrics,
         ..Default::default()
     })
 }

--- a/rafs/src/storage/backend/mod.rs
+++ b/rafs/src/storage/backend/mod.rs
@@ -8,7 +8,12 @@ use std::path::Path;
 use vm_memory::VolatileSlice;
 
 use crate::io_stats::{BackendMetrics, ERROR_HOLDER};
-use crate::storage::backend::{localfs::LocalFsError, oss::OssError, registry::RegistryError};
+#[cfg(feature = "backend-localfs")]
+use crate::storage::backend::localfs::LocalFsError;
+#[cfg(feature = "backend-oss")]
+use crate::storage::backend::oss::OssError;
+#[cfg(feature = "backend-registry")]
+use crate::storage::backend::registry::RegistryError;
 use crate::storage::utils::copyv;
 
 #[cfg(feature = "backend-localfs")]
@@ -33,8 +38,11 @@ pub struct ProxyConfig {
 pub enum BackendError {
     Unsupported(String),
     CopyData(Error),
+    #[cfg(feature = "backend-registry")]
     Registry(RegistryError),
+    #[cfg(feature = "backend-localfs")]
     LocalFs(LocalFsError),
+    #[cfg(feature = "backend-oss")]
     Oss(OssError),
 }
 
@@ -171,6 +179,7 @@ pub trait BlobBackendUploader {
     ) -> Result<usize>;
 }
 
+#[cfg(any(feature = "backend-oss", feature = "backend-registry"))]
 fn default_http_scheme() -> String {
     "https".to_string()
 }


### PR DESCRIPTION
This PR fixes two issues
- only use backends when the backend feature is on, otherwise build would fail due to un-imported crates.
- initialize localfs backend's metrics when blob file is specified in config as well