### PR TITLE
Fix rust macro usage

### DIFF
--- a/rafs/src/fs.rs
+++ b/rafs/src/fs.rs
@@ -32,8 +32,6 @@ use storage::device::BlobPrefetchControl;
 use storage::*;
 use storage::{cache::PrefetchWorker, device};
 
-use nydus_utils::{eacces, enotdir};
-
 /// Type of RAFS fuse handle.
 pub type Handle = u64;
 

--- a/rafs/src/lib.rs
+++ b/rafs/src/lib.rs
@@ -8,6 +8,8 @@
 extern crate log;
 #[macro_use]
 extern crate bitflags;
+#[macro_use]
+extern crate nydus_utils;
 
 use std::any::Any;
 use std::fs::File;
@@ -15,7 +17,6 @@ use std::io::{BufWriter, Error, Read, Result, Seek, SeekFrom, Write};
 use std::os::unix::io::AsRawFd;
 
 use crate::metadata::layout::{align_to_rafs, RAFS_ALIGNMENT};
-use nydus_utils::{einval, last_error};
 
 pub mod fs;
 pub mod metadata;

--- a/rafs/src/metadata/cached.rs
+++ b/rafs/src/metadata/cached.rs
@@ -20,7 +20,7 @@ use crate::metadata::layout::*;
 use crate::metadata::*;
 use crate::RafsIoReader;
 
