### PR TITLE
Contrib: fix update daemon

### DIFF
--- a/contrib/nydus-snapshotter/pkg/store/database.go
+++ b/contrib/nydus-snapshotter/pkg/store/database.go
@@ -113,7 +113,7 @@ func (d *Database) UpdateDaemon(ctx context.Context, dmn *daemon.Daemon) error {
 			return err
 		}
 
-		return putObject(bucket, dmn.ID, dmn)
+		return updateObject(bucket, dmn.ID, dmn)
 	})
 }
 


### PR DESCRIPTION
using updateObject not putObject which will cause error due to duplicate key.

related pr https://github.com/dragonflyoss/image-service/pull/154

Signed-off-by: yuhongqi <yuhongqi@bytedance.com>