### PR TITLE
Close a race happening when nydusify pushes blob to OSS.

### DIFF
--- a/contrib/nydusify/cmd/nydusify.go
+++ b/contrib/nydusify/cmd/nydusify.go
@@ -144,6 +144,7 @@ func main() {
 				&cli.StringFlag{Name: "backend-type", Value: "registry", Usage: "Specify Nydus blob storage backend type", EnvVars: []string{"BACKEND_TYPE"}},
 				&cli.StringFlag{Name: "backend-config", Value: "", Usage: "Specify Nydus blob storage backend in JSON config string", EnvVars: []string{"BACKEND_CONFIG"}},
 				&cli.StringFlag{Name: "backend-config-file", Value: "", TakesFile: true, Usage: "Specify Nydus blob storage backend config from path", EnvVars: []string{"BACKEND_CONFIG_FILE"}},
+				&cli.BoolFlag{Name: "backend-force-push", Value: false, Usage: "Force to push Nydus blob to storage backend, even if the blob already exists in storage backend", EnvVars: []string{"BACKEND_FORCE_PUSH"}},
 				&cli.StringFlag{Name: "build-cache", Value: "", Usage: "An remote image reference for accelerating nydus image build", EnvVars: []string{"BUILD_CACHE"}},
 				&cli.StringFlag{Name: "build-cache-tag", Value: "", Usage: "Use $target:$build-cache-tag as cache image reference, conflict with --build-cache", EnvVars: []string{"BUILD_CACHE_TAG"}},
 				&cli.StringFlag{Name: "build-cache-version", Value: "v1", Usage: "Specify the version of cache image, if the existed remote cache image does not match the version, cache records will be dropped", EnvVars: []string{"BUILD_CACHE_VERSION"}},
@@ -246,8 +247,9 @@ func main() {
 					MultiPlatform:  c.Bool("multi-platform"),
 					DockerV2Format: c.Bool("docker-v2-format"),
 
-					BackendType:   backendType,
-					BackendConfig: backendConfig,
+					BackendType:      backendType,
+					BackendConfig:    backendConfig,
+					BackendForcePush: c.Bool("backend-force-push"),
 				}
 
 				cvt, err := converter.New(opt)

--- a/contrib/nydusify/pkg/backend/backend.go
+++ b/contrib/nydusify/pkg/backend/backend.go
@@ -21,7 +21,7 @@ import (
 type Backend interface {
 	// TODO: Hopefully, we can pass `Layer` struct in, thus to be able to cook both
 	// file handle and file path.
-	Upload(ctx context.Context, blobID, blobPath string, blobSize int64) (*ocispec.Descriptor, error)
+	Upload(ctx context.Context, blobID, blobPath string, blobSize int64, forcePush bool) (*ocispec.Descriptor, error)
 	Check(blobID string) (bool, error)
 	Type() BackendType
 }

--- a/contrib/nydusify/pkg/backend/oss.go
+++ b/contrib/nydusify/pkg/backend/oss.go
@@ -123,6 +123,7 @@ func (b *OSSBackend) Upload(ctx context.Context, blobID, blobPath string, size i
 		}
 
 		if err := g.Wait(); err != nil {
+			b.bucket.AbortMultipartUpload(imur)
 			return nil, errors.Wrap(err, "Uploading parts failed")
 		}
 

--- a/contrib/nydusify/pkg/backend/registry.go
+++ b/contrib/nydusify/pkg/backend/registry.go
@@ -13,8 +13,11 @@ type Registry struct {
 	remote *remote.Remote
 }
 
-func (r *Registry) Upload(ctx context.Context, blobID, blobPath string,
-	size int64) (*ocispec.Descriptor, error) {
+func (r *Registry) Upload(
+	ctx context.Context, blobID, blobPath string, size int64, forcePush bool,
+) (*ocispec.Descriptor, error) {
+	// The `forcePush` option is useless for registry backend, because
+	// the blob existed in registry can't be pushed again.
 
 	desc := blobDesc(size, blobID)
 

--- a/contrib/nydusify/pkg/converter/converter.go
+++ b/contrib/nydusify/pkg/converter/converter.go
@@ -77,8 +77,9 @@ type Opt struct {
 	MultiPlatform  bool
 	DockerV2Format bool
 
-	BackendType   string
-	BackendConfig string
+	BackendType      string
+	BackendConfig    string
+	BackendForcePush bool
 }
 
 type Converter struct {
@@ -98,6 +99,8 @@ type Converter struct {
 	MultiPlatform  bool
 	DockerV2Format bool
 
+	BackendForcePush bool
+
 	storageBackend backend.Backend
 }
 
@@ -110,17 +113,18 @@ func New(opt Opt) (*Converter, error) {
 	}
 
 	return &Converter{
-		Logger:          opt.Logger,
-		SourceProviders: opt.SourceProviders,
-		TargetRemote:    opt.TargetRemote,
-		CacheRemote:     opt.CacheRemote,
-		CacheMaxRecords: opt.CacheMaxRecords,
-		CacheVersion:    opt.CacheVersion,
-		NydusImagePath:  opt.NydusImagePath,
-		WorkDir:         opt.WorkDir,
-		PrefetchDir:     opt.PrefetchDir,
-		MultiPlatform:   opt.MultiPlatform,
-		DockerV2Format:  opt.DockerV2Format,
+		Logger:           opt.Logger,
+		SourceProviders:  opt.SourceProviders,
+		TargetRemote:     opt.TargetRemote,
+		CacheRemote:      opt.CacheRemote,
+		CacheMaxRecords:  opt.CacheMaxRecords,
+		CacheVersion:     opt.CacheVersion,
+		NydusImagePath:   opt.NydusImagePath,
+		WorkDir:          opt.WorkDir,
+		PrefetchDir:      opt.PrefetchDir,
+		MultiPlatform:    opt.MultiPlatform,
+		DockerV2Format:   opt.DockerV2Format,
+		BackendForcePush: opt.BackendForcePush,
 
 		storageBackend: backend,
 	}, nil
@@ -187,6 +191,7 @@ func (cvt *Converter) convert(ctx context.Context) error {
 			parent:         parentBuildLayer,
 			dockerV2Format: cvt.DockerV2Format,
 			backend:        cvt.storageBackend,
+			forcePush:      cvt.BackendForcePush,
 		}
 		parentBuildLayer = buildLayer
 		buildLayers = append(buildLayers, buildLayer)

--- a/contrib/nydusify/pkg/converter/layer.go
+++ b/contrib/nydusify/pkg/converter/layer.go
@@ -53,6 +53,7 @@ type buildLayer struct {
 	blobPath        string
 	bootstrapPath   string
 	backend         backend.Backend
+	forcePush       bool
 }
 
 // parseSourceMount parses mounts object returned by the Mount method in
@@ -110,7 +111,7 @@ func (layer *buildLayer) pushBlob(ctx context.Context, blobSize int64) error {
 	blobID := filepath.Base(blobPath)
 
 	if err := utils.WithRetry(func() error {
-		desc, err := layer.backend.Upload(ctx, blobID, blobPath, blobSize)
+		desc, err := layer.backend.Upload(ctx, blobID, blobPath, blobSize, layer.forcePush)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
The race happens when a single blob has a large size, when nydusify tries to upload blob to OSS in a manner of `multiparts`.
As `append` is not atomic in golang, the regression is introduced.

To fix existed images, add an option to nydusify to push blob forcefully, no matter it exists of not.