### PR TITLE
contrib: enhance Makefile to support GOPROXY

### DIFF
--- a/contrib/nydus-snapshotter/Makefile
+++ b/contrib/nydus-snapshotter/Makefile
@@ -3,13 +3,18 @@ all:clear build
 VERSION=$(shell git rev-parse --verify HEAD --short=7)
 BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
 PACKAGES ?= $(shell go list ./... | grep -v /vendor/)
+#GOPROXY ?= https://goproxy.io
+
+ifdef GOPROXY
+PROXY := GOPROXY=${GOPROXY}
+endif
 
 .PHONY: build
 build:
-	GOOS=linux go build -ldflags="-s -w -X 'main.Version=${VERSION}'" -v -o bin/containerd-nydus-grpc ./cmd/containerd-nydus-grpc
+	GOOS=linux ${PROXY} build -ldflags="-s -w -X 'main.Version=${VERSION}'" -v -o bin/containerd-nydus-grpc ./cmd/containerd-nydus-grpc
 
 static-release:
-	CGO_ENABLED=0 GOOS=linux go build -ldflags '-s -w -X "main.Version=${VERSION}" -extldflags "-static"' -v -o bin/containerd-nydus-grpc ./cmd/containerd-nydus-grpc
+	CGO_ENABLED=0 ${PROXY} GOOS=linux go build -ldflags '-s -w -X "main.Version=${VERSION}" -extldflags "-static"' -v -o bin/containerd-nydus-grpc ./cmd/containerd-nydus-grpc
 
 .PHONY: clear
 clear:

--- a/contrib/nydusify/Makefile
+++ b/contrib/nydusify/Makefile
@@ -1,12 +1,17 @@
 GIT_COMMIT := $(shell git rev-list -1 HEAD)
 BUILD_TIME := $(shell date -u +%Y%m%d.%H%M)
 CURRENT_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+#GOPROXY ?= https://goproxy.io
+
+ifdef GOPROXY
+PROXY := GOPROXY=${GOPROXY}
+endif
 
 build:
-	@CGO_ENABLED=0 GOOS=linux go build -ldflags '-X main.versionGitCommit=${GIT_COMMIT} -X main.versionBuildTime=${BUILD_TIME}' -gcflags=all="-N -l" -o ./cmd ./cmd/nydusify.go
+	@CGO_ENABLED=0 ${PROXY} GOOS=linux go build -ldflags '-X main.versionGitCommit=${GIT_COMMIT} -X main.versionBuildTime=${BUILD_TIME}' -gcflags=all="-N -l" -o ./cmd ./cmd/nydusify.go
 
 static-release:
-	@CGO_ENABLED=0 GOOS=linux go build -ldflags '-X main.versionGitCommit=${GIT_COMMIT} -X main.versionBuildTime=${BUILD_TIME}' -o ./cmd ./cmd/nydusify.go
+	@CGO_ENABLED=0 ${PROXY} GOOS=linux go build -ldflags '-X main.versionGitCommit=${GIT_COMMIT} -X main.versionBuildTime=${BUILD_TIME}' -o ./cmd ./cmd/nydusify.go
 
 build-smoke:
-	@CGO_ENABLED=0 GOOS=linux go test -v -c -o ./nydusify-smoke ./tests
+	@CGO_ENABLED=0 ${PROXY} GOOS=linux go test -v -c -o ./nydusify-smoke ./tests


### PR DESCRIPTION
Enhance Makefiles to support GOPROXY, so we could use
make GOPROXY=xxxx

Signed-off-by: Liu Jiang <gerry@linux.alibaba.com>