### PR TITLE
Fix rafs root permission wongely set to 0750

### DIFF
--- a/contrib/nydusify/go.mod
+++ b/contrib/nydusify/go.mod
@@ -37,6 +37,7 @@ require (
 	go.etcd.io/bbolt v1.3.5 // indirect
 	go.opencensus.io v0.22.3 // indirect
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
+	golang.org/x/sys v0.0.0-20201201145000-ef89a241ccb3
 	golang.org/x/time v0.0.0-20200416051211-89c76fbcd5d1 // indirect
 	google.golang.org/genproto v0.0.0-20200527145253-8367513e4ece // indirect
 	google.golang.org/grpc v1.29.1 // indirect

--- a/contrib/nydusify/pkg/utils/archive.go
+++ b/contrib/nydusify/pkg/utils/archive.go
@@ -12,6 +12,8 @@ import (
 	"os"
 	"path/filepath"
 
+	"golang.org/x/sys/unix"
+
 	"github.com/containerd/containerd/archive"
 	"github.com/containerd/containerd/archive/compression"
 	"github.com/opencontainers/go-digest"
@@ -136,7 +138,11 @@ func UnpackTargz(ctx context.Context, dst string, r io.Reader) error {
 	}
 	defer ds.Close()
 
-	if err := os.MkdirAll(dst, 0770); err != nil {
+	// Guarantee that umask won't affect file/directory creation
+	mask := unix.Umask(0)
+	defer unix.Umask(mask)
+
+	if err := os.MkdirAll(dst, 0755); err != nil {
 		return err
 	}
 

--- a/rafs/src/fs.rs
+++ b/rafs/src/fs.rs
@@ -566,8 +566,16 @@ impl FileSystem for Rafs {
         _handle: Option<u64>,
     ) -> Result<(libc::stat64, Duration)> {
         let mut recorder = FopRecorder::settle(Getattr, ino, &self.ios);
-        let attr = self.get_inode_attr(ino).map(|r| {
+
+        let attr = self.get_inode_attr(ino).map(|mut r| {
             recorder.mark_success(0);
+            // Only touch permissions bits. This trick is some sort of workaround
+            // since nydusify gives root directory permission of 0o750 and fuse mount
+            // options `rootmode=` does not affect root directory's permission bits, ending
+            // up with preventing other users from accessing the container rootfs.
+            if ino == ROOT_ID {
+                r.mode = r.mode & !0o777 | 0o755;
+            }
             r
         })?;
         Ok((attr.into(), self.sb.meta.attr_timeout))


### PR DESCRIPTION
When rafs root inode has permission bits of 0750, other user can 't list the root dir. It may cause container insane that it can't change user.

So give the root directory of permission 0755 when converting image.
Moreover, during runtime, let rafs return 0755 for access() so we don't have to re-convert images.