### PR TITLE
Async blobcache persister

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1844,6 +1844,7 @@ dependencies = [
  "sha-1",
  "sha2",
  "spmc",
+ "tokio",
  "url",
  "vm-memory",
  "vmm-sys-util 0.6.0",

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -28,8 +28,8 @@ sha-1 = { version = "0.9.1", optional = true }
 hmac = { version = "0.8.1", optional = true }
 url = { version = "2.1.1", optional = true }
 httpdate = { version = "1.0", optional = true }
-reqwest = { version = "0.10.4", features = ["blocking", "json"], optional = true }
-
+reqwest = { version = "0.11.0", features = ["blocking", "json"], optional = true }
+tokio = { version = "1.5.0", features = ["rt-multi-thread"] }
 
 fuse-rs = { git = "https://github.com/cloud-hypervisor/fuse-backend-rs.git", rev = "cfd2cca" }
 

--- a/storage/src/cache/dummycache.rs
+++ b/storage/src/cache/dummycache.rs
@@ -51,7 +51,7 @@ impl RafsCache for DummyCache {
             d.as_mut_slice()
         };
 
-        self.read_backend_chunk(&bio.blob, chunk.as_ref(), one_chunk_buf, |_| Ok(()))?;
+        self.read_backend_chunk(&bio.blob, chunk.as_ref(), one_chunk_buf)?;
 
         if reuse {
             Ok(one_chunk_buf.len())

--- a/storage/src/cache/mod.rs
+++ b/storage/src/cache/mod.rs
@@ -23,7 +23,6 @@ pub mod dummycache;
 
 #[derive(Default, Clone)]
 struct MergedBackendRequest {
-    seq: u64,
     // Chunks that are continuous to each other.
     pub chunks: Vec<Arc<dyn RafsChunkInfo>>,
     pub blob_offset: u64,
@@ -32,14 +31,13 @@ struct MergedBackendRequest {
 }
 
 impl MergedBackendRequest {
-    fn new(seq: u64, first_cki: Arc<dyn RafsChunkInfo>, blob: Arc<RafsBlobEntry>) -> Self {
+    fn new(first_cki: Arc<dyn RafsChunkInfo>, blob: Arc<RafsBlobEntry>) -> Self {
         let mut chunks = Vec::<Arc<dyn RafsChunkInfo>>::new();
         let blob_size = first_cki.compress_size();
         let blob_offset = first_cki.compress_offset();
         chunks.push(first_cki);
 
         MergedBackendRequest {
-            seq,
             blob_offset,
             blob_size,
             chunks,

--- a/storage/src/cache/mod.rs
+++ b/storage/src/cache/mod.rs
@@ -94,17 +94,12 @@ pub trait RafsCache {
     /// It depends on `cki` how to describe the chunk data.
     /// Moreover, chunk data from backend can be validated as per nydus configuration.
     /// Above is not redundant with blob cache's validation given IO path backend -> blobcache
-    fn read_backend_chunk<F>(
+    fn read_backend_chunk(
         &self,
         blob: &RafsBlobEntry,
         cki: &dyn RafsChunkInfo,
         chunk: &mut [u8],
-        cacher: F,
-    ) -> Result<usize>
-    where
-        F: FnOnce(&[u8]) -> Result<()>,
-        Self: Sized,
-    {
+    ) -> Result<usize> {
         let offset = cki.compress_offset();
         let mut d;
 
@@ -179,7 +174,6 @@ pub trait RafsCache {
             self.need_validate(),
         )
         .map_err(|e| eio!(format!("fail to read from backend: {}", e)))?;
-        cacher(chunk)?;
         Ok(chunk.len())
     }
 


### PR DESCRIPTION
Let persisting chunk to blobcache file happen at the same time with responding to user IO request.
This will reduce read io latency when local disk is in a heavy workload. 