### PR TITLE
Builder: support --output-json for check subcommand

### DIFF
--- a/src/bin/nydus-image/validator.rs
+++ b/src/bin/nydus-image/validator.rs
@@ -33,7 +33,7 @@ impl Validator {
         Ok(Self { f_bootstrap })
     }
 
-    pub fn check(&mut self, verbosity: bool) -> Result<bool> {
+    pub fn check(&mut self, verbosity: bool) -> Result<Vec<String>> {
         let err = "failed to load bootstrap for validator";
         let mut rs = RafsSuper {
             mode: RafsMode::Direct,
@@ -53,6 +53,14 @@ impl Validator {
             true
         })?;
 
-        Ok(true)
+        let blob_ids = rs
+            .inodes
+            .get_blob_table()
+            .entries
+            .iter()
+            .map(|entry| entry.blob_id.to_string())
+            .collect::<Vec<String>>();
+
+        Ok(blob_ids)
     }
 }


### PR DESCRIPTION
Add `--output-json` option for check subcommand, use it for Nydusify
image checker to get blob ids from bootstrap, and compare with the blob
ids recorded in Nydus image manifest, to ensure the image validity.

Signed-off-by: Yan Song <imeoer@linux.alibaba.com>