### PR TITLE
image: add a flag controlling chunk size's alignment

### DIFF
--- a/rafs/src/io_stats.rs
+++ b/rafs/src/io_stats.rs
@@ -60,6 +60,9 @@ const BLOCK_READ_COUNT_MAX: usize = 8;
 /// <=200us, <=500us, <=1ms, <=20ms, <=50ms, <=100ms, <=500ms, >500ms
 const READ_LATENCY_RANGE_MAX: usize = 8;
 
+// Defining below global static metrics set so that a specific metrics counter can
+// be found as per the rafs backend mountpoint/id. Remind that nydusd can have
+// multiple backends mounted.
 lazy_static! {
     static ref IOS_SET: RwLock<HashMap<String, Arc<GlobalIOStats>>> = Default::default();
 }
@@ -596,7 +599,7 @@ pub struct BackendMetrics {
     // is responsible for calculating BPS from this field.
     read_amount_total: BasicMetric,
     read_cumulative_latency_total: BasicMetric,
-    // Categorize metrics per as to their latency and request size
+    // Categorize metrics as per their latency and request size
     read_latency_dist: [[BasicMetric; READ_LATENCY_RANGE_MAX]; BLOCK_READ_COUNT_MAX],
 }
 

--- a/rafs/src/storage/backend/oss.rs
+++ b/rafs/src/storage/backend/oss.rs
@@ -232,7 +232,7 @@ impl BlobBackend for OSS {
         _blob_readahead_size: u32,
     ) -> BackendResult<()> {
         Err(BackendError::Unsupported(
-            "Oss backend does not support prefetch per as to on-disk blob entries".to_string(),
+            "Oss backend does not support prefetch as per on-disk blob entries".to_string(),
         ))
     }
 

--- a/rafs/src/storage/backend/registry.rs
+++ b/rafs/src/storage/backend/registry.rs
@@ -595,7 +595,7 @@ impl BlobBackend for Registry {
         _blob_readahead_size: u32,
     ) -> BackendResult<()> {
         Err(BackendError::Unsupported(
-            "Registry backend does not support prefetch per as to on-disk blob entries".to_string(),
+            "Registry backend does not support prefetch as per on-disk blob entries".to_string(),
         ))
     }
 

--- a/rafs/src/storage/cache/blobcache.rs
+++ b/rafs/src/storage/cache/blobcache.rs
@@ -387,7 +387,7 @@ impl BlobCache {
             let cki = &bios[index].chunkinfo;
             let prior_bio = &bios[index - 1];
             let cur_bio = &bios[index];
-            // Even more chunks are continuous, still split them per as certain size.
+            // Even more chunks are continuous, still split them as per certain size.
             // So that to achieve an appropriate request size to backend.
             if Self::is_chunk_continuous(prior_bio, cur_bio) && mr.blob_size <= merging_size as u32
             {

--- a/rafs/src/storage/cache/mod.rs
+++ b/rafs/src/storage/cache/mod.rs
@@ -109,7 +109,7 @@ pub trait RafsCache {
     /// Read a whole chunk directly from *backend*.
     /// The fetched chunk could be compressed or not by different compressors.
     /// It depends on `cki` how to describe the chunk data.
-    /// Moreover, chunk data from backend can be validated per as to nydus configuration.
+    /// Moreover, chunk data from backend can be validated as per nydus configuration.
     /// Above is not redundant with blob cache's validation given IO path backend -> blobcache
     fn read_backend_chunk<F>(
         &self,
@@ -204,7 +204,7 @@ pub trait RafsCache {
     }
 
     /// Before storing chunk data into blob cache file. We have cook the raw chunk from
-    /// backend a bit per as to the chunk description as blob cache always saves plain data
+    /// backend a bit as per the chunk description as blob cache always saves plain data
     /// into cache file rather than compressed.
     /// An inside trick is that it tries to directly save data into caller's buffer.
     fn process_raw_chunk(

--- a/src/bin/nydus-image/main.rs
+++ b/src/bin/nydus-image/main.rs
@@ -213,6 +213,12 @@ fn main() -> Result<()> {
                         .help("JSON output path for build result")
                         .takes_value(true)
                 )
+                .arg(
+                    Arg::with_name("aligned-chunk")
+                        .long("aligned-chunk")
+                        .help("Whether to align chunks into blobcache")
+                        .takes_value(false)
+                )
         )
         .subcommand(
             SubCommand::with_name("check")
@@ -347,6 +353,8 @@ fn main() -> Result<()> {
             .unwrap_or_default()
             .parse()?;
 
+        let aligned_chunk = matches.is_present("aligned-chunk");
+
         let mut ib = builder::Builder::new(
             source_type,
             source_path,
@@ -360,6 +368,7 @@ fn main() -> Result<()> {
             prefetch_policy,
             !repeatable,
             whiteout_spec,
+            aligned_chunk,
         )?;
 
         // Some operations like listing xattr pairs of certain namespace need the process

--- a/src/bin/nydus-image/tree.rs
+++ b/src/bin/nydus-image/tree.rs
@@ -397,7 +397,7 @@ impl FilesystemTreeBuilder {
             )
             .with_context(|| format!("failed to create node {:?}", path))?;
 
-            // Per as to OCI spec, whiteout file should not be present within final image
+            // as per OCI spec, whiteout file should not be present within final image
             // or filesystem, only existed in layers.
             if child.whiteout_type(whiteout_spec).is_some()
                 && !child.is_overlayfs_opaque(whiteout_spec)


### PR DESCRIPTION
Sometimes, chunks are better to put into blobcache with
4k aligned, which makes advanced usage more convenient.

When filling local blobcache file, chunks are arranged per
as to the `decompress offset` within chunk info. Therefore,
provide a new flag to image tool thus to align chunks in blob
with 4k size.

Signed-off-by: Changwei Ge <chge@linux.alibaba.com>