### PR TITLE
snapshotter: change CleanupDatabase to CleanupDaemons

### DIFF
--- a/contrib/nydus-snapshotter/pkg/filesystem/nydus/fs.go
+++ b/contrib/nydus-snapshotter/pkg/filesystem/nydus/fs.go
@@ -249,7 +249,8 @@ func (fs *filesystem) NewDaemonConfig(labels map[string]string) (config.DaemonCo
 	if err != nil {
 		return config.DaemonConfig{}, err
 	}
-	// Overriding work_dir option of nyudsd config as we want to set it via snapshotter config option to let snapshotter handle blob cache GC.
+	// Overriding work_dir option of nyudsd config as we want to set it
+	// via snapshotter config option to let snapshotter handle blob cache GC.
 	cfg.Device.Cache.Config.WorkDir = fs.cacheMgr.CacheDir()
 	return cfg, nil
 }
@@ -347,7 +348,8 @@ func (fs *filesystem) generateDaemonConfig(d *daemon.Daemon, labels map[string]s
 	if err != nil {
 		return errors.Wrapf(err, "failed to generate daemon config for daemon %s", d.ID)
 	}
-	// Overriding work_dir option of nyudsd config as we want to set it via snapshotter config option to let snapshotter handle blob cache GC.
+	// Overriding work_dir option of nyudsd config as we want to set it
+	// via snapshotter config option to let snapshotter handle blob cache GC.
 	cfg.Device.Cache.Config.WorkDir = fs.cacheMgr.CacheDir()
 	return config.SaveConfig(cfg, d.ConfigFile())
 }

--- a/contrib/nydus-snapshotter/pkg/process/manager.go
+++ b/contrib/nydus-snapshotter/pkg/process/manager.go
@@ -250,7 +250,7 @@ func (m *Manager) Reconnect(ctx context.Context) error {
 
 	// cleanup database so that we'll have a clean database for this snapshotter process lifetime
 	log.L.Infof("found %d daemons running", len(daemons))
-	if err := m.store.CleanupDatabase(ctx); err != nil {
+	if err := m.store.CleanupDaemons(ctx); err != nil {
 		return errors.Wrapf(err, "failed to cleanup database")
 	}
 

--- a/contrib/nydus-snapshotter/pkg/process/store.go
+++ b/contrib/nydus-snapshotter/pkg/process/store.go
@@ -8,6 +8,7 @@ package process
 
 import (
 	"context"
+
 	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/daemon"
 	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/store"
 )
@@ -20,7 +21,7 @@ type Store interface {
 	List() []*daemon.Daemon
 	Size() int
 	WalkDaemons(ctx context.Context, cb func(*daemon.Daemon) error) error
-	CleanupDatabase(ctx context.Context) error
+	CleanupDaemons(ctx context.Context) error
 }
 
 var _ Store = &store.DaemonStore{}

--- a/contrib/nydus-snapshotter/pkg/store/daemonstore.go
+++ b/contrib/nydus-snapshotter/pkg/store/daemonstore.go
@@ -109,6 +109,6 @@ func (s *DaemonStore) WalkDaemons(ctx context.Context, cb func(d *daemon.Daemon)
 	return s.db.WalkDaemons(ctx, cb)
 }
 
-func (s *DaemonStore) CleanupDatabase(ctx context.Context) error {
-	return s.db.Cleanup(ctx)
+func (s *DaemonStore) CleanupDaemons(ctx context.Context) error {
+	return s.db.CleanupDaemons(ctx)
 }

--- a/contrib/nydus-snapshotter/pkg/store/database.go
+++ b/contrib/nydus-snapshotter/pkg/store/database.go
@@ -132,7 +132,7 @@ func (d *Database) WalkDaemons(ctx context.Context, cb func(info *daemon.Daemon)
 }
 
 // Cleanup deletes all daemon records
-func (d *Database) Cleanup(ctx context.Context) error {
+func (d *Database) CleanupDaemons(ctx context.Context) error {
 	return d.db.Update(func(tx *bolt.Tx) error {
 		bucket := tx.Bucket(daemonsBucketName)
 

--- a/docs/containerd-env-setup.md
+++ b/docs/containerd-env-setup.md
@@ -55,7 +55,7 @@ Then start `containerd-nydus-grpc` remote snapshotter:
     --cache-dir /var/lib/nydus/cache \
     --address /run/containerd/containerd-nydus-grpc.sock
 ```
-`cache-dir` argument represent the blob cache root dir, if unset, it will be set `root` + "/cache". It overrides the `work_dir` option in nydusd-config.json.`
+`cache-dir` argument represent the blob cache root dir, if unset, it will be set `root` + "/cache". It overrides the `work_dir` option in nydusd-config.json.
 ## Configure and Start containerd
 
 Nydus uses two features of containerd:


### PR DESCRIPTION
As boltdb is shared by daemon and snapshot/blob, so it is not
suitable for method name CleanupDatabase when clean daemons

Signed-off-by: luodaowen.backend <luodaowen.backend@bytedance.com>