### PR TITLE
Snapshotter recover test

### DIFF
--- a/contrib/nydus-snapshotter/pkg/filesystem/stargz/fs_test.go
+++ b/contrib/nydus-snapshotter/pkg/filesystem/stargz/fs_test.go
@@ -17,8 +17,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/config"
 	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/filesystem/meta"
-	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/filesystem/nydus"
 	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/label"
 	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/process"
 )
@@ -41,7 +41,6 @@ func Test_filesystem_createNewDaemon(t *testing.T) {
 
 	mgr, err := process.NewManager(process.Opt{
 		NydusdBinaryPath: "",
-		RootDir:          snapshotRoot,
 	})
 	require.Nil(t, err)
 
@@ -50,7 +49,7 @@ func Test_filesystem_createNewDaemon(t *testing.T) {
 			RootDir: snapshotRoot,
 		},
 		manager:     mgr,
-		daemonCfg:   nydus.DaemonConfig{},
+		daemonCfg:   config.DaemonConfig{},
 		resolver:    nil,
 		vpcRegistry: false,
 	}
@@ -68,13 +67,12 @@ func Test_filesystem_generateDaemonConfig(t *testing.T) {
 
 	content, err := ioutil.ReadFile("testdata/config/nydus.json")
 	require.Nil(t, err)
-	var cfg nydus.DaemonConfig
+	var cfg config.DaemonConfig
 	err = json.Unmarshal(content, &cfg)
 	require.Nil(t, err)
 
 	mgr, err := process.NewManager(process.Opt{
 		NydusdBinaryPath: "",
-		RootDir:          snapshotRoot,
 	})
 	require.Nil(t, err)
 

--- a/contrib/nydus-snapshotter/pkg/filesystem/stargz/fs_test.go
+++ b/contrib/nydus-snapshotter/pkg/filesystem/stargz/fs_test.go
@@ -109,6 +109,5 @@ func Test_filesystem_generateDaemonConfig(t *testing.T) {
 	})
 	require.Nil(t, err)
 	assert.Nil(t, ensureExists(filepath.Join(snapshotRoot, "config", d.ID, "config.json")))
-	assert.Nil(t, ensureExists(filepath.Join(snapshotRoot, "cache")))
 	assert.Nil(t, ensureExists(filepath.Join(snapshotRoot, "socket", d.ID)))
 }

--- a/contrib/nydus-snapshotter/pkg/store/database.go
+++ b/contrib/nydus-snapshotter/pkg/store/database.go
@@ -89,6 +89,15 @@ func (d *Database) initDatabase() error {
 	})
 }
 
+func (d *Database) Close() error {
+	err := d.db.Close()
+	if err != nil {
+		return errors.Wrapf(err, "Close boltdb failed")
+	}
+
+	return nil
+}
+
 // SaveDaemon saves daemon record from database
 func (d *Database) SaveDaemon(ctx context.Context, dmn *daemon.Daemon) error {
 	return d.db.Update(func(tx *bolt.Tx) error {

--- a/contrib/nydus-snapshotter/pkg/store/database_test.go
+++ b/contrib/nydus-snapshotter/pkg/store/database_test.go
@@ -54,7 +54,7 @@ func Test_daemon(t *testing.T) {
 	require.Equal(t, ok, true)
 
 	// Cleanup records
-	err = db.Cleanup(ctx)
+	err = db.CleanupDaemons(ctx)
 	require.Nil(t, err)
 	ids2 := make([]string, 0)
 	err = db.WalkDaemons(ctx, func(info *daemon.Daemon) error {


### PR DESCRIPTION
Snapshotter's test went insane for a long time. It is majorly caused by redefine some structs. Fix it in the PR.