### PR TITLE
nydus-image: fix disorder of writing chunks to blob

### DIFF
--- a/src/bin/nydus-image/core/blob.rs
+++ b/src/bin/nydus-image/core/blob.rs
@@ -144,7 +144,7 @@ impl Blob {
             SourceType::Directory => {
                 // Dump readahead nodes
                 for index in &readahead_files {
-                    let node = ctx.nodes.get_mut(**index as usize - 1).unwrap();
+                    let node = ctx.nodes.get_mut(*index as usize - 1).unwrap();
                     debug!("[{}]\treadahead {}", node.overlay, node);
                     if node.overlay == Overlay::UpperAddition
                         || node.overlay == Overlay::UpperModification

--- a/src/bin/nydus-image/core/prefetch.rs
+++ b/src/bin/nydus-image/core/prefetch.rs
@@ -141,11 +141,16 @@ impl Prefetch {
         self.readahead_files.get(&node.rootfs()).is_some()
     }
 
-    pub fn get_file_indexes(&self) -> Vec<&u64> {
-        self.readahead_files
+    pub fn get_file_indexes(&self) -> Vec<u64> {
+        let mut indexes: Vec<u64> = self
+            .readahead_files
             .values()
-            .filter_map(|index| index.as_ref())
-            .collect()
+            .filter_map(|index| *index)
+            .collect();
+
+        // Later, we might write chunks of data one by one according to inode number order.
+        indexes.sort_unstable();
+        indexes
     }
 
     pub fn get_prefetch_table(&mut self) -> Option<PrefetchTable> {


### PR DESCRIPTION
In rafs disk layout, we should enforce a rule that chunks
are dumped/written to blob file according to order of inode
number.

When prefetch files list is specified, e.g. "/", the specified
files will be dumped before dumping other files. But the `readahead_files`
collection is not sorted by its key - inode index.

So fix this by sorting it before consuming it.

This problem might affect prefetch merging possibility.

Signed-off-by: Changwei Ge <chge@linux.alibaba.com>