### PR TITLE
Nydusify: add default platform to existed oci manifest

### DIFF
--- a/contrib/nydusify/cmd/nydusify.go
+++ b/contrib/nydusify/cmd/nydusify.go
@@ -252,6 +252,8 @@ func main() {
 				&cli.BoolFlag{Name: "source-insecure", Required: false, Usage: "Allow http/insecure source registry communication", EnvVars: []string{"SOURCE_INSECURE"}},
 				&cli.BoolFlag{Name: "target-insecure", Required: false, Usage: "Allow http/insecure target registry communication", EnvVars: []string{"TARGET_INSECURE"}},
 
+				&cli.BoolFlag{Name: "multi-platform", Value: false, Usage: "Ensure the target image represents a manifest list, and it should consist of OCI and Nydus manifest", EnvVars: []string{"MULTI_PLATFORM"}},
+
 				&cli.StringFlag{Name: "work-dir", Value: "./output", Usage: "Work directory path for image check, will be cleaned before checking", EnvVars: []string{"WORK_DIR"}},
 				&cli.StringFlag{Name: "nydus-image", Value: "./nydus-image", Usage: "The nydus-image binary path", EnvVars: []string{"NYDUS_IMAGE"}},
 				&cli.StringFlag{Name: "nydusd", Value: "./nydusd", Usage: "The nydusd binary path", EnvVars: []string{"NYDUSD"}},
@@ -276,6 +278,7 @@ func main() {
 					WorkDir:        c.String("work-dir"),
 					Source:         c.String("source"),
 					Target:         c.String("target"),
+					MultiPlatform:  c.Bool("multi-platform"),
 					SourceInsecure: c.Bool("source-insecure"),
 					TargetInsecure: c.Bool("target-insecure"),
 					NydusImagePath: c.String("nydus-image"),

--- a/contrib/nydusify/pkg/checker/checker.go
+++ b/contrib/nydusify/pkg/checker/checker.go
@@ -26,6 +26,7 @@ type Opt struct {
 	Target         string
 	SourceInsecure bool
 	TargetInsecure bool
+	MultiPlatform  bool
 	NydusImagePath string
 	NydusdPath     string
 	BackendType    string
@@ -99,8 +100,9 @@ func (checker *Checker) Check(ctx context.Context) error {
 
 	rules := []rule.Rule{
 		&rule.ManifestRule{
-			SourceParsed: sourceParsed,
-			TargetParsed: targetParsed,
+			SourceParsed:  sourceParsed,
+			TargetParsed:  targetParsed,
+			MultiPlatform: checker.MultiPlatform,
 		},
 		&rule.BootstrapRule{
 			Parsed:          targetParsed,

--- a/contrib/nydusify/pkg/converter/converter.go
+++ b/contrib/nydusify/pkg/converter/converter.go
@@ -21,8 +21,6 @@ import (
 	"github.com/dragonflyoss/image-service/contrib/nydusify/pkg/utils"
 )
 
-const supportedPlatform = "linux/amd64"
-
 // PullWorkerCount specifies source layer pull concurrency
 var PullWorkerCount uint = 5
 
@@ -97,11 +95,11 @@ func findSupportedSource(ctx context.Context, sources []provider.SourceProvider)
 		if err != nil {
 			return nil, errors.Wrap(err, "Failed to get image config from source provider")
 		}
-		if fmt.Sprintf("%s/%s", config.OS, config.Architecture) == supportedPlatform {
+		if utils.IsSupportedPlatform(config.OS, config.Architecture) {
 			return source, nil
 		}
 	}
-	return nil, errors.New("Not found linux/amd64 platform in source image")
+	return nil, fmt.Errorf("Not found supported platform in source image")
 }
 
 func (cvt *Converter) convert(ctx context.Context) error {

--- a/contrib/nydusify/pkg/converter/provider/source.go
+++ b/contrib/nydusify/pkg/converter/provider/source.go
@@ -29,9 +29,6 @@ import (
 	"github.com/dragonflyoss/image-service/contrib/nydusify/pkg/utils"
 )
 
-const defaultOS = "linux"
-const defaultArch = "amd64"
-
 // SourceLayer is a layer of source image
 type SourceLayer interface {
 	Mount(ctx context.Context) ([]mount.Mount, func() error, error)

--- a/contrib/nydusify/pkg/parser/parser.go
+++ b/contrib/nydusify/pkg/parser/parser.go
@@ -183,11 +183,8 @@ func (parser *Parser) Parse(ctx context.Context) (*Parsed, error) {
 		for idx := range index.Manifests {
 			desc := index.Manifests[idx]
 			if desc.Platform != nil {
-				if desc.Platform.OS == "linux" && desc.Platform.Architecture == "amd64" ||
-					desc.Platform.OS == "" && desc.Platform.Architecture == "" {
-					if desc.Platform.OSFeatures != nil &&
-						len(desc.Platform.OSFeatures) == 1 &&
-						desc.Platform.OSFeatures[0] == utils.ManifestOSFeatureNydus {
+				if utils.IsSupportedPlatform(desc.Platform.OS, desc.Platform.Architecture) {
+					if utils.IsNydusPlatform(desc.Platform) {
 						nydusDesc = &desc
 					} else {
 						ociDesc = &desc

--- a/contrib/nydusify/pkg/utils/utils.go
+++ b/contrib/nydusify/pkg/utils/utils.go
@@ -18,6 +18,9 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
+const SupportedOS = "linux"
+const SupportedArch = "amd64"
+
 const defaultRetryAttempts = 3
 const defaultRetryInterval = time.Second * 2
 
@@ -51,6 +54,30 @@ func MarshalToDesc(data interface{}, mediaType string) (*ocispec.Descriptor, []b
 	}
 
 	return &desc, bytes, nil
+}
+
+func IsSupportedPlatform(os, arch string) bool {
+	// Default we assume that empty OS/Arch should be
+	// a supported platform likes linux/amd64
+	if os == "" && arch == "" {
+		logrus.Warnln("Found empty OS/Arch platform manifest")
+		return true
+	}
+	if os == SupportedOS && arch == SupportedArch {
+		return true
+	}
+	return false
+}
+
+func IsNydusPlatform(platform *ocispec.Platform) bool {
+	if platform != nil && platform.OSFeatures != nil {
+		for _, key := range platform.OSFeatures {
+			if key == ManifestOSFeatureNydus {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func UnpackFile(reader io.Reader, source, target string) error {


### PR DESCRIPTION
**Nydusify: add default platform to existed oci manifest**

```
Add default platform "linux/amd64" to existed manifest in
remote registry if pushing Nydus image as a manifest index
(multi-platform enabled), so that docker/containerd can
distinguish OCI and Nydus image using the platform field
in the manifest index.
```

**Nydusify: support --multi-platform option for checker**

```
Ensure target image represents as a manifest list, and it consists
of OCI and Nydus manifest, if the "--multi-platform" option of checker
be specified.
```