### PR TITLE
Mulitple chunks

### DIFF
--- a/rafs/src/fs.rs
+++ b/rafs/src/fs.rs
@@ -636,6 +636,7 @@ impl FileSystem for Rafs {
                 desc.bi_vec.extend_from_slice(&ra_desc.bi_vec)
             }
         };
+
         let start = self.ios.latency_start();
         // Avoid copying `desc`
         let r = self.device.read_to(w, &mut desc).map(|r| {

--- a/rafs/src/fs.rs
+++ b/rafs/src/fs.rs
@@ -612,9 +612,10 @@ impl FileSystem for Rafs {
             recorder.mark_success(0);
             return Ok(0);
         }
-        let desc = inode.alloc_bio_desc(offset, size as usize)?;
+        let mut desc = inode.alloc_bio_desc(offset, size as usize)?;
         let start = self.ios.latency_start();
-        let r = self.device.read_to(w, desc).map(|r| {
+        // Avoid copying `desc`
+        let r = self.device.read_to(w, &mut desc).map(|r| {
             recorder.mark_success(r);
             r
         });

--- a/rafs/src/metadata/cached_v5.rs
+++ b/rafs/src/metadata/cached_v5.rs
@@ -485,8 +485,8 @@ impl RafsInode for CachedInodeV5 {
         Ok(0)
     }
 
-    fn alloc_bio_desc(&self, offset: u64, size: usize) -> Result<RafsBioDesc> {
-        rafsv5_alloc_bio_desc(self, offset, size)
+    fn alloc_bio_desc(&self, offset: u64, size: usize, is_user: bool) -> Result<RafsBioDesc> {
+        rafsv5_alloc_bio_desc(self, offset, size, is_user)
     }
 
     fn get_name_size(&self) -> u16 {

--- a/rafs/src/metadata/cached_v5.rs
+++ b/rafs/src/metadata/cached_v5.rs
@@ -485,8 +485,8 @@ impl RafsInode for CachedInodeV5 {
         Ok(0)
     }
 
-    fn alloc_bio_desc(&self, offset: u64, size: usize, is_user: bool) -> Result<RafsBioDesc> {
-        rafsv5_alloc_bio_desc(self, offset, size, is_user)
+    fn alloc_bio_desc(&self, offset: u64, size: usize, user_io: bool) -> Result<RafsBioDesc> {
+        rafsv5_alloc_bio_desc(self, offset, size, user_io)
     }
 
     fn get_name_size(&self) -> u16 {

--- a/rafs/src/metadata/cached_v5.rs
+++ b/rafs/src/metadata/cached_v5.rs
@@ -797,13 +797,15 @@ mod cached_tests {
             .add(String::from("123333"), 0, 0, 0, 0, 0);
         let mut cached_inode = CachedInodeV5::new(blob_table, meta.clone());
         cached_inode.load(&meta, &mut reader).unwrap();
-        let desc1 = cached_inode.alloc_bio_desc(0, 100).unwrap();
+        let desc1 = cached_inode.alloc_bio_desc(0, 100, true).unwrap();
         assert_eq!(desc1.bi_size, 100);
         assert_eq!(desc1.bi_vec.len(), 1);
         assert_eq!(desc1.bi_vec[0].offset, 0);
         assert_eq!(desc1.bi_vec[0].blob.blob_id, "123333");
 
-        let desc2 = cached_inode.alloc_bio_desc(1024 * 1024 - 100, 200).unwrap();
+        let desc2 = cached_inode
+            .alloc_bio_desc(1024 * 1024 - 100, 200, true)
+            .unwrap();
         assert_eq!(desc2.bi_size, 200);
         assert_eq!(desc2.bi_vec.len(), 2);
         assert_eq!(desc2.bi_vec[0].offset, 1024 * 1024 - 100);
@@ -812,7 +814,7 @@ mod cached_tests {
         assert_eq!(desc2.bi_vec[1].size, 100);
 
         let desc3 = cached_inode
-            .alloc_bio_desc(1024 * 1024 + 8192, 1024 * 1024 * 4)
+            .alloc_bio_desc(1024 * 1024 + 8192, 1024 * 1024 * 4, true)
             .unwrap();
         assert_eq!(desc3.bi_size, 1024 * 1024 * 2);
         assert_eq!(desc3.bi_vec.len(), 3);

--- a/rafs/src/metadata/direct_v5.rs
+++ b/rafs/src/metadata/direct_v5.rs
@@ -744,8 +744,8 @@ impl RafsInode for OndiskInodeWrapper {
         Ok(0)
     }
 
-    fn alloc_bio_desc(&self, offset: u64, size: usize, is_user: bool) -> Result<RafsBioDesc> {
-        rafsv5_alloc_bio_desc(self, offset, size, is_user)
+    fn alloc_bio_desc(&self, offset: u64, size: usize, user_io: bool) -> Result<RafsBioDesc> {
+        rafsv5_alloc_bio_desc(self, offset, size, user_io)
     }
 
     impl_inode_wrapper!(is_dir, bool);

--- a/rafs/src/metadata/direct_v5.rs
+++ b/rafs/src/metadata/direct_v5.rs
@@ -744,8 +744,8 @@ impl RafsInode for OndiskInodeWrapper {
         Ok(0)
     }
 
-    fn alloc_bio_desc(&self, offset: u64, size: usize) -> Result<RafsBioDesc> {
-        rafsv5_alloc_bio_desc(self, offset, size)
+    fn alloc_bio_desc(&self, offset: u64, size: usize, is_user: bool) -> Result<RafsBioDesc> {
+        rafsv5_alloc_bio_desc(self, offset, size, is_user)
     }
 
     impl_inode_wrapper!(is_dir, bool);

--- a/rafs/src/metadata/layout/v5.rs
+++ b/rafs/src/metadata/layout/v5.rs
@@ -316,7 +316,7 @@ impl RafsV5InodeTable {
 
     pub fn get(&self, ino: Inode) -> Result<u32> {
         if ino == 0 || ino > self.data.len() as u64 {
-            return Err(enoent!("inode not found"));
+            return Err(enoent!());
         }
 
         let offset = u32::from_le(self.data[(ino - 1) as usize]) as usize;

--- a/rafs/src/metadata/layout/v5.rs
+++ b/rafs/src/metadata/layout/v5.rs
@@ -1072,7 +1072,7 @@ pub(crate) fn rafsv5_alloc_bio_desc<I: RafsInode + RafsV5InodeOps>(
     inode: &I,
     offset: u64,
     size: usize,
-    is_user: bool,
+    user_io: bool,
 ) -> Result<RafsBioDesc> {
     // Do not process zero size bio
     let mut desc = RafsBioDesc::new();
@@ -1101,7 +1101,7 @@ pub(crate) fn rafsv5_alloc_bio_desc<I: RafsInode + RafsV5InodeOps>(
     for idx in index_start..index_end {
         let chunk = inode.get_chunk_info(idx)?;
         let blob = inode.get_blob_by_index(chunk.blob_index())?;
-        if !add_chunk_to_bio_desc(offset, end, chunk, &mut desc, blksize as u32, blob, is_user) {
+        if !add_chunk_to_bio_desc(offset, end, chunk, &mut desc, blksize as u32, blob, user_io) {
             break;
         }
     }
@@ -1125,7 +1125,7 @@ fn add_chunk_to_bio_desc(
     desc: &mut RafsBioDesc,
     blksize: u32,
     blob: Arc<RafsBlobEntry>,
-    is_user: bool,
+    user_io: bool,
 ) -> bool {
     if offset >= (chunk.file_offset() + chunk.decompress_size() as u64) {
         return true;
@@ -1151,7 +1151,7 @@ fn add_chunk_to_bio_desc(
         chunk_start as u32,
         (chunk_end - chunk_start) as usize,
         blksize,
-        is_user,
+        user_io,
     );
 
     desc.bi_size += bio.size;

--- a/rafs/src/metadata/mod.rs
+++ b/rafs/src/metadata/mod.rs
@@ -841,7 +841,7 @@ pub trait RafsInode {
         descendants: &mut Vec<Arc<dyn RafsInode>>,
     ) -> Result<usize>;
 
-    fn alloc_bio_desc(&self, offset: u64, size: usize, is_user: bool) -> Result<RafsBioDesc>;
+    fn alloc_bio_desc(&self, offset: u64, size: usize, user_io: bool) -> Result<RafsBioDesc>;
 }
 
 /// Trait to store Rafs meta block and validate alignment.

--- a/rafs/src/metadata/mod.rs
+++ b/rafs/src/metadata/mod.rs
@@ -555,7 +555,7 @@ impl RafsSuper {
                                 hardlinks.insert(i.ino());
                             }
                         }
-                        let mut desc = i.alloc_bio_desc(0, i.size() as usize)?;
+                        let mut desc = i.alloc_bio_desc(0, i.size() as usize, false)?;
                         head_desc.bi_vec.append(desc.bi_vec.as_mut());
                         head_desc.bi_size += desc.bi_size;
 
@@ -572,7 +572,7 @@ impl RafsSuper {
                             hardlinks.insert(inode.ino());
                         }
                     }
-                    let mut desc = inode.alloc_bio_desc(0, inode.size() as usize)?;
+                    let mut desc = inode.alloc_bio_desc(0, inode.size() as usize, false)?;
                     head_desc.bi_vec.append(desc.bi_vec.as_mut());
                     head_desc.bi_size += desc.bi_size;
 
@@ -704,6 +704,7 @@ impl RafsSuper {
                     ra_desc.bi_vec.append(&mut cks.bi_vec);
                     ra_desc.bi_size += cks.bi_size;
                 }
+                left -= delta;
                 true
             }
         } else {
@@ -824,7 +825,7 @@ pub trait RafsInode {
         descendants: &mut Vec<Arc<dyn RafsInode>>,
     ) -> Result<usize>;
 
-    fn alloc_bio_desc(&self, offset: u64, size: usize) -> Result<RafsBioDesc>;
+    fn alloc_bio_desc(&self, offset: u64, size: usize, is_user: bool) -> Result<RafsBioDesc>;
 }
 
 /// Trait to store Rafs meta block and validate alignment.

--- a/rafs/src/metadata/mod.rs
+++ b/rafs/src/metadata/mod.rs
@@ -633,6 +633,119 @@ impl RafsSuper {
 
         Ok(())
     }
+
+    fn steal_chunks(desc: &mut RafsBioDesc, expected_size: u32) -> Option<&mut RafsBioDesc> {
+        enum State {
+            All,
+            None,
+            Partial(usize),
+        }
+
+        let mut total = 0;
+        let mut final_index = State::All;
+        let len = desc.bi_vec.len();
+
+        for (i, b) in desc.bi_vec.iter().enumerate() {
+            let compressed_size = b.chunkinfo.compress_size();
+
+            if compressed_size + total <= expected_size {
+                total += compressed_size;
+                continue;
+            } else {
+                if i != 0 {
+                    final_index = State::Partial(i - 1);
+                } else {
+                    final_index = State::None;
+                }
+                break;
+            }
+        }
+
+        match final_index {
+            State::None => None,
+            State::All => Some(desc),
+            State::Partial(fi) => {
+                for i in (fi..len).rev() {
+                    desc.bi_size -= desc.bi_vec[i].chunkinfo.decompress_size() as usize;
+                    desc.bi_vec.remove(i as usize);
+                }
+                Some(desc)
+            }
+        }
+    }
+
+    pub fn carry_more_until(
+        &self,
+        inode: &dyn RafsInode,
+        bound: u64,
+        expected_size: u64,
+    ) -> Result<RafsBioDesc> {
+        let mut left = expected_size;
+        let inode_size = inode.size();
+        let mut ra_desc = RafsBioDesc::new();
+
+        let extra_file_needed = if let Some(delta) = inode_size.checked_sub(bound) {
+            if delta >= expected_size {
+                let mut d = inode.alloc_bio_desc(bound, expected_size as usize, false)?;
+
+                // Stolen chunk bigger than expected size will involve more backend IO, thus
+                // to slow down current user IO.
+                if let Some(cks) = Self::steal_chunks(&mut d, left as u32) {
+                    ra_desc.bi_vec.append(&mut cks.bi_vec);
+                    ra_desc.bi_size += cks.bi_size;
+                }
+                false
+            } else {
+                let mut d = inode.alloc_bio_desc(bound, delta as usize, false)?;
+
+                // Stolen chunk bigger than expected size will involve more backend IO, thus
+                // to slow down current user IO.
+                if let Some(cks) = Self::steal_chunks(&mut d, left as u32) {
+                    ra_desc.bi_vec.append(&mut cks.bi_vec);
+                    ra_desc.bi_size += cks.bi_size;
+                }
+                true
+            }
+        } else {
+            true
+        };
+
+        if extra_file_needed {
+            let mut next_ino = inode.ino() + 1;
+            loop {
+                let next_inode = self.get_inode(next_ino, false);
+                if let Ok(ni) = next_inode {
+                    if !ni.is_reg() {
+                        next_ino = ni.ino() + 1;
+                        continue;
+                    }
+                    let next_size = ni.size();
+                    let sz = std::cmp::min(left, next_size);
+                    let mut d = ni.alloc_bio_desc(0, sz as usize, false)?;
+
+                    // Stolen chunk bigger than expected size will involve more backend IO, thus
+                    // to slow down current user IO.
+                    if let Some(cks) = Self::steal_chunks(&mut d, sz as u32) {
+                        ra_desc.bi_vec.append(&mut cks.bi_vec);
+                        ra_desc.bi_size += cks.bi_size;
+                    } else {
+                        break;
+                    }
+
+                    // Even stolen chunks are truncated, still consume expected size.
+                    left -= sz;
+                    if left == 0 {
+                        break;
+                    }
+                    next_ino = ni.ino() + 1;
+                } else {
+                    break;
+                }
+            }
+        }
+
+        Ok(ra_desc)
+    }
 }
 
 pub trait RafsSuperInodes {

--- a/storage/src/cache/blobcache.rs
+++ b/storage/src/cache/blobcache.rs
@@ -492,6 +492,7 @@ impl BlobCache {
         // With shared chunk bitmap applied, we don't have to try to recover blobcache
         // as principle is that chunk bitmap is trusted. The chunk must not be downloaded before.
 
+        // FIXME: get read lock from here
         let mut cache_guard = self.cache.write().expect("Expect cache lock not poisoned");
         let (fd, _, ref chunk_map) = cache_guard.set(blob)?;
 
@@ -500,6 +501,8 @@ impl BlobCache {
 
         let has_ready = chunk_map.has_ready(ck, false)?;
         let buffer_holder;
+
+        drop(cache_guard);
 
         let d_size = chunk.decompress_size() as usize;
         let mut d = DataBuffer::Allocated(alloc_buf(d_size));
@@ -606,6 +609,7 @@ impl BlobCache {
         for req in merged_requests {
             let blob = &req.blob_entry;
             let cache_guard = self.cache.read().unwrap();
+            // FIXME: Don't open code below snippet.
             let (fd, _, chunk_map) = match cache_guard.get(blob) {
                 Some(entry) => {
                     drop(cache_guard);
@@ -635,7 +639,7 @@ impl BlobCache {
                         }
                         // Encounter the same type of item, just enlarge this region.
                         // A sanity check, rafs layer should always passes continuous region.
-                        if i != 0 {
+                        if i != 0 && self.compressor() != compress::Algorithm::GZip {
                             let prior_cki = &req.chunks[i - 1];
                             assert!(
                                 chunk.decompress_offset()
@@ -658,7 +662,7 @@ impl BlobCache {
                 } else if (self.compressor() != compress::Algorithm::GZip
                     && !blob.with_extended_blob_table()
                     && !has_ready)
-                    || (self.compressor() == compress::Algorithm::GZip && has_ready)
+                    || (self.compressor() == compress::Algorithm::GZip)
                 {
                     // NOTE: Handle this branch very carefully since it has also to
                     // take care of the case that blobcache has no chunk bitmap.
@@ -709,8 +713,8 @@ impl BlobCache {
                         }
                         region = Some(RequestRegion::new(region_type, req.blob_entry.clone()));
                     }
-                    // A sanity check, rafs layer should always pass continuos region.
-                    if i != 0 {
+                    // A sanity check, rafs layer should always pass continuous region.
+                    if i != 0 && self.compressor() != compress::Algorithm::GZip {
                         let prior_cki = &req.chunks[i - 1];
                         assert!(
                             chunk.decompress_offset()

--- a/storage/src/cache/blobcache.rs
+++ b/storage/src/cache/blobcache.rs
@@ -483,10 +483,10 @@ impl BlobCache {
 
     fn convert_to_merge_request(continuous_bios: &[&RafsBio]) -> MergedBackendRequest {
         let first = continuous_bios[0];
-        let mut mr = MergedBackendRequest::new(first.chunkinfo.clone(), first.blob.clone());
+        let mut mr = MergedBackendRequest::new(first.chunkinfo.clone(), first.blob.clone(), first);
 
         for c in &continuous_bios[1..] {
-            mr.merge_one_chunk(Arc::clone(&c.chunkinfo));
+            mr.merge_one_chunk(Arc::clone(&c.chunkinfo), c);
         }
 
         mr
@@ -503,7 +503,7 @@ impl BlobCache {
         false
     }
 
-    fn generate_merged_requests(
+    fn generate_merged_requests_for_prefetch(
         &self,
         bios: &mut [RafsBio],
         tx: &mut spmc::Sender<MergedBackendRequest>,
@@ -523,6 +523,38 @@ impl BlobCache {
             }
         };
 
+        self.generate_merged_requests(bios, merging_size, &mut |mr: MergedBackendRequest| {
+            limiter(mr.blob_size);
+            // Safe to unwrap because channel won't be closed.
+            tx.send(mr).unwrap();
+        })
+    }
+
+    #[allow(dead_code)]
+    fn generate_merged_requests_for_user(
+        &self,
+        bios: &mut [RafsBio],
+        merging_size: usize,
+    ) -> Option<Vec<MergedBackendRequest>> {
+        let mut merged_requests: Vec<MergedBackendRequest> = Vec::new();
+
+        self.generate_merged_requests(bios, merging_size, &mut |mr: MergedBackendRequest| {
+            merged_requests.push(mr);
+        });
+
+        if merged_requests.is_empty() {
+            None
+        } else {
+            Some(merged_requests)
+        }
+    }
+
+    fn generate_merged_requests(
+        &self,
+        bios: &mut [RafsBio],
+        merging_size: usize,
+        op: &mut dyn FnMut(MergedBackendRequest),
+    ) {
         bios.sort_by_key(|entry| entry.chunkinfo.compress_offset());
         if bios.is_empty() {
             return;
@@ -548,8 +580,7 @@ impl BlobCache {
                     continue;
                 }
                 let mr = Self::convert_to_merge_request(&continuous_bios);
-                limiter(mr.blob_size);
-                tx.send(mr).unwrap();
+                (*op)(mr);
                 continuous_bios.truncate(0);
 
                 // current bio is not continuous with prior one,
@@ -563,8 +594,7 @@ impl BlobCache {
         // No more bio left, convert the collected bios to merged request and sent it.
         if !continuous_bios.is_empty() {
             let mr = Self::convert_to_merge_request(&continuous_bios);
-            limiter(mr.blob_size);
-            tx.send(mr).unwrap();
+            (*op)(mr);
         }
     }
 }
@@ -819,7 +849,7 @@ impl RafsCache for BlobCache {
         self.metrics.prefetch_unmerged_chunks.add(bios.len());
 
         if let Some(mr_sender) = self.mr_sender.lock().unwrap().as_mut() {
-            self.generate_merged_requests(bios, mr_sender, merging_size);
+            self.generate_merged_requests_for_prefetch(bios, mr_sender, merging_size);
         }
 
         Ok(0)
@@ -1202,7 +1232,11 @@ pub mod blob_cache_tests {
         let (mut send, recv) = spmc::channel::<MergedBackendRequest>();
         let mut bios = vec![bio];
 
-        blob_cache.generate_merged_requests(&mut bios, &mut send, merging_size as usize);
+        blob_cache.generate_merged_requests_for_prefetch(
+            &mut bios,
+            &mut send,
+            merging_size as usize,
+        );
         let mr = recv.recv().unwrap();
 
         assert_eq!(mr.blob_offset, single_chunk.compress_offset());
@@ -1255,7 +1289,11 @@ pub mod blob_cache_tests {
 
         let mut bios = vec![bio1, bio2];
         let (mut send, recv) = spmc::channel::<MergedBackendRequest>();
-        blob_cache.generate_merged_requests(&mut bios, &mut send, merging_size as usize);
+        blob_cache.generate_merged_requests_for_prefetch(
+            &mut bios,
+            &mut send,
+            merging_size as usize,
+        );
         let mr = recv.recv().unwrap();
 
         assert_eq!(mr.blob_offset, chunk1.compress_offset());
@@ -1311,7 +1349,11 @@ pub mod blob_cache_tests {
 
         let mut bios = vec![bio1, bio2];
         let (mut send, recv) = spmc::channel::<MergedBackendRequest>();
-        blob_cache.generate_merged_requests(&mut bios, &mut send, merging_size as usize);
+        blob_cache.generate_merged_requests_for_prefetch(
+            &mut bios,
+            &mut send,
+            merging_size as usize,
+        );
 
         let mr = recv.recv().unwrap();
         assert_eq!(mr.blob_offset, chunk1.compress_offset());
@@ -1368,7 +1410,11 @@ pub mod blob_cache_tests {
 
         let mut bios = vec![bio1, bio2];
         let (mut send, recv) = spmc::channel::<MergedBackendRequest>();
-        blob_cache.generate_merged_requests(&mut bios, &mut send, merging_size as usize);
+        blob_cache.generate_merged_requests_for_prefetch(
+            &mut bios,
+            &mut send,
+            merging_size as usize,
+        );
 
         let mr = recv.recv().unwrap();
         assert_eq!(mr.blob_offset, chunk1.compress_offset());
@@ -1447,7 +1493,11 @@ pub mod blob_cache_tests {
 
         let mut bios = vec![bio1, bio2, bio3];
         let (mut send, recv) = spmc::channel::<MergedBackendRequest>();
-        blob_cache.generate_merged_requests(&mut bios, &mut send, merging_size as usize);
+        blob_cache.generate_merged_requests_for_prefetch(
+            &mut bios,
+            &mut send,
+            merging_size as usize,
+        );
 
         let mr = recv.recv().unwrap();
         assert_eq!(mr.blob_offset, chunk1.compress_offset());

--- a/storage/src/cache/blobcache.rs
+++ b/storage/src/cache/blobcache.rs
@@ -1266,6 +1266,15 @@ impl RafsCache for BlobCache {
         Ok(())
     }
 
+    fn is_chunk_cached(&self, chunk: &dyn RafsChunkInfo, blob: &RafsBlobEntry) -> bool {
+        let cache_guard = self.cache.read().unwrap();
+        if let Some((_, _, chunk_map)) = cache_guard.get(blob) {
+            chunk_map.has_ready_lite(chunk).unwrap_or(false)
+        } else {
+            false
+        }
+    }
+
     #[inline]
     fn digester(&self) -> digest::Algorithm {
         self.digester

--- a/storage/src/cache/chunkmap/indexed.rs
+++ b/storage/src/cache/chunkmap/indexed.rs
@@ -175,7 +175,7 @@ impl ChunkIndexGetter for IndexedChunkMap {
     type Index = u32;
 
     fn get_index(chunk: &dyn RafsChunkInfo) -> Self::Index {
-        chunk.blob_index()
+        chunk.index()
     }
 }
 

--- a/storage/src/cache/chunkmap/mod.rs
+++ b/storage/src/cache/chunkmap/mod.rs
@@ -25,6 +25,9 @@ pub trait ChunkMap {
     fn has_ready(&self, chunk: &dyn RafsChunkInfo, wait: bool) -> Result<bool>;
     fn set_ready(&self, chunk: &dyn RafsChunkInfo) -> Result<()>;
     fn finish(&self, _chunk: &dyn RafsChunkInfo) {}
+    fn has_ready_lite(&self, _chunk: &dyn RafsChunkInfo) -> Result<bool> {
+        Ok(false)
+    }
 }
 
 /// convert RafsChunkInfo to ChunkMap inner index
@@ -160,6 +163,10 @@ where
         if let Some(i) = guard.remove(&index) {
             i.done();
         }
+    }
+
+    fn has_ready_lite(&self, chunk: &dyn RafsChunkInfo) -> Result<bool> {
+        self.c.has_ready(chunk, false)
     }
 }
 

--- a/storage/src/cache/chunkmap/mod.rs
+++ b/storage/src/cache/chunkmap/mod.rs
@@ -123,7 +123,14 @@ where
                             let mut t = self.inflight_tracer.lock().unwrap();
                             t.remove(&index);
                             i.notify();
-                            warn!("Waiting for another backend IO expires. chunk index {}, tracer scale {}", index, t.len());
+                            warn!(
+                                "Waiting for another backend IO expires. chunk index {}, \
+                            compressed offset {}, tracer scale {}",
+                                index,
+                                chunk.compress_offset(),
+                                t.len()
+                            );
+                            // TODO: Take argument `true` or `false` is strange since it is not used.
                             self.c.has_ready(chunk, false)
                         }
                         _ => self.c.has_ready(chunk, false),

--- a/storage/src/cache/chunkmap/mod.rs
+++ b/storage/src/cache/chunkmap/mod.rs
@@ -25,7 +25,7 @@ pub trait ChunkMap {
     fn has_ready(&self, chunk: &dyn RafsChunkInfo, wait: bool) -> Result<bool>;
     fn set_ready(&self, chunk: &dyn RafsChunkInfo) -> Result<()>;
     fn finish(&self, _chunk: &dyn RafsChunkInfo) {}
-    fn has_ready_lite(&self, _chunk: &dyn RafsChunkInfo) -> Result<bool> {
+    fn has_ready_nowait(&self, _chunk: &dyn RafsChunkInfo) -> Result<bool> {
         Ok(false)
     }
 }
@@ -90,6 +90,8 @@ pub struct BlobChunkMap<C, I> {
     inflight_tracer: Mutex<HashMap<I, Arc<ChunkSlot>>>,
 }
 
+// TODO: Use chunk's compress offset a.k.a blob address as key, so we don't need
+// ChunkIndexGetter<Index = I> anymore.
 impl<C, I> BlobChunkMap<C, I>
 where
     C: ChunkMap + ChunkIndexGetter<Index = I> + NoWaitSupport,
@@ -165,7 +167,7 @@ where
         }
     }
 
-    fn has_ready_lite(&self, chunk: &dyn RafsChunkInfo) -> Result<bool> {
+    fn has_ready_nowait(&self, chunk: &dyn RafsChunkInfo) -> Result<bool> {
         self.c.has_ready(chunk, false)
     }
 }

--- a/storage/src/cache/dummycache.rs
+++ b/storage/src/cache/dummycache.rs
@@ -111,6 +111,10 @@ impl RafsCache for DummyCache {
     fn release(&self) {
         self.backend().release()
     }
+
+    fn is_chunk_cached(&self, _chunk: &dyn RafsChunkInfo, _blob: &RafsBlobEntry) -> bool {
+        false
+    }
 }
 
 pub fn new(

--- a/storage/src/cache/dummycache.rs
+++ b/storage/src/cache/dummycache.rs
@@ -9,7 +9,7 @@ use vm_memory::VolatileSlice;
 
 use crate::backend::BlobBackend;
 use crate::cache::*;
-use crate::device::{BlobPrefetchControl, RafsBio, RafsChunkInfo};
+use crate::device::{BlobPrefetchControl, RafsBio};
 use crate::factory::CacheConfig;
 use crate::utils::{alloc_buf, copyv};
 use crate::{compress, StorageResult};
@@ -35,31 +35,50 @@ impl RafsCache for DummyCache {
         Ok(())
     }
 
-    fn read(&self, bio: &RafsBio, bufs: &[VolatileSlice], offset: usize) -> Result<usize> {
-        let chunk = &bio.chunkinfo;
-        let mut reuse = false;
+    fn read(&self, bios: &mut [RafsBio], bufs: &[VolatileSlice]) -> Result<usize> {
+        let mut buffer_holder: Vec<Vec<u8>> = Vec::new();
+        let offset = bios[0].offset;
+        let mut user_size = 0;
 
-        let d_size = chunk.decompress_size() as usize;
+        let bios_len = bios.len();
 
-        let mut d;
-        let one_chunk_buf = if bufs.len() == 1 && offset == 0 && bufs[0].len() >= d_size {
-            // Use the destination buffer to received the decompressed data.
-            reuse = true;
-            unsafe { std::slice::from_raw_parts_mut(bufs[0].as_ptr(), d_size) }
-        } else {
-            d = alloc_buf(d_size);
-            d.as_mut_slice()
-        };
+        for bio in bios {
+            if !bio.is_user {
+                continue;
+            }
 
-        self.read_backend_chunk(&bio.blob, chunk.as_ref(), one_chunk_buf, None)?;
-
-        if reuse {
-            Ok(one_chunk_buf.len())
-        } else {
-            copyv(&[one_chunk_buf], bufs, offset, bio.size, 0, 0)
-                .map(|r| r.0)
-                .map_err(|e| eother!(e))
+            user_size += bio.size;
+            let chunk = &bio.chunkinfo;
+            let mut reuse = false;
+            let d_size = chunk.decompress_size() as usize;
+            let one_chunk_buf =
+                if bufs.len() == 1 && bios_len == 1 && offset == 0 && bufs[0].len() >= d_size {
+                    // Use the destination buffer to received the decompressed data.
+                    reuse = true;
+                    unsafe { std::slice::from_raw_parts_mut(bufs[0].as_ptr(), d_size) }
+                } else {
+                    let d = alloc_buf(d_size);
+                    buffer_holder.push(d);
+                    buffer_holder.last_mut().unwrap().as_mut_slice()
+                };
+            self.read_backend_chunk(&bio.blob, chunk.as_ref(), one_chunk_buf, None)?;
+            if reuse {
+                return Ok(one_chunk_buf.len());
+            }
         }
+
+        let chunk_buffers: Vec<&[u8]> = buffer_holder.iter().map(|b| b.as_slice()).collect();
+
+        copyv(
+            chunk_buffers.as_slice(),
+            bufs,
+            offset as usize,
+            user_size,
+            0,
+            0,
+        )
+        .map(|(n, _)| n)
+        .map_err(|e| eother!(e))
     }
 
     fn blob_size(&self, blob: &RafsBlobEntry) -> Result<u64> {
@@ -87,20 +106,6 @@ impl RafsCache for DummyCache {
 
     fn stop_prefetch(&self) -> StorageResult<()> {
         Ok(())
-    }
-
-    fn write(&self, blob_id: &str, blk: &dyn RafsChunkInfo, buf: &[u8]) -> Result<usize> {
-        let out;
-        let wbuf = if blk.is_compressed() {
-            out = compress::compress(buf, self.compressor())?;
-            out.0.as_ref()
-        } else {
-            unsafe { slice::from_raw_parts(buf.as_ptr(), buf.len()) }
-        };
-
-        self.backend
-            .write(blob_id, wbuf, blk.compress_offset())
-            .map_err(|e| eother!(e))
     }
 
     fn release(&self) {

--- a/storage/src/cache/dummycache.rs
+++ b/storage/src/cache/dummycache.rs
@@ -35,7 +35,7 @@ impl RafsCache for DummyCache {
         Ok(())
     }
 
-    fn read(&self, bio: &RafsBio, bufs: &[VolatileSlice], offset: u64) -> Result<usize> {
+    fn read(&self, bio: &RafsBio, bufs: &[VolatileSlice], offset: usize) -> Result<usize> {
         let chunk = &bio.chunkinfo;
         let mut reuse = false;
 
@@ -56,7 +56,9 @@ impl RafsCache for DummyCache {
         if reuse {
             Ok(one_chunk_buf.len())
         } else {
-            copyv(one_chunk_buf, bufs, offset, bio.size)
+            copyv(&[one_chunk_buf], bufs, offset, bio.size, 0, 0)
+                .map(|r| r.0)
+                .map_err(|e| eother!(e))
         }
     }
 

--- a/storage/src/cache/dummycache.rs
+++ b/storage/src/cache/dummycache.rs
@@ -43,7 +43,7 @@ impl RafsCache for DummyCache {
         let bios_len = bios.len();
 
         for bio in bios {
-            if !bio.is_user {
+            if !bio.user_io {
                 continue;
             }
 

--- a/storage/src/cache/mod.rs
+++ b/storage/src/cache/mod.rs
@@ -22,24 +22,27 @@ pub mod blobcache;
 pub mod chunkmap;
 pub mod dummycache;
 
+/// A segment is always a continuous part in a single chunk, which is later copied
+/// from to user buffer memory.
 #[derive(Clone, Debug)]
 pub struct ChunkSegment {
-    seg_offset: u32,
-    seg_len: u32,
+    // From where within a chunk user data is stored
+    offset: u32,
+    // Tht user data total length in a chunk
+    len: u32,
 }
 
 impl ChunkSegment {
     fn new(offset: u32, len: u32) -> Self {
-        Self {
-            seg_offset: offset,
-            seg_len: len,
-        }
+        Self { offset, len }
     }
 }
 
+/// `IoInitiator` denotes that a chunk fulfill user io or internal io.
 #[derive(Clone, Debug)]
 pub enum IoInitiator {
     User(ChunkSegment),
+    // (Chunk index, blob/compressed offset)
     Internal(u32, u64),
 }
 
@@ -100,7 +103,6 @@ impl MergedBackendRequest {
         };
 
         self.chunks.push(cki);
-
         self.chunk_tags.push(tag);
     }
 }

--- a/storage/src/cache/mod.rs
+++ b/storage/src/cache/mod.rs
@@ -74,7 +74,7 @@ impl MergedBackendRequest {
         let blob_size = first_cki.compress_size();
         let blob_offset = first_cki.compress_offset();
 
-        let tag = if bio.is_user {
+        let tag = if bio.user_io {
             IoInitiator::User(ChunkSegment::new(bio.offset, bio.size as u32))
         } else {
             IoInitiator::Internal(first_cki.index(), first_cki.compress_offset())
@@ -96,7 +96,7 @@ impl MergedBackendRequest {
     fn merge_one_chunk(&mut self, cki: Arc<dyn RafsChunkInfo>, bio: &RafsBio) {
         self.blob_size += cki.compress_size();
 
-        let tag = if bio.is_user {
+        let tag = if bio.user_io {
             IoInitiator::User(ChunkSegment::new(bio.offset, bio.size as u32))
         } else {
             IoInitiator::Internal(cki.index(), cki.compress_offset())

--- a/storage/src/cache/mod.rs
+++ b/storage/src/cache/mod.rs
@@ -313,4 +313,6 @@ pub trait RafsCache {
 
         Ok(chunks)
     }
+
+    fn is_chunk_cached(&self, chunk: &dyn RafsChunkInfo, blob: &RafsBlobEntry) -> bool;
 }

--- a/storage/src/cache/mod.rs
+++ b/storage/src/cache/mod.rs
@@ -69,7 +69,7 @@ pub trait RafsCache {
     // TODO: Cache is indexed by each chunk's block id. When this read request can't
     // hit local cache and it spans two chunks, group more than one requests to backend
     // storage could benefit the performance.
-    fn read(&self, bio: &RafsBio, bufs: &[VolatileSlice], offset: u64) -> Result<usize>;
+    fn read(&self, bio: &RafsBio, bufs: &[VolatileSlice], offset: usize) -> Result<usize>;
 
     /// Write a chunk data through cache
     fn write(&self, blob_id: &str, blk: &dyn RafsChunkInfo, buf: &[u8]) -> Result<usize>;

--- a/storage/src/cache/mod.rs
+++ b/storage/src/cache/mod.rs
@@ -121,10 +121,7 @@ pub trait RafsCache {
     // TODO: Cache is indexed by each chunk's block id. When this read request can't
     // hit local cache and it spans two chunks, group more than one requests to backend
     // storage could benefit the performance.
-    fn read(&self, bio: &RafsBio, bufs: &[VolatileSlice], offset: usize) -> Result<usize>;
-
-    /// Write a chunk data through cache
-    fn write(&self, blob_id: &str, blk: &dyn RafsChunkInfo, buf: &[u8]) -> Result<usize>;
+    fn read(&self, bio: &mut [RafsBio], bufs: &[VolatileSlice]) -> Result<usize>;
 
     /// Get the size of a blob
     fn blob_size(&self, blob: &RafsBlobEntry) -> Result<u64>;

--- a/storage/src/device.rs
+++ b/storage/src/device.rs
@@ -179,7 +179,10 @@ impl FileReadWriteVolatile for RafsBioDevice<'_> {
             return self.fill_hole(bufs);
         }
 
-        self.dev.rw_layer.load().read(&self.bio, bufs, offset)
+        self.dev
+            .rw_layer
+            .load()
+            .read(&self.bio, bufs, offset as usize)
     }
 
     fn write_at_volatile(&mut self, slice: VolatileSlice, _offset: u64) -> Result<usize, Error> {

--- a/storage/src/device.rs
+++ b/storage/src/device.rs
@@ -112,24 +112,18 @@ impl RafsDevice {
     }
 
     /// Read a range of data from blob into the provided writer
-    pub fn read_to(&self, w: &mut dyn ZeroCopyWriter, desc: RafsBioDesc) -> io::Result<usize> {
-        let mut count: usize = 0;
-        for bio in desc.bi_vec.iter() {
-            let mut f = RafsBioDevice::new(bio, &self);
-            count += w.write_from(&mut f, bio.size, bio.offset as u64)?;
-        }
+    pub fn read_to(&self, w: &mut dyn ZeroCopyWriter, desc: &mut RafsBioDesc) -> io::Result<usize> {
+        let offset = desc.bi_vec[0].offset;
+        let size = desc.bi_size;
+        let mut f = RafsBioDevice::new(desc, self);
+        let count = w.write_from(&mut f, size, offset as u64)?;
+
         Ok(count)
     }
 
     /// Write a range of data to blob from the provided reader
-    pub fn write_from(&self, r: &mut dyn ZeroCopyReader, desc: RafsBioDesc) -> io::Result<usize> {
-        let mut count: usize = 0;
-        for bio in desc.bi_vec.iter() {
-            let mut f = RafsBioDevice::new(bio, &self);
-            let offset = bio.chunkinfo.compress_offset() + bio.offset as u64;
-            count += r.read_to(&mut f, bio.size, offset)?;
-        }
-        Ok(count)
+    pub fn write_from(&self, _r: &mut dyn ZeroCopyReader, _desc: RafsBioDesc) -> io::Result<usize> {
+        unimplemented!()
     }
 
     pub fn prefetch(&self, desc: &mut RafsBioDesc) -> StorageResult<usize> {
@@ -144,14 +138,13 @@ impl RafsDevice {
 }
 
 struct RafsBioDevice<'a> {
-    bio: &'a RafsBio,
     dev: &'a RafsDevice,
+    desc: &'a mut RafsBioDesc,
 }
 
 impl<'a> RafsBioDevice<'a> {
-    fn new(bio: &'a RafsBio, b: &'a RafsDevice) -> Self {
-        // FIXME: make sure bio is valid
-        RafsBioDevice { bio, dev: b }
+    fn new(desc: &'a mut RafsBioDesc, b: &'a RafsDevice) -> Self {
+        RafsBioDevice { desc, dev: b }
     }
 }
 
@@ -174,33 +167,21 @@ impl FileReadWriteVolatile for RafsBioDevice<'_> {
     fn read_vectored_at_volatile(
         &mut self,
         bufs: &[VolatileSlice],
-        offset: u64,
+        _offset: u64,
     ) -> Result<usize, Error> {
-        if self.bio.chunkinfo.is_hole() {
-            return self.fill_hole(bufs);
-        }
-
-        self.dev
-            .rw_layer
-            .load()
-            .read(&self.bio, bufs, offset as usize)
+        self.dev.rw_layer.load().read(&mut self.desc.bi_vec, bufs)
     }
 
-    fn write_at_volatile(&mut self, slice: VolatileSlice, _offset: u64) -> Result<usize, Error> {
-        // It's safe because the virtio buffer shouldn't be accessed concurrently.
-        let buf = unsafe { std::slice::from_raw_parts_mut(slice.as_ptr(), slice.len()) };
-
-        self.dev
-            .rw_layer
-            .load()
-            .write(&self.bio.blob.blob_id, self.bio.chunkinfo.as_ref(), buf)
+    fn write_at_volatile(&mut self, _slice: VolatileSlice, _offset: u64) -> Result<usize, Error> {
+        unimplemented!()
     }
 }
 
+#[allow(dead_code)]
 impl RafsBioDevice<'_> {
-    fn fill_hole(&self, bufs: &[VolatileSlice]) -> Result<usize, Error> {
+    fn fill_hole(&self, bufs: &[VolatileSlice], size: usize) -> Result<usize, Error> {
         let mut count: usize = 0;
-        let mut remain: usize = self.bio.size;
+        let mut remain = size;
 
         for &buf in bufs.iter() {
             let mut total = cmp::min(remain, buf.len());

--- a/storage/src/device.rs
+++ b/storage/src/device.rs
@@ -23,7 +23,7 @@ static ZEROS: &[u8] = &[0u8; 4096]; // why 4096? volatile slice default size, un
 // A rafs storage device
 #[derive(Clone)]
 pub struct RafsDevice {
-    rw_layer: ArcSwap<Arc<dyn RafsCache + Send + Sync>>,
+    pub rw_layer: ArcSwap<Arc<dyn RafsCache + Send + Sync>>,
 }
 
 bitflags! {

--- a/storage/src/device.rs
+++ b/storage/src/device.rs
@@ -258,7 +258,10 @@ pub struct RafsBio {
     pub size: usize,
     /// block size to read in one shot
     pub blksize: u32,
-    pub is_user: bool,
+    /// Distinguish from a bio that is not initiated by user or fuse frontend.
+    /// It might be initiated by user io amplification. With this flag, lower device
+    /// layer is acknowledged with how to fill up user provided buffer.
+    pub user_io: bool,
 }
 
 impl Debug for RafsBio {
@@ -269,7 +272,7 @@ impl Debug for RafsBio {
             .field("chunk index", &self.chunkinfo.index())
             .field("file offset", &self.offset)
             .field("size", &self.size)
-            .field("user", &self.is_user)
+            .field("user", &self.user_io)
             .finish()
     }
 }
@@ -281,7 +284,7 @@ impl RafsBio {
         offset: u32,
         size: usize,
         blksize: u32,
-        is_user: bool,
+        user_io: bool,
     ) -> Self {
         RafsBio {
             chunkinfo,
@@ -289,7 +292,7 @@ impl RafsBio {
             offset,
             size,
             blksize,
-            is_user,
+            user_io,
         }
     }
 }

--- a/storage/src/device.rs
+++ b/storage/src/device.rs
@@ -4,6 +4,7 @@
 
 use arc_swap::ArcSwap;
 use std::cmp;
+use std::fmt::Debug;
 use std::io;
 use std::io::Error;
 use std::sync::Arc;
@@ -276,6 +277,20 @@ pub struct RafsBio {
     pub size: usize,
     /// block size to read in one shot
     pub blksize: u32,
+    pub is_user: bool,
+}
+
+impl Debug for RafsBio {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        f.debug_struct("RafsBio")
+            .field("blob index", &self.blob.blob_index)
+            .field("blob compress offset", &self.chunkinfo.compress_offset())
+            .field("chunk index", &self.chunkinfo.index())
+            .field("file offset", &self.offset)
+            .field("size", &self.size)
+            .field("user", &self.is_user)
+            .finish()
+    }
 }
 
 impl RafsBio {
@@ -292,6 +307,7 @@ impl RafsBio {
             offset,
             size,
             blksize,
+            is_user: true,
         }
     }
 }

--- a/storage/src/device.rs
+++ b/storage/src/device.rs
@@ -281,6 +281,7 @@ impl RafsBio {
         offset: u32,
         size: usize,
         blksize: u32,
+        is_user: bool,
     ) -> Self {
         RafsBio {
             chunkinfo,
@@ -288,7 +289,7 @@ impl RafsBio {
             offset,
             size,
             blksize,
-            is_user: true,
+            is_user,
         }
     }
 }

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -36,6 +36,8 @@ pub const RAFS_MAX_BLOCK_SIZE: u64 = 1024 * 1024;
 pub enum StorageError {
     Unsupported,
     Timeout,
+    VolatileSlice(vm_memory::VolatileMemoryError),
+    MemOverflow,
 }
 
 pub type StorageResult<T> = std::result::Result<T, StorageError>;

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -38,6 +38,7 @@ pub enum StorageError {
     Timeout,
     VolatileSlice(vm_memory::VolatileMemoryError),
     MemOverflow,
+    NotContinuous,
 }
 
 pub type StorageResult<T> = std::result::Result<T, StorageError>;

--- a/storage/src/utils.rs
+++ b/storage/src/utils.rs
@@ -108,7 +108,7 @@ pub fn copyv(
 }
 
 pub struct MemSliceCursor<'a> {
-    mem_slice: &'a [VolatileSlice<'a>],
+    pub mem_slice: &'a [VolatileSlice<'a>],
     pub index: usize,
     pub offset: usize,
 }
@@ -151,6 +151,7 @@ impl<'a, 'b> MemSliceCursor<'b> {
     }
 
     pub fn consume(&mut self, mut size: usize) -> Vec<IoVec<&mut [u8]>> {
+        // FIXME: What if `size` is 0?
         let mut vectors: Vec<IoVec<&mut [u8]>> = Vec::new();
         loop {
             let slice = self.mem_slice[self.index];
@@ -176,6 +177,10 @@ impl<'a, 'b> MemSliceCursor<'b> {
             }
         }
         vectors
+    }
+
+    pub fn inner_slice(&self) -> &[VolatileSlice] {
+        self.mem_slice
     }
 }
 


### PR DESCRIPTION
Currently, rafs can only handle a bio/chunk down to blob layer. In case a target file range spans multiple chunks, it is clumsy and low efficiency.
Fetching data from backend for size smaller than 128KB takes similar time, so we introduce a feature to amplify user io to fetch more data from backend and store ti into blob cache to boost following rafs read.

From benchmark, with 1000 files of 8K size, read latency had decreased by 50%.