-use nydus_utils::{digest::RafsDigest, einval, enoent, enotdir, ByteSize};
+use nydus_utils::{digest::RafsDigest, ByteSize};
 
 pub struct CachedInodes {
     s_blob: Arc<OndiskBlobTable>,

--- a/rafs/src/metadata/direct.rs
+++ b/rafs/src/metadata/direct.rs
@@ -32,7 +32,7 @@ use crate::metadata::layout::*;
 use crate::metadata::*;
 use storage::utils::readahead;
 
-use nydus_utils::{digest::RafsDigest, ebadf, einval, enoent, enotdir, last_error};
+use nydus_utils::digest::RafsDigest;
 
 /// Impl get accessor for inode object.
 macro_rules! impl_inode_getter {

--- a/rafs/src/metadata/layout.rs
+++ b/rafs/src/metadata/layout.rs
@@ -42,7 +42,7 @@ use serde::Serialize;
 
 use nydus_utils::{
     digest::{self, RafsDigest},
-    einval, enoent, ByteSize,
+    ByteSize,
 };
 
 use super::*;

--- a/rafs/src/metadata/mod.rs
+++ b/rafs/src/metadata/mod.rs
@@ -36,10 +36,7 @@ use crate::*;
 mod noop;
 use noop::NoopInodes;
 
-use nydus_utils::{
-    digest::{self, RafsDigest},
-    ebadf, einval, enoent,
-};
+use nydus_utils::digest::{self, RafsDigest};
 
 pub mod cached;
 pub mod direct;

--- a/src/bin/nydus-image/builder.rs
+++ b/src/bin/nydus-image/builder.rs
@@ -25,11 +25,8 @@ use storage::compress;
 
 use nydus_utils::digest::{self, RafsDigest};
 
-use crate::stargz;
-use crate::trace::*;
-use crate::{root_tracer, timing_tracer};
-
 use crate::node::*;
+use crate::stargz;
 use crate::tree::Tree;
 
 // TODO: select BufWriter capacity by performance testing.

--- a/src/bin/nydus-image/main.rs
+++ b/src/bin/nydus-image/main.rs
@@ -5,10 +5,12 @@
 #[macro_use(crate_authors, crate_version)]
 extern crate clap;
 
+#[macro_use]
+mod trace;
+
 mod builder;
 mod node;
 mod stargz;
-mod trace;
 mod tree;
 mod uploader;
 mod validator;
@@ -38,7 +40,7 @@ use builder::SourceType;
 use node::WhiteoutSpec;
 use nydus_utils::{digest, setup_logging, BuildTimeInfo};
 use storage::compress;
-use trace::*;
+use trace::{EventTracerClass, TimingTracerClass, TraceClass};
 use uploader::Uploader;
 use validator::Validator;
 

--- a/src/bin/nydus-image/node.rs
+++ b/src/bin/nydus-image/node.rs
@@ -30,9 +30,6 @@ use rafs::metadata::layout::*;
 use rafs::metadata::*;
 use storage::compress;
 
-use crate::trace::{BuildRootTracer, EventTracerClass, TraceClass, TraceEvent, BUILDING_RECORDER};
-use crate::{event_tracer, root_tracer};
-
 const ROOT_PATH_NAME: &[u8] = &[b'/'];
 
 pub const OCISPEC_WHITEOUT_PREFIX: &str = ".wh.";

--- a/src/bin/nydus-image/tree.rs
+++ b/src/bin/nydus-image/tree.rs
@@ -35,9 +35,6 @@ use storage::device::RafsChunkFlags;
 
 use nydus_utils::digest::RafsDigest;
 
-use crate::trace::*;
-use crate::{event_tracer, root_tracer, timing_tracer};
-
 #[derive(Clone)]
 pub struct Tree {
     pub node: Node,

--- a/src/bin/nydusd/api_server_glue.rs
+++ b/src/bin/nydusd/api_server_glue.rs
@@ -18,7 +18,6 @@ use nydus_api::http_endpoint::{
     DaemonErrorKind, MetricsErrorKind,
 };
 use nydus_utils::metrics;
-use nydus_utils::{epipe, last_error};
 
 use crate::daemon::{
     DaemonError, FsBackendMountCmd, FsBackendType, FsBackendUmountCmd, NydusDaemon,

--- a/src/bin/nydusd/daemon.rs
+++ b/src/bin/nydusd/daemon.rs
@@ -37,7 +37,7 @@ use serde::{self, Deserialize, Serialize};
 use serde_json::Error as SerdeError;
 use serde_with::{serde_as, DisplayFromStr};
 
-use nydus_utils::{einval, last_error, BuildTimeInfo};
+use nydus_utils::BuildTimeInfo;
 use rafs::{
     fs::{Rafs, RafsConfig},
     trim_backend_config, RafsError, RafsIoRead,

--- a/src/bin/nydusd/fusedev.rs
+++ b/src/bin/nydusd/fusedev.rs
@@ -37,7 +37,7 @@ use daemon::{
     DaemonError, DaemonResult, DaemonState, DaemonStateMachineContext, DaemonStateMachineInput,
     DaemonStateMachineSubscriber, FsBackendCollection, FsBackendMountCmd, NydusDaemon, Trigger,
 };
-use nydus_utils::{eio, eother, BuildTimeInfo, FuseChannel, FuseSession};
+use nydus_utils::{BuildTimeInfo, FuseChannel, FuseSession};
 
 #[derive(Serialize)]
 struct FuseOp {

--- a/src/bin/nydusd/main.rs
+++ b/src/bin/nydusd/main.rs
@@ -12,6 +12,9 @@ extern crate lazy_static;
 extern crate rafs;
 extern crate serde_json;
 
+#[macro_use]
+extern crate nydus_utils;
+
 #[cfg(feature = "fusedev")]
 use std::convert::TryInto;
 use std::fs::File;

--- a/src/bin/nydusd/upgrade.rs
+++ b/src/bin/nydusd/upgrade.rs
@@ -4,8 +4,6 @@ use std::path::PathBuf;
 
 use crate::daemon::{DaemonResult, FsBackendMountCmd, FsBackendUmountCmd};
 
-use nydus_utils::einval;
-
 #[derive(Debug)]
 pub enum UpgradeMgrError {}
 pub struct UpgradeManager {}

--- a/storage/src/backend/localfs.rs
+++ b/storage/src/backend/localfs.rs
@@ -17,9 +17,7 @@ use vm_memory::VolatileSlice;
 use crate::backend::{BackendError, BackendResult, BlobBackend, BlobBackendUploader};
 use crate::utils::{readahead, readv};
 
-use nydus_utils::{
-    ebadf, einval, eio, last_error, metrics::BackendMetrics, round_down_4k, try_round_up_4k,
-};
+use nydus_utils::{metrics::BackendMetrics, round_down_4k, try_round_up_4k};
 
 const BLOB_ACCESSED_SUFFIX: &str = ".access";
 const BLOB_ACCESS_RECORD_SECOND: u32 = 10;

--- a/storage/src/backend/oss.rs
+++ b/storage/src/backend/oss.rs
@@ -17,7 +17,7 @@ use crate::backend::request::{HeaderMap, Progress, ReqBody, Request, RequestErro
 use crate::backend::{default_http_scheme, BackendError, BackendResult};
 use crate::backend::{BlobBackend, BlobBackendUploader, CommonConfig};
 
-use nydus_utils::{einval, metrics::BackendMetrics};
+use nydus_utils::metrics::BackendMetrics;
 
 const HEADER_DATE: &str = "Date";
 const HEADER_AUTHORIZATION: &str = "Authorization";

--- a/storage/src/backend/registry.rs
+++ b/storage/src/backend/registry.rs
@@ -21,8 +21,6 @@ use crate::backend::{default_http_scheme, BackendError, BackendResult};
 use crate::backend::{BlobBackend, BlobBackendUploader, CommonConfig};
 use nydus_utils::metrics::BackendMetrics;
 
-use nydus_utils::{einval, epipe};
-
 const REGISTRY_CLIENT_ID: &str = "nydus-registry-client";
 
 const HEADER_AUTHORIZATION: &str = "Authorization";

--- a/storage/src/backend/request.rs
+++ b/storage/src/backend/request.rs
@@ -19,7 +19,6 @@ use reqwest::{
 };
 
 use crate::backend::CommonConfig;
-use nydus_utils::einval;
 
 pub use reqwest::header::HeaderMap;
 

--- a/storage/src/cache/mod.rs
+++ b/storage/src/cache/mod.rs
@@ -15,7 +15,7 @@ use crate::device::{BlobPrefetchControl, RafsBio, RafsChunkInfo};
 use crate::utils::{alloc_buf, digest_check};
 use crate::{compress, StorageResult};
 
-use nydus_utils::{digest, eio};
+use nydus_utils::digest;
 
 pub mod blobcache;
 pub mod dummycache;

--- a/storage/src/compress/mod.rs
+++ b/storage/src/compress/mod.rs
@@ -15,8 +15,6 @@ use flate2::Compression;
 mod lz4_standard;
 use self::lz4_standard::*;
 
-use nydus_utils::einval;
-
 const COMPRESSION_MINIMUM_RATIO: usize = 100;
 
 #[derive(Clone, Copy, Debug, PartialEq)]

--- a/storage/src/device.rs
+++ b/storage/src/device.rs
@@ -16,7 +16,6 @@ use crate::cache::RafsCache;
 use crate::{compress, factory, StorageResult};
 
 use nydus_utils::digest::{self, RafsDigest};
-use nydus_utils::eio;
 
 static ZEROS: &[u8] = &[0u8; 4096]; // why 4096? volatile slice default size, unfortunately
 

--- a/storage/src/factory.rs
+++ b/storage/src/factory.rs
@@ -14,7 +14,7 @@ use crate::backend::*;
 use crate::cache::*;
 use crate::compress;
 
-use nydus_utils::{digest, einval};
+use nydus_utils::digest;
 
 // storage backend config
 #[derive(Default, Clone, Deserialize)]

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -8,6 +8,8 @@ extern crate log;
 extern crate serde;
 #[macro_use]
 extern crate bitflags;
+#[macro_use]
+extern crate nydus_utils;
 
 pub mod backend;
 pub mod cache;

--- a/storage/src/utils.rs
+++ b/storage/src/utils.rs
@@ -12,7 +12,7 @@ use vm_memory::{Bytes, VolatileSlice};
 
 use nydus_utils::{
     digest::{self, RafsDigest},
-    einval, last_error, round_down_4k,
+    round_down_4k,
 };
 
 pub fn readv(fd: RawFd, bufs: &[VolatileSlice], offset: u64, max_size: usize) -> Result<usize> {

--- a/utils/src/digest.rs
+++ b/utils/src/digest.rs
@@ -15,8 +15,6 @@ use std::str::FromStr;
 pub const RAFS_DIGEST_LENGTH: usize = 32;
 type DigestData = [u8; RAFS_DIGEST_LENGTH];
 
-use crate::error::einval;
-
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum Algorithm {
     Blake3,

--- a/utils/src/exec.rs
+++ b/utils/src/exec.rs
@@ -5,8 +5,6 @@
 use std::io::Result;
 use std::process::{Command, Stdio};
 
-use crate::error::*;
-
 pub fn exec(cmd: &str, output: bool) -> Result<String> {
     debug!("exec `{}`", cmd);
 

--- a/utils/src/fuse.rs
+++ b/utils/src/fuse.rs
@@ -17,7 +17,6 @@ use nix::poll::{poll, PollFd, PollFlags};
 use nix::unistd::{close, dup, getgid, getuid, read};
 use nix::Error as nixError;
 
-use crate::error::*;
 use epoll::{ControlOptions, Event, Events};
 use nix::fcntl::{fcntl, FcntlArg, OFlag};
 

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -22,7 +22,6 @@ extern crate lazy_static;
 
 #[macro_use]
 pub mod error;
-pub use error::*;
 
 pub mod exec;
 pub use exec::*;


### PR DESCRIPTION
Currently, we have to also 'use' data structures defined in trace module when add tracing point and the error macros defined in `nydus_utils/error module`.
Fix this by decorating module declaration.