### PR TITLE
snapshotter: introduce "prefetch" daemon mode to do prefetch for none daemon mode

### DIFF
--- a/contrib/nydus-snapshotter/config/config.go
+++ b/contrib/nydus-snapshotter/config/config.go
@@ -17,7 +17,6 @@ const (
 	DefaultDaemonMode  string = "multiple"
 	DaemonModeMultiple string = "multiple"
 	DaemonModeShared   string = "shared"
-	DaemonModeSingle   string = "single"
 	DaemonModeNone     string = "none"
 	DaemonModePrefetch string = "prefetch"
 	defaultGCPeriod           = 24 * time.Hour

--- a/contrib/nydus-snapshotter/config/config.go
+++ b/contrib/nydus-snapshotter/config/config.go
@@ -19,6 +19,7 @@ const (
 	DaemonModeShared   string = "shared"
 	DaemonModeSingle   string = "single"
 	DaemonModeNone     string = "none"
+	DaemonModePrefetch string = "prefetch"
 	defaultGCPeriod           = 24 * time.Hour
 
 	defaultNydusDaemonConfigPath string = "/etc/nydus/config.json"

--- a/contrib/nydus-snapshotter/pkg/daemon/config.go
+++ b/contrib/nydus-snapshotter/pkg/daemon/config.go
@@ -102,6 +102,13 @@ func WithSharedDaemon() NewDaemonOpt {
 	}
 }
 
+func WithPrefetchDaemon() NewDaemonOpt {
+	return func(d *Daemon) error {
+		d.DaemonMode = config.DaemonModePrefetch
+		return nil
+	}
+}
+
 func WithAPISock(apiSock string) NewDaemonOpt {
 	return func(d *Daemon) error {
 		d.ApiSock = &apiSock

--- a/contrib/nydus-snapshotter/pkg/daemon/daemon.go
+++ b/contrib/nydus-snapshotter/pkg/daemon/daemon.go
@@ -103,7 +103,7 @@ func (d *Daemon) IsMultipleDaemon() bool {
 }
 
 func (d *Daemon) IsSharedDaemon() bool {
-	return d.DaemonMode == config.DaemonModeShared || d.DaemonMode == config.DaemonModeSingle
+	return d.DaemonMode == config.DaemonModeShared
 }
 
 func (d *Daemon) IsPrefetchDaemon() bool {

--- a/contrib/nydus-snapshotter/pkg/daemon/daemon.go
+++ b/contrib/nydus-snapshotter/pkg/daemon/daemon.go
@@ -106,6 +106,10 @@ func (d *Daemon) IsSharedDaemon() bool {
 	return d.DaemonMode == config.DaemonModeShared || d.DaemonMode == config.DaemonModeSingle
 }
 
+func (d *Daemon) IsPrefetchDaemon() bool {
+	return d.DaemonMode == config.DaemonModePrefetch
+}
+
 func NewDaemon(opt ...NewDaemonOpt) (*Daemon, error) {
 	d := &Daemon{Pid: 0}
 	d.ID = newID()

--- a/contrib/nydus-snapshotter/pkg/filesystem/fs/fs.go
+++ b/contrib/nydus-snapshotter/pkg/filesystem/fs/fs.go
@@ -18,6 +18,7 @@ const (
 	SingleInstance FSMode = iota
 	MultiInstance
 	NoneInstance
+	PrefetchInstance
 )
 
 type FileSystem interface {

--- a/contrib/nydus-snapshotter/pkg/filesystem/fs/fs.go
+++ b/contrib/nydus-snapshotter/pkg/filesystem/fs/fs.go
@@ -15,7 +15,7 @@ import (
 type FSMode int
 
 const (
-	SingleInstance FSMode = iota
+	SharedInstance FSMode = iota
 	MultiInstance
 	NoneInstance
 	PrefetchInstance

--- a/contrib/nydus-snapshotter/pkg/filesystem/nydus/config.go
+++ b/contrib/nydus-snapshotter/pkg/filesystem/nydus/config.go
@@ -94,8 +94,8 @@ func WithDaemonMode(daemonMode string) NewFSOpt {
 		switch mode {
 		case config.DaemonModeNone:
 			d.mode = fs.NoneInstance
-		case config.DaemonModeShared, config.DaemonModeSingle:
-			d.mode = fs.SingleInstance
+		case config.DaemonModeShared:
+			d.mode = fs.SharedInstance
 		case config.DaemonModePrefetch:
 			d.mode = fs.PrefetchInstance
 		case config.DaemonModeMultiple:

--- a/contrib/nydus-snapshotter/pkg/filesystem/nydus/config.go
+++ b/contrib/nydus-snapshotter/pkg/filesystem/nydus/config.go
@@ -96,6 +96,8 @@ func WithDaemonMode(daemonMode string) NewFSOpt {
 			d.mode = fs.NoneInstance
 		case config.DaemonModeShared, config.DaemonModeSingle:
 			d.mode = fs.SingleInstance
+		case config.DaemonModePrefetch:
+			d.mode = fs.PrefetchInstance
 		case config.DaemonModeMultiple:
 			fallthrough
 		default:

--- a/contrib/nydus-snapshotter/pkg/filesystem/nydus/fs.go
+++ b/contrib/nydus-snapshotter/pkg/filesystem/nydus/fs.go
@@ -56,8 +56,8 @@ func NewFileSystem(ctx context.Context, opt ...NewFSOpt) (_ fspkg.FileSystem, re
 		return nil, errors.Wrap(err, "failed to reconnect daemons")
 	}
 
-	// Both SingleInstance and PrefetchInstance use shared daemon
-	if fs.mode == fspkg.SingleInstance || fs.mode == fspkg.PrefetchInstance {
+	// Both SharedInstance and PrefetchInstance use shared daemon
+	if fs.mode == fspkg.SharedInstance || fs.mode == fspkg.PrefetchInstance {
 		isPrefetch := fs.mode == fspkg.PrefetchInstance
 
 		// Check if daemon is already running
@@ -241,7 +241,7 @@ func (fs *filesystem) MountPoint(snapshotID string) (string, error) {
 		return "", fmt.Errorf("don't need nydus daemon of snapshot %s", snapshotID)
 	} else {
 		if d, err := fs.manager.GetBySnapshotID(snapshotID); err == nil {
-			if fs.mode == fspkg.SingleInstance {
+			if fs.mode == fspkg.SharedInstance {
 				return d.SharedMountPoint(), nil
 			}
 			return d.MountPoint(), nil
@@ -275,7 +275,7 @@ func (fs *filesystem) mount(d *daemon.Daemon, labels map[string]string) error {
 	if err != nil {
 		return err
 	}
-	if fs.mode == fspkg.SingleInstance || fs.mode == fspkg.PrefetchInstance {
+	if fs.mode == fspkg.SharedInstance || fs.mode == fspkg.PrefetchInstance {
 		err = d.SharedMount()
 		if err != nil {
 			return errors.Wrapf(err, "failed to shared mount")
@@ -298,7 +298,7 @@ func (fs *filesystem) addSnapshot(imageID string, labels map[string]string) erro
 }
 
 func (fs *filesystem) newDaemon(snapshotID string, imageID string) (*daemon.Daemon, error) {
-	if fs.mode == fspkg.SingleInstance || fs.mode == fspkg.PrefetchInstance {
+	if fs.mode == fspkg.SharedInstance || fs.mode == fspkg.PrefetchInstance {
 		return fs.createSharedDaemon(snapshotID, imageID)
 	}
 	return fs.createNewDaemon(snapshotID, imageID)

--- a/contrib/nydus-snapshotter/pkg/process/manager.go
+++ b/contrib/nydus-snapshotter/pkg/process/manager.go
@@ -201,7 +201,6 @@ func (m *Manager) DestroyDaemon(d *daemon.Daemon) error {
 
 func (m *Manager) isOneDaemon() bool {
 	return m.DaemonMode == config.DaemonModeShared ||
-		m.DaemonMode == config.DaemonModeSingle  ||
 		m.DaemonMode == config.DaemonModePrefetch
 }
 
@@ -210,7 +209,7 @@ func (m *Manager) isNoneDaemon() bool {
 }
 
 func (m *Manager) IsSharedDaemon() bool {
-	return m.DaemonMode == config.DaemonModeShared || m.DaemonMode == config.DaemonModeSingle
+	return m.DaemonMode == config.DaemonModeShared
 }
 
 func (m *Manager) IsPrefetchDaemon() bool {

--- a/contrib/nydus-snapshotter/pkg/process/manager.go
+++ b/contrib/nydus-snapshotter/pkg/process/manager.go
@@ -205,6 +205,10 @@ func (m *Manager) isOneDaemon() bool {
 		m.DaemonMode == config.DaemonModePrefetch
 }
 
+func (m *Manager) isNoneDaemon() bool {
+	return m.DaemonMode == config.DaemonModeNone
+}
+
 func (m *Manager) IsSharedDaemon() bool {
 	return m.DaemonMode == config.DaemonModeShared || m.DaemonMode == config.DaemonModeSingle
 }
@@ -219,6 +223,10 @@ func (m *Manager) Reconnect(ctx context.Context) error {
 		daemons      []*daemon.Daemon
 		sharedDaemon *daemon.Daemon = nil
 	)
+
+	if m.isNoneDaemon() {
+		return nil
+	}
 
 	if err := m.store.WalkDaemons(ctx, func(d *daemon.Daemon) error {
 		log.L.WithField("daemon", d.ID).


### PR DESCRIPTION
    When using snapshotter "none" daemon mode, rafs will be mounted at
    container start time, as there's no nydusd daemon and rafs couldn't be
    mounted at snapshot creation time, so prefetch won't be started until
    rafs is mounted. This slows down the prefetch performance.

    So introduce a new "prefetch" daemon mode, which is almost the same as
    "none" daemon mode, the only difference is "prefetch" mode will start a
    nydusd in shared mode and mounts the rafs at snapshot creation time, so
    that starts prefetch earlier.

  Signed-off-by: Eryu Guan <eguan@linux.alibaba.com>