### PR TITLE
Snapshotter: remove chunkmap file in blob GC

### DIFF
--- a/contrib/nydus-snapshotter/config/daemonconfig.go
+++ b/contrib/nydus-snapshotter/config/daemonconfig.go
@@ -32,6 +32,7 @@ type DaemonConfig struct {
 	EnableXattr    bool         `json:"enable_xattr,omitempty"`
 	FSPrefetch     struct {
 		Enable       bool `json:"enable"`
+		PrefetchAll  bool `json:"prefetch_all"`
 		ThreadsCount int  `json:"threads_count"`
 		MergingSize  int  `json:"merging_size"`
 	} `json:"fs_prefetch,omitempty"`

--- a/contrib/nydus-snapshotter/pkg/cache/store.go
+++ b/contrib/nydus-snapshotter/pkg/cache/store.go
@@ -7,6 +7,10 @@ import (
 	"github.com/pkg/errors"
 )
 
+const (
+	chunkMapFileSuffix = ".chunk_map"
+)
+
 type Store interface {
 	DelBlob(blob string) error
 }
@@ -21,9 +25,22 @@ func NewStore(cacheDir string) *CacheStore {
 
 func (cs *CacheStore) DelBlob(blob string) error {
 	blobPath := cs.blobPath(blob)
+
+	// Remove the blob chunkmap file named $blob_id.chunk_map first.
+	chunkMapPath := blobPath + chunkMapFileSuffix
+	if err := os.Remove(chunkMapPath); err != nil {
+		// Older versions of nydusd do not support chunkmap, and there
+		// is no chunkmap file generation, so just ignore the error.
+		if !os.IsNotExist(err) {
+			return errors.Wrapf(err, "remove blob chunkmap %v err", chunkMapPath)
+		}
+	}
+
+	// Then remove the blob file named $blob_id.
 	if err := os.Remove(blobPath); err != nil {
 		return errors.Wrapf(err, "remove blob %v err", blobPath)
 	}
+
 	return nil
 }
 


### PR DESCRIPTION
Two commits, actually:

**Snapshotter: remove chunkmap file in blob GC**

Nydusd now supports a bitmap-based chunk ready state sharing
capability called chunkmap, which should be deleted before
the blob file is deleted during the GC process.

**Snapshotter: add PrefetchAll config in DaemonConfig**

We introduced 'prefetch_all' option to control if nydus should prefetch
all blobs in background. So add this option to snapshotter, that we
could enable/disable it.