### PR TITLE
improve blobcache and rafs prefetch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1103,6 +1103,7 @@ dependencies = [
  "nix",
  "nydus-api",
  "nydus-utils",
+ "openssl",
  "rafs",
  "rlimit",
  "rust-fsm",
@@ -1143,9 +1144,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.4.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b631f7e854af39a1739f401cf34a8a013dfe09eac4fa4dba91e9768bd28168d"
+checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
 
 [[package]]
 name = "opaque-debug"
@@ -1155,15 +1156,15 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.30"
+version = "0.10.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d575eff3665419f9b83678ff2815858ad9d11567e082f5ac1814baba4e2bcb4"
+checksum = "549430950c79ae24e6d02e0b7404534ecf311d94cc9f861e9e4020187d13d885"
 dependencies = [
  "bitflags",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "foreign-types",
- "lazy_static",
  "libc",
+ "once_cell",
  "openssl-sys",
 ]
 
@@ -1174,14 +1175,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
-name = "openssl-sys"
-version = "0.9.58"
+name = "openssl-src"
+version = "111.15.0+1.1.1k"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a842db4709b604f0fe5d1170ae3565899be2ad3d9cbc72dedc789ac0511f78de"
+checksum = "b1a5f6ae2ac04393b217ea9f700cd04fa9bf3d93fae2872069f3d15d908af70a"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a7907e3bfa08bb85105209cdfcb6c63d109f8f6c1ed6ca318fff5c1853fbc1d"
 dependencies = [
  "autocfg",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ nydus-api = { path = "api" }
 vm-memory = { version = ">=0.2.0", optional = true }
 chrono = "0.4.19"
 storage = { path = "storage" }
+openssl = { version = "0.10.35", features = ["vendored"] }
 
 event-manager = { git = "https://github.com/rust-vmm/event-manager.git", tag = "v0.2.0" }
 fuse-rs = { git = "https://github.com/cloud-hypervisor/fuse-backend-rs.git", optional = true, rev = "cfd2cca" }

--- a/rafs/src/fs.rs
+++ b/rafs/src/fs.rs
@@ -15,17 +15,19 @@ use std::os::unix::ffi::OsStrExt;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
-use std::time::Duration;
+use std::thread::sleep;
+use std::time::{Duration, SystemTime};
 
 use nix::unistd::{getegid, geteuid};
 use serde::Deserialize;
-use std::time::SystemTime;
 
 use fuse_rs::abi::linux_abi::Attr;
 use fuse_rs::api::filesystem::*;
 use fuse_rs::api::BackendFileSystem;
 
-use crate::metadata::{Inode, RafsInode, RafsSuper, RAFS_DEFAULT_BLOCK_SIZE};
+use crate::metadata::{
+    layout::RAFS_ROOT_INODE, Inode, RafsInode, RafsSuper, RAFS_DEFAULT_BLOCK_SIZE,
+};
 use crate::*;
 use nydus_utils::metrics::{self, FopRecorder, StatsFop::*};
 use storage::device::BlobPrefetchControl;
@@ -51,6 +53,10 @@ fn default_merging_size() -> usize {
     128 * 1024
 }
 
+fn default_prefetch_all() -> bool {
+    true
+}
+
 #[derive(Clone, Default, Deserialize)]
 pub struct FsPrefetchControl {
     #[serde(default)]
@@ -68,6 +74,8 @@ pub struct FsPrefetchControl {
     //                        Please note that if the value is less than Rafs chunk size,
     //                        it will be raised to the chunk size.
     bandwidth_rate: u32,
+    #[serde(default = "default_prefetch_all")]
+    prefetch_all: bool,
 }
 
 /// Not everything can be safely exported from configuration.
@@ -139,6 +147,7 @@ pub struct Rafs {
     pub sb: Arc<RafsSuper>,
     digest_validate: bool,
     fs_prefetch: bool,
+    prefetch_all: bool,
     initialized: bool,
     xattr_enabled: bool,
     ios: Arc<metrics::GlobalIOStats>,
@@ -190,6 +199,7 @@ impl Rafs {
             ios: metrics::new(id),
             digest_validate: conf.digest_validate,
             fs_prefetch: conf.fs_prefetch.enable,
+            prefetch_all: conf.fs_prefetch.prefetch_all,
             xattr_enabled: conf.enable_xattr,
             i_uid: geteuid().into(),
             i_gid: getegid().into(),
@@ -274,6 +284,8 @@ impl Rafs {
             let sb = self.sb.clone();
             let device = self.device.clone();
 
+            let prefetch_all = self.prefetch_all;
+
             let _ = std::thread::spawn(move || {
                 let mut reader = r;
                 let inodes = match prefetch_files {
@@ -301,6 +313,24 @@ impl Rafs {
                 .unwrap_or_else(|e| {
                     info!("No file to be prefetched {:?}", e);
                 });
+
+                if prefetch_all {
+                    let mut root = Vec::new();
+                    root.push(RAFS_ROOT_INODE);
+                    // Sleeping for 2 seconds is indeed a trick to prefetch the entire rootfs.
+                    // FIXME: As nydus can't give different policies different priorities, this is a
+                    // workaround. Remove the sleeping when IO priority mechanism is ready.
+                    sleep(Duration::from_secs(2));
+                    sb.prefetch_hint_files(&mut reader, Some(root), &|mut desc| {
+                        device.prefetch(&mut desc).unwrap_or_else(|e| {
+                            warn!("Prefetch error, {:?}", e);
+                            0
+                        });
+                    })
+                    .unwrap_or_else(|e| {
+                        info!("No file to be prefetched {:?}", e);
+                    })
+                }
 
                 // For now, we only have hinted prefetch. So stopping prefetch workers once
                 // it's done is Okay. But if we involve more policies someday, we have to be

--- a/rafs/src/metadata/cached.rs
+++ b/rafs/src/metadata/cached.rs
@@ -741,7 +741,7 @@ mod cached_tests {
         let mut blob_table = Arc::new(OndiskBlobTable::new());
         Arc::get_mut(&mut blob_table)
             .unwrap()
-            .add(String::from("123333"), 0, 0, 0, 0);
+            .add(String::from("123333"), 0, 0, 0, 0, 0);
         let mut cached_inode = CachedInode::new(blob_table, meta.clone());
         cached_inode.load(&meta, &mut reader).unwrap();
         let desc1 = cached_inode.alloc_bio_desc(0, 100).unwrap();

--- a/rafs/src/metadata/layout.rs
+++ b/rafs/src/metadata/layout.rs
@@ -575,6 +575,7 @@ impl OndiskBlobTable {
         readahead_size: u32,
         chunk_count: u32,
         blob_cache_size: u64,
+        compressed_blob_size: u64,
     ) -> u32 {
         let blob_index = self.entries.len() as u32;
         self.entries.push(Arc::new(RafsBlobEntry {
@@ -585,7 +586,8 @@ impl OndiskBlobTable {
             chunk_count,
             blob_cache_size,
         }));
-        self.extended.add(chunk_count, blob_cache_size);
+        self.extended
+            .add(chunk_count, blob_cache_size, compressed_blob_size);
         blob_index
     }
 

--- a/rafs/src/metadata/layout.rs
+++ b/rafs/src/metadata/layout.rs
@@ -634,7 +634,7 @@ impl OndiskBlobTable {
             let id_bytes = unsafe { std::slice::from_raw_parts(id_offset, bytes_len) };
 
             let blob_id = std::str::from_utf8(id_bytes).map_err(|e| einval!(e))?;
-            info!("blob {:?} lies on", blob_id);
+            debug!("blob {:?} lies on", blob_id);
             // Move to next entry frame, including splitter 0
             frame = unsafe { frame.add(size_of::<BlobEntryFrontPart>() + bytes_len + 1) };
 

--- a/src/bin/nydus-image/builder/directory.rs
+++ b/src/bin/nydus-image/builder/directory.rs
@@ -114,7 +114,7 @@ impl Builder for DirectoryBuilder {
         }
 
         // Dump blob file
-        let (blob_hash, blob_size, blob_readahead_size, blob_cache_size) =
+        let (blob_hash, blob_size, blob_readahead_size, blob_cache_size, compressed_blob_size) =
             timing_tracer!({ blob.dump(&mut ctx) }, "dump_blob")?;
 
         // Dump bootstrap file
@@ -124,6 +124,7 @@ impl Builder for DirectoryBuilder {
             blob_size,
             blob_readahead_size,
             blob_cache_size,
+            compressed_blob_size,
         )?;
         blob.flush(&ctx)?;
 

--- a/src/bin/nydus-image/core/blob.rs
+++ b/src/bin/nydus-image/core/blob.rs
@@ -124,7 +124,7 @@ impl Blob {
     }
 
     /// Dump blob file and generate chunks
-    pub fn dump(&mut self, ctx: &mut BuildContext) -> Result<(Sha256, usize, usize, u64)> {
+    pub fn dump(&mut self, ctx: &mut BuildContext) -> Result<(Sha256, usize, usize, u64, u64)> {
         // NOTE: Don't try to sort readahead files by their sizes,  thus to keep files
         // belonging to the same directory arranged in adjacent in blob file. Together with
         // BFS style collecting descendants inodes, it will have a higher merging possibility.
@@ -135,6 +135,7 @@ impl Blob {
         let mut blob_readahead_size = 0usize;
         let mut blob_size = 0usize;
         let mut blob_cache_size = 0u64;
+        let mut compressed_blob_size = 0u64;
         let mut compress_offset = 0u64;
         let mut decompress_offset = 0u64;
         let mut blob_hash = Sha256::new();
@@ -156,6 +157,7 @@ impl Blob {
                                 &mut compress_offset,
                                 &mut decompress_offset,
                                 &mut blob_cache_size,
+                                &mut compressed_blob_size,
                                 &mut ctx.chunk_cache,
                                 &mut ctx.chunk_count_map,
                                 ctx.compressor,
@@ -190,6 +192,7 @@ impl Blob {
                                 &mut compress_offset,
                                 &mut decompress_offset,
                                 &mut blob_cache_size,
+                                &mut compressed_blob_size,
                                 &mut ctx.chunk_cache,
                                 &mut ctx.chunk_count_map,
                                 ctx.compressor,
@@ -229,7 +232,13 @@ impl Blob {
 
         self.blob_size = blob_size;
 
-        Ok((blob_hash, blob_size, blob_readahead_size, blob_cache_size))
+        Ok((
+            blob_hash,
+            blob_size,
+            blob_readahead_size,
+            blob_cache_size,
+            compressed_blob_size,
+        ))
     }
 
     pub fn flush(self, ctx: &BuildContext) -> Result<()> {

--- a/src/bin/nydus-image/core/bootstrap.rs
+++ b/src/bin/nydus-image/core/bootstrap.rs
@@ -241,8 +241,9 @@ impl Bootstrap {
         blob_size: usize,
         mut blob_readahead_size: usize,
         blob_cache_size: u64,
+        compressed_blob_size: u64,
     ) -> Result<(Vec<String>, usize)> {
-        // Set blob hash as blob id if not specified.
+        // Name blob id by blob hash if not specified.
         if ctx.blob_id.is_empty() {
             ctx.blob_id = format!("{:x}", blob_hash.finalize());
         }
@@ -260,6 +261,7 @@ impl Bootstrap {
                 u32::try_from(blob_readahead_size)?,
                 *ctx.chunk_count_map.count(blob_index).unwrap_or(&0),
                 blob_cache_size,
+                compressed_blob_size,
             );
         }
 

--- a/src/bin/nydus-image/core/node.rs
+++ b/src/bin/nydus-image/core/node.rs
@@ -251,6 +251,7 @@ impl Node {
         compress_offset: &mut u64,
         decompress_offset: &mut u64,
         blob_cache_size: &mut u64,
+        compressed_blob_size: &mut u64,
         chunk_cache: &mut HashMap<RafsDigest, OndiskChunkInfo>,
         chunk_count_map: &mut ChunkCountMap,
         compressor: compress::Algorithm,
@@ -356,6 +357,7 @@ impl Node {
                 chunk_size
             };
             *blob_cache_size = *decompress_offset + chunk_size;
+            *compressed_blob_size += compressed_size as u64;
             *decompress_offset += aligned_chunk_size;
 
             // Calculate blob hash

--- a/src/bin/nydus-image/main.rs
+++ b/src/bin/nydus-image/main.rs
@@ -99,7 +99,7 @@ fn main() -> Result<()> {
     let (bti_string, _) = BuildTimeInfo::dump(crate_version!());
 
     // TODO: Try to use yaml to define below options
-    let cmd = App::new("nydus image builder")
+    let cmd = App::new("")
         .version(bti_string.as_str())
         .author(crate_authors!())
         .about("Build image using nydus format.")

--- a/src/bin/nydusd/api_server_glue.rs
+++ b/src/bin/nydusd/api_server_glue.rs
@@ -206,9 +206,9 @@ impl ApiServer {
     /// External supervisor wants this instance to fetch `/dev/fuse` fd. Before
     /// invoking this method, supervisor should already listens on a Unix socket and
     /// waits for connection from this instance. Then supervisor should send the *fd*
-    /// back. Note, the http response does not mean this process already finish Takeover
+    /// back. Note, the http response does not mean this process already finishes Takeover
     /// procedure. Supervisor has to continuously query the state of Nydusd until it gets
-    /// to *RUNNING*, which means new Nydusd has successfully serve as a fuse server.
+    /// to *RUNNING*, which means new Nydusd has successfully served as a fuse server.
     fn do_takeover(&self) -> ApiResponse {
         let d = self.daemon.as_ref();
         d.trigger_takeover()

--- a/storage/src/cache/blobcache.rs
+++ b/storage/src/cache/blobcache.rs
@@ -81,7 +81,7 @@ impl BlobCacheState {
         // The builder now records the number of chunks in the blob table, so we can
         // use IndexedChunkMap as a chunk map, but for the old Nydus bootstrap, we
         // need downgrade to use DigestedChunkMap as a compatible solution.
-        let chunk_map = if blob.chunk_count != 0 {
+        let chunk_map = if blob.with_extended_blob_table() {
             Arc::new(IndexedChunkMap::new(&blob_file_path, blob.chunk_count)?)
                 as Arc<dyn ChunkMap + Sync + Send>
         } else {

--- a/storage/src/cache/blobcache.rs
+++ b/storage/src/cache/blobcache.rs
@@ -498,7 +498,7 @@ fn kick_prefetch_workers(cache: Arc<BlobCache>) {
                         .set(&mr.blob_entry);
                     if let Ok((fd, _, chunk_map)) = entry {
                         for c in continuous_chunks {
-                            if chunk_map.has_ready(c.as_ref()).ok().unwrap_or_default() {
+                            if chunk_map.has_ready(c.as_ref()).unwrap_or_default() {
                                 continue;
                             }
                             // Always validate if chunk's hash is equal to `block_id` by which

--- a/storage/src/cache/blobcache.rs
+++ b/storage/src/cache/blobcache.rs
@@ -766,13 +766,6 @@ pub fn new(
         prefetch_threads: Mutex::new(Vec::<_>::new()),
     });
 
-    cache
-        .metrics
-        .prefetch_policy
-        .lock()
-        .unwrap()
-        .insert("hinted".to_string());
-
     if enabled {
         kick_prefetch_workers(cache.clone());
     }

--- a/storage/src/cache/blobcache.rs
+++ b/storage/src/cache/blobcache.rs
@@ -1024,7 +1024,7 @@ mod blob_cache_tests {
             Arc::new(MockBackend {
                 metrics: BackendMetrics::new("id", "mock"),
             }) as Arc<dyn BlobBackend + Send + Sync>,
-            compress::Algorithm::Lz4Block,
+            compress::Algorithm::LZ4Block,
             digest::Algorithm::Blake3,
             "id",
         )

--- a/storage/src/cache/chunkmap/digested.rs
+++ b/storage/src/cache/chunkmap/digested.rs
@@ -35,9 +35,6 @@ impl ChunkMap for DigestedChunkMap {
     }
 
     fn set_ready(&self, chunk: &dyn RafsChunkInfo) -> Result<()> {
-        if self.has_ready(chunk)? {
-            return Ok(());
-        }
         self.cache.write().unwrap().insert(*chunk.block_id(), true);
         Ok(())
     }

--- a/storage/src/cache/chunkmap/indexed.rs
+++ b/storage/src/cache/chunkmap/indexed.rs
@@ -89,8 +89,8 @@ impl IndexedChunkMap {
                 fd,
                 0,
             )
-        } as *const u8;
-        if base as *mut core::ffi::c_void == libc::MAP_FAILED {
+        };
+        if base == libc::MAP_FAILED {
             return Err(last_error!("failed to mmap blob chunk_map"));
         }
         if base.is_null() {
@@ -114,7 +114,7 @@ impl IndexedChunkMap {
         Ok(Self {
             chunk_count,
             size: expected_size as usize,
-            base,
+            base: base as *const u8,
         })
     }
 

--- a/storage/src/cache/chunkmap/indexed.rs
+++ b/storage/src/cache/chunkmap/indexed.rs
@@ -131,7 +131,7 @@ impl IndexedChunkMap {
     fn read_u8(&self, idx: u32) -> Result<(u8, u8)> {
         self.check_index(idx)?;
         let start = HEADER_SIZE + (idx as usize >> 3);
-        let current = unsafe { self.base.add(start) as *mut u8 as *const AtomicU8 };
+        let current = unsafe { self.base.add(start) as *const AtomicU8 };
         let pos = 8 - ((idx & 0b111) + 1);
         let mask = 1 << pos;
         Ok((unsafe { (*current).load(Ordering::Acquire) }, mask))
@@ -140,7 +140,7 @@ impl IndexedChunkMap {
     fn write_u8(&self, idx: u32, current: u8, expected: u8) -> Result<bool> {
         self.check_index(idx)?;
         let start = HEADER_SIZE + (idx as usize >> 3);
-        let atomic_value = unsafe { &*{ self.base.add(start) as *mut u8 as *const AtomicU8 } };
+        let atomic_value = unsafe { &*{ self.base.add(start) as *const AtomicU8 } };
         Ok(atomic_value
             .compare_exchange(current, expected, Ordering::Acquire, Ordering::Relaxed)
             .is_ok())
@@ -150,7 +150,7 @@ impl IndexedChunkMap {
 impl Drop for IndexedChunkMap {
     fn drop(&mut self) {
         if !self.base.is_null() {
-            unsafe { libc::munmap(self.base as *mut u8 as *mut libc::c_void, self.size) };
+            unsafe { libc::munmap(self.base as *mut libc::c_void, self.size) };
             self.base = std::ptr::null();
         }
     }

--- a/storage/src/cache/dummycache.rs
+++ b/storage/src/cache/dummycache.rs
@@ -12,7 +12,7 @@ use crate::cache::*;
 use crate::device::{BlobPrefetchControl, RafsBio, RafsChunkInfo};
 use crate::factory::CacheConfig;
 use crate::utils::{alloc_buf, copyv};
-use crate::{compress, StorageError, StorageResult};
+use crate::{compress, StorageResult};
 
 use nydus_utils::{digest, eother};
 
@@ -80,11 +80,11 @@ impl RafsCache for DummyCache {
 
     /// Prefetch works when blobcache is enabled
     fn prefetch(&self, _bios: &mut [RafsBio]) -> StorageResult<usize> {
-        Err(StorageError::Unsupported)
+        Ok(0)
     }
 
     fn stop_prefetch(&self) -> StorageResult<()> {
-        Err(StorageError::Unsupported)
+        Ok(())
     }
 
     fn write(&self, blob_id: &str, blk: &dyn RafsChunkInfo, buf: &[u8]) -> Result<usize> {

--- a/storage/src/cache/mod.rs
+++ b/storage/src/cache/mod.rs
@@ -32,24 +32,19 @@ struct MergedBackendRequest {
 }
 
 impl MergedBackendRequest {
-    fn new(seq: u64) -> Self {
+    fn new(seq: u64, first_cki: Arc<dyn RafsChunkInfo>, blob: Arc<RafsBlobEntry>) -> Self {
+        let mut chunks = Vec::<Arc<dyn RafsChunkInfo>>::new();
+        let blob_size = first_cki.compress_size();
+        let blob_offset = first_cki.compress_offset();
+        chunks.push(first_cki);
+
         MergedBackendRequest {
             seq,
-            ..Default::default()
+            blob_offset,
+            blob_size,
+            chunks,
+            blob_entry: blob,
         }
-    }
-
-    fn reset(&mut self) {
-        self.blob_offset = 0;
-        self.blob_size = 0;
-        self.chunks.clear();
-    }
-
-    fn merge_begin(&mut self, first_cki: Arc<dyn RafsChunkInfo>, blob: Arc<RafsBlobEntry>) {
-        self.blob_offset = first_cki.compress_offset();
-        self.blob_size = first_cki.compress_size();
-        self.chunks.push(first_cki);
-        self.blob_entry = blob;
     }
 
     fn merge_one_chunk(&mut self, cki: Arc<dyn RafsChunkInfo>) {

--- a/storage/src/device.rs
+++ b/storage/src/device.rs
@@ -219,6 +219,8 @@ impl RafsBioDevice<'_> {
 #[derive(Clone, Debug, Default)]
 pub struct RafsBlobEntry {
     /// Number of chunks in blob file.
+    /// A helper to distinguish bootstrap with extended blob table or not:
+    ///     Bootstrap with extended blob table always has non-zero `chunk_count`
     pub chunk_count: u32,
     /// The data range to be prefetched in blob file.
     pub readahead_offset: u32,
@@ -229,6 +231,12 @@ pub struct RafsBlobEntry {
     pub blob_index: u32,
     /// The expected decompress size of blob cache file.
     pub blob_cache_size: u64,
+}
+
+impl RafsBlobEntry {
+    pub fn with_extended_blob_table(&self) -> bool {
+        self.chunk_count != 0
+    }
 }
 
 // Rafs device blob IO descriptor

--- a/utils/src/digest.rs
+++ b/utils/src/digest.rs
@@ -66,7 +66,7 @@ impl DigestHasher for Sha256 {
     }
 }
 
-#[derive(Clone, Copy, Hash, PartialEq, Eq, Debug)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, Debug, Default)]
 pub struct RafsDigest {
     pub data: DigestData,
 }
@@ -88,14 +88,6 @@ impl RafsDigest {
         match algorithm {
             Algorithm::Blake3 => Box::new(blake3::Hasher::new()) as Box<dyn DigestHasher>,
             Algorithm::Sha256 => Box::new(Sha256::new()) as Box<dyn DigestHasher>,
-        }
-    }
-}
-
-impl Default for RafsDigest {
-    fn default() -> Self {
-        Self {
-            data: [0u8; RAFS_DIGEST_LENGTH],
         }
     }
 }


### PR DESCRIPTION
As shared chunk bitmap file is already introduced, in which 1 bit of value 1 indicates that a chunk is successfully downloaded.
Rafs/prefetch no longer has to validate the whole chunk by calculating its sha256, but just to probe if the corresponding it is ever set. This will save unnecessary read from disk.

More over try to deduce locking contention to improve performance.