### PR TITLE
snapshotter: rename snapshotter name to be easily imported

### DIFF
--- a/contrib/nydus-snapshotter/cmd/containerd-nydus-grpc/app/snapshotter/main.go
+++ b/contrib/nydus-snapshotter/cmd/containerd-nydus-grpc/app/snapshotter/main.go
@@ -11,13 +11,13 @@ import (
 
 	"github.com/pkg/errors"
 
-	"contrib/nydus-snapshotter/config"
-	"contrib/nydus-snapshotter/pkg/filesystem/nydus"
-	"contrib/nydus-snapshotter/pkg/filesystem/stargz"
-	"contrib/nydus-snapshotter/pkg/signature"
-	"contrib/nydus-snapshotter/pkg/utils/signals"
-	"contrib/nydus-snapshotter/snapshot"
-	"contrib/nydus-snapshotter/pkg/process"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/config"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/filesystem/nydus"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/filesystem/stargz"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/signature"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/utils/signals"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/snapshot"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/process"
 )
 
 func Start(ctx context.Context, cfg config.Config) error {

--- a/contrib/nydus-snapshotter/cmd/containerd-nydus-grpc/main.go
+++ b/contrib/nydus-snapshotter/cmd/containerd-nydus-grpc/main.go
@@ -13,11 +13,11 @@ import (
 	"github.com/pkg/errors"
 	"github.com/urfave/cli/v2"
 
-	"contrib/nydus-snapshotter/cmd/containerd-nydus-grpc/app/snapshotter"
-	"contrib/nydus-snapshotter/cmd/containerd-nydus-grpc/pkg/command"
-	"contrib/nydus-snapshotter/cmd/containerd-nydus-grpc/pkg/logging"
-	"contrib/nydus-snapshotter/config"
-	"contrib/nydus-snapshotter/pkg/errdefs"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/cmd/containerd-nydus-grpc/app/snapshotter"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/cmd/containerd-nydus-grpc/pkg/command"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/cmd/containerd-nydus-grpc/pkg/logging"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/config"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/errdefs"
 )
 
 func main() {

--- a/contrib/nydus-snapshotter/cmd/containerd-nydus-grpc/pkg/command/flags.go
+++ b/contrib/nydus-snapshotter/cmd/containerd-nydus-grpc/pkg/command/flags.go
@@ -10,8 +10,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
-	"contrib/nydus-snapshotter/config"
-	"contrib/nydus-snapshotter/pkg/filesystem/nydus"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/config"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/filesystem/nydus"
 	"os"
 )
 

--- a/contrib/nydus-snapshotter/config/config.go
+++ b/contrib/nydus-snapshotter/config/config.go
@@ -8,7 +8,7 @@ package config
 
 import (
 	"github.com/pkg/errors"
-	"contrib/nydus-snapshotter/pkg/filesystem/nydus"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/filesystem/nydus"
 )
 
 const defaultNydusDaemonConfigPath string = "/etc/nydus/config.json"

--- a/contrib/nydus-snapshotter/export/snapshotter/snapshotter.go
+++ b/contrib/nydus-snapshotter/export/snapshotter/snapshotter.go
@@ -5,12 +5,12 @@ import (
 	"github.com/containerd/containerd/plugin"
 	"github.com/pkg/errors"
 
-	"contrib/nydus-snapshotter/config"
-	"contrib/nydus-snapshotter/pkg/filesystem/nydus"
-	"contrib/nydus-snapshotter/pkg/filesystem/stargz"
-	"contrib/nydus-snapshotter/pkg/signature"
-	"contrib/nydus-snapshotter/snapshot"
-	"contrib/nydus-snapshotter/pkg/process"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/config"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/filesystem/nydus"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/filesystem/stargz"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/signature"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/snapshot"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/process"
 )
 
 func init() {

--- a/contrib/nydus-snapshotter/go.mod
+++ b/contrib/nydus-snapshotter/go.mod
@@ -1,4 +1,4 @@
-module contrib/nydus-snapshotter
+module github.com/dragonflyoss/image-service/contrib/nydus-snapshotter
 
 go 1.14
 

--- a/contrib/nydus-snapshotter/pkg/auth/keychain.go
+++ b/contrib/nydus-snapshotter/pkg/auth/keychain.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/google/go-containerregistry/pkg/authn"
 
-	"contrib/nydus-snapshotter/pkg/label"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/label"
 )
 
 const (

--- a/contrib/nydus-snapshotter/pkg/auth/keychain_test.go
+++ b/contrib/nydus-snapshotter/pkg/auth/keychain_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"contrib/nydus-snapshotter/pkg/label"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/label"
 )
 
 func TestFromLabels(t *testing.T) {

--- a/contrib/nydus-snapshotter/pkg/daemon/daemon.go
+++ b/contrib/nydus-snapshotter/pkg/daemon/daemon.go
@@ -13,8 +13,8 @@ import (
 
 	"github.com/pkg/errors"
 
-	"contrib/nydus-snapshotter/pkg/nydussdk"
-	"contrib/nydus-snapshotter/pkg/nydussdk/model"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/nydussdk"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/nydussdk/model"
 )
 
 const (

--- a/contrib/nydus-snapshotter/pkg/filesystem/nydus/config.go
+++ b/contrib/nydus-snapshotter/pkg/filesystem/nydus/config.go
@@ -9,9 +9,9 @@ package nydus
 import (
 	"errors"
 
-	"contrib/nydus-snapshotter/pkg/filesystem/meta"
-	"contrib/nydus-snapshotter/pkg/signature"
-	"contrib/nydus-snapshotter/pkg/process"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/filesystem/meta"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/signature"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/process"
 )
 
 type NewFSOpt func(d *filesystem) error

--- a/contrib/nydus-snapshotter/pkg/filesystem/nydus/daemonconfig.go
+++ b/contrib/nydus-snapshotter/pkg/filesystem/nydus/daemonconfig.go
@@ -12,9 +12,9 @@ import (
 
 	"github.com/pkg/errors"
 
-	"contrib/nydus-snapshotter/pkg/auth"
-	"contrib/nydus-snapshotter/pkg/daemon"
-	"contrib/nydus-snapshotter/pkg/utils/registry"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/auth"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/daemon"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/utils/registry"
 )
 
 type DaemonConfig struct {

--- a/contrib/nydus-snapshotter/pkg/filesystem/nydus/fs.go
+++ b/contrib/nydus-snapshotter/pkg/filesystem/nydus/fs.go
@@ -16,14 +16,14 @@ import (
 	"github.com/containerd/containerd/snapshots/storage"
 	"github.com/pkg/errors"
 
-	"contrib/nydus-snapshotter/pkg/daemon"
-	"contrib/nydus-snapshotter/pkg/errdefs"
-	"contrib/nydus-snapshotter/pkg/filesystem/meta"
-	"contrib/nydus-snapshotter/pkg/label"
-	"contrib/nydus-snapshotter/pkg/process"
-	"contrib/nydus-snapshotter/pkg/signature"
-	"contrib/nydus-snapshotter/pkg/utils/retry"
-	"contrib/nydus-snapshotter/snapshot"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/daemon"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/errdefs"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/filesystem/meta"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/label"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/process"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/signature"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/utils/retry"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/snapshot"
 )
 
 type FSMode int

--- a/contrib/nydus-snapshotter/pkg/filesystem/stargz/config.go
+++ b/contrib/nydus-snapshotter/pkg/filesystem/stargz/config.go
@@ -9,9 +9,9 @@ package stargz
 import (
 	"errors"
 
-	"contrib/nydus-snapshotter/pkg/filesystem/meta"
-	"contrib/nydus-snapshotter/pkg/filesystem/nydus"
-	"contrib/nydus-snapshotter/pkg/process"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/filesystem/meta"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/filesystem/nydus"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/process"
 )
 
 func WithMeta(root string) NewFSOpt {

--- a/contrib/nydus-snapshotter/pkg/filesystem/stargz/fs.go
+++ b/contrib/nydus-snapshotter/pkg/filesystem/stargz/fs.go
@@ -19,15 +19,15 @@ import (
 	"github.com/containerd/containerd/snapshots/storage"
 	"github.com/pkg/errors"
 
-	"contrib/nydus-snapshotter/pkg/auth"
-	"contrib/nydus-snapshotter/pkg/daemon"
-	"contrib/nydus-snapshotter/pkg/errdefs"
-	"contrib/nydus-snapshotter/pkg/filesystem/meta"
-	"contrib/nydus-snapshotter/pkg/filesystem/nydus"
-	"contrib/nydus-snapshotter/pkg/label"
-	"contrib/nydus-snapshotter/pkg/process"
-	"contrib/nydus-snapshotter/pkg/utils/retry"
-	"contrib/nydus-snapshotter/snapshot"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/auth"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/daemon"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/errdefs"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/filesystem/meta"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/filesystem/nydus"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/label"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/process"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/utils/retry"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/snapshot"
 )
 
 type filesystem struct {

--- a/contrib/nydus-snapshotter/pkg/filesystem/stargz/fs_test.go
+++ b/contrib/nydus-snapshotter/pkg/filesystem/stargz/fs_test.go
@@ -17,10 +17,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"contrib/nydus-snapshotter/pkg/filesystem/meta"
-	"contrib/nydus-snapshotter/pkg/filesystem/nydus"
-	"contrib/nydus-snapshotter/pkg/label"
-	"contrib/nydus-snapshotter/pkg/process"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/filesystem/meta"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/filesystem/nydus"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/label"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/process"
 )
 
 func ensureExists(path string) error {

--- a/contrib/nydus-snapshotter/pkg/filesystem/stargz/resolver_test.go
+++ b/contrib/nydus-snapshotter/pkg/filesystem/stargz/resolver_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"contrib/nydus-snapshotter/pkg/auth"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/auth"
 )
 
 func TestResolver_resolve(t *testing.T) {

--- a/contrib/nydus-snapshotter/pkg/nydussdk/client.go
+++ b/contrib/nydus-snapshotter/pkg/nydussdk/client.go
@@ -20,8 +20,8 @@ import (
 
 	"github.com/pkg/errors"
 
-	"contrib/nydus-snapshotter/pkg/nydussdk/model"
-	"contrib/nydus-snapshotter/pkg/utils/retry"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/nydussdk/model"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/utils/retry"
 )
 
 const (

--- a/contrib/nydus-snapshotter/pkg/nydussdk/client_test.go
+++ b/contrib/nydus-snapshotter/pkg/nydussdk/client_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"contrib/nydus-snapshotter/pkg/nydussdk/model"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/nydussdk/model"
 )
 
 var BTI = model.BuildTimeInfo{

--- a/contrib/nydus-snapshotter/pkg/process/manager.go
+++ b/contrib/nydus-snapshotter/pkg/process/manager.go
@@ -17,10 +17,10 @@ import (
 	"github.com/containerd/containerd/log"
 	"github.com/pkg/errors"
 
-	"contrib/nydus-snapshotter/pkg/daemon"
-	"contrib/nydus-snapshotter/pkg/errdefs"
-	"contrib/nydus-snapshotter/pkg/store"
-	"contrib/nydus-snapshotter/pkg/utils/mount"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/daemon"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/errdefs"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/store"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/utils/mount"
 )
 
 type configGenerator = func(*daemon.Daemon) error

--- a/contrib/nydus-snapshotter/pkg/process/store.go
+++ b/contrib/nydus-snapshotter/pkg/process/store.go
@@ -8,8 +8,8 @@ package process
 
 import (
 	"context"
-	"contrib/nydus-snapshotter/pkg/daemon"
-	"contrib/nydus-snapshotter/pkg/store"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/daemon"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/store"
 )
 
 type Store interface {

--- a/contrib/nydus-snapshotter/pkg/signature/signature.go
+++ b/contrib/nydus-snapshotter/pkg/signature/signature.go
@@ -14,8 +14,8 @@ import (
 
 	"github.com/pkg/errors"
 
-	"contrib/nydus-snapshotter/pkg/label"
-	"contrib/nydus-snapshotter/pkg/utils/signer"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/label"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/utils/signer"
 )
 
 type Verifier struct {

--- a/contrib/nydus-snapshotter/pkg/store/database.go
+++ b/contrib/nydus-snapshotter/pkg/store/database.go
@@ -12,7 +12,7 @@ import (
 	"os"
 	"path/filepath"
 
-	"contrib/nydus-snapshotter/pkg/daemon"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/daemon"
 
 	"github.com/pkg/errors"
 	bolt "go.etcd.io/bbolt"

--- a/contrib/nydus-snapshotter/pkg/store/store.go
+++ b/contrib/nydus-snapshotter/pkg/store/store.go
@@ -10,7 +10,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/pkg/errors"
-	"contrib/nydus-snapshotter/pkg/daemon"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/daemon"
 	"path/filepath"
 	"sync"
 )

--- a/contrib/nydus-snapshotter/snapshot/snapshot.go
+++ b/contrib/nydus-snapshotter/snapshot/snapshot.go
@@ -23,10 +23,10 @@ import (
 	"github.com/containerd/continuity/fs"
 	"github.com/pkg/errors"
 
-	"contrib/nydus-snapshotter/pkg/daemon"
-	"contrib/nydus-snapshotter/pkg/label"
-	"contrib/nydus-snapshotter/pkg/process"
-	"contrib/nydus-snapshotter/pkg/snapshot"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/daemon"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/label"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/process"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/snapshot"
 )
 
 var _ snapshots.Snapshotter = &snapshotter{}


### PR DESCRIPTION
Current snapshotter module name makes it hard to be imported to
other projects like containerd.
So rename it

Signed-off-by: Changwei Ge <chge@linux.alibaba.com>