### PR TITLE
fix nydusd daemon process double wait and change p.Kill() to     p.Signal(syscall.SIGTERM) when destroy nydusd daemon process

### DIFF
--- a/contrib/nydus-snapshotter/pkg/process/manager.go
+++ b/contrib/nydus-snapshotter/pkg/process/manager.go
@@ -121,8 +121,7 @@ func (m *Manager) StartDaemon(d *daemon.Daemon) error {
 		return err
 	}
 	d.Pid = cmd.Process.Pid
-	// make sure to wait after start
-	go cmd.Wait()
+	// process wait when destroy daemon and kill process
 	return nil
 
 }
@@ -182,7 +181,7 @@ func (m *Manager) DestroyDaemon(d *daemon.Daemon) error {
 		if err != nil {
 			return err
 		}
-		err = p.Kill()
+		err = p.Signal(syscall.SIGTERM)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
There are two process wait, when destroy daemon, if first wait function run first, the second wait function will fail and output error as below. It is happened occasionally.
![image](https://user-images.githubusercontent.com/14847074/120108491-eb7d1e00-c197-11eb-8eb3-48cfc803db54.png)

1. https://github.com/dragonflyoss/image-service/blob/v0.1.0/contrib/nydus-snapshotter/pkg/process/manager.go#L124
2. https://github.com/dragonflyoss/image-service/blob/v0.1.0/contrib/nydus-snapshotter/pkg/process/manager.go#L188

The other question is here why not use p.Signal(syscall.SIGTERM) to gracefully exit?  p.Kill() will kill -9.
https://github.com/dragonflyoss/image-service/blob/v0.1.0/contrib/nydus-snapshotter/pkg/process/manager.go#L184