### PR TITLE
Snapshotter can be configured to  disable cache manager

### DIFF
--- a/contrib/nydus-snapshotter/cmd/containerd-nydus-grpc/pkg/command/flags.go
+++ b/contrib/nydus-snapshotter/cmd/containerd-nydus-grpc/pkg/command/flags.go
@@ -45,6 +45,7 @@ type Args struct {
 	EnableMetrics        bool
 	MetricsFile          string
 	EnableStargz         bool
+	DisableCacheManager  bool
 }
 
 type Flags struct {
@@ -154,6 +155,12 @@ func buildFlags(args *Args) []cli.Flag {
 			Usage:       "whether to support stargz image",
 			Destination: &args.EnableStargz,
 		},
+		&cli.BoolFlag{
+			Name:        "disable-cache-manager",
+			Value:       false,
+			Usage:       "whether to disable blob cache manager",
+			Destination: &args.DisableCacheManager,
+		},
 	}
 }
 
@@ -199,6 +206,7 @@ func Validate(args *Args, cfg *config.Config) error {
 	cfg.EnableMetrics = args.EnableMetrics
 	cfg.MetricsFile = args.MetricsFile
 	cfg.EnableStargz = args.EnableStargz
+	cfg.DisableCacheManager = args.DisableCacheManager
 
 	d, err := time.ParseDuration(args.GCPeriod)
 	if err != nil {

--- a/contrib/nydus-snapshotter/config/config.go
+++ b/contrib/nydus-snapshotter/config/config.go
@@ -45,6 +45,7 @@ type Config struct {
 	MetricsFile          string        `toml:"metrics_file"`
 	EnableStargz         bool          `toml:"enable_stargz"`
 	LogLevel             string        `toml:"-"`
+	DisableCacheManager  bool          `toml:"disable_cache_manager"`
 }
 
 func (c *Config) FillupWithDefaults() error {

--- a/contrib/nydus-snapshotter/pkg/daemon/config.go
+++ b/contrib/nydus-snapshotter/pkg/daemon/config.go
@@ -70,17 +70,6 @@ func WithLogLevel(logLevel string) NewDaemonOpt {
 	}
 }
 
-func WithCacheDir(dir string) NewDaemonOpt {
-	return func(d *Daemon) error {
-		// this may be failed, should handle that
-		if err := os.MkdirAll(dir, 0755); err != nil {
-			return errors.Wrapf(err, "failed to create cache dir %s", dir)
-		}
-		d.CacheDir = dir
-		return nil
-	}
-}
-
 func WithRootMountPoint(rootMountPoint string) NewDaemonOpt {
 	return func(d *Daemon) error {
 		if err := os.MkdirAll(rootMountPoint, 0755); err != nil {

--- a/contrib/nydus-snapshotter/pkg/daemon/daemon.go
+++ b/contrib/nydus-snapshotter/pkg/daemon/daemon.go
@@ -32,7 +32,6 @@ type Daemon struct {
 	SocketDir      string
 	LogDir         string
 	LogLevel       string
-	CacheDir       string
 	SnapshotDir    string
 	Pid            int
 	ImageID        string

--- a/contrib/nydus-snapshotter/pkg/filesystem/nydus/fs.go
+++ b/contrib/nydus-snapshotter/pkg/filesystem/nydus/fs.go
@@ -318,7 +318,6 @@ func (fs *filesystem) createNewDaemon(snapshotID string, imageID string) (*daemo
 		daemon.WithConfigDir(fs.ConfigRoot()),
 		daemon.WithSnapshotDir(fs.SnapshotRoot()),
 		daemon.WithLogDir(fs.LogRoot()),
-		daemon.WithCacheDir(fs.cacheMgr.CacheDir()),
 		daemon.WithImageID(imageID),
 		daemon.WithLogLevel(fs.logLevel),
 	); err != nil {
@@ -349,7 +348,6 @@ func (fs *filesystem) createSharedDaemon(snapshotID string, imageID string) (*da
 		daemon.WithAPISock(sharedDaemon.APISock()),
 		daemon.WithConfigDir(fs.ConfigRoot()),
 		daemon.WithLogDir(fs.LogRoot()),
-		daemon.WithCacheDir(fs.cacheMgr.CacheDir()),
 		daemon.WithImageID(imageID),
 		daemon.WithLogLevel(fs.logLevel),
 	); err != nil {

--- a/contrib/nydus-snapshotter/pkg/filesystem/stargz/fs.go
+++ b/contrib/nydus-snapshotter/pkg/filesystem/stargz/fs.go
@@ -144,7 +144,6 @@ func (f *filesystem) createNewDaemon(snapshotID string, imageID string) (*daemon
 		daemon.WithConfigDir(f.ConfigRoot()),
 		daemon.WithSnapshotDir(f.SnapshotRoot()),
 		daemon.WithLogDir(f.LogRoot()),
-		daemon.WithCacheDir(f.CacheRoot()),
 		daemon.WithImageID(imageID),
 		daemon.WithLogLevel(f.logLevel),
 	)


### PR DESCRIPTION
    In some cases we don't want cache manager to do blob cache gc for us,
    so introduce a new 'disable_cache_manager' config to run snapshotter
    without cache manager.