### PR TITLE
contrib: pass log level from snapshotter to nydusd

### DIFF
--- a/contrib/nydus-snapshotter/Makefile
+++ b/contrib/nydus-snapshotter/Makefile
@@ -11,7 +11,7 @@ endif
 
 .PHONY: build
 build:
-	GOOS=linux ${PROXY} build -ldflags="-s -w -X 'main.Version=${VERSION}'" -v -o bin/containerd-nydus-grpc ./cmd/containerd-nydus-grpc
+	GOOS=linux ${PROXY} go build -ldflags="-s -w -X 'main.Version=${VERSION}'" -v -o bin/containerd-nydus-grpc ./cmd/containerd-nydus-grpc
 
 static-release:
 	CGO_ENABLED=0 ${PROXY} GOOS=linux go build -ldflags '-s -w -X "main.Version=${VERSION}" -extldflags "-static"' -v -o bin/containerd-nydus-grpc ./cmd/containerd-nydus-grpc

--- a/contrib/nydus-snapshotter/Makefile
+++ b/contrib/nydus-snapshotter/Makefile
@@ -6,7 +6,7 @@ PACKAGES ?= $(shell go list ./... | grep -v /vendor/)
 #GOPROXY ?= https://goproxy.io
 
 ifdef GOPROXY
-PROXY := GOPROXY=${GOPROXY}
+PROXY := GOPROXY="${GOPROXY}"
 endif
 
 .PHONY: build

--- a/contrib/nydus-snapshotter/cmd/containerd-nydus-grpc/pkg/command/flags.go
+++ b/contrib/nydus-snapshotter/cmd/containerd-nydus-grpc/pkg/command/flags.go
@@ -176,6 +176,7 @@ func Validate(args *Args, cfg *config.Config) error {
 			return errors.Wrapf(err, "failed to find publicKey file %q", args.PublicKeyFile)
 		}
 	}
+	cfg.LogLevel = args.LogLevel
 	cfg.DaemonCfg = daemonCfg
 	cfg.RootDir = args.RootDir
 

