### PR TITLE
Enhance rafs inspector

### DIFF
--- a/src/bin/nydus-image/core/tree.rs
+++ b/src/bin/nydus-image/core/tree.rs
@@ -33,7 +33,7 @@ pub struct Tree {
 // TODO: To decouple from storage backend from Rafs/metadata, use this function to
 // digest status from trait object. Is it possible also to do this for `RafsInode`?
 // Right now, it is hard. Perhaps someday we can get rid of the rafs import procedure,
-//  which involve the whole nydusd rafs/mount. It is hard to optimize a process that
+// which involve the whole nydusd rafs/mount. It is hard to optimize a process that
 // serves another goal. Luckily, `RafsInode` won't affect the work of decouple.
 fn cast_chunk_info(cki: &dyn RafsChunkInfo) -> OndiskChunkInfo {
     OndiskChunkInfo {

--- a/src/bin/nydus-image/main.rs
+++ b/src/bin/nydus-image/main.rs
@@ -253,6 +253,7 @@ fn main() -> Result<()> {
                 .arg(
                     Arg::with_name("bootstrap")
                         .long("bootstrap")
+                        .short("B")
                         .help("bootstrap path")
                         .required(true)
                         .takes_value(true),


### PR DESCRIPTION
Now we can inspect rafs layout through tool `nydus-image inspect` more conveniently.
It can 
1. list all files that are sharing the same chunk
2. print more detailed information of a chunk
3. look up a file by its inode number
