### PR TITLE
snapshotter: introduce enable stargz option

### DIFF
--- a/contrib/nydus-snapshotter/cmd/containerd-nydus-grpc/pkg/command/flags.go
+++ b/contrib/nydus-snapshotter/cmd/containerd-nydus-grpc/pkg/command/flags.go
@@ -37,6 +37,7 @@ type Args struct {
 	SharedDaemon         bool
 	AsyncRemove          bool
 	EnableMetrics        bool
+	EnableStargz         bool
 }
 
 type Flags struct {
@@ -117,6 +118,12 @@ func buildFlags(args *Args) []cli.Flag {
 			Usage:       "whether to collect metrics",
 			Destination: &args.EnableMetrics,
 		},
+		&cli.BoolFlag{
+			Name:        "enable-stargz",
+			Value:       false,
+			Usage:       "whether to support stargz image",
+			Destination: &args.EnableStargz,
+		},
 	}
 }
 
@@ -150,5 +157,6 @@ func Validate(args *Args, cfg *config.Config) error {
 	cfg.SharedDaemon = args.SharedDaemon
 	cfg.AsyncRemove = args.AsyncRemove
 	cfg.EnableMetrics = args.EnableMetrics
+	cfg.EnableStargz = args.EnableStargz
 	return nil
 }

--- a/contrib/nydus-snapshotter/config/config.go
+++ b/contrib/nydus-snapshotter/config/config.go
@@ -14,6 +14,7 @@ import (
 const (
 	defaultNydusDaemonConfigPath string = "/etc/nydus/config.json"
 	defaultNydusdBinaryPath      string = "/usr/local/bin/nydusd"
+	defaultNydusImageBinaryPath  string = "/usr/local/bin/nydus-image"
 )
 
 type Config struct {
@@ -25,10 +26,11 @@ type Config struct {
 	RootDir              string             `toml:"-"`
 	ValidateSignature    bool               `toml:"validate_signature"`
 	NydusdBinaryPath     string             `toml:"nydusd_binary_path"`
-	NydusImageBinaryPath string             `toml:"-"`
+	NydusImageBinaryPath string             `toml:"nydus_image_binary"`
 	SharedDaemon         bool               `toml:"shared_daemon"`
 	AsyncRemove          bool               `toml:"async_remove"`
 	EnableMetrics        bool               `toml:"enable_metrics"`
+	EnableStargz         bool               `toml:"enable_stargz"`
 }
 
 func (c *Config) FillupWithDefaults() error {
@@ -38,6 +40,10 @@ func (c *Config) FillupWithDefaults() error {
 
 	if c.NydusdBinaryPath == "" {
 		c.NydusdBinaryPath = defaultNydusdBinaryPath
+	}
+
+	if c.NydusImageBinaryPath == "" {
+		c.NydusImageBinaryPath = defaultNydusImageBinaryPath
 	}
 
 	var daemonCfg nydus.DaemonConfig


### PR DESCRIPTION
Defaults to disable stargz fs support so that we
can avoid some unnecessary checking.

Signed-off-by: Eric Ren <renzhen@linux.alibaba.com>