### PR TITLE
Prefetch: fix overlapped prefetch merge requests

### DIFF
--- a/rafs/src/fs.rs
+++ b/rafs/src/fs.rs
@@ -453,9 +453,13 @@ impl Rafs {
             attr.gid = self.i_gid;
         }
 
-        attr.atime = self.i_time;
-        attr.ctime = self.i_time;
-        attr.mtime = self.i_time;
+        // Older rafs image doesn't include ctime, in such case we use
+        // runtime timestamp.
+        if attr.ctime == 0 {
+            attr.atime = self.i_time;
+            attr.ctime = self.i_time;
+            attr.mtime = self.i_time;
+        }
 
         Ok(attr)
     }
@@ -468,9 +472,13 @@ impl Rafs {
             entry.attr.st_gid = self.i_gid;
         }
 
-        entry.attr.st_atime = self.i_time as i64;
-        entry.attr.st_ctime = self.i_time as i64;
-        entry.attr.st_mtime = self.i_time as i64;
+        // Older rafs image doesn't include ctime, in such case we use
+        // runtime timestamp.
+        if entry.attr.st_ctime == 0 {
+            entry.attr.st_atime = self.i_time as i64;
+            entry.attr.st_ctime = self.i_time as i64;
+            entry.attr.st_mtime = self.i_time as i64;
+        }
 
         entry
     }

--- a/rafs/src/metadata/cached.rs
+++ b/rafs/src/metadata/cached.rs
@@ -208,6 +208,8 @@ pub struct CachedInode {
     // extra info need cache
     i_blksize: u32,
     i_rdev: u32,
+    i_ctime_nsec: u32,
+    i_ctime: u64,
     i_target: OsString, // for symbol link
     i_xattr: HashMap<OsString, Vec<u8>>,
     i_data: Vec<Arc<CachedChunkInfo>>,
@@ -303,6 +305,8 @@ impl CachedInode {
         self.i_child_idx = inode.i_child_index;
         self.i_child_cnt = inode.i_child_count;
         self.i_rdev = inode.i_rdev;
+        self.i_ctime = inode.i_ctime;
+        self.i_ctime_nsec = inode.i_ctime_nsec;
     }
 
     fn add_child(&mut self, child: Arc<CachedInode>) {
@@ -491,7 +495,9 @@ impl RafsInode for CachedInode {
             i_name_size: self.i_name.len() as u16,
             i_symlink_size,
             i_rdev: self.i_rdev,
-            i_reserved: [0; 20],
+            i_ctime: self.i_ctime,
+            i_ctime_nsec: self.i_ctime_nsec,
+            i_reserved: [0; 8],
         })
     }
 

--- a/rafs/src/metadata/direct.rs
+++ b/rafs/src/metadata/direct.rs
@@ -640,6 +640,8 @@ impl RafsInode for OndiskInodeWrapper {
             nlink: inode.i_nlink as u32,
             uid: inode.i_uid,
             gid: inode.i_gid,
+            ctime: inode.i_ctime,
+            ctimensec: inode.i_ctime_nsec,
             blksize: RAFS_INODE_BLOCKSIZE,
             rdev: inode.i_rdev,
             ..Default::default()

--- a/rafs/src/metadata/layout.rs
+++ b/rafs/src/metadata/layout.rs
@@ -752,9 +752,12 @@ pub struct OndiskInode {
     pub i_name_size: u16,
     /// symlink path size, [char; i_symlink_size]
     pub i_symlink_size: u16, // 104
-    //// inode device block number, ignored for non-special files
-    pub i_rdev: u32,          // 108
-    pub i_reserved: [u8; 20], // 128
+    // inode device block number, ignored for non-special files
+    pub i_rdev: u32,
+    // for alignment reason, we put nsec first
+    pub i_ctime_nsec: u32,
+    pub i_ctime: u64,        // 120
+    pub i_reserved: [u8; 8], // 128
 }
 
 bitflags! {

--- a/rafs/src/metadata/mod.rs
+++ b/rafs/src/metadata/mod.rs
@@ -370,8 +370,6 @@ impl RafsSuper {
             }
         }
 
-        fetcher(head_desc);
-
         Ok(())
     }
 
@@ -487,6 +485,8 @@ impl RafsSuper {
                 self.build_prefetch_desc(f_ino, &mut head_desc, &mut hardlinks, fetcher)
                     .map_err(|e| RafsError::Prefetch(e.to_string()))?;
             }
+            // The left chunks whose size is smaller than 4MB will be fetched here.
+            fetcher(&mut head_desc);
         } else if hint_entries != 0 {
             // Try to prefetch according to the list of files specified by the
             // builder's `--prefetch-policy fs` option.
@@ -509,6 +509,8 @@ impl RafsSuper {
                 self.build_prefetch_desc(ino as u64, &mut head_desc, &mut hardlinks, fetcher)
                     .map_err(|e| RafsError::Prefetch(e.to_string()))?;
             }
+            // The left chunks whose size is smaller than 4MB will be fetched here.
+            fetcher(&mut head_desc);
         }
 
         Ok(())

--- a/src/bin/nydus-image/builder/stargz.rs
+++ b/src/bin/nydus-image/builder/stargz.rs
@@ -495,7 +495,10 @@ impl StargzIndexTreeBuilder {
             i_name_size: name_size,
             i_symlink_size: symlink_size,
             i_rdev: entry.rdev(),
-            i_reserved: [0; 20],
+            // TODO: add ctime from entry.ModTime()
+            i_ctime: 0,
+            i_ctime_nsec: 0,
+            i_reserved: [0; 8],
         };
 
         Ok(Node {

--- a/src/bin/nydus-image/core/node.rs
+++ b/src/bin/nydus-image/core/node.rs
@@ -430,6 +430,8 @@ impl Node {
             self.inode.i_uid = meta.st_uid();
             self.inode.i_gid = meta.st_gid();
         }
+        self.inode.i_ctime = meta.st_ctime() as u64;
+        self.inode.i_ctime_nsec = meta.st_ctime_nsec() as u32;
         self.inode.i_projid = 0;
         self.inode.i_size = meta.st_size();
         // Ignore actual nlink value and calculate from rootfs directory instead

--- a/src/bin/nydus-image/inspect.rs
+++ b/src/bin/nydus-image/inspect.rs
@@ -330,6 +330,8 @@ impl RafsInspector {
     Nlink:              {nlink}
     UID:                {uid}
     GID:                {gid}
+    Ctime:              {ctime}
+    CtimeNsec:          {ctime_nsec}
     Blocks:             {blocks}"#,
                     inode_number = inode.i_ino,
                     name = f,
@@ -339,6 +341,8 @@ impl RafsInspector {
                     nlink = inode.i_nlink,
                     uid = inode.i_uid,
                     gid = inode.i_gid,
+                    ctime = inode.i_ctime,
+                    ctime_nsec = inode.i_ctime_nsec,
                     blocks = inode.i_blocks,
                 );
 


### PR DESCRIPTION
Two commits, actually:

**Prefetch: fix overlapped prefetch merge requests**

The left chunks whose size is smaller than 4MB will be fetched
after 4MB merge requests.

**Rafs: add ctime support**

Save ctime in inode and use it for ctime/mtime/atime.
There are applications that might check ctime/mtime so
we cannot just drop it and use runtime system time as ctime.