### PR TITLE
Blobcache handles single inflight backend IO

### DIFF
--- a/storage/src/cache/blobcache.rs
+++ b/storage/src/cache/blobcache.rs
@@ -202,7 +202,10 @@ impl BlobCache {
         // Try to recover cache from blobcache first
         // For gzip, we can only trust ready blobcache because we cannot validate chunks due to
         // stargz format limitations (missing chunk level digest)
-        if (self.compressor() != compress::Algorithm::GZip || has_ready)
+        // With shared chunk bitmap applied, we don't have try to recover blobcache
+        // as principle is that chunk bitmap is trusted. The chunk must not be downloaded before.
+        if (self.compressor() != compress::Algorithm::GZip && !blob.with_extended_blob_table()
+            || has_ready)
             && self
                 .read_blobcache_chunk(fd, chunk, one_chunk_buf, !has_ready || self.need_validate())
                 .is_ok()

--- a/storage/src/cache/chunkmap/digested.rs
+++ b/storage/src/cache/chunkmap/digested.rs
@@ -9,6 +9,7 @@ use std::sync::RwLock;
 use nydus_utils::digest::RafsDigest;
 
 use super::ChunkMap;
+use crate::cache::chunkmap::{ChunkIndexGetter, NoWaitSupport};
 use crate::device::RafsChunkInfo;
 
 /// The DigestedChunkMap is an implementation that uses a hash map
@@ -20,6 +21,8 @@ pub struct DigestedChunkMap {
     /// HashMap<chunk_digest, has_ready>
     cache: RwLock<HashMap<RafsDigest, bool>>,
 }
+
+impl NoWaitSupport for DigestedChunkMap {}
 
 impl DigestedChunkMap {
     pub fn new() -> Self {
@@ -37,5 +40,13 @@ impl ChunkMap for DigestedChunkMap {
     fn set_ready(&self, chunk: &dyn RafsChunkInfo) -> Result<()> {
         self.cache.write().unwrap().insert(*chunk.block_id(), true);
         Ok(())
+    }
+}
+
+impl ChunkIndexGetter for DigestedChunkMap {
+    type Index = RafsDigest;
+
+    fn get_index(chunk: &dyn RafsChunkInfo) -> Self::Index {
+        *chunk.block_id()
     }
 }

--- a/storage/src/cache/chunkmap/digested.rs
+++ b/storage/src/cache/chunkmap/digested.rs
@@ -30,7 +30,7 @@ impl DigestedChunkMap {
 }
 
 impl ChunkMap for DigestedChunkMap {
-    fn has_ready(&self, chunk: &dyn RafsChunkInfo) -> Result<bool> {
+    fn has_ready(&self, chunk: &dyn RafsChunkInfo, _wait: bool) -> Result<bool> {
         Ok(self.cache.read().unwrap().get(chunk.block_id()).is_some())
     }
 

--- a/storage/src/cache/chunkmap/indexed.rs
+++ b/storage/src/cache/chunkmap/indexed.rs
@@ -2,16 +2,24 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::HashMap;
 use std::fs::OpenOptions;
 use std::io::Result;
 use std::os::unix::io::AsRawFd;
-use std::sync::atomic::{AtomicU8, Ordering};
+use std::sync::{
+    atomic::{AtomicU8, Ordering},
+    Arc, Condvar, Mutex, WaitTimeoutResult,
+};
+use std::time::Duration;
 
 use nydus_utils::div_round_up;
 
 use super::ChunkMap;
 use crate::device::RafsChunkInfo;
 use crate::utils::readahead;
+use crate::{StorageError, StorageResult};
+
+use crate::cache::blobcache::SINGLE_INFLIGHT_WAIT_TIMEOUT;
 
 /// The magic number of blob chunk_map file, it's ASCII hex of string "BMAP".
 const MAGIC: u32 = 0x424D_4150;
@@ -43,6 +51,53 @@ pub struct IndexedChunkMap {
     chunk_count: u32,
     size: usize,
     base: *const u8,
+    inflight_tracer: Arc<Mutex<HashMap<u32, Arc<ChunkSlot>>>>,
+}
+
+#[derive(PartialEq)]
+enum Status {
+    Inflight,
+    Complete,
+}
+
+struct ChunkSlot {
+    on_trip: Mutex<Status>,
+    condvar: Condvar,
+}
+
+impl ChunkSlot {
+    fn new() -> Self {
+        ChunkSlot {
+            on_trip: Mutex::new(Status::Inflight),
+            condvar: Condvar::new(),
+        }
+    }
+
+    fn notify(&self) {
+        self.condvar.notify_all();
+    }
+
+    fn done(&self) {
+        // Not expect poisoned lock here
+        *self.on_trip.lock().unwrap() = Status::Complete;
+        self.notify();
+    }
+
+    fn wait_for_inflight(&self, timeout: Duration) -> StorageResult<()> {
+        let mut inflight = self.on_trip.lock().unwrap();
+        let mut tor: WaitTimeoutResult;
+        while *inflight == Status::Inflight {
+            // Do not expect poisoned lock, so unwrap here.
+            let r = self.condvar.wait_timeout(inflight, timeout).unwrap();
+            inflight = r.0;
+            tor = r.1;
+            if tor.timed_out() {
+                return Err(StorageError::Timeout);
+            }
+        }
+
+        Ok(())
+    }
 }
 
 unsafe impl Send for IndexedChunkMap {}
@@ -115,10 +170,11 @@ impl IndexedChunkMap {
             chunk_count,
             size: expected_size as usize,
             base: base as *const u8,
+            inflight_tracer: Arc::new(Mutex::new(HashMap::new())),
         })
     }
 
-    fn check_index(&self, idx: u32) -> Result<()> {
+    fn validate_index(&self, idx: u32) -> Result<()> {
         if idx > self.chunk_count - 1 {
             return Err(einval!(format!(
                 "chunk index {} exceeds chunk count {}",
@@ -128,22 +184,33 @@ impl IndexedChunkMap {
         Ok(())
     }
 
-    fn read_u8(&self, idx: u32) -> Result<(u8, u8)> {
-        self.check_index(idx)?;
+    fn read_u8(&self, idx: u32) -> u8 {
         let start = HEADER_SIZE + (idx as usize >> 3);
         let current = unsafe { self.base.add(start) as *const AtomicU8 };
-        let pos = 8 - ((idx & 0b111) + 1);
-        let mask = 1 << pos;
-        Ok((unsafe { (*current).load(Ordering::Acquire) }, mask))
+        unsafe { (*current).load(Ordering::Acquire) }
     }
 
-    fn write_u8(&self, idx: u32, current: u8, expected: u8) -> Result<bool> {
-        self.check_index(idx)?;
+    fn write_u8(&self, idx: u32, current: u8) -> bool {
+        let mask = Self::index_to_mask(idx);
+        let expected = current | mask;
         let start = HEADER_SIZE + (idx as usize >> 3);
         let atomic_value = unsafe { &*{ self.base.add(start) as *const AtomicU8 } };
-        Ok(atomic_value
+        atomic_value
             .compare_exchange(current, expected, Ordering::Acquire, Ordering::Relaxed)
-            .is_ok())
+            .is_ok()
+    }
+
+    #[inline]
+    fn index_to_mask(index: u32) -> u8 {
+        let pos = 8 - ((index & 0b111) + 1);
+        1 << pos
+    }
+
+    fn is_chunk_ready(&self, index: u32) -> (bool, u8) {
+        let mask = Self::index_to_mask(index);
+        let current = self.read_u8(index);
+        let ready = current & mask == mask;
+        (ready, current)
     }
 }
 
@@ -157,26 +224,182 @@ impl Drop for IndexedChunkMap {
 }
 
 impl ChunkMap for IndexedChunkMap {
-    fn has_ready(&self, chunk: &dyn RafsChunkInfo) -> Result<bool> {
-        let (current, mask) = self.read_u8(chunk.index())?;
-        Ok((current & mask) == mask)
+    fn has_ready(&self, chunk: &dyn RafsChunkInfo, wait: bool) -> Result<bool> {
+        let index = chunk.index();
+        let _ = self.validate_index(index)?;
+        let (ready, _) = self.is_chunk_ready(index);
+        if !ready {
+            let mut guard = self.inflight_tracer.lock().unwrap();
+            trace!(
+                "chunk index {}, tracer scale {}",
+                chunk.index(),
+                guard.len()
+            );
+            if let Some(i) = guard.get(&index).cloned() {
+                if wait {
+                    drop(guard);
+                    match i.wait_for_inflight(Duration::from_millis(SINGLE_INFLIGHT_WAIT_TIMEOUT)) {
+                        Err(StorageError::Timeout) => {
+                            // Notice that lock of tracer is already dropped.
+                            let mut t = self.inflight_tracer.lock().unwrap();
+                            t.remove(&index);
+                            i.notify();
+                            warn!("Waiting for another backend IO expires. chunk index {}, tracer scale {}", chunk.index(), t.len());
+                            return Ok(self.is_chunk_ready(chunk.index()).0);
+                        }
+                        _ => {
+                            return Ok(self.is_chunk_ready(chunk.index()).0);
+                        }
+                    };
+                }
+            } else {
+                // Double check to close the window where prior slot was just
+                // removed after backend IO returned.
+                if self.is_chunk_ready(index).0 {
+                    return Ok(true);
+                }
+                guard.insert(index, Arc::new(ChunkSlot::new()));
+            }
+        }
+        Ok(ready)
     }
 
     fn set_ready(&self, chunk: &dyn RafsChunkInfo) -> Result<()> {
         // Loop to write one byte (a bitmap with 8 bits capacity) to
         // blob chunk_map file until success.
+        let index = chunk.index();
+        let _ = self.validate_index(index)?;
         loop {
-            let index = chunk.index();
-            let (current, mask) = self.read_u8(index)?;
-            let ready = (current & mask) == mask;
+            let (ready, current) = self.is_chunk_ready(index);
             if ready {
                 break;
             }
-            let expected = current | mask;
-            if self.write_u8(index, current, expected)? {
+
+            if self.write_u8(index, current) {
                 break;
             }
         }
+
+        self.finish(chunk);
+
         Ok(())
+    }
+
+    fn finish(&self, chunk: &dyn RafsChunkInfo) {
+        let index = chunk.index();
+        let mut guard = self.inflight_tracer.lock().unwrap();
+        if let Some(i) = guard.remove(&index) {
+            i.done();
+        }
+    }
+}
+
+#[cfg(test)]
+mod this_test {
+    use std::sync::Arc;
+    use std::thread;
+    use std::time::Duration;
+
+    use vmm_sys_util::tempfile::TempFile;
+
+    use super::IndexedChunkMap;
+    use crate::cache::blobcache::blob_cache_tests::MockChunkInfo;
+    use crate::cache::chunkmap::ChunkMap;
+    use crate::device::RafsChunkInfo;
+
+    #[test]
+    fn test_inflight_tracer_race() {
+        let tmp_file = TempFile::new().unwrap();
+        let map = Arc::new(IndexedChunkMap::new(tmp_file.as_path().to_str().unwrap(), 10).unwrap());
+
+        let chunk_4: Arc<dyn RafsChunkInfo> = Arc::new({
+            let mut c = MockChunkInfo::new();
+            c.index = 4;
+            c
+        });
+
+        map.as_ref().has_ready(chunk_4.as_ref(), false).unwrap();
+        let map_cloned = map.clone();
+
+        assert_eq!(map.inflight_tracer.lock().unwrap().len(), 1);
+
+        let chunk_4_cloned = chunk_4.clone();
+        let t1 = thread::Builder::new()
+            .spawn(move || {
+                for _ in 0..4 {
+                    let ready = map_cloned.has_ready(chunk_4_cloned.as_ref(), true).unwrap();
+                    assert_eq!(ready, true);
+                }
+            })
+            .unwrap();
+
+        let map_cloned_2 = map.clone();
+        let chunk_4_cloned_2 = chunk_4.clone();
+        let t2 = thread::Builder::new()
+            .spawn(move || {
+                for _ in 0..2 {
+                    let ready = map_cloned_2
+                        .has_ready(chunk_4_cloned_2.as_ref(), true)
+                        .unwrap();
+                    assert_eq!(ready, true);
+                }
+            })
+            .unwrap();
+
+        thread::sleep(Duration::from_secs(1));
+
+        map.set_ready(chunk_4.as_ref()).unwrap();
+
+        // Fuzz
+        map.set_ready(chunk_4.as_ref()).unwrap();
+        map.set_ready(chunk_4.as_ref()).unwrap();
+
+        assert_eq!(map.inflight_tracer.lock().unwrap().len(), 0);
+
+        t1.join().unwrap();
+        t2.join().unwrap();
+    }
+
+    #[test]
+    /// Case description:
+    ///     Never invoke `set_ready` method, thus to let each caller of `has_ready` reach
+    ///     a point of timeout.
+    /// Expect:
+    ///     The chunk of index 4 is never marked as ready/downloaded.
+    ///     Each caller of `has_ready` can escape from where it is blocked.
+    ///     After timeout, no slot is left in inflight tracer.
+    fn test_inflight_tracer_timeout() {
+        let tmp_file = TempFile::new().unwrap();
+        let map = Arc::new(IndexedChunkMap::new(tmp_file.as_path().to_str().unwrap(), 10).unwrap());
+
+        let chunk_4: Arc<dyn RafsChunkInfo> = Arc::new({
+            let mut c = MockChunkInfo::new();
+            c.index = 4;
+            c
+        });
+
+        map.as_ref().has_ready(chunk_4.as_ref(), false).unwrap();
+        let map_cloned = map.clone();
+
+        assert_eq!(map.inflight_tracer.lock().unwrap().len(), 1);
+
+        let chunk_4_cloned = chunk_4.clone();
+        let t1 = thread::Builder::new()
+            .spawn(move || {
+                for _ in 0..4 {
+                    map_cloned.has_ready(chunk_4_cloned.as_ref(), true).unwrap();
+                }
+            })
+            .unwrap();
+
+        t1.join().unwrap();
+
+        assert_eq!(map.inflight_tracer.lock().unwrap().len(), 1);
+
+        let ready = map.as_ref().has_ready(chunk_4.as_ref(), false).unwrap();
+        assert_eq!(ready, false);
+
+        map.finish(chunk_4.as_ref());
+        assert_eq!(map.inflight_tracer.lock().unwrap().len(), 0);
     }
 }

--- a/storage/src/cache/chunkmap/indexed.rs
+++ b/storage/src/cache/chunkmap/indexed.rs
@@ -2,24 +2,17 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashMap;
 use std::fs::OpenOptions;
 use std::io::Result;
 use std::os::unix::io::AsRawFd;
-use std::sync::{
-    atomic::{AtomicU8, Ordering},
-    Arc, Condvar, Mutex, WaitTimeoutResult,
-};
-use std::time::Duration;
+use std::sync::atomic::{AtomicU8, Ordering};
 
 use nydus_utils::div_round_up;
 
 use super::ChunkMap;
+use crate::cache::chunkmap::{ChunkIndexGetter, NoWaitSupport};
 use crate::device::RafsChunkInfo;
 use crate::utils::readahead;
-use crate::{StorageError, StorageResult};
-
-use crate::cache::blobcache::SINGLE_INFLIGHT_WAIT_TIMEOUT;
 
 /// The magic number of blob chunk_map file, it's ASCII hex of string "BMAP".
 const MAGIC: u32 = 0x424D_4150;
@@ -51,57 +44,13 @@ pub struct IndexedChunkMap {
     chunk_count: u32,
     size: usize,
     base: *const u8,
-    inflight_tracer: Arc<Mutex<HashMap<u32, Arc<ChunkSlot>>>>,
-}
-
-#[derive(PartialEq)]
-enum Status {
-    Inflight,
-    Complete,
-}
-
-struct ChunkSlot {
-    on_trip: Mutex<Status>,
-    condvar: Condvar,
-}
-
-impl ChunkSlot {
-    fn new() -> Self {
-        ChunkSlot {
-            on_trip: Mutex::new(Status::Inflight),
-            condvar: Condvar::new(),
-        }
-    }
-
-    fn notify(&self) {
-        self.condvar.notify_all();
-    }
-
-    fn done(&self) {
-        // Not expect poisoned lock here
-        *self.on_trip.lock().unwrap() = Status::Complete;
-        self.notify();
-    }
-
-    fn wait_for_inflight(&self, timeout: Duration) -> StorageResult<()> {
-        let mut inflight = self.on_trip.lock().unwrap();
-        let mut tor: WaitTimeoutResult;
-        while *inflight == Status::Inflight {
-            // Do not expect poisoned lock, so unwrap here.
-            let r = self.condvar.wait_timeout(inflight, timeout).unwrap();
-            inflight = r.0;
-            tor = r.1;
-            if tor.timed_out() {
-                return Err(StorageError::Timeout);
-            }
-        }
-
-        Ok(())
-    }
 }
 
 unsafe impl Send for IndexedChunkMap {}
+
 unsafe impl Sync for IndexedChunkMap {}
+
+impl NoWaitSupport for IndexedChunkMap {}
 
 impl IndexedChunkMap {
     pub fn new(blob_path: &str, chunk_count: u32) -> Result<Self> {
@@ -170,7 +119,6 @@ impl IndexedChunkMap {
             chunk_count,
             size: expected_size as usize,
             base: base as *const u8,
-            inflight_tracer: Arc::new(Mutex::new(HashMap::new())),
         })
     }
 
@@ -223,44 +171,19 @@ impl Drop for IndexedChunkMap {
     }
 }
 
+impl ChunkIndexGetter for IndexedChunkMap {
+    type Index = u32;
+
+    fn get_index(chunk: &dyn RafsChunkInfo) -> Self::Index {
+        chunk.blob_index()
+    }
+}
+
 impl ChunkMap for IndexedChunkMap {
-    fn has_ready(&self, chunk: &dyn RafsChunkInfo, wait: bool) -> Result<bool> {
+    fn has_ready(&self, chunk: &dyn RafsChunkInfo, _wait: bool) -> Result<bool> {
         let index = chunk.index();
         let _ = self.validate_index(index)?;
         let (ready, _) = self.is_chunk_ready(index);
-        if !ready {
-            let mut guard = self.inflight_tracer.lock().unwrap();
-            trace!(
-                "chunk index {}, tracer scale {}",
-                chunk.index(),
-                guard.len()
-            );
-            if let Some(i) = guard.get(&index).cloned() {
-                if wait {
-                    drop(guard);
-                    match i.wait_for_inflight(Duration::from_millis(SINGLE_INFLIGHT_WAIT_TIMEOUT)) {
-                        Err(StorageError::Timeout) => {
-                            // Notice that lock of tracer is already dropped.
-                            let mut t = self.inflight_tracer.lock().unwrap();
-                            t.remove(&index);
-                            i.notify();
-                            warn!("Waiting for another backend IO expires. chunk index {}, tracer scale {}", chunk.index(), t.len());
-                            return Ok(self.is_chunk_ready(chunk.index()).0);
-                        }
-                        _ => {
-                            return Ok(self.is_chunk_ready(chunk.index()).0);
-                        }
-                    };
-                }
-            } else {
-                // Double check to close the window where prior slot was just
-                // removed after backend IO returned.
-                if self.is_chunk_ready(index).0 {
-                    return Ok(true);
-                }
-                guard.insert(index, Arc::new(ChunkSlot::new()));
-            }
-        }
         Ok(ready)
     }
 
@@ -279,127 +202,6 @@ impl ChunkMap for IndexedChunkMap {
                 break;
             }
         }
-
-        self.finish(chunk);
-
         Ok(())
-    }
-
-    fn finish(&self, chunk: &dyn RafsChunkInfo) {
-        let index = chunk.index();
-        let mut guard = self.inflight_tracer.lock().unwrap();
-        if let Some(i) = guard.remove(&index) {
-            i.done();
-        }
-    }
-}
-
-#[cfg(test)]
-mod this_test {
-    use std::sync::Arc;
-    use std::thread;
-    use std::time::Duration;
-
-    use vmm_sys_util::tempfile::TempFile;
-
-    use super::IndexedChunkMap;
-    use crate::cache::blobcache::blob_cache_tests::MockChunkInfo;
-    use crate::cache::chunkmap::ChunkMap;
-    use crate::device::RafsChunkInfo;
-
-    #[test]
-    fn test_inflight_tracer_race() {
-        let tmp_file = TempFile::new().unwrap();
-        let map = Arc::new(IndexedChunkMap::new(tmp_file.as_path().to_str().unwrap(), 10).unwrap());
-
-        let chunk_4: Arc<dyn RafsChunkInfo> = Arc::new({
-            let mut c = MockChunkInfo::new();
-            c.index = 4;
-            c
-        });
-
-        map.as_ref().has_ready(chunk_4.as_ref(), false).unwrap();
-        let map_cloned = map.clone();
-
-        assert_eq!(map.inflight_tracer.lock().unwrap().len(), 1);
-
-        let chunk_4_cloned = chunk_4.clone();
-        let t1 = thread::Builder::new()
-            .spawn(move || {
-                for _ in 0..4 {
-                    let ready = map_cloned.has_ready(chunk_4_cloned.as_ref(), true).unwrap();
-                    assert_eq!(ready, true);
-                }
-            })
-            .unwrap();
-
-        let map_cloned_2 = map.clone();
-        let chunk_4_cloned_2 = chunk_4.clone();
-        let t2 = thread::Builder::new()
-            .spawn(move || {
-                for _ in 0..2 {
-                    let ready = map_cloned_2
-                        .has_ready(chunk_4_cloned_2.as_ref(), true)
-                        .unwrap();
-                    assert_eq!(ready, true);
-                }
-            })
-            .unwrap();
-
-        thread::sleep(Duration::from_secs(1));
-
-        map.set_ready(chunk_4.as_ref()).unwrap();
-
-        // Fuzz
-        map.set_ready(chunk_4.as_ref()).unwrap();
-        map.set_ready(chunk_4.as_ref()).unwrap();
-
-        assert_eq!(map.inflight_tracer.lock().unwrap().len(), 0);
-
-        t1.join().unwrap();
-        t2.join().unwrap();
-    }
-
-    #[test]
-    /// Case description:
-    ///     Never invoke `set_ready` method, thus to let each caller of `has_ready` reach
-    ///     a point of timeout.
-    /// Expect:
-    ///     The chunk of index 4 is never marked as ready/downloaded.
-    ///     Each caller of `has_ready` can escape from where it is blocked.
-    ///     After timeout, no slot is left in inflight tracer.
-    fn test_inflight_tracer_timeout() {
-        let tmp_file = TempFile::new().unwrap();
-        let map = Arc::new(IndexedChunkMap::new(tmp_file.as_path().to_str().unwrap(), 10).unwrap());
-
-        let chunk_4: Arc<dyn RafsChunkInfo> = Arc::new({
-            let mut c = MockChunkInfo::new();
-            c.index = 4;
-            c
-        });
-
-        map.as_ref().has_ready(chunk_4.as_ref(), false).unwrap();
-        let map_cloned = map.clone();
-
-        assert_eq!(map.inflight_tracer.lock().unwrap().len(), 1);
-
-        let chunk_4_cloned = chunk_4.clone();
-        let t1 = thread::Builder::new()
-            .spawn(move || {
-                for _ in 0..4 {
-                    map_cloned.has_ready(chunk_4_cloned.as_ref(), true).unwrap();
-                }
-            })
-            .unwrap();
-
-        t1.join().unwrap();
-
-        assert_eq!(map.inflight_tracer.lock().unwrap().len(), 1);
-
-        let ready = map.as_ref().has_ready(chunk_4.as_ref(), false).unwrap();
-        assert_eq!(ready, false);
-
-        map.finish(chunk_4.as_ref());
-        assert_eq!(map.inflight_tracer.lock().unwrap().len(), 0);
     }
 }

--- a/storage/src/cache/chunkmap/mod.rs
+++ b/storage/src/cache/chunkmap/mod.rs
@@ -4,10 +4,20 @@
 
 use std::io::Result;
 
+use crate::cache::blobcache::SINGLE_INFLIGHT_WAIT_TIMEOUT;
 use crate::device::RafsChunkInfo;
+use crate::{StorageError, StorageResult};
+use std::collections::HashMap;
+use std::fmt::Display;
+use std::hash::Hash;
+use std::sync::{Arc, Condvar, Mutex, WaitTimeoutResult};
+use std::time::Duration;
 
 pub mod digested;
 pub mod indexed;
+
+/// only to mark ChunkMap who doesn't support wait
+pub trait NoWaitSupport {}
 
 /// The chunk map checks whether a chunk data has been cached in
 /// blob cache based on the chunk info.
@@ -15,6 +25,135 @@ pub trait ChunkMap {
     fn has_ready(&self, chunk: &dyn RafsChunkInfo, wait: bool) -> Result<bool>;
     fn set_ready(&self, chunk: &dyn RafsChunkInfo) -> Result<()>;
     fn finish(&self, _chunk: &dyn RafsChunkInfo) {}
+}
+
+/// convert RafsChunkInfo to ChunkMap inner index
+pub trait ChunkIndexGetter {
+    type Index;
+
+    fn get_index(chunk: &dyn RafsChunkInfo) -> Self::Index;
+}
+
+#[derive(PartialEq)]
+enum Status {
+    Inflight,
+    Complete,
+}
+
+struct ChunkSlot {
+    on_trip: Mutex<Status>,
+    condvar: Condvar,
+}
+
+impl ChunkSlot {
+    fn new() -> Self {
+        ChunkSlot {
+            on_trip: Mutex::new(Status::Inflight),
+            condvar: Condvar::new(),
+        }
+    }
+
+    fn notify(&self) {
+        self.condvar.notify_all();
+    }
+
+    fn done(&self) {
+        // Not expect poisoned lock here
+        *self.on_trip.lock().unwrap() = Status::Complete;
+        self.notify();
+    }
+
+    fn wait_for_inflight(&self, timeout: Duration) -> StorageResult<()> {
+        let mut inflight = self.on_trip.lock().unwrap();
+        let mut tor: WaitTimeoutResult;
+        while *inflight == Status::Inflight {
+            // Do not expect poisoned lock, so unwrap here.
+            let r = self.condvar.wait_timeout(inflight, timeout).unwrap();
+            inflight = r.0;
+            tor = r.1;
+            if tor.timed_out() {
+                return Err(StorageError::Timeout);
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// general chunk map
+/// support single inflight io if backend ChunkMap doesn't support
+pub struct BlobChunkMap<C, I> {
+    c: C,
+    inflight_tracer: Mutex<HashMap<I, Arc<ChunkSlot>>>,
+}
+
+impl<C, I> BlobChunkMap<C, I>
+where
+    C: ChunkMap + ChunkIndexGetter<Index = I> + NoWaitSupport,
+    I: Eq + Hash + Display,
+{
+    pub fn from(c: C) -> Self {
+        Self {
+            c,
+            inflight_tracer: Mutex::new(HashMap::new()),
+        }
+    }
+}
+
+impl<C, I> ChunkMap for BlobChunkMap<C, I>
+where
+    C: ChunkMap + ChunkIndexGetter<Index = I> + NoWaitSupport,
+    I: Eq + Hash + Display,
+{
+    fn has_ready(&self, chunk: &dyn RafsChunkInfo, wait: bool) -> Result<bool> {
+        let ready = self.c.has_ready(chunk, false)?;
+
+        if !ready {
+            let index = C::get_index(chunk);
+            let mut guard = self.inflight_tracer.lock().unwrap();
+            trace!("chunk index {}, tracer scale {}", index, guard.len());
+            if let Some(i) = guard.get(&index).cloned() {
+                if wait {
+                    drop(guard);
+                    return match i
+                        .wait_for_inflight(Duration::from_millis(SINGLE_INFLIGHT_WAIT_TIMEOUT))
+                    {
+                        Err(StorageError::Timeout) => {
+                            // Notice that lock of tracer is already dropped.
+                            let mut t = self.inflight_tracer.lock().unwrap();
+                            t.remove(&index);
+                            i.notify();
+                            warn!("Waiting for another backend IO expires. chunk index {}, tracer scale {}", index, t.len());
+                            self.c.has_ready(chunk, false)
+                        }
+                        _ => self.c.has_ready(chunk, false),
+                    };
+                }
+            } else {
+                // Double check to close the window where prior slot was just
+                // removed after backend IO returned.
+                if self.c.has_ready(chunk, false)? {
+                    return Ok(true);
+                }
+                guard.insert(index, Arc::new(ChunkSlot::new()));
+            }
+        }
+        Ok(ready)
+    }
+
+    fn set_ready(&self, chunk: &dyn RafsChunkInfo) -> Result<()> {
+        self.c.set_ready(chunk).map(|_| {
+            self.finish(chunk);
+        })
+    }
+
+    fn finish(&self, chunk: &dyn RafsChunkInfo) {
+        let index = C::get_index(chunk);
+        let mut guard = self.inflight_tracer.lock().unwrap();
+        if let Some(i) = guard.remove(&index) {
+            i.done();
+        }
+    }
 }
 
 #[cfg(test)]
@@ -28,8 +167,10 @@ mod tests {
     use super::digested::DigestedChunkMap;
     use super::indexed::IndexedChunkMap;
     use super::*;
+    use crate::cache::blobcache::blob_cache_tests::MockChunkInfo;
     use crate::device::{RafsChunkFlags, RafsChunkInfo};
     use nydus_utils::digest::{Algorithm, RafsDigest};
+    use vmm_sys_util::tempfile::TempFile;
 
     struct Chunk {
         index: u32,
@@ -198,5 +339,105 @@ mod tests {
             "IndexedChunkMap vs DigestedChunkMap: {}ms vs {}ms",
             elapsed1, elapsed2
         );
+    }
+
+    #[test]
+    fn test_inflight_tracer_race() {
+        let tmp_file = TempFile::new().unwrap();
+        let map = Arc::new(BlobChunkMap::from(
+            IndexedChunkMap::new(tmp_file.as_path().to_str().unwrap(), 10).unwrap(),
+        ));
+
+        let chunk_4: Arc<dyn RafsChunkInfo> = Arc::new({
+            let mut c = MockChunkInfo::new();
+            c.index = 4;
+            c
+        });
+
+        map.as_ref().has_ready(chunk_4.as_ref(), false).unwrap();
+        let map_cloned = map.clone();
+
+        assert_eq!(map.inflight_tracer.lock().unwrap().len(), 1);
+
+        let chunk_4_cloned = chunk_4.clone();
+        let t1 = thread::Builder::new()
+            .spawn(move || {
+                for _ in 0..4 {
+                    let ready = map_cloned.has_ready(chunk_4_cloned.as_ref(), true).unwrap();
+                    assert_eq!(ready, true);
+                }
+            })
+            .unwrap();
+
+        let map_cloned_2 = map.clone();
+        let chunk_4_cloned_2 = chunk_4.clone();
+        let t2 = thread::Builder::new()
+            .spawn(move || {
+                for _ in 0..2 {
+                    let ready = map_cloned_2
+                        .has_ready(chunk_4_cloned_2.as_ref(), true)
+                        .unwrap();
+                    assert_eq!(ready, true);
+                }
+            })
+            .unwrap();
+
+        thread::sleep(Duration::from_secs(1));
+
+        map.set_ready(chunk_4.as_ref()).unwrap();
+
+        // Fuzz
+        map.set_ready(chunk_4.as_ref()).unwrap();
+        map.set_ready(chunk_4.as_ref()).unwrap();
+
+        assert_eq!(map.inflight_tracer.lock().unwrap().len(), 0);
+
+        t1.join().unwrap();
+        t2.join().unwrap();
+    }
+
+    #[test]
+    /// Case description:
+    ///     Never invoke `set_ready` method, thus to let each caller of `has_ready` reach
+    ///     a point of timeout.
+    /// Expect:
+    ///     The chunk of index 4 is never marked as ready/downloaded.
+    ///     Each caller of `has_ready` can escape from where it is blocked.
+    ///     After timeout, no slot is left in inflight tracer.
+    fn test_inflight_tracer_timeout() {
+        let tmp_file = TempFile::new().unwrap();
+        let map = Arc::new(BlobChunkMap::from(
+            IndexedChunkMap::new(tmp_file.as_path().to_str().unwrap(), 10).unwrap(),
+        ));
+
+        let chunk_4: Arc<dyn RafsChunkInfo> = Arc::new({
+            let mut c = MockChunkInfo::new();
+            c.index = 4;
+            c
+        });
+
+        map.as_ref().has_ready(chunk_4.as_ref(), false).unwrap();
+        let map_cloned = map.clone();
+
+        assert_eq!(map.inflight_tracer.lock().unwrap().len(), 1);
+
+        let chunk_4_cloned = chunk_4.clone();
+        let t1 = thread::Builder::new()
+            .spawn(move || {
+                for _ in 0..4 {
+                    map_cloned.has_ready(chunk_4_cloned.as_ref(), true).unwrap();
+                }
+            })
+            .unwrap();
+
+        t1.join().unwrap();
+
+        assert_eq!(map.inflight_tracer.lock().unwrap().len(), 1);
+
+        let ready = map.as_ref().has_ready(chunk_4.as_ref(), false).unwrap();
+        assert_eq!(ready, false);
+
+        map.finish(chunk_4.as_ref());
+        assert_eq!(map.inflight_tracer.lock().unwrap().len(), 0);
     }
 }

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -34,6 +34,7 @@ pub const RAFS_DEFAULT_BLOCK_SIZE: u64 = 1024 * 1024;
 #[derive(Debug)]
 pub enum StorageError {
     Unsupported,
+    Timeout,
 }
 
 pub type StorageResult<T> = std::result::Result<T, StorageError>;


### PR DESCRIPTION
If there is already a backend IO going fetching a chunk from remote storage. Blobcache does not have to issue another one for the same data chunk. Waiting is an ideal behavior saving backend width and reduce IO latency.

When there is several big files residing in Rafs, sequential read will gain performance profit.