### PR TITLE
rafs: use mtime instead of ctime

### DIFF
--- a/rafs/src/fs.rs
+++ b/rafs/src/fs.rs
@@ -452,9 +452,9 @@ impl Rafs {
             attr.gid = self.i_gid;
         }
 
-        // Older rafs image doesn't include ctime, in such case we use
+        // Older rafs image doesn't include mtime, in such case we use
         // runtime timestamp.
-        if attr.ctime == 0 {
+        if attr.mtime == 0 {
             attr.atime = self.i_time;
             attr.ctime = self.i_time;
             attr.mtime = self.i_time;
@@ -471,9 +471,9 @@ impl Rafs {
             entry.attr.st_gid = self.i_gid;
         }
 
-        // Older rafs image doesn't include ctime, in such case we use
+        // Older rafs image doesn't include mtime, in such case we use
         // runtime timestamp.
-        if entry.attr.st_ctime == 0 {
+        if entry.attr.st_mtime == 0 {
             entry.attr.st_atime = self.i_time as i64;
             entry.attr.st_ctime = self.i_time as i64;
             entry.attr.st_mtime = self.i_time as i64;

--- a/rafs/src/metadata/cached.rs
+++ b/rafs/src/metadata/cached.rs
@@ -208,8 +208,8 @@ pub struct CachedInode {
     // extra info need cache
     i_blksize: u32,
     i_rdev: u32,
-    i_ctime_nsec: u32,
-    i_ctime: u64,
+    i_mtime_nsec: u32,
+    i_mtime: u64,
     i_target: OsString, // for symbol link
     i_xattr: HashMap<OsString, Vec<u8>>,
     i_data: Vec<Arc<CachedChunkInfo>>,
@@ -305,8 +305,8 @@ impl CachedInode {
         self.i_child_idx = inode.i_child_index;
         self.i_child_cnt = inode.i_child_count;
         self.i_rdev = inode.i_rdev;
-        self.i_ctime = inode.i_ctime;
-        self.i_ctime_nsec = inode.i_ctime_nsec;
+        self.i_mtime = inode.i_mtime;
+        self.i_mtime_nsec = inode.i_mtime_nsec;
     }
 
     fn add_child(&mut self, child: Arc<CachedInode>) {
@@ -495,8 +495,8 @@ impl RafsInode for CachedInode {
             i_name_size: self.i_name.len() as u16,
             i_symlink_size,
             i_rdev: self.i_rdev,
-            i_ctime: self.i_ctime,
-            i_ctime_nsec: self.i_ctime_nsec,
+            i_mtime: self.i_mtime,
+            i_mtime_nsec: self.i_mtime_nsec,
             i_reserved: [0; 8],
         })
     }

--- a/rafs/src/metadata/direct.rs
+++ b/rafs/src/metadata/direct.rs
@@ -640,8 +640,8 @@ impl RafsInode for OndiskInodeWrapper {
             nlink: inode.i_nlink as u32,
             uid: inode.i_uid,
             gid: inode.i_gid,
-            ctime: inode.i_ctime,
-            ctimensec: inode.i_ctime_nsec,
+            mtime: inode.i_mtime,
+            mtimensec: inode.i_mtime_nsec,
             blksize: RAFS_INODE_BLOCKSIZE,
             rdev: inode.i_rdev,
             ..Default::default()

--- a/rafs/src/metadata/layout.rs
+++ b/rafs/src/metadata/layout.rs
@@ -755,8 +755,8 @@ pub struct OndiskInode {
     // inode device block number, ignored for non-special files
     pub i_rdev: u32,
     // for alignment reason, we put nsec first
-    pub i_ctime_nsec: u32,
-    pub i_ctime: u64,        // 120
+    pub i_mtime_nsec: u32,
+    pub i_mtime: u64,        // 120
     pub i_reserved: [u8; 8], // 128
 }
 

--- a/src/bin/nydus-image/builder/stargz.rs
+++ b/src/bin/nydus-image/builder/stargz.rs
@@ -494,9 +494,9 @@ impl StargzIndexTreeBuilder {
             i_name_size: name_size,
             i_symlink_size: symlink_size,
             i_rdev: entry.rdev(),
-            // TODO: add ctime from entry.ModTime()
-            i_ctime: 0,
-            i_ctime_nsec: 0,
+            // TODO: add mtime from entry.ModTime()
+            i_mtime: 0,
+            i_mtime_nsec: 0,
             i_reserved: [0; 8],
         };
 

--- a/src/bin/nydus-image/core/node.rs
+++ b/src/bin/nydus-image/core/node.rs
@@ -430,8 +430,8 @@ impl Node {
             self.inode.i_uid = meta.st_uid();
             self.inode.i_gid = meta.st_gid();
         }
-        self.inode.i_ctime = meta.st_ctime() as u64;
-        self.inode.i_ctime_nsec = meta.st_ctime_nsec() as u32;
+        self.inode.i_mtime = meta.st_mtime() as u64;
+        self.inode.i_mtime_nsec = meta.st_mtime_nsec() as u32;
         self.inode.i_projid = 0;
         self.inode.i_size = meta.st_size();
         // Ignore actual nlink value and calculate from rootfs directory instead

--- a/src/bin/nydus-image/inspect.rs
+++ b/src/bin/nydus-image/inspect.rs
@@ -330,8 +330,8 @@ impl RafsInspector {
     Nlink:              {nlink}
     UID:                {uid}
     GID:                {gid}
-    Ctime:              {ctime}
-    CtimeNsec:          {ctime_nsec}
+    Mtime:              {mtime}
+    MtimeNsec:          {mtime_nsec}
     Blocks:             {blocks}"#,
                     inode_number = inode.i_ino,
                     name = f,
@@ -341,8 +341,8 @@ impl RafsInspector {
                     nlink = inode.i_nlink,
                     uid = inode.i_uid,
                     gid = inode.i_gid,
-                    ctime = inode.i_ctime,
-                    ctime_nsec = inode.i_ctime_nsec,
+                    mtime = inode.i_mtime,
+                    mtime_nsec = inode.i_mtime_nsec,
                     blocks = inode.i_blocks,
                 );
 


### PR DESCRIPTION
The modified timestamp (mtime) signifies the last time the contents
of a file were modified. A program or process either edited or
manipulated the file. “Modified” means something inside the file was
amended or deleted, or new data was added.

The changed timestamps aren’t referring to changes made to the contents
of a file. Rather, it’s the time at which the metadata related to the
file was changed. File permission changes, for example, will update the
changed timestamp.

So the rafs metadata should record `mtime` instead of `ctime` because
`mtime` is often used to detect content change.

Signed-off-by: Liu Jiang <gerry@linux.alibaba.com>