### PR TITLE
action: save all static binaries in top directory

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,14 +27,16 @@ jobs:
     - name: Build nydus-rs
       run: |
         make docker-static
+        sudo mv target-fusedev/x86_64-unknown-linux-musl/release/nydusd .
+        sudo mv target-fusedev/x86_64-unknown-linux-musl/release/nydus-image .
         sudo chown -R $(id -un):$(id -gn) .
     - name: store-artifacts
       uses: actions/upload-artifact@v2
       with:
         name: nydus-artifacts
         path: |
-          target-fusedev/x86_64-unknown-linux-musl/release/nydusd
-          target-fusedev/x86_64-unknown-linux-musl/release/nydus-image
+          nydusd
+          nydus-image
   build-nydusify-nydus-snapshotter:
     runs-on: ubuntu-latest
     steps:
@@ -52,13 +54,15 @@ jobs:
     - name: build nydus-snapshotter
       run: |
         make nydus-snapshotter-static
+        sudo mv contrib/nydusify/cmd/nydusify .
+        sudo mv contrib/nydus-snapshotter/bin/containerd-nydus-grpc .
     - name: store-artifacts
       uses: actions/upload-artifact@v2
       with:
         name: nydus-artifacts
         path: |
-          contrib/nydusify/cmd/nydusify
-          contrib/nydus-snapshotter/bin/containerd-nydus-grpc
+          nydusify
+          containerd-nydus-grpc
   upload-artifacts:
     runs-on: ubuntu-latest
     needs: [build-nydus-rs, build-nydusify-nydus-snapshotter]
@@ -74,11 +78,12 @@ jobs:
       uses: actions/download-artifact@v2
       with:
         name: nydus-artifacts
-        path: nydus-artifacts
+        path: nydus-static
     - name: upload artifacts
       run: |
         tag=$(echo $GITHUB_REF | cut -d/ -f3-)
         tarball="nydus-static-$tag-x86_64.tgz"
-        tar cf - nydus-artifacts | gzip > ${tarball}
+        chmod +x nydus-static/*
+        tar cf - nydus-static | gzip > ${tarball}
         echo "uploading ${tarball} for tag $tag ..."
         GITHUB_TOKEN=${{ secrets.HUB_UPLOAD_TOKEN }} hub release create -m "Nydus Image Service $tag" -m "Nydus Image Service $tag release" -a "${tarball}" "$tag"


### PR DESCRIPTION
And make sure they have executable bits set. It seems that actions/upload-artifact
action drops the executable bits.
