### PR TITLE
snapshotter: set default GCPeriod if not set in config

### DIFF
--- a/contrib/nydus-snapshotter/config/config.go
+++ b/contrib/nydus-snapshotter/config/config.go
@@ -62,6 +62,10 @@ func (c *Config) FillupWithDefaults() error {
 		c.DaemonMode = DefaultDaemonMode
 	}
 
+	if c.GCPeriod == 0 {
+		c.GCPeriod = defaultGCPeriod
+	}
+
 	if len(c.CacheDir) == 0 {
 		c.CacheDir = filepath.Join(c.RootDir, "cache")
 	}


### PR DESCRIPTION
Otherwise containerd failed to start due to failure to create new cache
manager.

panic: non-positive interval for NewTicker

goroutine 138 [running]:
time.NewTicker(0x0, 0x0)
        /home/eryu.gey/workspace/go/src/time/tick.go:23 +0x151
github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/cache.(*Manager).runGC(0xc000419080)
        /home/eryu.gey/workspace/src/go/src/github.com/containerd/containerd/vendor/github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/cache/manager.go:54 +0x56
created by github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/cache.NewManager
        /home/eryu.gey/workspace/src/go/src/github.com/containerd/containerd/vendor/github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/cache/manager.go:40 +0x171

Signed-off-by: Eryu Guan <eguan@linux.alibaba.com>