### PR TITLE
docker: no need to replace crates.io source to tuna

### DIFF
--- a/misc/smoke/Dockerfile
+++ b/misc/smoke/Dockerfile
@@ -1,12 +1,5 @@
 FROM rust:1.49.0
 
-RUN echo '[source.crates-io] \n\
-  registry = "https://github.com/rust-lang/crates.io-index" \n\
-  replace-with = "thu" \n\
-  [source.thu] \n\
-  registry = "https://mirrors.tuna.tsinghua.edu.cn/git/crates.io-index.git"'\
-  >> /usr/local/cargo/config
-
 RUN rustup component add clippy
 RUN rustup component add rustfmt
 


### PR DESCRIPTION
No need to replace crates.io source when perform smoke within github action. This will reduce smoke test duration.