--- a/contrib/nydus-snapshotter/config/config.go
+++ b/contrib/nydus-snapshotter/config/config.go
@@ -19,6 +19,7 @@ const (
 	DaemonModeShared   string = "shared"
 	DaemonModeNone     string = "none"
 	DaemonModePrefetch string = "prefetch"
+	DefaultLogLevel    string = "info"
 	defaultGCPeriod           = 24 * time.Hour
 
 	defaultNydusDaemonConfigPath string = "/etc/nydus/config.json"
@@ -43,9 +44,13 @@ type Config struct {
 	EnableMetrics        bool          `toml:"enable_metrics"`
 	MetricsFile          string        `toml:"metrics_file"`
 	EnableStargz         bool          `toml:"enable_stargz"`
+	LogLevel             string        `toml:"-"`
 }
 
 func (c *Config) FillupWithDefaults() error {
+	if c.LogLevel == "" {
+		c.LogLevel = DefaultLogLevel
+	}
 	if c.DaemonCfgPath == "" {
 		c.DaemonCfgPath = defaultNydusDaemonConfigPath
 	}

--- a/contrib/nydus-snapshotter/pkg/daemon/config.go
+++ b/contrib/nydus-snapshotter/pkg/daemon/config.go
@@ -59,6 +59,17 @@ func WithLogDir(dir string) NewDaemonOpt {
 	}
 }
 
+func WithLogLevel(logLevel string) NewDaemonOpt {
+	return func(d *Daemon) error {
+		if logLevel == "" {
+			d.LogLevel = config.DefaultLogLevel
+		} else {
+			d.LogLevel = logLevel
+		}
+		return nil
+	}
+}
+
 func WithCacheDir(dir string) NewDaemonOpt {
 	return func(d *Daemon) error {
 		// this may be failed, should handle that
@@ -79,7 +90,6 @@ func WithRootMountPoint(rootMountPoint string) NewDaemonOpt {
 		return nil
 	}
 }
-
 
 func WithSnapshotDir(dir string) NewDaemonOpt {
 	return func(d *Daemon) error {

--- a/contrib/nydus-snapshotter/pkg/daemon/daemon.go
+++ b/contrib/nydus-snapshotter/pkg/daemon/daemon.go
@@ -31,6 +31,7 @@ type Daemon struct {
 	ConfigDir      string
 	SocketDir      string
 	LogDir         string
+	LogLevel       string
 	CacheDir       string
 	SnapshotDir    string
 	Pid            int

--- a/contrib/nydus-snapshotter/pkg/filesystem/nydus/config.go
+++ b/contrib/nydus-snapshotter/pkg/filesystem/nydus/config.go
@@ -106,3 +106,14 @@ func WithDaemonMode(daemonMode string) NewFSOpt {
 		return nil
 	}
 }
+
+func WithLogLevel(logLevel string) NewFSOpt {
+	return func(d *filesystem) error {
+		if logLevel == "" {
+			d.logLevel = config.DefaultLogLevel
+		} else {
+			d.logLevel = logLevel
+		}
+		return nil
+	}
+}

--- a/contrib/nydus-snapshotter/pkg/filesystem/nydus/fs.go
+++ b/contrib/nydus-snapshotter/pkg/filesystem/nydus/fs.go
@@ -39,6 +39,7 @@ type filesystem struct {
 	vpcRegistry      bool
 	nydusdBinaryPath string
 	mode             fspkg.FSMode
+	logLevel         string
 }
 
 // NewFileSystem initialize Filesystem instance
@@ -108,6 +109,7 @@ func (fs *filesystem) newSharedDaemon() (*daemon.Daemon, error) {
 		daemon.WithSnapshotDir(fs.SnapshotRoot()),
 		daemon.WithLogDir(fs.LogRoot()),
 		daemon.WithRootMountPoint(filepath.Join(fs.RootDir, "mnt")),
+		daemon.WithLogLevel(fs.logLevel),
 		modeOpt,
 	)
 	if err != nil {
@@ -318,6 +320,7 @@ func (fs *filesystem) createNewDaemon(snapshotID string, imageID string) (*daemo
 		daemon.WithLogDir(fs.LogRoot()),
 		daemon.WithCacheDir(fs.cacheMgr.CacheDir()),
 		daemon.WithImageID(imageID),
+		daemon.WithLogLevel(fs.logLevel),
 	); err != nil {
 		return nil, err
 	}
@@ -348,6 +351,7 @@ func (fs *filesystem) createSharedDaemon(snapshotID string, imageID string) (*da
 		daemon.WithLogDir(fs.LogRoot()),
 		daemon.WithCacheDir(fs.cacheMgr.CacheDir()),
 		daemon.WithImageID(imageID),
+		daemon.WithLogLevel(fs.logLevel),
 	); err != nil {
 		return nil, err
 	}

--- a/contrib/nydus-snapshotter/pkg/filesystem/stargz/config.go
+++ b/contrib/nydus-snapshotter/pkg/filesystem/stargz/config.go
@@ -67,4 +67,15 @@ func WithDaemonConfig(cfg config.DaemonConfig) NewFSOpt {
 	}
 }
 
+func WithLogLevel(logLevel string) NewFSOpt {
+	return func(d *filesystem) error {
+		if logLevel == "" {
+			d.logLevel = config.DefaultLogLevel
+		} else {
+			d.logLevel = logLevel
+		}
+		return nil
+	}
+}
+
 type NewFSOpt func(d *filesystem) error

--- a/contrib/nydus-snapshotter/pkg/filesystem/stargz/fs.go
+++ b/contrib/nydus-snapshotter/pkg/filesystem/stargz/fs.go
@@ -38,6 +38,7 @@ type filesystem struct {
 	vpcRegistry           bool
 	nydusdBinaryPath      string
 	nydusdImageBinaryPath string
+	logLevel              string
 }
 
 func NewFileSystem(ctx context.Context, opt ...NewFSOpt) (fs.FileSystem, error) {
@@ -145,6 +146,7 @@ func (f *filesystem) createNewDaemon(snapshotID string, imageID string) (*daemon
 		daemon.WithLogDir(f.LogRoot()),
 		daemon.WithCacheDir(f.CacheRoot()),
 		daemon.WithImageID(imageID),
+		daemon.WithLogLevel(f.logLevel),
 	)
 	if err != nil {
 		return nil, err

--- a/contrib/nydus-snapshotter/pkg/process/manager.go
+++ b/contrib/nydus-snapshotter/pkg/process/manager.go
@@ -129,7 +129,7 @@ func (m *Manager) StartDaemon(d *daemon.Daemon) error {
 func (m *Manager) buildStartCommand(d *daemon.Daemon) (*exec.Cmd, error) {
 	args := []string{
 		"--apisock", d.APISock(),
-		"--log-level", "info",
+		"--log-level", d.LogLevel,
 		"--log-file", d.LogFile(),
 		"--thread-num", "10",
 	}

--- a/contrib/nydus-snapshotter/snapshot/snapshot.go
+++ b/contrib/nydus-snapshotter/snapshot/snapshot.go
@@ -114,6 +114,7 @@ func NewSnapshotter(ctx context.Context, cfg *config.Config) (snapshots.Snapshot
 		nydus.WithVPCRegistry(cfg.ConvertVpcRegistry),
 		nydus.WithVerifier(verifier),
 		nydus.WithDaemonMode(cfg.DaemonMode),
+		nydus.WithLogLevel(cfg.LogLevel),
 	)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to initialize nydus filesystem")
@@ -129,6 +130,7 @@ func NewSnapshotter(ctx context.Context, cfg *config.Config) (snapshots.Snapshot
 				stargz.WithNydusdBinaryPath(cfg.NydusdBinaryPath),
 				stargz.WithNydusImageBinaryPath(cfg.NydusImageBinaryPath),
 				stargz.WithDaemonConfig(cfg.DaemonCfg),
+				stargz.WithLogLevel(cfg.LogLevel),
 			)
 			if err != nil {
 				return nil, errors.Wrap(err, "failed to initialize stargz filesystem")


### PR DESCRIPTION
pass corresponding log level to nydusd, so it will not always be info.

related issue https://github.com/dragonflyoss/image-service/issues/145

Signed-off-by: yuhongqi <yuhongqi@bytedance.com>