### PR TITLE
daemon: Turn on the xattr feature of passthrough_fs

### DIFF
--- a/src/bin/nydusd/daemon.rs
+++ b/src/bin/nydusd/daemon.rs
@@ -421,6 +421,7 @@ fn fs_backend_factory(cmd: &FsBackendMountCmd) -> DaemonResult<BackFileSystem> {
                 do_import: false,
                 writeback: true,
                 no_open: true,
+                xattr: true,
                 ..Default::default()
             };
             // TODO: Passthrough Fs needs to enlarge rlimit against host. We can exploit `MountCmd`


### PR DESCRIPTION
The filesystem of overlayfs upperdir needs to support xattr.
Passthrough_fs supports xattr but not enabled by nydusd daemon. This
commit enables it.

Signed-off-by: Jiachen Zhang <zhangjiachen.jaycee@bytedance.com>