### PR TITLE
Introduce secure-container support to nydus-snapshotter and various bug fixes

### DIFF
--- a/api/src/http_endpoint.rs
+++ b/api/src/http_endpoint.rs
@@ -152,6 +152,7 @@ pub enum HttpError {
     BlobcacheMetrics(ApiError),
     BackendMetrics(ApiError),
     FsBackendInfo(ApiError),
+    InflightMetrics(ApiError),
 }
 
 fn success_response(body: Option<String>) -> Response {
@@ -395,7 +396,7 @@ impl EndpointHandler for MetricsInflightHandler {
         match (req.method(), req.body.as_ref()) {
             (Method::Get, None) => {
                 let r = kicker(ApiRequest::ExportInflightMetrics);
-                Ok(convert_to_response(r, HttpError::BlobcacheMetrics))
+                Ok(convert_to_response(r, HttpError::InflightMetrics))
             }
             _ => Err(HttpError::BadRequest),
         }

--- a/contrib/nydus-snapshotter/cmd/containerd-nydus-grpc/pkg/command/flags.go
+++ b/contrib/nydus-snapshotter/cmd/containerd-nydus-grpc/pkg/command/flags.go
@@ -33,6 +33,7 @@ type Args struct {
 	ConvertVpcRegistry   bool
 	NydusdBinaryPath     string
 	NydusImageBinaryPath string
+	SharedDaemon         bool
 	DaemonMode           string
 	AsyncRemove          bool
 	EnableMetrics        bool
@@ -100,6 +101,12 @@ func buildFlags(args *Args) []cli.Flag {
 			Usage:       "whether automatically convert the image to vpc registry to accelerate image pulling",
 			Destination: &args.ConvertVpcRegistry,
 		},
+	       &cli.BoolFlag{
+			Name:        "shared-daemon",
+			Value:       false,
+			Usage:       "Deprecated, equivalent to \"--daemon-mode shared\"",
+			Destination: &args.SharedDaemon,
+		},
 		&cli.StringFlag{
 			Name:        "daemon-mode",
 			Value:       config.DefaultDaemonMode,
@@ -160,6 +167,10 @@ func Validate(args *Args, cfg *config.Config) error {
 	cfg.NydusdBinaryPath = args.NydusdBinaryPath
 	cfg.NydusImageBinaryPath = args.NydusImageBinaryPath
 	cfg.DaemonMode = args.DaemonMode
+	// Give --shared-daemon higher priority
+	if args.SharedDaemon {
+		cfg.DaemonMode = config.DaemonModeShared
+	}
 	cfg.AsyncRemove = args.AsyncRemove
 	cfg.EnableMetrics = args.EnableMetrics
 	cfg.MetricsFile = args.MetricsFile

--- a/contrib/nydus-snapshotter/cmd/containerd-nydus-grpc/pkg/command/flags.go
+++ b/contrib/nydus-snapshotter/cmd/containerd-nydus-grpc/pkg/command/flags.go
@@ -21,7 +21,6 @@ const (
 	defaultPublicKey      = "/signing/nydus-image-signing-public.key"
 	defaultNydusdPath     = "/bin/nydusd"
 	defaultNydusImagePath = "/bin/nydusd-img"
-	defaultDaemonMode     = "multiple"
 )
 
 type Args struct {
@@ -103,7 +102,7 @@ func buildFlags(args *Args) []cli.Flag {
 		},
 		&cli.StringFlag{
 			Name:        "daemon-mode",
-			Value:       defaultDaemonMode,
+			Value:       config.DefaultDaemonMode,
 			Usage:       "daemon mode to use, could be \"multiple\", \"shared\" or \"none\"",
 			Destination: &args.DaemonMode,
 		},

--- a/contrib/nydus-snapshotter/cmd/containerd-nydus-grpc/pkg/command/flags.go
+++ b/contrib/nydus-snapshotter/cmd/containerd-nydus-grpc/pkg/command/flags.go
@@ -37,6 +37,7 @@ type Args struct {
 	SharedDaemon         bool
 	AsyncRemove          bool
 	EnableMetrics        bool
+	MetricsFile          string
 	EnableStargz         bool
 }
 
@@ -118,6 +119,11 @@ func buildFlags(args *Args) []cli.Flag {
 			Usage:       "whether to collect metrics",
 			Destination: &args.EnableMetrics,
 		},
+		&cli.StringFlag{
+			Name:        "metrics-file",
+			Usage:       "file path to output metrics",
+			Destination: &args.MetricsFile,
+		},
 		&cli.BoolFlag{
 			Name:        "enable-stargz",
 			Value:       false,
@@ -157,6 +163,7 @@ func Validate(args *Args, cfg *config.Config) error {
 	cfg.SharedDaemon = args.SharedDaemon
 	cfg.AsyncRemove = args.AsyncRemove
 	cfg.EnableMetrics = args.EnableMetrics
+	cfg.MetricsFile = args.MetricsFile
 	cfg.EnableStargz = args.EnableStargz
 	return nil
 }

--- a/contrib/nydus-snapshotter/cmd/containerd-nydus-grpc/pkg/command/flags.go
+++ b/contrib/nydus-snapshotter/cmd/containerd-nydus-grpc/pkg/command/flags.go
@@ -8,7 +8,6 @@ package command
 
 import (
 	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/config"
-	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/filesystem/nydus"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
@@ -143,8 +142,8 @@ func NewFlags() *Flags {
 }
 
 func Validate(args *Args, cfg *config.Config) error {
-	var daemonCfg nydus.DaemonConfig
-	if err := nydus.LoadConfig(args.ConfigPath, &daemonCfg); err != nil {
+	var daemonCfg config.DaemonConfig
+	if err := config.LoadConfig(args.ConfigPath, &daemonCfg); err != nil {
 		return errors.Wrapf(err, "failed to load config file %q", args.ConfigPath)
 	}
 

--- a/contrib/nydus-snapshotter/cmd/containerd-nydus-grpc/pkg/command/flags.go
+++ b/contrib/nydus-snapshotter/cmd/containerd-nydus-grpc/pkg/command/flags.go
@@ -22,6 +22,7 @@ const (
 	defaultPublicKey      = "/signing/nydus-image-signing-public.key"
 	defaultNydusdPath     = "/bin/nydusd"
 	defaultNydusImagePath = "/bin/nydusd-img"
+	defaultDaemonMode     = "multiple"
 )
 
 type Args struct {
@@ -34,7 +35,7 @@ type Args struct {
 	ConvertVpcRegistry   bool
 	NydusdBinaryPath     string
 	NydusImageBinaryPath string
-	SharedDaemon         bool
+	DaemonMode           string
 	AsyncRemove          bool
 	EnableMetrics        bool
 	MetricsFile          string
@@ -101,11 +102,11 @@ func buildFlags(args *Args) []cli.Flag {
 			Usage:       "whether automatically convert the image to vpc registry to accelerate image pulling",
 			Destination: &args.ConvertVpcRegistry,
 		},
-		&cli.BoolFlag{
-			Name:        "shared-daemon",
-			Value:       false,
-			Usage:       "whether to use a single shared nydus daemon",
-			Destination: &args.SharedDaemon,
+		&cli.StringFlag{
+			Name:        "daemon-mode",
+			Value:       defaultDaemonMode,
+			Usage:       "daemon mode to use, could be \"multiple\" or \"shared\"",
+			Destination: &args.DaemonMode,
 		},
 		&cli.BoolFlag{
 			Name:        "async-remove",
@@ -160,7 +161,7 @@ func Validate(args *Args, cfg *config.Config) error {
 	cfg.Address = args.Address
 	cfg.NydusdBinaryPath = args.NydusdBinaryPath
 	cfg.NydusImageBinaryPath = args.NydusImageBinaryPath
-	cfg.SharedDaemon = args.SharedDaemon
+	cfg.DaemonMode = args.DaemonMode
 	cfg.AsyncRemove = args.AsyncRemove
 	cfg.EnableMetrics = args.EnableMetrics
 	cfg.MetricsFile = args.MetricsFile

--- a/contrib/nydus-snapshotter/cmd/containerd-nydus-grpc/pkg/command/flags.go
+++ b/contrib/nydus-snapshotter/cmd/containerd-nydus-grpc/pkg/command/flags.go
@@ -105,7 +105,7 @@ func buildFlags(args *Args) []cli.Flag {
 		&cli.StringFlag{
 			Name:        "daemon-mode",
 			Value:       defaultDaemonMode,
-			Usage:       "daemon mode to use, could be \"multiple\" or \"shared\"",
+			Usage:       "daemon mode to use, could be \"multiple\", \"shared\" or \"none\"",
 			Destination: &args.DaemonMode,
 		},
 		&cli.BoolFlag{

--- a/contrib/nydus-snapshotter/config/config.go
+++ b/contrib/nydus-snapshotter/config/config.go
@@ -11,6 +11,12 @@ import (
 )
 
 const (
+	DefaultDaemonMode  string = "multiple"
+	DaemonModeMultiple string = "multiple"
+	DaemonModeShared   string = "shared"
+	DaemonModeSingle   string = "single"
+	DaemonModeNone     string = "none"
+
 	defaultNydusDaemonConfigPath string = "/etc/nydus/config.json"
 	defaultNydusdBinaryPath      string = "/usr/local/bin/nydusd"
 	defaultNydusImageBinaryPath  string = "/usr/local/bin/nydus-image"
@@ -47,7 +53,7 @@ func (c *Config) FillupWithDefaults() error {
 	}
 
 	if c.DaemonMode == "" {
-		c.DaemonMode = "multiple"
+		c.DaemonMode = DefaultDaemonMode
 	}
 
 	var daemonCfg DaemonConfig

--- a/contrib/nydus-snapshotter/config/config.go
+++ b/contrib/nydus-snapshotter/config/config.go
@@ -27,7 +27,7 @@ type Config struct {
 	ValidateSignature    bool               `toml:"validate_signature"`
 	NydusdBinaryPath     string             `toml:"nydusd_binary_path"`
 	NydusImageBinaryPath string             `toml:"nydus_image_binary"`
-	SharedDaemon         bool               `toml:"shared_daemon"`
+	DaemonMode           string             `toml:"daemon_mode"`
 	AsyncRemove          bool               `toml:"async_remove"`
 	EnableMetrics        bool               `toml:"enable_metrics"`
 	MetricsFile          string             `toml:"metrics_file"`
@@ -45,6 +45,10 @@ func (c *Config) FillupWithDefaults() error {
 
 	if c.NydusImageBinaryPath == "" {
 		c.NydusImageBinaryPath = defaultNydusImageBinaryPath
+	}
+
+	if c.DaemonMode == "" {
+		c.DaemonMode = "multiple"
 	}
 
 	var daemonCfg nydus.DaemonConfig

--- a/contrib/nydus-snapshotter/config/config.go
+++ b/contrib/nydus-snapshotter/config/config.go
@@ -7,7 +7,6 @@
 package config
 
 import (
-	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/filesystem/nydus"
 	"github.com/pkg/errors"
 )
 
@@ -21,7 +20,7 @@ type Config struct {
 	Address              string             `toml:"-"`
 	ConvertVpcRegistry   bool               `toml:"-"`
 	DaemonCfgPath        string             `toml:"daemon_cfg_path"`
-	DaemonCfg            nydus.DaemonConfig `toml:"-"`
+	DaemonCfg            DaemonConfig       `toml:"-"`
 	PublicKeyFile        string             `toml:"-"`
 	RootDir              string             `toml:"-"`
 	ValidateSignature    bool               `toml:"validate_signature"`
@@ -51,8 +50,8 @@ func (c *Config) FillupWithDefaults() error {
 		c.DaemonMode = "multiple"
 	}
 
-	var daemonCfg nydus.DaemonConfig
-	if err := nydus.LoadConfig(c.DaemonCfgPath, &daemonCfg); err != nil {
+	var daemonCfg DaemonConfig
+	if err := LoadConfig(c.DaemonCfgPath, &daemonCfg); err != nil {
 		return errors.Wrapf(err, "failed to load config file %q", c.DaemonCfgPath)
 	}
 	c.DaemonCfg = daemonCfg

--- a/contrib/nydus-snapshotter/config/config.go
+++ b/contrib/nydus-snapshotter/config/config.go
@@ -30,6 +30,7 @@ type Config struct {
 	SharedDaemon         bool               `toml:"shared_daemon"`
 	AsyncRemove          bool               `toml:"async_remove"`
 	EnableMetrics        bool               `toml:"enable_metrics"`
+	MetricsFile          string             `toml:"metrics_file"`
 	EnableStargz         bool               `toml:"enable_stargz"`
 }
 

--- a/contrib/nydus-snapshotter/config/daemonconfig.go
+++ b/contrib/nydus-snapshotter/config/daemonconfig.go
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package nydus
+package config
 
 import (
 	"encoding/json"

--- a/contrib/nydus-snapshotter/config/daemonconfig_test.go
+++ b/contrib/nydus-snapshotter/config/daemonconfig_test.go
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package nydus
+package config
 
 import (
 	"encoding/json"

--- a/contrib/nydus-snapshotter/pkg/daemon/config.go
+++ b/contrib/nydus-snapshotter/pkg/daemon/config.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/config"
 	"github.com/pkg/errors"
 )
 
@@ -96,7 +97,7 @@ func WithImageID(imageID string) NewDaemonOpt {
 
 func WithSharedDaemon() NewDaemonOpt {
 	return func(d *Daemon) error {
-		d.DaemonMode = "shared"
+		d.DaemonMode = config.DaemonModeShared
 		return nil
 	}
 }

--- a/contrib/nydus-snapshotter/pkg/daemon/config.go
+++ b/contrib/nydus-snapshotter/pkg/daemon/config.go
@@ -96,7 +96,7 @@ func WithImageID(imageID string) NewDaemonOpt {
 
 func WithSharedDaemon() NewDaemonOpt {
 	return func(d *Daemon) error {
-		d.SharedDaemon = true
+		d.DaemonMode = "shared"
 		return nil
 	}
 }

--- a/contrib/nydus-snapshotter/pkg/daemon/daemon.go
+++ b/contrib/nydus-snapshotter/pkg/daemon/daemon.go
@@ -33,7 +33,7 @@ type Daemon struct {
 	SnapshotDir    string
 	Pid            int
 	ImageID        string
-	SharedDaemon   bool
+	DaemonMode     string
 	ApiSock        *string
 	RootMountPoint *string
 }
@@ -110,9 +110,18 @@ func (d *Daemon) SharedUmount() error {
 	return client.Umount(d.MountPoint())
 }
 
+func (d *Daemon) IsMultipleDaemon() bool {
+	return d.DaemonMode == "multiple"
+}
+
+func (d *Daemon) IsSharedDaemon() bool {
+	return d.DaemonMode == "shared" || d.DaemonMode == "single"
+}
+
 func NewDaemon(opt ...NewDaemonOpt) (*Daemon, error) {
 	d := &Daemon{Pid: 0}
 	d.ID = newID()
+	d.DaemonMode = "multiple"
 	for _, o := range opt {
 		err := o(d)
 		if err != nil {

--- a/contrib/nydus-snapshotter/pkg/daemon/daemon.go
+++ b/contrib/nydus-snapshotter/pkg/daemon/daemon.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/config"
 	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/nydussdk"
 	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/nydussdk/model"
 )
@@ -98,17 +99,17 @@ func (d *Daemon) SharedUmount() error {
 }
 
 func (d *Daemon) IsMultipleDaemon() bool {
-	return d.DaemonMode == "multiple"
+	return d.DaemonMode == config.DaemonModeMultiple
 }
 
 func (d *Daemon) IsSharedDaemon() bool {
-	return d.DaemonMode == "shared" || d.DaemonMode == "single"
+	return d.DaemonMode == config.DaemonModeShared || d.DaemonMode == config.DaemonModeSingle
 }
 
 func NewDaemon(opt ...NewDaemonOpt) (*Daemon, error) {
 	d := &Daemon{Pid: 0}
 	d.ID = newID()
-	d.DaemonMode = "multiple"
+	d.DaemonMode = config.DefaultDaemonMode
 	for _, o := range opt {
 		err := o(d)
 		if err != nil {

--- a/contrib/nydus-snapshotter/pkg/daemon/daemon.go
+++ b/contrib/nydus-snapshotter/pkg/daemon/daemon.go
@@ -7,6 +7,7 @@
 package daemon
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -50,21 +51,7 @@ func (d *Daemon) MountPoint() string {
 }
 
 func (d *Daemon) BootstrapFile() (string, error) {
-	// the meta file is stored to <snapshotid>/image/image.boot
-	bootstrap := filepath.Join(d.SnapshotDir, d.SnapshotID, "fs", "image", "image.boot")
-	_, err := os.Stat(bootstrap)
-	if err == nil {
-		return bootstrap, nil
-	}
-	if os.IsNotExist(err) {
-		// for backward compatibility check meta file from legacy location
-		bootstrap = filepath.Join(d.SnapshotDir, d.SnapshotID, "fs", "image.boot")
-		_, err = os.Stat(bootstrap)
-		if err == nil {
-			return bootstrap, nil
-		}
-	}
-	return "", errors.Wrap(err, "failed to find bootstrap file")
+	return GetBootstrapFile(d.SnapshotDir, d.SnapshotID)
 }
 
 func (d *Daemon) ConfigFile() string {
@@ -129,4 +116,22 @@ func NewDaemon(opt ...NewDaemonOpt) (*Daemon, error) {
 		}
 	}
 	return d, nil
+}
+
+func GetBootstrapFile(dir, id string) (string, error) {
+	// the meta file is stored to <snapshotid>/image/image.boot
+	bootstrap := filepath.Join(dir, id, "fs", "image", "image.boot")
+	_, err := os.Stat(bootstrap)
+	if err == nil {
+		return bootstrap, nil
+	}
+	if os.IsNotExist(err) {
+		// for backward compatibility check meta file from legacy location
+		bootstrap = filepath.Join(dir, id, "fs", "image.boot")
+		_, err = os.Stat(bootstrap)
+		if err == nil {
+			return bootstrap, nil
+		}
+	}
+	return "", errors.Wrap(err, fmt.Sprintf("failed to find bootstrap file for ID %s", id))
 }

--- a/contrib/nydus-snapshotter/pkg/filesystem/fs/fs.go
+++ b/contrib/nydus-snapshotter/pkg/filesystem/fs/fs.go
@@ -9,6 +9,7 @@ package fs
 import (
 	"context"
 	"github.com/containerd/containerd/snapshots/storage"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/config"
 )
 
 type FSMode int
@@ -28,5 +29,5 @@ type FileSystem interface {
 	PrepareLayer(ctx context.Context, snapshot storage.Snapshot, labels map[string]string) error
 	MountPoint(snapshotID string) (string, error)
 	BootstrapFile(snapshotID string) (string, error)
-	NewDaemonConfigContent(labels map[string]string) (string, error)
+	NewDaemonConfig(labels map[string]string) (config.DaemonConfig, error)
 }

--- a/contrib/nydus-snapshotter/pkg/filesystem/fs/fs.go
+++ b/contrib/nydus-snapshotter/pkg/filesystem/fs/fs.go
@@ -16,6 +16,7 @@ type FSMode int
 const (
 	SingleInstance FSMode = iota
 	MultiInstance
+	NoneInstance
 )
 
 type FileSystem interface {
@@ -26,4 +27,6 @@ type FileSystem interface {
 	Support(ctx context.Context, labels map[string]string) bool
 	PrepareLayer(ctx context.Context, snapshot storage.Snapshot, labels map[string]string) error
 	MountPoint(snapshotID string) (string, error)
+	BootstrapFile(snapshotID string) (string, error)
+	NewDaemonConfigContent(labels map[string]string) (string, error)
 }

--- a/contrib/nydus-snapshotter/pkg/filesystem/nydus/config.go
+++ b/contrib/nydus-snapshotter/pkg/filesystem/nydus/config.go
@@ -80,11 +80,11 @@ func WithDaemonMode(daemonMode string) NewFSOpt {
 	return func(d *filesystem) error {
 		mode := strings.ToLower(daemonMode)
 		switch mode {
-		case "none", "no":
+		case config.DaemonModeNone:
 			d.mode = fs.NoneInstance
-		case "single", "shared":
+		case config.DaemonModeShared, config.DaemonModeSingle:
 			d.mode = fs.SingleInstance
-		case "multiple":
+		case config.DaemonModeMultiple:
 			fallthrough
 		default:
 			d.mode = fs.MultiInstance

--- a/contrib/nydus-snapshotter/pkg/filesystem/nydus/config.go
+++ b/contrib/nydus-snapshotter/pkg/filesystem/nydus/config.go
@@ -79,6 +79,8 @@ func WithDaemonMode(daemonMode string) NewFSOpt {
 	return func(d *filesystem) error {
 		mode := strings.ToLower(daemonMode)
 		switch mode {
+		case "none", "no":
+			d.mode = fs.NoneInstance
 		case "single", "shared":
 			d.mode = fs.SingleInstance
 		case "multiple":

--- a/contrib/nydus-snapshotter/pkg/filesystem/nydus/config.go
+++ b/contrib/nydus-snapshotter/pkg/filesystem/nydus/config.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"strings"
 
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/config"
 	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/filesystem/fs"
 	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/filesystem/meta"
 	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/process"
@@ -58,9 +59,9 @@ func WithVerifier(verifier *signature.Verifier) NewFSOpt {
 	}
 }
 
-func WithDaemonConfig(cfg DaemonConfig) NewFSOpt {
+func WithDaemonConfig(cfg config.DaemonConfig) NewFSOpt {
 	return func(d *filesystem) error {
-		if (DaemonConfig{}) == cfg {
+		if (config.DaemonConfig{}) == cfg {
 			return errors.New("daemon config is empty")
 		}
 		d.daemonCfg = cfg

--- a/contrib/nydus-snapshotter/pkg/filesystem/nydus/config.go
+++ b/contrib/nydus-snapshotter/pkg/filesystem/nydus/config.go
@@ -8,6 +8,7 @@ package nydus
 
 import (
 	"errors"
+	"strings"
 
 	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/filesystem/fs"
 	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/filesystem/meta"
@@ -74,11 +75,15 @@ func WithVPCRegistry(vpcRegistry bool) NewFSOpt {
 	}
 }
 
-func WithSharedDaemon(sharedDaemon bool) NewFSOpt {
+func WithDaemonMode(daemonMode string) NewFSOpt {
 	return func(d *filesystem) error {
-		if sharedDaemon {
+		mode := strings.ToLower(daemonMode)
+		switch mode {
+		case "single", "shared":
 			d.mode = fs.SingleInstance
-		} else {
+		case "multiple":
+			fallthrough
+		default:
 			d.mode = fs.MultiInstance
 		}
 		return nil

--- a/contrib/nydus-snapshotter/pkg/filesystem/nydus/daemonconfig.go
+++ b/contrib/nydus-snapshotter/pkg/filesystem/nydus/daemonconfig.go
@@ -13,7 +13,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/auth"
-	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/daemon"
 	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/utils/registry"
 )
 
@@ -79,10 +78,10 @@ func SaveConfig(c DaemonConfig, configFile string) error {
 	return ioutil.WriteFile(configFile, b, 0755)
 }
 
-func NewDaemonConfig(cfg DaemonConfig, d *daemon.Daemon, vpcRegistry bool, labels map[string]string) (DaemonConfig, error) {
-	image, err := registry.ParseImage(d.ImageID)
+func NewDaemonConfig(cfg DaemonConfig, imageID string, vpcRegistry bool, labels map[string]string) (DaemonConfig, error) {
+	image, err := registry.ParseImage(imageID)
 	if err != nil {
-		return DaemonConfig{}, errors.Wrapf(err, "failed to parse image %s", d.ImageID)
+		return DaemonConfig{}, errors.Wrapf(err, "failed to parse image %s", imageID)
 	}
 	registryHost := image.Host
 	if vpcRegistry {

--- a/contrib/nydus-snapshotter/pkg/filesystem/nydus/fs.go
+++ b/contrib/nydus-snapshotter/pkg/filesystem/nydus/fs.go
@@ -275,7 +275,7 @@ func (fs *filesystem) createSharedDaemon(snapshotID string, imageID string) (*da
 
 // generateDaemonConfig generate Daemon configuration
 func (fs *filesystem) generateDaemonConfig(d *daemon.Daemon, labels map[string]string) error {
-	cfg, err := NewDaemonConfig(fs.daemonCfg, d, fs.vpcRegistry, labels)
+	cfg, err := NewDaemonConfig(fs.daemonCfg, d.ImageID, fs.vpcRegistry, labels)
 	if err != nil {
 		return errors.Wrapf(err, "failed to generate daemon config for daemon %s", d.ID)
 	}

--- a/contrib/nydus-snapshotter/pkg/filesystem/nydus/fs.go
+++ b/contrib/nydus-snapshotter/pkg/filesystem/nydus/fs.go
@@ -8,7 +8,6 @@ package nydus
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"path/filepath"
 	"time"
@@ -224,23 +223,18 @@ func (fs *filesystem) BootstrapFile(id string) (string, error) {
 	return daemon.GetBootstrapFile(fs.SnapshotRoot(), id)
 }
 
-func (fs *filesystem) NewDaemonConfigContent(labels map[string]string) (string, error) {
+func (fs *filesystem) NewDaemonConfig(labels map[string]string) (config.DaemonConfig, error) {
 	imageID, ok := labels[label.ImageRef]
 	if !ok {
-		return "", fmt.Errorf("no image ID found in label")
+		return config.DaemonConfig{}, fmt.Errorf("no image ID found in label")
 	}
 
-	config, err := config.NewDaemonConfig(fs.daemonCfg, imageID, fs.vpcRegistry, labels)
+	cfg, err := config.NewDaemonConfig(fs.daemonCfg, imageID, fs.vpcRegistry, labels)
 	if err != nil {
-		return "", err
+		return config.DaemonConfig{}, err
 	}
 
-	b, err := json.Marshal(config)
-	if err != nil {
-		return "", errors.Wrapf(err, "failed to marshal config")
-	}
-
-	return string(b), nil
+	return cfg, nil
 }
 
 func (fs *filesystem) mount(d *daemon.Daemon, labels map[string]string) error {

--- a/contrib/nydus-snapshotter/pkg/filesystem/nydus/fs.go
+++ b/contrib/nydus-snapshotter/pkg/filesystem/nydus/fs.go
@@ -194,6 +194,10 @@ func (fs *filesystem) MountPoint(snapshotID string) (string, error) {
 	return "", fmt.Errorf("failed to find nydus mountpoint of snapshot %s", snapshotID)
 }
 
+func (fs *filesystem) BootstrapFile(id string) (string, error) {
+	return daemon.GetBootstrapFile(fs.SnapshotRoot(), id)
+}
+
 func (fs *filesystem) mount(d *daemon.Daemon, labels map[string]string) error {
 	err := fs.generateDaemonConfig(d, labels)
 	if err != nil {

--- a/contrib/nydus-snapshotter/pkg/filesystem/nydus/fs.go
+++ b/contrib/nydus-snapshotter/pkg/filesystem/nydus/fs.go
@@ -17,6 +17,7 @@ import (
 	"github.com/containerd/containerd/snapshots/storage"
 	"github.com/pkg/errors"
 
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/config"
 	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/daemon"
 	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/errdefs"
 	fspkg "github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/filesystem/fs"
@@ -31,7 +32,7 @@ type filesystem struct {
 	meta.FileSystemMeta
 	manager          *process.Manager
 	verifier         *signature.Verifier
-	daemonCfg        DaemonConfig
+	daemonCfg        config.DaemonConfig
 	vpcRegistry      bool
 	nydusdBinaryPath string
 	mode             fspkg.FSMode
@@ -229,7 +230,7 @@ func (fs *filesystem) NewDaemonConfigContent(labels map[string]string) (string, 
 		return "", fmt.Errorf("no image ID found in label")
 	}
 
-	config, err := NewDaemonConfig(fs.daemonCfg, imageID, fs.vpcRegistry, labels)
+	config, err := config.NewDaemonConfig(fs.daemonCfg, imageID, fs.vpcRegistry, labels)
 	if err != nil {
 		return "", err
 	}
@@ -319,11 +320,11 @@ func (fs *filesystem) createSharedDaemon(snapshotID string, imageID string) (*da
 
 // generateDaemonConfig generate Daemon configuration
 func (fs *filesystem) generateDaemonConfig(d *daemon.Daemon, labels map[string]string) error {
-	cfg, err := NewDaemonConfig(fs.daemonCfg, d.ImageID, fs.vpcRegistry, labels)
+	cfg, err := config.NewDaemonConfig(fs.daemonCfg, d.ImageID, fs.vpcRegistry, labels)
 	if err != nil {
 		return errors.Wrapf(err, "failed to generate daemon config for daemon %s", d.ID)
 	}
-	return SaveConfig(cfg, d.ConfigFile())
+	return config.SaveConfig(cfg, d.ConfigFile())
 }
 
 func (fs *filesystem) hasDaemon() bool {

--- a/contrib/nydus-snapshotter/pkg/filesystem/stargz/config.go
+++ b/contrib/nydus-snapshotter/pkg/filesystem/stargz/config.go
@@ -9,8 +9,8 @@ package stargz
 import (
 	"errors"
 
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/config"
 	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/filesystem/meta"
-	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/filesystem/nydus"
 	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/process"
 )
 
@@ -57,9 +57,9 @@ func WithNydusImageBinaryPath(p string) NewFSOpt {
 	}
 }
 
-func WithDaemonConfig(cfg nydus.DaemonConfig) NewFSOpt {
+func WithDaemonConfig(cfg config.DaemonConfig) NewFSOpt {
 	return func(d *filesystem) error {
-		if (nydus.DaemonConfig{}) == cfg {
+		if (config.DaemonConfig{}) == cfg {
 			return errors.New("daemon config is empty")
 		}
 		d.daemonCfg = cfg

--- a/contrib/nydus-snapshotter/pkg/filesystem/stargz/fs.go
+++ b/contrib/nydus-snapshotter/pkg/filesystem/stargz/fs.go
@@ -19,12 +19,12 @@ import (
 	"github.com/containerd/containerd/snapshots/storage"
 	"github.com/pkg/errors"
 
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/config"
 	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/auth"
 	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/daemon"
 	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/errdefs"
 	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/filesystem/fs"
 	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/filesystem/meta"
-	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/filesystem/nydus"
 	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/label"
 	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/process"
 	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/utils/retry"
@@ -33,7 +33,7 @@ import (
 type filesystem struct {
 	meta.FileSystemMeta
 	manager               *process.Manager
-	daemonCfg             nydus.DaemonConfig
+	daemonCfg             config.DaemonConfig
 	resolver              *Resolver
 	vpcRegistry           bool
 	nydusdBinaryPath      string
@@ -198,13 +198,13 @@ func (f *filesystem) mount(d *daemon.Daemon, labels map[string]string) error {
 }
 
 func (f *filesystem) generateDaemonConfig(d *daemon.Daemon, labels map[string]string) error {
-	cfg, err := nydus.NewDaemonConfig(f.daemonCfg, d.ImageID, f.vpcRegistry, labels)
+	cfg, err := config.NewDaemonConfig(f.daemonCfg, d.ImageID, f.vpcRegistry, labels)
 	if err != nil {
 		return errors.Wrapf(err, "failed to generate daemon config for daemon %s", d.ID)
 	}
 	cfg.Device.Cache.Compressed = true
 	cfg.DigestValidate = false
-	return nydus.SaveConfig(cfg, d.ConfigFile())
+	return config.SaveConfig(cfg, d.ConfigFile())
 }
 
 func (f *filesystem) WaitUntilReady(ctx context.Context, snapshotID string) error {

--- a/contrib/nydus-snapshotter/pkg/filesystem/stargz/fs.go
+++ b/contrib/nydus-snapshotter/pkg/filesystem/stargz/fs.go
@@ -190,7 +190,7 @@ func (f *filesystem) mount(d *daemon.Daemon, labels map[string]string) error {
 }
 
 func (f *filesystem) generateDaemonConfig(d *daemon.Daemon, labels map[string]string) error {
-	cfg, err := nydus.NewDaemonConfig(f.daemonCfg, d, f.vpcRegistry, labels)
+	cfg, err := nydus.NewDaemonConfig(f.daemonCfg, d.ImageID, f.vpcRegistry, labels)
 	if err != nil {
 		return errors.Wrapf(err, "failed to generate daemon config for daemon %s", d.ID)
 	}

--- a/contrib/nydus-snapshotter/pkg/filesystem/stargz/fs.go
+++ b/contrib/nydus-snapshotter/pkg/filesystem/stargz/fs.go
@@ -181,6 +181,14 @@ func (f *filesystem) Mount(ctx context.Context, snapshotID string, labels map[st
 	return nil
 }
 
+func (fs *filesystem) BootstrapFile(id string) (string, error) {
+	panic("stargz has no bootstrap file")
+}
+
+func (fs *filesystem) NewDaemonConfigContent(labels map[string]string) (string, error) {
+	panic("implement me")
+}
+
 func (f *filesystem) mount(d *daemon.Daemon, labels map[string]string) error {
 	err := f.generateDaemonConfig(d, labels)
 	if err != nil {

--- a/contrib/nydus-snapshotter/pkg/filesystem/stargz/fs.go
+++ b/contrib/nydus-snapshotter/pkg/filesystem/stargz/fs.go
@@ -185,7 +185,7 @@ func (fs *filesystem) BootstrapFile(id string) (string, error) {
 	panic("stargz has no bootstrap file")
 }
 
-func (fs *filesystem) NewDaemonConfigContent(labels map[string]string) (string, error) {
+func (fs *filesystem) NewDaemonConfig(labels map[string]string) (config.DaemonConfig, error) {
 	panic("implement me")
 }
 

--- a/contrib/nydus-snapshotter/pkg/metric/exporter/export.go
+++ b/contrib/nydus-snapshotter/pkg/metric/exporter/export.go
@@ -11,7 +11,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"path/filepath"
 	"time"
 
 	"github.com/pkg/errors"
@@ -27,10 +26,16 @@ type Exporter struct {
 	outputFile string
 }
 
-func WithOutputFile(dir string) Opt {
+func WithOutputFile(metricsFile string) Opt {
 	return func(e *Exporter) error {
-		e.outputFile = filepath.Join(dir, "metrics.log")
+		if metricsFile == "" {
+			return errors.New("metrics file path is empty")
+		}
 
+		if _, err := os.Create(metricsFile); err != nil {
+			return errors.Wrapf(err, "failed to create metrics file: %s", metricsFile)
+		}
+		e.outputFile = metricsFile
 		return nil
 	}
 }

--- a/contrib/nydus-snapshotter/pkg/metric/exporter/export.go
+++ b/contrib/nydus-snapshotter/pkg/metric/exporter/export.go
@@ -18,7 +18,6 @@ import (
 	dto "github.com/prometheus/client_model/go"
 	"github.com/prometheus/common/expfmt"
 
-	metrics "github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/metric"
 	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/nydussdk/model"
 )
 
@@ -49,12 +48,12 @@ func NewExporter(opts ...Opt) (*Exporter, error) {
 }
 
 func (e *Exporter) ExportFsMetrics(m *model.FsMetric, imageRef string) error {
-	metrics.ReadCount.WithLabelValues(imageRef).Set(float64(m.DataRead))
-	metrics.OpenFdCount.WithLabelValues(imageRef).Set(float64(m.NrOpens))
-	metrics.OpenFdMaxCount.WithLabelValues(imageRef).Set(float64(m.NrMaxOpens))
-	metrics.LastFopTimestamp.WithLabelValues(imageRef).Set(float64(m.LastFopTp))
+	ReadCount.WithLabelValues(imageRef).Set(float64(m.DataRead))
+	OpenFdCount.WithLabelValues(imageRef).Set(float64(m.NrOpens))
+	OpenFdMaxCount.WithLabelValues(imageRef).Set(float64(m.NrMaxOpens))
+	LastFopTimestamp.WithLabelValues(imageRef).Set(float64(m.LastFopTp))
 
-	for _, h := range metrics.FsMetricHists {
+	for _, h := range FsMetricHists {
 		o, err := h.ToConstHistogram(m, imageRef)
 		if err != nil {
 			return errors.Wrapf(err, "failed to new const histogram for %s", h.Desc.String())
@@ -66,7 +65,7 @@ func (e *Exporter) ExportFsMetrics(m *model.FsMetric, imageRef string) error {
 }
 
 func (e *Exporter) output() error {
-	ms, err := metrics.Registry.Gather()
+	ms, err := Registry.Gather()
 	if err != nil {
 		return errors.Wrap(err, "failed to gather all prometheus collectors")
 	}

--- a/contrib/nydus-snapshotter/pkg/metric/exporter/metrics.go
+++ b/contrib/nydus-snapshotter/pkg/metric/exporter/metrics.go
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package metrics
+package exporter
 
 import (
 	"time"

--- a/contrib/nydus-snapshotter/pkg/metric/exporter/registry.go
+++ b/contrib/nydus-snapshotter/pkg/metric/exporter/registry.go
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package metrics
+package exporter
 
 import (
 	"github.com/prometheus/client_golang/prometheus"

--- a/contrib/nydus-snapshotter/pkg/metric/exporter/types.go
+++ b/contrib/nydus-snapshotter/pkg/metric/exporter/types.go
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package metrics
+package exporter
 
 import (
 	"fmt"

--- a/contrib/nydus-snapshotter/pkg/metric/serve.go
+++ b/contrib/nydus-snapshotter/pkg/metric/serve.go
@@ -119,7 +119,7 @@ outer:
 					continue
 				}
 
-				fsMetrics, err := client.GetFsMetric(s.pm.SharedDaemon, d.SnapshotID)
+				fsMetrics, err := client.GetFsMetric(s.pm.IsSharedDaemon(), d.SnapshotID)
 				if err != nil {
 					log.G(ctx).Errorf("failed to get fs metric: %v", err)
 					continue

--- a/contrib/nydus-snapshotter/pkg/metric/serve.go
+++ b/contrib/nydus-snapshotter/pkg/metric/serve.go
@@ -12,10 +12,15 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"time"
 
+	"github.com/containerd/containerd/log"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/daemon"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/metric/exporter"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/nydussdk"
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/process"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"golang.org/x/sync/errgroup"
 )
 
 type ServerOpt func(*Server) error
@@ -23,21 +28,22 @@ type ServerOpt func(*Server) error
 const sockFileName = "metrics.sock"
 
 type Server struct {
-	listener     net.Listener
-	SockPath     string
-	exportToFile bool
+	listener net.Listener
+	rootDir  string
+	pm       *process.Manager
+	exp      *exporter.Exporter
 }
 
-func WithSockPath(rootDir string) ServerOpt {
+func WithRootDir(rootDir string) ServerOpt {
 	return func(s *Server) error {
-		s.SockPath = filepath.Join(rootDir, sockFileName)
+		s.rootDir = rootDir
 		return nil
 	}
 }
 
-func WithExportToFile(toFile bool) ServerOpt {
+func WithProcessManager(pm *process.Manager) ServerOpt {
 	return func(s *Server) error {
-		s.exportToFile = toFile
+		s.pm = pm
 		return nil
 	}
 }
@@ -50,23 +56,75 @@ func NewServer(ctx context.Context, opts ...ServerOpt) (*Server, error) {
 		}
 	}
 
-	if _, err := os.Stat(s.SockPath); err == nil {
-		err = os.Remove(s.SockPath)
+	exp, err := exporter.NewExporter(
+		exporter.WithOutputFile(s.rootDir),
+	)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to new metric exporter")
+	}
+	s.exp = exp
+
+	sockPath := filepath.Join(s.rootDir, sockFileName)
+
+	if _, err := os.Stat(sockPath); err == nil {
+		err = os.Remove(sockPath)
 		if err != nil {
 			return nil, err
 		}
 	}
-	ln, err := NewListener(s.SockPath)
+	ln, err := NewListener(sockPath)
 	if err != nil {
 		return nil, err
 	}
 	s.listener = ln
 
+	log.G(ctx).Infof("Starting metrics server on %s", sockPath)
+
 	return &s, nil
 }
 
-func (s *Server) Serve(ctx context.Context, stop <-chan struct{}) error {
-	handler := promhttp.HandlerFor(Registry, promhttp.HandlerOpts{
+func (s *Server) collectDaemonMetric(ctx context.Context) error {
+	// TODO(renzhen): make collect interval time configurable
+	timer := time.NewTicker(time.Duration(1) * time.Minute)
+
+outer:
+	for {
+		select {
+		case <-timer.C:
+			daemons := s.pm.ListDaemons()
+			for _, d := range daemons {
+				if d.ID == daemon.SharedNydusDaemonID {
+					continue
+				}
+
+				client, err := nydussdk.NewNydusClient(d.APISock())
+				if err != nil {
+					log.G(ctx).Errorf("failed to connect nydusd: %v", err)
+					continue
+				}
+
+				fsMetrics, err := client.GetFsMetric(s.pm.SharedDaemon, d.SnapshotID)
+				if err != nil {
+					log.G(ctx).Errorf("failed to get fs metric: %v", err)
+					continue
+				}
+
+				if err := s.exp.ExportFsMetrics(fsMetrics, d.ImageID); err != nil {
+					log.G(ctx).Errorf("failed to export fs metrics for %s: %v", d.ImageID, err)
+					continue
+				}
+			}
+		case <-ctx.Done():
+			log.G(ctx).Infof("cancel daemon metrics collecting")
+			break outer
+		}
+	}
+
+	return nil
+}
+
+func (s *Server) Serve(ctx context.Context) error {
+	handler := promhttp.HandlerFor(exporter.Registry, promhttp.HandlerOpts{
 		ErrorHandling: promhttp.HTTPErrorOnError,
 	})
 	mux := http.NewServeMux()
@@ -75,22 +133,22 @@ func (s *Server) Serve(ctx context.Context, stop <-chan struct{}) error {
 		Handler: mux,
 	}
 
-	// Run the server
-	errs, ctx := errgroup.WithContext(ctx)
-	errs.Go(func() error {
-		return server.Serve(s.listener)
-	})
-	if err := errs.Wait(); err != nil {
-		return errors.Wrap(err, "failed to start metrics server")
-	}
+	// Process manager starts to collect metrics from daemons periodically.
+	go func() {
+		if err := s.collectDaemonMetric(ctx); err != nil {
+			log.G(ctx).Errorf("failed to collect daemon metric, err: %v", err)
+		}
+	}()
 
 	// Shutdown the server when stop is closed
-	select {
-	case <-stop:
+	go func() {
+		sig := <-ctx.Done()
+		log.G(ctx).Infof("caught signal %s: shutting down", sig)
 		if err := server.Shutdown(context.Background()); err != nil {
-			return errors.Wrap(err, "failed to shutdown metric server")
+			log.G(ctx).Errorf("failed to shutdown metric server, err: %v", err)
 		}
-	}
+	}()
 
-	return nil
+	// Run the server
+	return errors.Wrap(server.Serve(s.listener), "failed to start metrics server")
 }

--- a/contrib/nydus-snapshotter/pkg/process/manager.go
+++ b/contrib/nydus-snapshotter/pkg/process/manager.go
@@ -13,9 +13,6 @@ import (
 	"os/exec"
 	"sync"
 	"syscall"
-	"time"
-
-	metricExp "github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/metric/exporter"
 
 	"github.com/containerd/containerd/log"
 	"github.com/pkg/errors"
@@ -24,8 +21,6 @@ import (
 	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/errdefs"
 	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/store"
 	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/utils/mount"
-
-	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/nydussdk"
 )
 
 type configGenerator = func(*daemon.Daemon) error
@@ -251,44 +246,6 @@ func (m *Manager) Reconnect(ctx context.Context) error {
 	for _, d := range daemons {
 		if err := m.NewDaemon(d); err != nil {
 			return errors.Wrapf(err, "failed to daemon(%s) to daemon store", d.ID)
-		}
-	}
-
-	return nil
-}
-
-func (m *Manager) CollectDaemonMetric(ctx context.Context, exp *metricExp.Exporter) error {
-	// TODO(renzhen): make collect interval time configurable
-	timer := time.NewTicker(time.Duration(1) * time.Minute)
-
-	for {
-		select {
-		case <-timer.C:
-			daemons := m.ListDaemons()
-			for _, d := range daemons {
-				if d.ID == daemon.SharedNydusDaemonID {
-					continue
-				}
-
-				client, err := nydussdk.NewNydusClient(d.APISock())
-				if err != nil {
-					log.G(ctx).Errorf("failed to connect nydusd: %v", err)
-					continue
-				}
-
-				fsMetrics, err := client.GetFsMetric(m.SharedDaemon, d.SnapshotID)
-				if err != nil {
-					log.G(ctx).Errorf("failed to get fs metric: %v", err)
-					continue
-				}
-
-				if err := exp.ExportFsMetrics(fsMetrics, d.ImageID); err != nil {
-					log.G(ctx).Errorf("failed to export fs metrics for %s: %v", d.ImageID, err)
-					continue
-				}
-			}
-		case <-ctx.Done():
-			log.G(ctx).Infof("cancel daemom metrics collecting")
 		}
 	}
 

--- a/contrib/nydus-snapshotter/pkg/process/manager.go
+++ b/contrib/nydus-snapshotter/pkg/process/manager.go
@@ -17,6 +17,7 @@ import (
 	"github.com/containerd/containerd/log"
 	"github.com/pkg/errors"
 
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/config"
 	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/daemon"
 	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/errdefs"
 	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/store"
@@ -197,7 +198,7 @@ func (m *Manager) DestroyDaemon(d *daemon.Daemon) error {
 }
 
 func (m *Manager) IsSharedDaemon() bool {
-	return m.DaemonMode == "shared" || m.DaemonMode == "single"
+	return m.DaemonMode == config.DaemonModeShared || m.DaemonMode == config.DaemonModeSingle
 }
 
 // Reconnect already running daemons，and rebuild daemons management structs.

--- a/contrib/nydus-snapshotter/pkg/store/store.go
+++ b/contrib/nydus-snapshotter/pkg/store/store.go
@@ -9,16 +9,17 @@ package store
 import (
 	"context"
 	"fmt"
-	"github.com/pkg/errors"
-	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/daemon"
+	"os"
 	"path/filepath"
 	"sync"
+
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/daemon"
+	"github.com/pkg/errors"
 )
 
 const (
 	databaseFileName = "nydus.db"
 )
-
 
 type DaemonStore struct {
 	sync.Mutex
@@ -49,7 +50,7 @@ func (s *DaemonStore) Get(id string) (*daemon.Daemon, error) {
 	if d, ok := s.idxByID[id]; ok {
 		return d, nil
 	}
-	return nil, fmt.Errorf("failed to get daemon by id (%s)", id)
+	return nil, os.ErrNotExist
 }
 
 func (s *DaemonStore) GetBySnapshot(snapshotID string) (*daemon.Daemon, error) {
@@ -58,7 +59,8 @@ func (s *DaemonStore) GetBySnapshot(snapshotID string) (*daemon.Daemon, error) {
 	if d, ok := s.idxBySnapshotID[snapshotID]; ok {
 		return d, nil
 	}
-	return nil, fmt.Errorf("failed to get daemon by snapshotID (%s)", snapshotID)
+
+	return nil, os.ErrNotExist
 }
 
 func (s *DaemonStore) List() []*daemon.Daemon {

--- a/contrib/nydus-snapshotter/snapshot/snapshot.go
+++ b/contrib/nydus-snapshotter/snapshot/snapshot.go
@@ -70,10 +70,11 @@ func NewSnapshotter(ctx context.Context, cfg *config.Config) (snapshots.Snapshot
 		return nil, errors.Wrap(err, "failed to initialize verifier")
 	}
 
+	cfg.DaemonMode = strings.ToLower(cfg.DaemonMode)
 	pm, err := process.NewManager(process.Opt{
 		NydusdBinaryPath: cfg.NydusdBinaryPath,
 		RootDir:          cfg.RootDir,
-		SharedDaemon:     cfg.SharedDaemon,
+		DaemonMode:       cfg.DaemonMode,
 	})
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to new process manager")
@@ -87,7 +88,7 @@ func NewSnapshotter(ctx context.Context, cfg *config.Config) (snapshots.Snapshot
 		nydus.WithDaemonConfig(cfg.DaemonCfg),
 		nydus.WithVPCRegistry(cfg.ConvertVpcRegistry),
 		nydus.WithVerifier(verifier),
-		nydus.WithSharedDaemon(cfg.SharedDaemon),
+		nydus.WithDaemonMode(cfg.DaemonMode),
 	)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to initialize nydus filesystem")

--- a/contrib/nydus-snapshotter/snapshot/snapshot.go
+++ b/contrib/nydus-snapshotter/snapshot/snapshot.go
@@ -78,7 +78,7 @@ func NewSnapshotter(ctx context.Context, cfg *config.Config) (snapshots.Snapshot
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to new process manager")
 	}
-	hasDaemon := cfg.DaemonMode != "none" && cfg.DaemonMode != "no"
+	hasDaemon := cfg.DaemonMode != config.DaemonModeNone
 
 	nydusFs, err := nydus.NewFileSystem(
 		ctx,

--- a/contrib/nydus-snapshotter/snapshot/snapshot.go
+++ b/contrib/nydus-snapshotter/snapshot/snapshot.go
@@ -269,12 +269,14 @@ func (o *snapshotter) Prepare(ctx context.Context, key, parent string, opts ...s
 			if err := o.prepareRemoteSnapshot(ctx, id, info.Labels); err != nil {
 				return nil, err
 			}
+			return o.remoteMounts(ctx, s, id)
 		} else if o.stargzFs != nil {
 			if id, info, err := o.findStargzMetaLayer(ctx, key); err == nil {
 				logCtx.Infof("found stargz meta layer id %s, parpare remote snapshot", id)
 				if err := o.prepareStargzRemoteSnapshot(ctx, id, info.Labels); err != nil {
 					return nil, err
 				}
+				return o.remoteMounts(ctx, s, id)
 			}
 		}
 	}

--- a/contrib/nydus-snapshotter/snapshot/snapshot.go
+++ b/contrib/nydus-snapshotter/snapshot/snapshot.go
@@ -25,7 +25,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/config"
-	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/daemon"
 	fspkg "github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/filesystem/fs"
 	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/filesystem/nydus"
 	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/filesystem/stargz"
@@ -46,7 +45,6 @@ type snapshotter struct {
 	fs          fspkg.FileSystem
 	stargzFs    fspkg.FileSystem
 	manager     *process.Manager
-	daemon      *daemon.Daemon
 }
 
 func (o *snapshotter) Cleanup(ctx context.Context) error {

--- a/contrib/nydus-snapshotter/snapshot/snapshot.go
+++ b/contrib/nydus-snapshotter/snapshot/snapshot.go
@@ -112,6 +112,7 @@ func NewSnapshotter(ctx context.Context, cfg *config.Config) (snapshots.Snapshot
 		metricServer, err := metrics.NewServer(
 			ctx,
 			metrics.WithRootDir(cfg.RootDir),
+			metrics.WithMetricsFile(cfg.MetricsFile),
 			metrics.WithProcessManager(pm),
 		)
 		if err != nil {

--- a/contrib/nydus-snapshotter/snapshot/snapshot.go
+++ b/contrib/nydus-snapshotter/snapshot/snapshot.go
@@ -669,10 +669,10 @@ func (o *snapshotter) cleanupSnapshotDirectory(ctx context.Context, dir string) 
 	// We use Filesystem's Unmount API so that it can do necessary finalization
 	// before/after the unmount.
 	log.G(ctx).WithField("dir", dir).Infof("cleanupSnapshotDirectory %s", dir)
-	if err := o.fs.Umount(ctx, dir); err != nil {
+	if err := o.fs.Umount(ctx, dir); err != nil && !os.IsNotExist(err) {
 		log.G(ctx).WithError(err).WithField("dir", dir).Error("failed to unmount")
 	} else if o.stargzFs != nil {
-		if err := o.stargzFs.Umount(ctx, dir); err != nil {
+		if err := o.stargzFs.Umount(ctx, dir); err != nil && !os.IsNotExist(err) {
 			log.G(ctx).WithError(err).WithField("dir", dir).Error("failed to unmount")
 		}
 	}

--- a/rafs/src/fs.rs
+++ b/rafs/src/fs.rs
@@ -220,10 +220,14 @@ impl Rafs {
 
         info!("update sb is successful");
 
+        let mut device_conf = conf.device.clone();
+        device_conf.cache.cache_validate = conf.digest_validate;
+        device_conf.cache.prefetch_worker = TryFrom::try_from(&conf)?;
+
         // step 2: update device (only localfs is supported)
         self.device
             .update(
-                conf.device,
+                device_conf,
                 self.sb.meta.get_compressor(),
                 self.sb.meta.get_digester(),
                 self.id.as_str(),

--- a/rafs/src/metadata/mod.rs
+++ b/rafs/src/metadata/mod.rs
@@ -647,7 +647,7 @@ pub trait RafsInode {
             self.has_hole(),
         );
 
-        debug!(
+        trace!(
             "alloc bio desc offset {} size {} i_size {} blksize {} index_start {} index_end {} i_child_count {}",
             offset, size, self.size(), blksize, index_start, index_end, self.get_child_count()
         );

--- a/storage/src/factory.rs
+++ b/storage/src/factory.rs
@@ -55,14 +55,16 @@ impl BackendConfig {
 
 #[derive(Default, Clone, Deserialize)]
 pub struct CacheConfig {
-    #[serde(default, rename = "validate")]
-    pub cache_validate: bool,
     #[serde(default, rename = "compressed")]
     pub cache_compressed: bool,
     #[serde(default, rename = "type")]
     pub cache_type: String,
     #[serde(default, rename = "config")]
     pub cache_config: Value,
+    // Whether to validate cache is up to upper layer - Rafs. So don't try to
+    // get it from a user configuration file.
+    #[serde(skip_serializing, skip_deserializing)]
+    pub cache_validate: bool,
     #[serde(skip_serializing, skip_deserializing)]
     pub prefetch_worker: PrefetchWorker,
 }


### PR DESCRIPTION
This PR mainly brings the secure-container support to nydus-snapshotter, which introduces a new "none" instance mode, and snapshotter returns the rafs bootstrap file instead of a mounted rafs dir, so that secure-container such as kata-containers could parse the bootstrap file directly.