### PR TITLE
blobcache/stargz: fix stargz gzip member can't be cached

### DIFF
--- a/storage/src/cache/dummycache.rs
+++ b/storage/src/cache/dummycache.rs
@@ -51,7 +51,7 @@ impl RafsCache for DummyCache {
             d.as_mut_slice()
         };
 
-        self.read_backend_chunk(&bio.blob, chunk.as_ref(), one_chunk_buf)?;
+        self.read_backend_chunk(&bio.blob, chunk.as_ref(), one_chunk_buf, None)?;
 
         if reuse {
             Ok(one_chunk_buf.len())


### PR DESCRIPTION
For stargz blobcache, each member file is cacned as gzip reg/chunk.
Now, blobcache stores decompessed data into blobcache, which later
can't be decompressed.

Error message follows:

[2021-08-20 16:19:27.004643 +08:00] ERROR [storage/src/cache/mod.rs:195] failed to decompress chunk: invalid gzip header
[2021-08-20 16:19:27.079728 +08:00] ERROR [storage/src/cache/mod.rs:195] failed to decompress chunk: invalid gzip header
[2021-08-20 16:19:27.084288 +08:00] ERROR [storage/src/cache/mod.rs:195] failed to decompress chunk: invalid gzip header
[2021-08-20 16:19:27.088826 +08:00] ERROR [storage/src/cache/mod.rs:195] failed to decompress chunk: invalid gzip header
[2021-08-20 16:19:27.102827 +08:00] ERROR [storage/src/cache/mod.rs:195] failed to decompress chunk: invalid gzip header
[2021-08-20 16:19:27.246938 +08:00] ERROR [storage/src/cache/mod.rs:195] failed to decompress chunk: invalid gzip header

Signed-off-by: Changwei Ge <chge@linux.alibaba.com>