### PR TITLE
Change logger from stderrlog to flexi_logger

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -381,6 +381,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "flexi_logger"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ab94b6ac8eb69f1496a6993f26f785b5fd6d99b7416023eb2a6175c0b242b1"
+dependencies = [
+ "chrono",
+ "glob",
+ "log",
+ "thiserror",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -577,6 +589,12 @@ dependencies = [
  "log",
  "url",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
 
 [[package]]
 name = "governor"
@@ -799,12 +817,6 @@ dependencies = [
 
 [[package]]
 name = "lazy_static"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76f033c7ad61445c5b347c7382dd1237847eb1bce590fe50365dcb33d546be73"
-
-[[package]]
-name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
@@ -959,7 +971,7 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b0d88c06fe90d5ee94048ba40409ef1d9315d86f6f38c2efdaad4fb50c58b2d"
 dependencies = [
- "lazy_static 1.4.0",
+ "lazy_static",
  "libc",
  "log",
  "openssl",
@@ -1051,7 +1063,7 @@ version = "0.1.0"
 dependencies = [
  "epoll",
  "http",
- "lazy_static 1.4.0",
+ "lazy_static",
  "log",
  "micro_http",
  "serde",
@@ -1072,8 +1084,9 @@ dependencies = [
  "env_logger",
  "epoll",
  "event-manager",
+ "flexi_logger",
  "fuse-rs",
- "lazy_static 1.4.0",
+ "lazy_static",
  "libc",
  "log",
  "nix",
@@ -1087,7 +1100,6 @@ dependencies = [
  "serde_json",
  "serde_with",
  "sha2",
- "stderrlog",
  "uuid",
  "vhost",
  "vhost_user_backend",
@@ -1135,7 +1147,7 @@ dependencies = [
  "bitflags",
  "cfg-if 0.1.10",
  "foreign-types",
- "lazy_static 1.4.0",
+ "lazy_static",
  "libc",
  "openssl-sys",
 ]
@@ -1313,7 +1325,7 @@ dependencies = [
  "governor",
  "hmac",
  "httpdate",
- "lazy_static 1.4.0",
+ "lazy_static",
  "libc",
  "log",
  "lz4-sys",
@@ -1436,7 +1448,7 @@ dependencies = [
  "aho-corasick",
  "memchr",
  "regex-syntax",
- "thread_local 1.1.0",
+ "thread_local",
 ]
 
 [[package]]
@@ -1470,7 +1482,7 @@ dependencies = [
  "hyper",
  "hyper-tls",
  "js-sys",
- "lazy_static 1.4.0",
+ "lazy_static",
  "log",
  "mime",
  "mime_guess",
@@ -1536,7 +1548,7 @@ version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
 dependencies = [
- "lazy_static 1.4.0",
+ "lazy_static",
  "winapi 0.3.8",
 ]
 
@@ -1716,19 +1728,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02a8428da277a8e3a15271d79943e80ccc2ef254e78813a166a08d65e4c3ece5"
 
 [[package]]
-name = "stderrlog"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e5ee9b90a5452c570a0b0ac1c99ae9498db7e56e33d74366de7f2a7add7f25"
-dependencies = [
- "atty",
- "chrono",
- "log",
- "termcolor",
- "thread_local 0.3.4",
-]
-
-[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1813,13 +1812,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "thread_local"
-version = "0.3.4"
+name = "thiserror"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1697c4b57aeeb7a536b647165a2825faddffb1d3bad386d507709bd51a90bb14"
+checksum = "318234ffa22e0920fe9a40d7b8369b5f649d490980cf7aadcf1eb91594869b42"
 dependencies = [
- "lazy_static 0.2.11",
- "unreachable",
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cae2447b6282786c3493999f40a9be2a6ad20cb8bd268b0a0dbf5a065535c0ab"
+dependencies = [
+ "proc-macro2 1.0.17",
+ "quote 1.0.6",
+ "syn 1.0.27",
 ]
 
 [[package]]
@@ -1828,7 +1837,7 @@ version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb9bc092d0d51e76b2b19d9d85534ffc9ec2db959a2523cdae0697e2972cd447"
 dependencies = [
- "lazy_static 1.4.0",
+ "lazy_static",
 ]
 
 [[package]]
@@ -1851,7 +1860,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "iovec",
- "lazy_static 1.4.0",
+ "lazy_static",
  "memchr",
  "mio",
  "num_cpus",
@@ -1954,15 +1963,6 @@ name = "unicode-xid"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "826e7639553986605ec5979c7dd957c7895e93eabed50ab2ffa7f6128a75097c"
-
-[[package]]
-name = "unreachable"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
-dependencies = [
- "void",
-]
 
 [[package]]
 name = "url"
@@ -2122,7 +2122,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e53963b583d18a5aa3aaae4b4c1cb535218246131ba22a71f05b518098571df"
 dependencies = [
  "bumpalo",
- "lazy_static 1.4.0",
+ "lazy_static",
  "log",
  "proc-macro2 1.0.17",
  "quote 1.0.6",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -389,7 +389,9 @@ dependencies = [
  "atty",
  "chrono",
  "glob",
+ "lazy_static",
  "log",
+ "regex",
  "thiserror",
  "yansi",
 ]
@@ -1118,6 +1120,7 @@ dependencies = [
  "built",
  "chrono",
  "epoll",
+ "flexi_logger",
  "fuse-rs",
  "libc",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -386,10 +386,12 @@ version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ab94b6ac8eb69f1496a6993f26f785b5fd6d99b7416023eb2a6175c0b242b1"
 dependencies = [
+ "atty",
  "chrono",
  "glob",
  "log",
  "thiserror",
+ "yansi",
 ]
 
 [[package]]
@@ -2251,3 +2253,9 @@ checksum = "244c3741f4240ef46274860397c7c74e50eb23624996930e484c16679633a54c"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "yansi"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fc79f4a1e39857fc00c3f662cbf2651c771f00e9c15fe2abc341806bd46bd71"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ epoll = ">=4.0.1"
 libc = "0.2"
 vmm-sys-util = ">=0.3.1"
 clap = "2.33"
-stderrlog = "0.4"
+flexi_logger = { version = "0.17", default_features = false }
 serde = { version = ">=1.0.27", features = ["serde_derive", "rc"] }
 serde_json = "1.0.51"
 serde_with = { version="1.6.0", features = [ "macros" ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ epoll = ">=4.0.1"
 libc = "0.2"
 vmm-sys-util = ">=0.3.1"
 clap = "2.33"
-flexi_logger = { version = "0.17", default_features = false }
+flexi_logger = { version = "0.17"}
 serde = { version = ">=1.0.27", features = ["serde_derive", "rc"] }
 serde_json = "1.0.51"
 serde_with = { version="1.6.0", features = [ "macros" ] }

--- a/src/bin/nydus-image/main.rs
+++ b/src/bin/nydus-image/main.rs
@@ -4,7 +4,6 @@
 
 #[macro_use(crate_authors, crate_version)]
 extern crate clap;
-extern crate flexi_logger;
 
 mod builder;
 mod node;
@@ -37,7 +36,7 @@ use serde::Serialize;
 
 use builder::SourceType;
 use node::WhiteoutSpec;
-use nydus_utils::BuildTimeInfo;
+use nydus_utils::{setup_logging, BuildTimeInfo};
 use rafs::metadata::digest;
 use rafs::storage::compress;
 use trace::*;
@@ -276,9 +275,7 @@ fn main() -> Result<()> {
         )
         .get_matches();
 
-    // safe because it has default value
-    let v = cmd.value_of("log-level").unwrap();
-    flexi_logger::Logger::with_env_or_str(v).start()?;
+    setup_logging(None, cmd.value_of("log-level"))?;
 
     // FIXME: only register tracer in `create` subcommand.
     register_tracer!(TraceClass::Timing, TimingTracerClass);

--- a/src/bin/nydus-image/main.rs
+++ b/src/bin/nydus-image/main.rs
@@ -270,12 +270,15 @@ fn main() -> Result<()> {
                 .default_value("info")
                 .help("Specify log level: trace, debug, info, warn, error")
                 .takes_value(true)
+                .possible_values(&["trace", "debug", "info", "warn", "error"])
                 .required(false)
                 .global(true),
         )
         .get_matches();
 
-    setup_logging(None, cmd.value_of("log-level"))?;
+    // Safe to unwrap because it has default value and possible values are defined.
+    let level = cmd.value_of("log-level").unwrap().parse().unwrap();
+    setup_logging(None, level)?;
 
     // FIXME: only register tracer in `create` subcommand.
     register_tracer!(TraceClass::Timing, TimingTracerClass);

--- a/src/bin/nydus-image/main.rs
+++ b/src/bin/nydus-image/main.rs
@@ -4,7 +4,7 @@
 
 #[macro_use(crate_authors, crate_version)]
 extern crate clap;
-extern crate stderrlog;
+extern crate flexi_logger;
 
 mod builder;
 mod node;
@@ -37,7 +37,7 @@ use serde::Serialize;
 
 use builder::SourceType;
 use node::WhiteoutSpec;
-use nydus_utils::{log_level_to_verbosity, BuildTimeInfo};
+use nydus_utils::BuildTimeInfo;
 use rafs::metadata::digest;
 use rafs::storage::compress;
 use trace::*;
@@ -276,18 +276,9 @@ fn main() -> Result<()> {
         )
         .get_matches();
 
-    let v = cmd
-        .value_of("log-level")
-        .unwrap()
-        .parse()
-        .unwrap_or(log::LevelFilter::Warn);
-
-    stderrlog::new()
-        .quiet(false)
-        .verbosity(log_level_to_verbosity(v))
-        .timestamp(stderrlog::Timestamp::Second)
-        .init()
-        .context("failed to init logger")?;
+    // safe because it has default value
+    let v = cmd.value_of("log-level").unwrap();
+    flexi_logger::Logger::with_env_or_str(v).start()?;
 
     // FIXME: only register tracer in `create` subcommand.
     register_tracer!(TraceClass::Timing, TimingTracerClass);

--- a/src/bin/nydusd/main.rs
+++ b/src/bin/nydusd/main.rs
@@ -9,9 +9,9 @@ extern crate clap;
 extern crate log;
 #[macro_use]
 extern crate lazy_static;
+extern crate flexi_logger;
 extern crate rafs;
 extern crate serde_json;
-extern crate stderrlog;
 
 #[cfg(feature = "fusedev")]
 use std::convert::TryInto;
@@ -36,7 +36,7 @@ use event_manager::{EventManager, EventSubscriber, SubscriberOps};
 use vmm_sys_util::eventfd::EventFd;
 
 use nydus_api::http::start_http_thread;
-use nydus_utils::{dump_program_info, log_level_to_verbosity, BuildTimeInfo};
+use nydus_utils::{dump_program_info, BuildTimeInfo};
 
 mod daemon;
 use daemon::{DaemonError, FsBackendMountCmd, FsBackendType, NydusDaemonSubscriber};
@@ -258,15 +258,12 @@ fn main() -> Result<()> {
         .parse()
         .unwrap_or(log::LevelFilter::Info);
 
-    stderrlog::new()
-        .quiet(false)
-        .verbosity(log_level_to_verbosity(log::LevelFilter::Trace))
-        .timestamp(stderrlog::Timestamp::Millisecond)
-        .init()
+    flexi_logger::Logger::with_env_or_str("trace")
+        .start()
         .unwrap();
-    // We rely on `log` macro to limit current log level rather than `stderrlog`
-    // So we set stderrlog verbosity to TRACE which is High enough. Otherwise, we
-    // can't change log level to a higher level than what is passed to `stderrlog`.
+    // We rely on `log` macro to limit current log level rather than `flexi_logger`
+    // So we set `flexi_logger` log level to "trace" which is High enough. Otherwise, we
+    // can't change log level to a higher level than what is passed to `flexi_logger`.
     log::set_max_level(v);
     dump_program_info();
 

--- a/src/bin/nydusd/main.rs
+++ b/src/bin/nydusd/main.rs
@@ -153,6 +153,7 @@ fn main() -> Result<()> {
                 .default_value("info")
                 .help("Specify log level: trace, debug, info, warn, error")
                 .takes_value(true)
+                .possible_values(&["trace", "debug", "info", "warn", "error"])
                 .required(false)
                 .global(true),
         )
@@ -259,10 +260,15 @@ fn main() -> Result<()> {
 
     let cmd_arguments_parsed = cmd_arguments.get_matches();
 
-    setup_logging(
-        cmd_arguments_parsed.value_of("log-file"),
-        cmd_arguments_parsed.value_of("log-level"),
-    )?;
+    let logging_file = cmd_arguments_parsed.value_of("log-file").map(|l| l.into());
+    // Safe to unwrap because it has default value and possible values are defined
+    let level = cmd_arguments_parsed
+        .value_of("log-level")
+        .unwrap()
+        .parse()
+        .unwrap();
+
+    setup_logging(logging_file, level)?;
 
     dump_program_info();
 

--- a/src/bin/nydusd/main.rs
+++ b/src/bin/nydusd/main.rs
@@ -160,7 +160,7 @@ fn main() -> Result<()> {
         .arg(
             Arg::with_name("log-file")
                 .long("log-file")
-                .help("Specify the path to log file")
+                .help("Specify the path to log file. If log filename has not extension, the default \".log\" will be added.")
                 .takes_value(true)
                 .required(false)
                 .global(true),

--- a/tests/builder.rs
+++ b/tests/builder.rs
@@ -242,7 +242,7 @@ impl<'a> Builder<'a> {
     }
 
     pub fn build_upper(&mut self, compressor: &str) -> Result<()> {
-        let upper_dir = self.work_dir.join("upper").to_path_buf();
+        let upper_dir = self.work_dir.join("upper");
 
         exec(
             format!(

--- a/tests/nydusd.rs
+++ b/tests/nydusd.rs
@@ -27,7 +27,7 @@ pub fn new(
     digest_validate: bool,
 ) -> Result<Nydusd> {
     let cache_path = work_dir.join("cache");
-    fs::create_dir_all(cache_path.clone())?;
+    fs::create_dir_all(cache_path)?;
 
     let cache = format!(
         r###"
@@ -148,8 +148,8 @@ impl Nydusd {
     }
 
     pub fn is_mounted(&self, mount_path: &str) -> Result<bool> {
-        let ret = exec(format!("cat /proc/mounts").as_str(), true)?;
-        for line in ret.split("\n") {
+        let ret = exec("cat /proc/mounts", true)?;
+        for line in ret.split('\n') {
             if line.contains(self.work_dir.join(mount_path).to_str().unwrap()) {
                 return Ok(true);
             }

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -14,7 +14,7 @@ use vmm_sys_util::tempdir::TempDir;
 
 use nydus_utils::{eother, exec, setup_logging};
 
-const COMPAT_BOOTSTRAPS: &'static [&'static str] = &[
+const COMPAT_BOOTSTRAPS: [&str; 2] = [
     "blake3-lz4_block-non_repeatable",
     "sha256-nocompress-repeatable",
 ];
@@ -58,7 +58,7 @@ fn test(
     let tmp_dir_prefix =
         std::env::var("TEST_WORKDIR_PREFIX").expect("Please specify `TEST_WORKDIR_PREFIX` env");
     let tmp_dir = {
-        let path = if tmp_dir_prefix.ends_with("/") {
+        let path = if tmp_dir_prefix.ends_with('/') {
             tmp_dir_prefix
         } else {
             format!("{}/", tmp_dir_prefix)
@@ -66,8 +66,8 @@ fn test(
         TempDir::new_with_prefix(path).map_err(|e| eother!(e))?
     };
     let work_dir = tmp_dir.as_path().to_path_buf();
-    let lower_texture = format!("directory/lower.result");
-    let overlay_texture = format!("directory/overlay.result");
+    let lower_texture = "directory/lower.result".to_string();
+    let overlay_texture = "directory/overlay.result".to_string();
 
     let mut builder = builder::new(&work_dir, whiteout_spec);
 
@@ -208,7 +208,7 @@ fn integration_test_special_files() -> Result<()> {
 
     builder.build_special_files()?;
 
-    for mode in vec!["direct", "cached"] {
+    for mode in &["direct", "cached"] {
         let nydusd = nydusd::new(
             &work_dir,
             true,

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 #[macro_use]
 extern crate log;
-extern crate stderrlog;
 
 mod builder;
 mod nydusd;
@@ -13,7 +12,7 @@ use std::path::PathBuf;
 
 use vmm_sys_util::tempdir::TempDir;
 
-use nydus_utils::{eother, exec};
+use nydus_utils::{eother, exec, setup_logging};
 
 const COMPAT_BOOTSTRAPS: &'static [&'static str] = &[
     "blake3-lz4_block-non_repeatable",
@@ -130,13 +129,8 @@ fn test(
 }
 
 #[test]
-fn integration_test_init() -> Result<()> {
-    stderrlog::new()
-        .quiet(false)
-        .timestamp(stderrlog::Timestamp::Second)
-        .verbosity(log::LevelFilter::Trace as usize - 1)
-        .init()
-        .map_err(|e| eother!(e))
+fn integration_test_init() {
+    setup_logging(None, log::LevelFilter::Trace).unwrap()
 }
 
 #[test]

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -11,6 +11,7 @@ built = { version = "=0.4.3", features = ["git2", "chrono"] }
 
 [dependencies]
 log = "0.4.8"
+flexi_logger = { version = "0.17"}
 libc = "0.2"
 nix = "0.17"
 epoll = ">=4.0.1"


### PR DESCRIPTION
Nydusd now can log both to standard error and specified logging file. Just specify the logging file by adding option `--log-file` when nydusd starts