### PR TITLE
Support snapshotter reconnect to already running daemons

### DIFF
--- a/contrib/nydus-snapshotter/go.mod
+++ b/contrib/nydus-snapshotter/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/sirupsen/logrus v1.6.0
 	github.com/stretchr/testify v1.5.1
 	github.com/urfave/cli/v2 v2.2.0
-	go.etcd.io/bbolt v1.3.5 // indirect
+	go.etcd.io/bbolt v1.3.5
 	google.golang.org/grpc v1.31.0
 	gotest.tools/v3 v3.0.2 // indirect
 )

--- a/contrib/nydus-snapshotter/pkg/daemon/config.go
+++ b/contrib/nydus-snapshotter/pkg/daemon/config.go
@@ -115,7 +115,7 @@ func WithSharedDaemon() NewDaemonOpt {
 
 func WithAPISock(apiSock string) NewDaemonOpt {
 	return func(d *Daemon) error {
-		d.apiSock = &apiSock
+		d.ApiSock = &apiSock
 		return nil
 	}
 }

--- a/contrib/nydus-snapshotter/pkg/daemon/config.go
+++ b/contrib/nydus-snapshotter/pkg/daemon/config.go
@@ -7,7 +7,6 @@
 package daemon
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 
@@ -54,18 +53,7 @@ func WithSocketDir(dir string) NewDaemonOpt {
 
 func WithLogDir(dir string) NewDaemonOpt {
 	return func(d *Daemon) error {
-		s := filepath.Join(dir, d.ID)
-		// this may be failed, should handle that
-		if err := os.MkdirAll(s, 0755); err != nil {
-			return errors.Wrapf(err, "failed to create log dir %s", s)
-		}
-		logs, err := prepareDaemonLogs(s)
-		if err != nil {
-			return errors.Wrap(err, "failed to prepare logs")
-		}
-		d.LogDir = s
-		d.Stdout = logs[0]
-		d.Stderr = logs[1]
+		d.LogDir = filepath.Join(dir, d.ID)
 		return nil
 	}
 }
@@ -118,20 +106,4 @@ func WithAPISock(apiSock string) NewDaemonOpt {
 		d.ApiSock = &apiSock
 		return nil
 	}
-}
-
-
-func prepareDaemonLogs(logDir string) ([]*os.File, error) {
-	var (
-		err      error
-		logFiles = make([]*os.File, 2)
-	)
-	for i, logName := range []string{"stdout.log", "stderr.log"} {
-		logPath := filepath.Join(logDir, logName)
-		logFiles[i], err = os.Create(logPath)
-		if err != nil {
-			return nil, errors.Wrap(err, fmt.Sprintf("failed to create logfile %s", logPath))
-		}
-	}
-	return logFiles, nil
 }

--- a/contrib/nydus-snapshotter/pkg/daemon/daemon.go
+++ b/contrib/nydus-snapshotter/pkg/daemon/daemon.go
@@ -18,6 +18,11 @@ import (
 	"contrib/nydus-snapshotter/pkg/nydussdk/model"
 )
 
+const (
+	APISocketFileName   = "api.sock"
+	SharedNydusDaemonID = "shared_daemon"
+)
+
 type NewDaemonOpt func(d *Daemon) error
 
 type Daemon struct {
@@ -26,15 +31,15 @@ type Daemon struct {
 	ConfigDir      string
 	SocketDir      string
 	LogDir         string
-	Stdout         io.WriteCloser
-	Stderr         io.WriteCloser
+	Stdout         io.WriteCloser `json:"-"`
+	Stderr         io.WriteCloser `json:"-"`
 	CacheDir       string
 	SnapshotDir    string
 	Pid            int
 	client         nydussdk.Interface
 	ImageID        string
 	SharedDaemon   bool
-	apiSock        *string
+	ApiSock        *string
 	RootMountPoint *string
 	mu             sync.Mutex
 }
@@ -73,10 +78,10 @@ func (d *Daemon) ConfigFile() string {
 }
 
 func (d *Daemon) APISock() string {
-	if d.apiSock != nil {
-		return *d.apiSock
+	if d.ApiSock != nil {
+		return *d.ApiSock
 	}
-	return filepath.Join(d.SocketDir, "api.sock")
+	return filepath.Join(d.SocketDir, APISocketFileName)
 }
 
 func (d *Daemon) binary() string {
@@ -104,7 +109,7 @@ func (d *Daemon) SharedMount() error {
 }
 
 func NewDaemon(opt ...NewDaemonOpt) (*Daemon, error) {
-	d := &Daemon{Pid: -1}
+	d := &Daemon{Pid: 0}
 	d.ID = newID()
 	for _, o := range opt {
 		err := o(d)

--- a/contrib/nydus-snapshotter/pkg/daemon/daemon.go
+++ b/contrib/nydus-snapshotter/pkg/daemon/daemon.go
@@ -108,6 +108,14 @@ func (d *Daemon) SharedMount() error {
 	return client.SharedMount(d.MountPoint(), bootstrap, d.ConfigFile())
 }
 
+func (d *Daemon) SharedUmount() error {
+	client, err := nydussdk.NewNydusClient(d.APISock())
+	if err != nil {
+		return errors.Wrap(err, "failed to mount")
+	}
+	return client.Umount(d.MountPoint())
+}
+
 func NewDaemon(opt ...NewDaemonOpt) (*Daemon, error) {
 	d := &Daemon{Pid: 0}
 	d.ID = newID()

--- a/contrib/nydus-snapshotter/pkg/daemon/daemon.go
+++ b/contrib/nydus-snapshotter/pkg/daemon/daemon.go
@@ -81,6 +81,10 @@ func (d *Daemon) APISock() string {
 	return filepath.Join(d.SocketDir, APISocketFileName)
 }
 
+func (d *Daemon) LogFile() string {
+	return filepath.Join(d.LogDir, "stderr.log")
+}
+
 func (d *Daemon) binary() string {
 	return "/bin/nydusd"
 }

--- a/contrib/nydus-snapshotter/pkg/daemon/daemon.go
+++ b/contrib/nydus-snapshotter/pkg/daemon/daemon.go
@@ -30,7 +30,7 @@ type Daemon struct {
 	Stderr         io.WriteCloser
 	CacheDir       string
 	SnapshotDir    string
-	Process        *os.Process
+	Pid            int
 	client         nydussdk.Interface
 	ImageID        string
 	SharedDaemon   bool
@@ -104,7 +104,7 @@ func (d *Daemon) SharedMount() error {
 }
 
 func NewDaemon(opt ...NewDaemonOpt) (*Daemon, error) {
-	d := &Daemon{}
+	d := &Daemon{Pid: -1}
 	d.ID = newID()
 	for _, o := range opt {
 		err := o(d)

--- a/contrib/nydus-snapshotter/pkg/daemon/daemon.go
+++ b/contrib/nydus-snapshotter/pkg/daemon/daemon.go
@@ -7,7 +7,6 @@
 package daemon
 
 import (
-	"io"
 	"os"
 	"path/filepath"
 	"sync"
@@ -31,8 +30,6 @@ type Daemon struct {
 	ConfigDir      string
 	SocketDir      string
 	LogDir         string
-	Stdout         io.WriteCloser `json:"-"`
-	Stderr         io.WriteCloser `json:"-"`
 	CacheDir       string
 	SnapshotDir    string
 	Pid            int

--- a/contrib/nydus-snapshotter/pkg/filesystem/nydus/config.go
+++ b/contrib/nydus-snapshotter/pkg/filesystem/nydus/config.go
@@ -11,6 +11,7 @@ import (
 
 	"contrib/nydus-snapshotter/pkg/filesystem/meta"
 	"contrib/nydus-snapshotter/pkg/signature"
+	"contrib/nydus-snapshotter/pkg/process"
 )
 
 type NewFSOpt func(d *filesystem) error
@@ -33,6 +34,17 @@ func WithNydusdBinaryPath(p string) NewFSOpt {
 			return errors.New("nydusd binary path is required")
 		}
 		d.nydusdBinaryPath = p
+		return nil
+	}
+}
+
+func WithProcessManager(pm *process.Manager) NewFSOpt {
+	return func(d *filesystem) error {
+		if pm == nil {
+			return errors.New("process manager cannot be nil")
+		}
+
+		d.manager = pm
 		return nil
 	}
 }

--- a/contrib/nydus-snapshotter/pkg/filesystem/stargz/config.go
+++ b/contrib/nydus-snapshotter/pkg/filesystem/stargz/config.go
@@ -11,6 +11,7 @@ import (
 
 	"contrib/nydus-snapshotter/pkg/filesystem/meta"
 	"contrib/nydus-snapshotter/pkg/filesystem/nydus"
+	"contrib/nydus-snapshotter/pkg/process"
 )
 
 func WithMeta(root string) NewFSOpt {
@@ -31,6 +32,17 @@ func WithNydusdBinaryPath(p string) NewFSOpt {
 			return errors.New("nydusd binary path is required")
 		}
 		d.nydusdBinaryPath = p
+		return nil
+	}
+}
+
+func WithProcessManager(pm *process.Manager) NewFSOpt {
+	return func(d *filesystem) error {
+		if pm == nil {
+			return errors.New("process manager cannot be nil")
+		}
+
+		d.manager = pm
 		return nil
 	}
 }

--- a/contrib/nydus-snapshotter/pkg/filesystem/stargz/fs.go
+++ b/contrib/nydus-snapshotter/pkg/filesystem/stargz/fs.go
@@ -49,9 +49,7 @@ func NewFileSystem(ctx context.Context, opt ...NewFSOpt) (snapshot.FileSystem, e
 		}
 	}
 	fs.resolver = NewResolver()
-	fs.manager = process.NewManager(process.Opt{
-		NydusdBinaryPath: fs.nydusdBinaryPath,
-	})
+
 	return &fs, nil
 }
 

--- a/contrib/nydus-snapshotter/pkg/filesystem/stargz/fs_test.go
+++ b/contrib/nydus-snapshotter/pkg/filesystem/stargz/fs_test.go
@@ -38,13 +38,18 @@ func Test_filesystem_createNewDaemon(t *testing.T) {
 	defer func() {
 		_ = os.RemoveAll(snapshotRoot)
 	}()
+
+	mgr, err := process.NewManager(process.Opt{
+		NydusdBinaryPath: "",
+		RootDir:          snapshotRoot,
+	})
+	require.Nil(t, err)
+
 	f := filesystem{
 		FileSystemMeta: meta.FileSystemMeta{
 			RootDir: snapshotRoot,
 		},
-		manager: process.NewManager(process.Opt{
-			NydusdBinaryPath: "",
-		}),
+		manager:     mgr,
 		daemonCfg:   nydus.DaemonConfig{},
 		resolver:    nil,
 		vpcRegistry: false,
@@ -66,13 +71,18 @@ func Test_filesystem_generateDaemonConfig(t *testing.T) {
 	var cfg nydus.DaemonConfig
 	err = json.Unmarshal(content, &cfg)
 	require.Nil(t, err)
+
+	mgr, err := process.NewManager(process.Opt{
+		NydusdBinaryPath: "",
+		RootDir:          snapshotRoot,
+	})
+	require.Nil(t, err)
+
 	f := filesystem{
 		FileSystemMeta: meta.FileSystemMeta{
 			RootDir: snapshotRoot,
 		},
-		manager: process.NewManager(process.Opt{
-			NydusdBinaryPath: "",
-		}),
+		manager:     mgr,
 		daemonCfg:   cfg,
 		resolver:    nil,
 		vpcRegistry: false,

--- a/contrib/nydus-snapshotter/pkg/process/manager.go
+++ b/contrib/nydus-snapshotter/pkg/process/manager.go
@@ -94,8 +94,6 @@ func (m *Manager) ListDaemons() []*daemon.Daemon {
 }
 
 func (m *Manager) CleanUpDaemonResource(d *daemon.Daemon) {
-	_ = d.Stderr.Close()
-	_ = d.Stdout.Close()
 	resource := []string{d.ConfigDir, d.LogDir}
 	if !d.SharedDaemon {
 		resource = append(resource, d.SocketDir)

--- a/contrib/nydus-snapshotter/pkg/process/manager.go
+++ b/contrib/nydus-snapshotter/pkg/process/manager.go
@@ -130,6 +130,7 @@ func (m *Manager) buildStartCommand(d *daemon.Daemon) (*exec.Cmd, error) {
 	args := []string{
 		"--apisock", d.APISock(),
 		"--log-level", "info",
+		"--log-file", d.LogFile(),
 		"--thread-num", "10",
 	}
 	if !d.SharedDaemon {

--- a/contrib/nydus-snapshotter/pkg/process/manager.go
+++ b/contrib/nydus-snapshotter/pkg/process/manager.go
@@ -7,7 +7,6 @@
 package process
 
 import (
-	"bufio"
 	"context"
 	"fmt"
 	"os"
@@ -119,23 +118,12 @@ func (m *Manager) StartDaemon(d *daemon.Daemon) error {
 	if err != nil {
 		return errors.Wrap(err, fmt.Sprintf("failed to create start command for daemon %s", d.ID))
 	}
-	stderr, err := cmd.StderrPipe()
-	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("failed to get stderr pipe for daemon %s", d.ID))
-	}
 	if err := cmd.Start(); err != nil {
 		return err
 	}
 	d.Pid = cmd.Process.Pid
 	// make sure to wait after start
-	go func() {
-		scanner := bufio.NewScanner(stderr)
-		for scanner.Scan() {
-			log.L.WithField("daemon", d.ID).Debug(scanner.Text())
-		}
-		log.L.WithField("daemon", d.ID).Info("quits")
-		cmd.Wait()
-	}()
+	go cmd.Wait()
 	return nil
 
 }

--- a/contrib/nydus-snapshotter/pkg/process/store.go
+++ b/contrib/nydus-snapshotter/pkg/process/store.go
@@ -7,6 +7,7 @@
 package process
 
 import (
+	"context"
 	"contrib/nydus-snapshotter/pkg/daemon"
 	"contrib/nydus-snapshotter/pkg/store"
 )
@@ -15,9 +16,11 @@ type Store interface {
 	Get(id string) (*daemon.Daemon, error)
 	GetBySnapshot(snapshotID string) (*daemon.Daemon, error)
 	Add(*daemon.Daemon) error
-	Delete(*daemon.Daemon)
+	Delete(*daemon.Daemon) error
 	List() []*daemon.Daemon
 	Size() int
+	WalkDaemons(ctx context.Context, cb func(*daemon.Daemon) error) error
+	CleanupDatabase(ctx context.Context) error
 }
 
 var _ Store = &store.DaemonStore{}

--- a/contrib/nydus-snapshotter/pkg/store/database.go
+++ b/contrib/nydus-snapshotter/pkg/store/database.go
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2021. Ant Financial. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package store
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+
+	"contrib/nydus-snapshotter/pkg/daemon"
+
+	"github.com/pkg/errors"
+	bolt "go.etcd.io/bbolt"
+)
+
+// Bucket names
+var (
+	daemonsBucketName = []byte("daemons") // Contains daemon info <daemon_id>=<daemon>
+)
+
+var (
+	// ErrNotFound errors when the querying object not exists
+	ErrNotFound = errors.New("object not found")
+	// ErrAlreadyExists errors when duplicated object found
+	ErrAlreadyExists = errors.New("object already exists")
+)
+
+// Database keeps infos that need to survive among snapshotter restart
+type Database struct {
+	db *bolt.DB
+}
+
+// NewDatabase creates a new or open existing database file
+func NewDatabase(dbfile string) (*Database, error) {
+	if err := ensureDirectory(filepath.Dir(dbfile)); err != nil {
+		return nil, err
+	}
+
+	db, err := bolt.Open(dbfile, 0600, nil)
+	if err != nil {
+		return nil, err
+	}
+	d := &Database{db: db}
+	if err := d.initDatabase(); err != nil {
+		return nil, errors.Wrap(err, "failed to initialize database")
+	}
+	return d, nil
+}
+
+func ensureDirectory(dir string) error {
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		return os.MkdirAll(dir, 0700)
+	}
+
+	return nil
+}
+
+func (d *Database) initDatabase() error {
+	return d.db.Update(func(tx *bolt.Tx) error {
+		if _, err := tx.CreateBucketIfNotExists(daemonsBucketName); err != nil {
+			return err
+		}
+		return nil
+	})
+}
+
+// SaveDaemon saves daemon record from database
+func (d *Database) SaveDaemon(ctx context.Context, dmn *daemon.Daemon) error {
+	return d.db.Update(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket(daemonsBucketName)
+
+		var existing daemon.Daemon
+		if err := getObject(bucket, dmn.ID, &existing); err == nil {
+			return ErrAlreadyExists
+		}
+
+		return putObject(bucket, dmn.ID, dmn)
+	})
+}
+
+// DeleteDaemon deletes daemon record from database
+func (d *Database) DeleteDaemon(ctx context.Context, id string) error {
+	return d.db.Update(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket(daemonsBucketName)
+
+		if err := bucket.Delete([]byte(id)); err != nil {
+			return errors.Wrapf(err, "failed to delete daemon for %q", id)
+		}
+
+		return nil
+	})
+}
+
+// WalkDaemons iterates all daemon records and invoke callback on each
+func (d *Database) WalkDaemons(ctx context.Context, cb func(info *daemon.Daemon) error) error {
+	return d.db.View(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket(daemonsBucketName)
+		return bucket.ForEach(func(key, value []byte) error {
+			dmn := &daemon.Daemon{}
+			if err := json.Unmarshal(value, dmn); err != nil {
+				return errors.Wrapf(err, "failed to unmarshal %s", key)
+			}
+
+			return cb(dmn)
+		})
+	})
+}
+
+// Cleanup deletes all daemon records
+func (d *Database) Cleanup(ctx context.Context) error {
+	return d.db.Update(func(tx *bolt.Tx) error {
+		bucket := tx.Bucket(daemonsBucketName)
+
+		return bucket.ForEach(func(k, _ []byte) error {
+			return bucket.Delete(k)
+		})
+	})
+}
+
+func putObject(bucket *bolt.Bucket, key string, obj interface{}) error {
+	keyBytes := []byte(key)
+
+	if bucket.Get(keyBytes) != nil {
+		return errors.Errorf("object with key %q already exists", key)
+	}
+
+	value, err := json.Marshal(obj)
+	if err != nil {
+		return errors.Wrapf(err, "failed to marshall object with key %q", key)
+	}
+
+	if err := bucket.Put(keyBytes, value); err != nil {
+		return errors.Wrapf(err, "failed to insert object with key %q", key)
+	}
+
+	return nil
+}
+
+func getObject(bucket *bolt.Bucket, key string, obj interface{}) error {
+	if obj == nil {
+		return errors.Errorf("invalid arg: obj cannot be nil")
+	}
+
+	value := bucket.Get([]byte(key))
+	if value == nil {
+		return ErrNotFound
+	}
+
+	if err := json.Unmarshal(value, obj); err != nil {
+		return errors.Wrapf(err, "failed to unmarshall object with key %q", key)
+	}
+
+	return nil
+}

--- a/contrib/nydus-snapshotter/pkg/store/database_test.go
+++ b/contrib/nydus-snapshotter/pkg/store/database_test.go
@@ -1,0 +1,66 @@
+package store
+
+import (
+	"context"
+	"github.com/stretchr/testify/require"
+	"gitlab.alipay-inc.com/antsys/nydus-snapshotter/pkg/daemon"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func Test_database(t *testing.T) {
+	rootDir := "testdata/snapshot"
+	err := os.MkdirAll(rootDir, 0755)
+	require.Nil(t, err)
+	defer func() {
+		_ = os.RemoveAll(rootDir)
+	}()
+
+	dbFile := filepath.Join(rootDir, databaseFileName)
+	db, err := NewDatabase(dbFile)
+	require.Nil(t, err)
+
+	ctx := context.TODO()
+	// Add daemons
+	d1 := daemon.Daemon{ID: "d1"}
+	d2 := daemon.Daemon{ID: "d2"}
+	d3 := daemon.Daemon{ID: "d3"}
+	err = db.SaveDaemon(ctx, &d1)
+	require.Nil(t, err)
+	err = db.SaveDaemon(ctx, &d2)
+	require.Nil(t, err)
+	db.SaveDaemon(ctx, &d3)
+	require.Nil(t, err)
+	// duplicate daemon id should fail
+	err = db.SaveDaemon(ctx, &d1)
+	require.Error(t, err)
+
+	// Delete one daemon
+	err = db.DeleteDaemon(ctx, "d2")
+	require.Nil(t, err)
+
+	// Check records
+	ids := make(map[string]string)
+	err = db.WalkDaemons(ctx, func(info *daemon.Daemon) error {
+		ids[info.ID] = ""
+		return nil
+	})
+	_, ok := ids["d1"]
+	require.Equal(t, ok, true)
+	_, ok = ids["d2"]
+	require.Equal(t, ok, false)
+	_, ok = ids["d3"]
+	require.Equal(t, ok, true)
+
+	// Cleanup records
+	err = db.Cleanup(ctx)
+	require.Nil(t, err)
+	ids2 := make([]string, 0)
+	err = db.WalkDaemons(ctx, func(info *daemon.Daemon) error {
+		ids2 = append(ids2, info.ID)
+		return nil
+	})
+	require.Nil(t, err)
+	require.Equal(t, len(ids2), 0)
+}

--- a/contrib/nydus-snapshotter/pkg/store/store.go
+++ b/contrib/nydus-snapshotter/pkg/store/store.go
@@ -7,10 +7,16 @@
 package store
 
 import (
+	"context"
 	"fmt"
-	"sync"
-
+	"github.com/pkg/errors"
 	"contrib/nydus-snapshotter/pkg/daemon"
+	"path/filepath"
+	"sync"
+)
+
+const (
+	databaseFileName = "nydus.db"
 )
 
 
@@ -19,13 +25,22 @@ type DaemonStore struct {
 	idxBySnapshotID map[string]*daemon.Daemon // index by snapshot ID per image
 	idxByID         map[string]*daemon.Daemon // index by ID per daemon include upgraded daemon
 	daemons         []*daemon.Daemon          // all daemon
+	db              *Database                 // save daemons in database
 }
 
-func NewDaemonStore() *DaemonStore {
+func NewDaemonStore(rootDir string) (*DaemonStore, error) {
+	dbfile := filepath.Join(rootDir, databaseFileName)
+
+	db, err := NewDatabase(dbfile)
+	if err != nil {
+		return &DaemonStore{}, errors.Wrapf(err, "failed to new database")
+	}
+
 	return &DaemonStore{
 		idxBySnapshotID: make(map[string]*daemon.Daemon),
 		idxByID:         make(map[string]*daemon.Daemon),
-	}
+		db:              db,
+	}, nil
 }
 
 func (s *DaemonStore) Get(id string) (*daemon.Daemon, error) {
@@ -74,15 +89,20 @@ func (s *DaemonStore) Add(d *daemon.Daemon) error {
 	s.daemons = append(s.daemons, d)
 	s.idxBySnapshotID[d.SnapshotID] = d
 	s.idxByID[d.ID] = d
-	return nil
+
+	// save daemon info in case snapshotter restarts so that we can restore the
+	// daemon structs and reconnect the daemons.
+	return s.db.SaveDaemon(context.TODO(), d)
 }
 
-func (s *DaemonStore) Delete(d *daemon.Daemon) {
+func (s *DaemonStore) Delete(d *daemon.Daemon) error {
 	s.Lock()
 	defer s.Unlock()
 	delete(s.idxBySnapshotID, d.SnapshotID)
 	delete(s.idxByID, d.ID)
 	s.daemons = s.filterOutDeletedDaemon(d)
+
+	return s.db.DeleteDaemon(context.TODO(), d.ID)
 }
 
 func (s *DaemonStore) filterOutDeletedDaemon(d *daemon.Daemon) []*daemon.Daemon {
@@ -94,4 +114,12 @@ func (s *DaemonStore) filterOutDeletedDaemon(d *daemon.Daemon) []*daemon.Daemon 
 		res = append(res, md)
 	}
 	return res
+}
+
+func (s *DaemonStore) WalkDaemons(ctx context.Context, cb func(d *daemon.Daemon) error) error {
+	return s.db.WalkDaemons(ctx, cb)
+}
+
+func (s *DaemonStore) CleanupDatabase(ctx context.Context) error {
+	return s.db.Cleanup(ctx)
 }


### PR DESCRIPTION
This patch set includes fixes as below:
- persist daemon info in database, so that snapshotter can reconnect to running daemons;
- output daemon's log to daemon's own log file;
-  umount daemon with API when daemon in shared mode.

Signed-off-by: 慕陶 <jihui.xjh@antfin.com>
Signed-off-by: Eric Ren <renzhen@linux.alibaba.com>

