### PR TITLE
storage: add ability to use user-defined blob redirected host

### DIFF
--- a/contrib/nydus-snapshotter/config/daemonconfig.go
+++ b/contrib/nydus-snapshotter/config/daemonconfig.go
@@ -49,11 +49,12 @@ type DeviceConfig struct {
 			ReadAheadSec  int    `json:"readahead_sec,omitempty"`
 
 			// Registry backend configs
-			Host          string `json:"host,omitempty"`
-			Repo          string `json:"repo,omitempty"`
-			Auth          string `json:"auth,omitempty"`
-			RegistryToken string `json:"registry_token,omitempty"`
-			BlobUrlScheme string `json:"blob_url_scheme,omitempty"`
+			Host               string `json:"host,omitempty"`
+			Repo               string `json:"repo,omitempty"`
+			Auth               string `json:"auth,omitempty"`
+			RegistryToken      string `json:"registry_token,omitempty"`
+			BlobUrlScheme      string `json:"blob_url_scheme,omitempty"`
+			BlobRedirectedHost string `json:"blob_redirected_host,omitempty"`
 
 			// OSS backend configs
 			EndPoint        string `json:"endpoint,omitempty"`

--- a/docs/nydusd.md
+++ b/docs/nydusd.md
@@ -196,6 +196,8 @@ We are working on enabling cloud-hypervisor support for nydus.
         "auth": "<base64_encoded_auth>",
         // Bearer token for auth, optional
         "registry_token": "<bearer_token>"
+        // Redirected blob download host, optional
+        "blob_redirected_host": "<blob_redirected_host>"
       }
     },
     ...


### PR DESCRIPTION
    When using registry backend, blob data may be stored on other storages,
    such as OSS, and registry will redirect download request to URL pointing
    to such storage, so backend downloads blob file from there.

    But this redirected link might not be optimal, e.g. we may want to use
    OSS cache endpoint. So introduce a new 'blob_redirected_host' config
    option in Registry backend config, and replace the redirected blob url
    from registry with this user-defined host to have better performance.

    Signed-off-by: Eryu Guan <eguan@linux.alibaba.com>