### PR TITLE
rafs/prefetch: fix prfetch outage with layered image building

### DIFF
--- a/contrib/nydusify/nydus/builder.go
+++ b/contrib/nydusify/nydus/builder.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"path/filepath"
 )
 
 type BuilderOption struct {
@@ -65,7 +64,6 @@ func (builder *Builder) Run(option BuilderOption) error {
 	}
 
 	if option.PrefetchDir != "" {
-		option.PrefetchDir = filepath.Join(option.RootfsPath, option.PrefetchDir)
 		args = append(args, "--prefetch-policy", "fs")
 	}
 

--- a/src/bin/nydus-image/builder.rs
+++ b/src/bin/nydus-image/builder.rs
@@ -63,9 +63,10 @@ pub struct Builder {
     /// Store all blob id entry during build.
     blob_table: OndiskBlobTable,
     /// Readahead file list, use BTreeMap to keep stable iteration order, HashMap<path, Option<index>>.
+    /// Files from this collection are all regular files and will be persisted to blob following a certain scheme.
     readahead_files: BTreeMap<PathBuf, Option<u64>>,
     /// Specify files or directories which need to prefetch. Their inode indexes will
-    /// be persist to prefetch table.
+    /// be persist to prefetch table. They could be directory's or regular file's index
     hint_readahead_files: BTreeMap<PathBuf, Option<u64>>,
     prefetch_policy: PrefetchPolicy,
     /// Store all nodes during build, node index of root starting from 1,


### PR DESCRIPTION
Previously, when converting image, a prefetch list is input to
builder from stdin, which is later persisted to bootstrap prefetch
table.

During parsing the prefetch table, builder checks file's existance.
But for layered building, we can't guarantee that the source directory
of parent boostrap is located from local file system.

So builder no longger accecpts abosolute paths, but relative paths to
source rootfs.

It must start with "/"

Signed-off-by: Changwei Ge <chge@linux.alibaba.com>