### PR TITLE
Return 404 if resource can't be found

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1070,6 +1070,7 @@ dependencies = [
  "lazy_static",
  "log",
  "micro_http",
+ "rafs",
  "serde",
  "serde_derive",
  "serde_json",

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -17,3 +17,4 @@ serde_json = ">=1.0.9"
 vmm-sys-util = ">=0.3.1"
 url = "2.1.1"
 http = "0.2.1"
+rafs = {path = "../rafs"}

--- a/api/src/http.rs
+++ b/api/src/http.rs
@@ -31,8 +31,8 @@ const HTTP_ROOT: &str = "/api/v1";
 pub trait EndpointHandler: Sync + Send {
     /// Handles an HTTP request.
     /// After parsing the request, the handler could decide to send an
-    /// associated API request down to the Nydusd API server to e.g. create
-    /// or start a VM. The request will block waiting for an answer from the
+    /// associated API request down to the Nydusd API server to e.g. get current working status.
+    /// The request will block waiting for an answer from the
     /// API server and translate that into an HTTP response.
     fn handle_request(
         &self,
@@ -124,7 +124,7 @@ fn handle_http_request(
     let uri_parsed = request.uri().get_abs_path().parse::<Uri>();
 
     let mut response = match uri_parsed {
-        Ok(uri) => match HTTP_ROUTES.routes.get(&uri.path().to_string()) {
+        Ok(uri) => match HTTP_ROUTES.routes.get(uri.path()) {
             Some(route) => route
                 .handle_request(&request, &|r| {
                     kick_api_server(api_notifier, to_api, from_api, r)
@@ -152,14 +152,19 @@ pub fn extract_query_part(req: &Request, key: &str) -> Option<String> {
     // Better that we can add query part support to Micro-http in the future. But
     // right now, below way makes it easy to obtain query parts from uri.
     let http_prefix: String = String::from("http:");
-    let url = Url::parse((http_prefix + &req.uri().get_abs_path().to_string()).as_str()).unwrap();
+    let url = Url::parse(&(http_prefix + req.uri().get_abs_path()))
+        .map_err(|e| {
+            error!("Can't parse request {:?}", e);
+            e
+        })
+        .ok()?;
     let v: Option<String> = None;
-    for (k, v) in url.query_pairs().into_owned() {
-        if k.as_str() != key.chars().as_str() {
+    for (k, v) in url.query_pairs() {
+        if k != key {
             continue;
         } else {
             trace!("Got query part {:?}", (k, &v));
-            return Some(v);
+            return Some(v.into_owned());
         }
     }
     v
@@ -168,13 +173,22 @@ pub fn extract_query_part(req: &Request, key: &str) -> Option<String> {
 const EVENT_UNIX_SOCKET: u64 = 1;
 const EVENT_HTTP_DIE: u64 = 2;
 
+/// Start a HTTP server parsing http requests and send to nydus API server a concrete
+/// request to operate nydus or fetch working status.
+/// The HTTP server sends request by `to_api` channel and wait for response from `from_api` channel
+/// `api_notifier` is used to notify an execution context to fetch above request and handle it.
+/// We can't forward signal to native rust thread, so we rely on `exit_evtfd` to notify
+/// the server to exit. Therefore, it adds the unix domain socket fd receiving http request
+/// to a global epoll_fd associated with a event_fd which will be used later to notify
+/// the server thread to exit.
 pub fn start_http_thread(
     path: &str,
-    evt_fd: EventFd,
+    api_notifier: EventFd,
     to_api: Sender<ApiRequest>,
     from_api: Receiver<ApiResponse>,
     exit_evtfd: EventFd,
 ) -> Result<thread::JoinHandle<Result<()>>> {
+    // Try to remove existed unix domain socket
     std::fs::remove_file(path).unwrap_or_default();
     let socket_path = PathBuf::from(path);
 
@@ -184,6 +198,7 @@ pub fn start_http_thread(
             let epoll_fd = epoll::create(true).unwrap();
 
             let mut server = HttpServer::new(socket_path).unwrap();
+            // Must start the server successfully or just die by panic
             server.start_server().unwrap();
             epoll::ctl(
                 epoll_fd,
@@ -214,16 +229,19 @@ pub fn start_http_thread(
                         EVENT_UNIX_SOCKET => match server.requests() {
                             Ok(request_vec) => {
                                 for server_request in request_vec {
+                                    // Ignore error when sending response
                                     server
                                         .respond(server_request.process(|request| {
                                             handle_http_request(
-                                                request, &evt_fd, &to_api, &from_api,
+                                                request,
+                                                &api_notifier,
+                                                &to_api,
+                                                &from_api,
                                             )
                                         }))
-                                        .or_else(|e| -> Result<()> {
-                                            error!("HTTP server error on response: {}", e);
-                                            Ok(())
-                                        })?;
+                                        .unwrap_or_else(|e| {
+                                            error!("HTTP server error on response: {}", e)
+                                        });
                                 }
                             }
                             Err(e) => {


### PR DESCRIPTION
Returning http status code 404 to clients is more suggestive and friendly to users.