### PR TITLE
Nydusify supports option --aligned and a couple of bugfixes

### DIFF
--- a/contrib/nydusify/cmd/nydusify.go
+++ b/contrib/nydusify/cmd/nydusify.go
@@ -145,6 +145,7 @@ func main() {
 				&cli.StringFlag{Name: "backend-config", Value: "", Usage: "Specify Nydus blob storage backend in JSON config string", EnvVars: []string{"BACKEND_CONFIG"}},
 				&cli.StringFlag{Name: "backend-config-file", Value: "", TakesFile: true, Usage: "Specify Nydus blob storage backend config from path", EnvVars: []string{"BACKEND_CONFIG_FILE"}},
 				&cli.BoolFlag{Name: "backend-force-push", Value: false, Usage: "Force to push Nydus blob to storage backend, even if the blob already exists in storage backend", EnvVars: []string{"BACKEND_FORCE_PUSH"}},
+				&cli.BoolFlag{Name: "backend-aligned-chunk", Value: false, Usage: "Produce 4096 aligned decompressed_offset in Nydus bootstrap", EnvVars: []string{"BACKEND_ALIGNED_CHUNK"}},
 				&cli.StringFlag{Name: "build-cache", Value: "", Usage: "An remote image reference for accelerating nydus image build", EnvVars: []string{"BUILD_CACHE"}},
 				&cli.StringFlag{Name: "build-cache-tag", Value: "", Usage: "Use $target:$build-cache-tag as cache image reference, conflict with --build-cache", EnvVars: []string{"BUILD_CACHE_TAG"}},
 				&cli.StringFlag{Name: "build-cache-version", Value: "v1", Usage: "Specify the version of cache image, if the existed remote cache image does not match the version, cache records will be dropped", EnvVars: []string{"BUILD_CACHE_VERSION"}},
@@ -250,6 +251,7 @@ func main() {
 					BackendType:      backendType,
 					BackendConfig:    backendConfig,
 					BackendForcePush: c.Bool("backend-force-push"),
+					BackendAlignedChunk: c.Bool("backend-aligned-chunk"),
 
 					NydusifyVersion: version,
 					Source:          c.String("source"),

--- a/contrib/nydusify/pkg/build/builder.go
+++ b/contrib/nydusify/pkg/build/builder.go
@@ -24,6 +24,7 @@ type BuilderOption struct {
 	OutputJSONPath      string
 	// A regular file or fifo into which commands nydus-image to dump contents.
 	BlobPath string
+	AlignedChunk	    bool
 }
 
 type Builder struct {
@@ -54,6 +55,10 @@ func (builder *Builder) Run(option BuilderOption) error {
 			option.ParentBootstrapPath,
 		}
 	}
+	if option.AlignedChunk {
+		args = append(args, "--aligned-chunk")
+	}
+
 	args = append(
 		args,
 		"--bootstrap",

--- a/contrib/nydusify/pkg/build/workflow.go
+++ b/contrib/nydusify/pkg/build/workflow.go
@@ -101,7 +101,7 @@ func NewWorkflow(option WorkflowOption) (*Workflow, error) {
 
 // Build nydus bootstrap and blob, returned blobPath's basename is sha256 hex string
 func (workflow *Workflow) Build(
-	layerDir, whiteoutSpec, parentBootstrapPath, bootstrapPath string,
+	layerDir, whiteoutSpec, parentBootstrapPath, bootstrapPath string, alignedChunk bool,
 ) (string, error) {
 	workflow.bootstrapPath = bootstrapPath
 
@@ -119,6 +119,7 @@ func (workflow *Workflow) Build(
 		WhiteoutSpec:        whiteoutSpec,
 		OutputJSONPath:      workflow.buildOutputJSONPath(),
 		BlobPath:            blobPath,
+		AlignedChunk:	     alignedChunk,
 	}); err != nil {
 		return "", errors.Wrapf(err, "build layer %s", layerDir)
 	}

--- a/contrib/nydusify/pkg/converter/build_info.go
+++ b/contrib/nydusify/pkg/converter/build_info.go
@@ -35,17 +35,25 @@ func (info *BuildInfo) SetSourceReference(val SourceReference) {
 }
 
 func (info *BuildInfo) Dump() map[string]string {
-	data := map[string]string{
-		"nydus.trace.nydusify-version": info.nydusifyVersion,
-		"nydus.trace.source-reference": info.sourceReference.Reference,
-		"nydus.trace.source-digest":    info.sourceReference.Digest,
+	data := map[string]string{}
+
+	if len(info.sourceReference.Reference) > 0 {
+		data["nydus.trace.source-reference"] = info.sourceReference.Reference
+	}
+
+	if len(info.sourceReference.Digest) > 0 {
+		data["nydus.trace.source-digest"] = info.sourceReference.Digest
+	}
+
+	if len(info.nydusifyVersion) > 0 {
+		data["nydus.trace.nydusify-version"] = info.nydusifyVersion
 	}
 
 	// In the case where all layers are hit by the build cache,
 	// we may not get the builder version because the builder has never
 	// been called. This version information is not really that important,
 	// as a fallback, we can use Nydusify version to troubleshoot.
-	if info.builderVersion != "" {
+	if len(info.builderVersion) > 0 {
 		data["nydus.trace.builder-version"] = info.builderVersion
 	}
 

--- a/contrib/nydusify/pkg/converter/converter.go
+++ b/contrib/nydusify/pkg/converter/converter.go
@@ -272,10 +272,15 @@ func (cvt *Converter) convert(ctx context.Context) error {
 	if err != nil {
 		return errors.Wrap(err, "Get source manifest")
 	}
-	buildInfo.SetSourceReference(SourceReference{
-		Reference: cvt.Source,
-		Digest:    sourceManifest.Digest.String(),
-	})
+
+	// In the buildkit environment, the source manifest may be empty because
+	// the source image is built from a Dockerfile.
+	if sourceManifest != nil {
+		buildInfo.SetSourceReference(SourceReference{
+			Reference: cvt.Source,
+			Digest:    sourceManifest.Digest.String(),
+		})
+	}
 
 	// Push OCI manifest, Nydus manifest and manifest index
 	mm := &manifestManager{

--- a/contrib/nydusify/pkg/converter/converter.go
+++ b/contrib/nydusify/pkg/converter/converter.go
@@ -80,6 +80,7 @@ type Opt struct {
 	BackendType      string
 	BackendConfig    string
 	BackendForcePush bool
+	BackendAlignedChunk bool
 
 	NydusifyVersion string
 	Source          string
@@ -103,6 +104,7 @@ type Converter struct {
 	DockerV2Format bool
 
 	BackendForcePush bool
+	BackendAlignedChunk bool
 
 	NydusifyVersion string
 	Source          string
@@ -131,6 +133,7 @@ func New(opt Opt) (*Converter, error) {
 		MultiPlatform:    opt.MultiPlatform,
 		DockerV2Format:   opt.DockerV2Format,
 		BackendForcePush: opt.BackendForcePush,
+		BackendAlignedChunk: opt.BackendAlignedChunk,
 		NydusifyVersion:  opt.NydusifyVersion,
 		Source:           opt.Source,
 
@@ -200,6 +203,7 @@ func (cvt *Converter) convert(ctx context.Context) error {
 			dockerV2Format: cvt.DockerV2Format,
 			backend:        cvt.storageBackend,
 			forcePush:      cvt.BackendForcePush,
+			alignedChunk:   cvt.BackendAlignedChunk,
 		}
 		parentBuildLayer = buildLayer
 		buildLayers = append(buildLayers, buildLayer)

--- a/contrib/nydusify/pkg/converter/layer.go
+++ b/contrib/nydusify/pkg/converter/layer.go
@@ -54,6 +54,7 @@ type buildLayer struct {
 	bootstrapPath   string
 	backend         backend.Backend
 	forcePush       bool
+	alignedChunk    bool
 }
 
 // parseSourceMount parses mounts object returned by the Mount method in
@@ -291,7 +292,7 @@ func (layer *buildLayer) Build(ctx context.Context) error {
 		parentBootstrapPath = parentLayer.bootstrapPath
 	}
 	blobPath, err := layer.buildWorkflow.Build(
-		layer.sourceMount.Source, layer.sourceMount.WhiteoutSpec, parentBootstrapPath, layer.bootstrapPath,
+		layer.sourceMount.Source, layer.sourceMount.WhiteoutSpec, parentBootstrapPath, layer.bootstrapPath, layer.alignedChunk,
 	)
 	if err != nil {
 		return buildDone(errors.Wrapf(err, "Build source layer %s", layer.source.Digest()))

--- a/contrib/nydusify/pkg/parser/parser.go
+++ b/contrib/nydusify/pkg/parser/parser.go
@@ -221,14 +221,12 @@ func (parser *Parser) Parse(ctx context.Context) (*Parsed, error) {
 					} else {
 						ociDesc = &desc
 					}
-					break
 				}
 			} else {
 				// FIXME: Returning the first image without platform specified is subtle.
 				// It might not violate Image spec.
 				ociDesc = &desc
 				logrus.Warn("Will cook a image without platform, %s", ociDesc.Digest)
-				break
 			}
 		}
 	}


### PR DESCRIPTION
    Add a new option to produce 4096 aligned decompressed_offset in a converted nydus image bootstrap, so that when blobcache backend is in use, we can end up with a blob file in which the offset of chunks are aligned to 4K.

In the buildkit environment, the source manifest may be empty because the source image is built from a Dockerfile.
Parser parses manifest list by specified image reference, Prior to this patch, Parser would return immediately after parsing the OCI manifest, causing the checker to never find the Nydus manifest