### PR TITLE
nydus: silent clippy warnings against nightly-1.50

### DIFF
--- a/rafs/src/fs.rs
+++ b/rafs/src/fs.rs
@@ -357,7 +357,7 @@ impl Rafs {
                 ino: child.ino(),
                 offset: cur_offset,
                 type_: 0,
-                name: child.name()?.as_bytes(),
+                name: child.name().as_bytes(),
             }) {
                 Ok(0) => {
                     self.ios

--- a/rafs/src/metadata/cached.rs
+++ b/rafs/src/metadata/cached.rs
@@ -70,11 +70,11 @@ impl CachedInodes {
                 dir_ino_set.push(child_inode.i_ino);
                 continue;
             }
-            self.add_into_parent(child_inode)?;
+            self.add_into_parent(child_inode);
         }
         while !dir_ino_set.is_empty() {
             let ino = dir_ino_set.pop().unwrap();
-            self.add_into_parent(self.get_node(ino)?)?;
+            self.add_into_parent(self.get_node(ino)?);
         }
         debug!("all {} inodes loaded", self.s_inodes.len());
 
@@ -102,13 +102,12 @@ impl CachedInodes {
         self.get_node(ino)
     }
 
-    fn add_into_parent(&mut self, child_inode: Arc<CachedInode>) -> Result<()> {
+    fn add_into_parent(&mut self, child_inode: Arc<CachedInode>) {
         if let Ok(parent_inode) = self.get_node_mut(child_inode.parent()) {
             Arc::get_mut(parent_inode)
                 .unwrap()
                 .add_child(child_inode.clone());
         }
-        Ok(())
     }
 }
 
@@ -284,8 +283,8 @@ impl RafsInode for CachedInode {
         Ok(())
     }
 
-    fn name(&self) -> Result<OsString> {
-        Ok(self.i_name.clone())
+    fn name(&self) -> OsString {
+        self.i_name.clone()
     }
 
     fn get_symlink(&self) -> Result<OsString> {
@@ -412,7 +411,7 @@ impl RafsInode for CachedInode {
 
         for child_inode in &self.i_child {
             if child_inode.is_dir() {
-                trace!("Got dir {:?}", child_inode.name().unwrap());
+                trace!("Got dir {:?}", child_inode.name());
                 child_dirs.push(child_inode.clone());
             } else {
                 if child_inode.is_empty_size() {

--- a/rafs/src/metadata/mod.rs
+++ b/rafs/src/metadata/mod.rs
@@ -382,7 +382,7 @@ impl RafsSuper {
 
     pub(crate) fn path_from_ino(&self, ino: Inode) -> Result<PathBuf> {
         if ino == ROOT_ID {
-            return Ok(self.get_inode(ino, false)?.name()?.into());
+            return Ok(self.get_inode(ino, false)?.name().into());
         }
 
         let mut path = PathBuf::new();
@@ -391,7 +391,7 @@ impl RafsSuper {
 
         loop {
             inode = self.get_inode(cur_ino, false)?;
-            let e: PathBuf = inode.name()?.into();
+            let e: PathBuf = inode.name().into();
             path = e.join(path);
 
             if inode.ino() == ROOT_ID {
@@ -585,7 +585,7 @@ pub trait RafsSuperInodes {
                 digest,
                 expected_digest,
                 inode.ino(),
-                inode.name()?
+                inode.name()
             );
         }
 
@@ -600,7 +600,7 @@ pub trait RafsInode {
     /// must validate it before accessing any fields of the object.
     fn validate(&self) -> Result<()>;
 
-    fn name(&self) -> Result<OsString>;
+    fn name(&self) -> OsString;
     fn get_symlink(&self) -> Result<OsString>;
     fn get_digest(&self) -> RafsDigest;
     fn get_child_by_name(&self, name: &OsStr) -> Result<Arc<dyn RafsInode>>;

--- a/rafs/src/storage/device.rs
+++ b/rafs/src/storage/device.rs
@@ -67,7 +67,7 @@ impl RafsDevice {
     pub fn read_to(&self, w: &mut dyn ZeroCopyWriter, desc: RafsBioDesc) -> io::Result<usize> {
         let mut count: usize = 0;
         for bio in desc.bi_vec.iter() {
-            let mut f = RafsBioDevice::new(bio, &self)?;
+            let mut f = RafsBioDevice::new(bio, &self);
             count += w.write_from(&mut f, bio.size, bio.offset as u64)?;
         }
         Ok(count)
@@ -77,7 +77,7 @@ impl RafsDevice {
     pub fn write_from(&self, r: &mut dyn ZeroCopyReader, desc: RafsBioDesc) -> io::Result<usize> {
         let mut count: usize = 0;
         for bio in desc.bi_vec.iter() {
-            let mut f = RafsBioDevice::new(bio, &self)?;
+            let mut f = RafsBioDevice::new(bio, &self);
             let offset = bio.chunkinfo.compress_offset() + bio.offset as u64;
             count += r.read_to(&mut f, bio.size, offset)?;
         }
@@ -101,9 +101,9 @@ struct RafsBioDevice<'a> {
 }
 
 impl<'a> RafsBioDevice<'a> {
-    fn new(bio: &'a RafsBio, b: &'a RafsDevice) -> io::Result<Self> {
+    fn new(bio: &'a RafsBio, b: &'a RafsDevice) -> Self {
         // FIXME: make sure bio is valid
-        Ok(RafsBioDevice { bio, dev: b })
+        RafsBioDevice { bio, dev: b }
     }
 }
 

--- a/src/bin/nydus-image/tree.rs
+++ b/src/bin/nydus-image/tree.rs
@@ -54,7 +54,7 @@ impl<'a> MetadataTreeBuilder<'a> {
         let child_count = inode.get_child_count();
 
         let parent_path = if let Some(parent) = parent {
-            parent.join(inode.name()?)
+            parent.join(inode.name())
         } else {
             PathBuf::from_str("/").unwrap()
         };
@@ -63,7 +63,7 @@ impl<'a> MetadataTreeBuilder<'a> {
         if inode.is_dir() {
             for idx in child_index..(child_index + child_count) {
                 let child = self.rs.get_inode(idx as Inode, true)?;
-                let child_path = parent_path.join(child.name()?);
+                let child_path = parent_path.join(child.name());
                 let child = self.parse_node(child, child_path.clone())?;
                 if let Some(chunk_cache) = chunk_cache {
                     if child.is_reg() {


### PR DESCRIPTION
From 1.50, looks like clippy starts to complain about unnecessary Resuler wrapper.
For example:

error: this function's return value is unnecessarily wrapped by `Result`
   --> rafs/src/metadata/cached.rs:105:5
       |
       105 | /     fn add_into_parent(&mut self, child_inode: Arc<CachedInode>) -> Result<()> {
           106 | |         if let Ok(parent_inode) = self.get_node_mut(child_inode.parent()) {
               107 | |             Arc::get_mut(parent_inode)
               108 | |                 .unwrap()
               ...   |
               111 | |         Ok(())
               112 | |     }
                   | |_____^
                       |

Signed-off-by: Changwei Ge <chge@linux.alibaba.com>