### PR TITLE
openapi: fix openapi yaml grammer mistake

### DIFF
--- a/api/openapi/nydus-rs.yaml
+++ b/api/openapi/nydus-rs.yaml
@@ -194,20 +194,19 @@ paths:
           schema:
             type: string
         - name: latest
-          desciption: "The returned list represents all files that are ever read ignoring the frequency. The metics of each file will be cleared after this request."
+          description: "The returned list represents all files that are ever read ignoring the frequency. The metics of each file will be cleared after this request."
           in: query
           required: false
           schema:
-            type: bool
+            type: boolean
       responses:
         "200":
           content:
             application/json:
               schema:
-                latest:
-                  $ref: "#/components/schemas/RafsLatestReadFiles"
-                other:
-                  $ref: "#/components/schemas/RafsFilesMetrics"
+                oneOf:
+                  - $ref: "#/components/schemas/RafsLatestReadFiles"
+                  - $ref: "#/components/schemas/RafsFilesMetrics"
           description: Rafs all opened files metrics export
         "500":
           content:


### PR DESCRIPTION
Openapi code generator throw errors out as below:

Exception in thread "main" org.openapitools.codegen.SpecValidationException: There were issues with the specification. The option can be disabled via validateSpec (Maven/Gradle) or --skip-validate-spec (CLI).
 | Error count: 3, Warning count: 2
Errors:
    -attribute paths.'/metrics/files'(get).responses.200.content.'application/json'.schema.other is unexpected
    -attribute paths.'/metrics/files'(get).parameters.[latest].desciption is unexpected
    -attribute paths.'/metrics/files'(get).responses.200.content.'application/json'.schema.latest is unexpected
Warnings:
    -attribute paths.'/metrics/files'(get).responses.200.content.'application/json'.schema.other is unexpected
    -attribute paths.'/metrics/files'(get).parameters.[latest].desciption is unexpected
    -attribute paths.'/metrics/files'(get).responses.200.content.'application/json'.schema.latest is unexpected

    at org.openapitools.codegen.config.CodegenConfigurator.toContext(CodegenConfigurator.java:546)
    at org.openapitools.codegen.config.CodegenConfigurator.toClientOptInput(CodegenConfigurator.java:573)
    at org.openapitools.codegen.cmd.Generate.execute(Generate.java:433)
    at org.openapitools.codegen.cmd.OpenApiGeneratorCommand.run(OpenApiGeneratorCommand.java:32)
    at org.openapitools.codegen.OpenAPIGenerator.main(OpenAPIGenerator.java:66)

Signed-off-by: Changwei Ge <chge@linux.alibaba.com>