### PR TITLE
Verify blob's crc64 after it is uploaded

### DIFF
--- a/contrib/nydusify/cmd/nydusify.go
+++ b/contrib/nydusify/cmd/nydusify.go
@@ -250,6 +250,9 @@ func main() {
 					BackendType:      backendType,
 					BackendConfig:    backendConfig,
 					BackendForcePush: c.Bool("backend-force-push"),
+
+					NydusifyVersion: version,
+					Source:          c.String("source"),
 				}
 
 				cvt, err := converter.New(opt)

--- a/contrib/nydusify/go.mod
+++ b/contrib/nydusify/go.mod
@@ -39,6 +39,7 @@ require (
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
 	golang.org/x/text v0.3.3 // indirect
 	golang.org/x/time v0.0.0-20200416051211-89c76fbcd5d1 // indirect
+	golang.org/x/tools v0.0.0-20190624222133-a101b041ded4
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	google.golang.org/genproto v0.0.0-20200527145253-8367513e4ece // indirect
 	google.golang.org/grpc v1.29.1 // indirect

--- a/contrib/nydusify/go.sum
+++ b/contrib/nydusify/go.sum
@@ -218,6 +218,7 @@ golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGm
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=
 golang.org/x/tools v0.0.0-20190311212946-11955173bddd/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 golang.org/x/tools v0.0.0-20190524140312-2c0ae7006135/go.mod h1:RgjU9mgBXZiqYHBnxXauZ1Gv1EHHAz9KjViQ78xBX0Q=
+golang.org/x/tools v0.0.0-20190624222133-a101b041ded4 h1:1mMox4TgefDwqluYCv677yNXwlfTkija4owZve/jr78=
 golang.org/x/tools v0.0.0-20190624222133-a101b041ded4/go.mod h1:/rFqwRUd4F7ZHNgwSSTFct+R/Kf4OFW1sUzUTQQTgfc=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=

--- a/contrib/nydusify/go.sum
+++ b/contrib/nydusify/go.sum
@@ -57,6 +57,7 @@ github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c h1:+pKlWGMw7gf6bQ
 github.com/docker/go-events v0.0.0-20190806004212-e31b211e4f1c/go.mod h1:Uw6UezgYA44ePAFQYUehOuCzmy5zmg/+nl2ZfMWGkpA=
 github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
+github.com/dragonflyoss/image-service v1.0.0 h1:Yb5+EcQ4ZXetpSlnw9wCkCiuJMCR5stO3z6sRxN8ljI=
 github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=

--- a/contrib/nydusify/pkg/build/workflow.go
+++ b/contrib/nydusify/pkg/build/workflow.go
@@ -24,6 +24,7 @@ type WorkflowOption struct {
 
 type Workflow struct {
 	WorkflowOption
+	BuilderVersion      string
 	bootstrapPath       string
 	blobsDir            string
 	backendConfig       string
@@ -33,7 +34,8 @@ type Workflow struct {
 }
 
 type debugJSON struct {
-	Blobs []string
+	Version string
+	Blobs   []string
 }
 
 // Dump output json file of every layer to $workdir/bootstraps directory
@@ -53,6 +55,10 @@ func (workflow *Workflow) getLatestBlobPath() (string, error) {
 		return "", err
 	}
 	blobIDs := data.Blobs
+
+	// Record builder version of current build environment for easy
+	// debugging and troubleshooting afterwards.
+	workflow.BuilderVersion = data.Version
 
 	if len(blobIDs) == 0 {
 		return "", nil

--- a/contrib/nydusify/pkg/converter/build_info.go
+++ b/contrib/nydusify/pkg/converter/build_info.go
@@ -1,0 +1,53 @@
+// Copyright 2021 Ant Group. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package converter
+
+type SourceReference struct {
+	Reference string
+	Digest    string
+}
+
+// BuildInfo provides trace information of current build environment,
+// it should be recorded to target image manifest for easy image
+// debugging and troubleshooting afterwards.
+type BuildInfo struct {
+	builderVersion  string
+	nydusifyVersion string
+	sourceReference SourceReference
+}
+
+func NewBuildInfo() *BuildInfo {
+	return &BuildInfo{}
+}
+
+func (info *BuildInfo) SetBuilderVersion(val string) {
+	info.builderVersion = val
+}
+
+func (info *BuildInfo) SetNydusifyVersion(val string) {
+	info.nydusifyVersion = val
+}
+
+func (info *BuildInfo) SetSourceReference(val SourceReference) {
+	info.sourceReference = val
+}
+
+func (info *BuildInfo) Dump() map[string]string {
+	data := map[string]string{
+		"nydus.trace.nydusify-version": info.nydusifyVersion,
+		"nydus.trace.source-reference": info.sourceReference.Reference,
+		"nydus.trace.source-digest":    info.sourceReference.Digest,
+	}
+
+	// In the case where all layers are hit by the build cache,
+	// we may not get the builder version because the builder has never
+	// been called. This version information is not really that important,
+	// as a fallback, we can use Nydusify version to troubleshoot.
+	if info.builderVersion != "" {
+		data["nydus.trace.builder-version"] = info.builderVersion
+	}
+
+	return data
+}

--- a/contrib/nydusify/pkg/converter/manifest.go
+++ b/contrib/nydusify/pkg/converter/manifest.go
@@ -32,6 +32,7 @@ type manifestManager struct {
 	remote         *remote.Remote
 	multiPlatform  bool
 	dockerV2Format bool
+	buildInfo      *BuildInfo
 }
 
 // Try to get manifests from exists target image
@@ -247,8 +248,9 @@ func (mm *manifestManager) Push(ctx context.Context, buildLayers []*buildLayer) 
 			Versioned: specs.Versioned{
 				SchemaVersion: 2,
 			},
-			Config: *configDesc,
-			Layers: layers,
+			Config:      *configDesc,
+			Layers:      layers,
+			Annotations: mm.buildInfo.Dump(),
 		},
 	}
 

--- a/src/bin/nydus-image/main.rs
+++ b/src/bin/nydus-image/main.rs
@@ -30,7 +30,7 @@ use clap::{App, Arg, SubCommand};
 use std::collections::HashMap;
 use std::fs::metadata;
 use std::fs::OpenOptions;
-use std::io::{self, BufWriter};
+use std::io::BufWriter;
 use std::path::{Path, PathBuf};
 
 use nix::unistd::{getegid, geteuid};
@@ -57,46 +57,46 @@ use validator::Validator;
 
 #[derive(Serialize, Default)]
 pub struct ResultOutput {
+    version: String,
     blobs: Vec<String>,
     trace: serde_json::Map<String, serde_json::Value>,
 }
 
 impl ResultOutput {
-    fn dump<W>(&self, writer: W) -> Result<()>
-    where
-        W: io::Write,
-    {
-        serde_json::to_writer(writer, &self).context("Write output file failed")
-    }
-}
+    fn dump(
+        matches: &clap::ArgMatches,
+        build_info: &BuildTimeInfo,
+        blob_ids: Vec<String>,
+    ) -> Result<()> {
+        let output_json: Option<PathBuf> = matches
+            .value_of("output-json")
+            .map(|o| o.to_string().into());
 
-fn dump_result_output(matches: &clap::ArgMatches, blob_ids: Vec<String>) -> Result<()> {
-    let output_json: Option<PathBuf> = matches
-        .value_of("output-json")
-        .map(|o| o.to_string().into());
+        if let Some(ref f) = output_json {
+            let w = OpenOptions::new()
+                .truncate(true)
+                .create(true)
+                .write(true)
+                .open(f)
+                .with_context(|| format!("Output file {:?} can't be opened", f))?;
 
-    if let Some(ref f) = output_json {
-        let w = OpenOptions::new()
-            .truncate(true)
-            .create(true)
-            .write(true)
-            .open(f)
-            .with_context(|| format!("{:?} can't be opened", f))?;
+            let trace = root_tracer!().dump_summary_map().unwrap_or_default();
+            let version = format!("{}-{}", build_info.package_ver, build_info.git_commit);
+            let output = Self {
+                version,
+                trace,
+                blobs: blob_ids,
+            };
 
-        let trace = root_tracer!().dump_summary_map().unwrap_or_default();
-
-        ResultOutput {
-            trace,
-            blobs: blob_ids,
+            serde_json::to_writer(w, &output).context("Write output file failed")?;
         }
-        .dump(w)?;
-    }
 
-    Ok(())
+        Ok(())
+    }
 }
 
 fn main() -> Result<()> {
-    let (bti_string, _) = BuildTimeInfo::dump(crate_version!());
+    let (bti_string, build_info) = BuildTimeInfo::dump(crate_version!());
 
     // TODO: Try to use yaml to define below options
     let cmd = App::new("nydus image builder")
@@ -444,7 +444,7 @@ fn main() -> Result<()> {
             )?;
         }
 
-        dump_result_output(matches, blob_ids.clone())?;
+        ResultOutput::dump(matches, &build_info, blob_ids.clone())?;
 
         info!(
             "Image build(size={}Bytes) successfully. Blobs table: {:?}",
@@ -461,7 +461,7 @@ fn main() -> Result<()> {
 
         info!("bootstrap is valid, blobs: {:?}", blob_ids);
 
-        dump_result_output(matches, blob_ids)?;
+        ResultOutput::dump(matches, &build_info, blob_ids)?;
     }
 
     Ok(())

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -101,8 +101,8 @@ pub fn dump_program_info(prog_version: &str) {
 
 #[derive(Serialize, Clone)]
 pub struct BuildTimeInfo {
-    package_ver: String,
-    git_commit: String,
+    pub package_ver: String,
+    pub git_commit: String,
     build_time: String,
     profile: String,
     rustc: String,


### PR DESCRIPTION
It will be safer if we can verify the blob's crc64 returned from OSS after it is uploaded.