### PR TITLE
Improve and fix nydus-image building tracer

### DIFF
--- a/src/bin/nydus-image/builder.rs
+++ b/src/bin/nydus-image/builder.rs
@@ -412,7 +412,7 @@ impl Builder {
                 }
                 Ok(true)
             },
-            "apply layers",
+            "apply_tree",
             Result<bool>
         )?;
 
@@ -420,7 +420,7 @@ impl Builder {
         self.upper_inode_map.clear();
         self.readahead_files.clear();
 
-        timing_tracer!({ self.build_rafs_wrap(&mut tree) }, "build rafs");
+        timing_tracer!({ self.build_rafs_wrap(&mut tree) }, "build_rafs");
 
         Ok(())
     }
@@ -560,10 +560,8 @@ impl Builder {
 
     /// Dump bootstrap and blob file, return (Vec<blob_id>, blob_size)
     fn dump_to_file(&mut self) -> Result<(Vec<String>, usize)> {
-        let (blob_hash, blob_size, mut blob_readahead_size) = timing_tracer!(
-            { self.dump_blob() },
-            "write all nodes to blob including hashing"
-        )?;
+        let (blob_hash, blob_size, mut blob_readahead_size) =
+            timing_tracer!({ self.dump_blob() }, "dump_blob")?;
 
         // Set blob hash as blob id if not specified.
         if self.blob_id.is_empty() {
@@ -686,7 +684,7 @@ impl Builder {
 
                 Ok(())
             },
-            "write all nodes to bootstrap",
+            "dump_bootstrap",
             Result<()>
         )?;
 
@@ -740,8 +738,7 @@ impl Builder {
             self.apply_to_bootstrap()?;
         }
         // Dump blob and bootstrap file
-        let (blob_ids, blob_size) =
-            timing_tracer!({ self.dump_to_file() }, "dump bootstrap and blob")?;
+        let (blob_ids, blob_size) = self.dump_to_file()?;
 
         Ok((blob_ids, blob_size))
     }

--- a/src/bin/nydus-image/main.rs
+++ b/src/bin/nydus-image/main.rs
@@ -410,7 +410,7 @@ fn main() -> Result<()> {
         event_tracer!("egid", "{}", getegid());
 
         let (blob_ids, blob_size) =
-            timing_tracer!({ ib.build().context("build failed") }, "total build time")?;
+            timing_tracer!({ ib.build().context("build failed") }, "total_build")?;
 
         // Validate output bootstrap file
         if !matches.is_present("disable-check") {
@@ -421,7 +421,7 @@ fn main() -> Result<()> {
                         .check(false)
                         .context("failed to validate bootstrap")
                 },
-                "validate bootstrap out of band"
+                "validate_bootstrap"
             )?;
         }
 

--- a/src/bin/nydus-image/main.rs
+++ b/src/bin/nydus-image/main.rs
@@ -31,7 +31,6 @@ use std::fs::metadata;
 use std::fs::OpenOptions;
 use std::io;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
 
 use nix::unistd::{getegid, geteuid};
 use serde::Serialize;

--- a/src/bin/nydus-image/node.rs
+++ b/src/bin/nydus-image/node.rs
@@ -278,8 +278,11 @@ impl Node {
                     trace!(
                         "\t\tbuilding duplicated chunk: {} compressor {}",
                         chunk,
-                        compressor,
+                        compressor
                     );
+
+                    event_tracer!("dedup total chunk size", +chunk_size);
+                    event_tracer!("dedup chunks", +1);
                     continue;
                 }
             }

--- a/src/bin/nydus-image/node.rs
+++ b/src/bin/nydus-image/node.rs
@@ -281,8 +281,9 @@ impl Node {
                         compressor
                     );
 
-                    event_tracer!("dedup total chunk size", +chunk_size);
-                    event_tracer!("dedup chunks", +1);
+                    event_tracer!("dedup_decompressed_size", +chunk_size);
+                    event_tracer!("dedup_chunks", +1);
+
                     continue;
                 }
             }
@@ -318,7 +319,8 @@ impl Node {
 
             // Dump compressed chunk data to blob
             if let Some(f_blob) = f_blob.as_mut() {
-                event_tracer!("blob compressed size", +compressed_size);
+                event_tracer!("blob_decompressed_size", +chunk_size);
+                event_tracer!("blob_compressed_size", +compressed_size);
                 f_blob
                     .write_all(&compressed)
                     .context("failed to write blob")?;

--- a/src/bin/nydus-image/node.rs
+++ b/src/bin/nydus-image/node.rs
@@ -281,8 +281,12 @@ impl Node {
                         compressor
                     );
 
-                    event_tracer!("dedup_decompressed_size", +chunk_size);
-                    event_tracer!("dedup_chunks", +1);
+                    // The chunks of hardlink should be always deduplicated, so don't
+                    // trace this situation here.
+                    if !self.is_hardlink() {
+                        event_tracer!("dedup_decompressed_size", +chunk_size);
+                        event_tracer!("dedup_chunks", +1);
+                    }
 
                     continue;
                 }

--- a/src/bin/nydus-image/tree.rs
+++ b/src/bin/nydus-image/tree.rs
@@ -84,7 +84,7 @@ impl<'a> MetadataTreeBuilder<'a> {
         }
 
         let child_count = inode.get_child_count();
-        event_tracer!("loading files from parent", +child_count);
+        event_tracer!("load_from_parent_bootstrap", +child_count);
 
         let parent_path = if let Some(parent) = parent {
             parent.join(inode.name())
@@ -410,7 +410,7 @@ impl FilesystemTreeBuilder {
             .with_context(|| format!("failed to read dir {:?}", parent.path))?;
         let children = children.collect::<Result<Vec<DirEntry>, std::io::Error>>()?;
 
-        event_tracer!("loading files from directory", +children.len());
+        event_tracer!("load_from_directory", +children.len());
 
         for child in children {
             let path = child.path();
@@ -486,7 +486,7 @@ impl Tree {
 
         tree.children = timing_tracer!(
             { tree_builder.load_children(RAFS_ROOT_INODE, None, &mut chunk_cache) },
-            "load nodes from parent"
+            "load_from_parent_bootstrap"
         )?;
 
         Ok(tree)
@@ -511,7 +511,7 @@ impl Tree {
 
         tree.children = timing_tracer!(
             { tree_builder.load_children(&mut tree.node, whiteout_spec) },
-            "load nodes from local directory"
+            "load_from_directory"
         )?;
 
         Ok(tree)
@@ -529,7 +529,7 @@ impl Tree {
         // Handle whiteout file
         if handle_whiteout {
             if let Some(whiteout_type) = target.whiteout_type(whiteout_spec) {
-                event_tracer!("whiteout files", +1);
+                event_tracer!("whiteout_files", +1);
                 if whiteout_type == WhiteoutType::OverlayFSOpaque {
                     self.remove(target, whiteout_spec)?;
                     return self.apply(target, false, whiteout_spec);


### PR DESCRIPTION
Nydus-image builder tracer wrongly sets its initial value to  0 ending up with smaller counters recorded.
Moreover, add UT for image tracer.