### PR TITLE
Improve Makefile by trimming unnecessary steps and try to re-use same targets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,12 +50,7 @@ env_logger = "0.8.2"
 
 [features]
 fusedev = ["nydus-utils/fusedev", "fuse-rs/fusedev"]
-virtiofs = [
-    "fuse-rs/vhost-user-fs",
-    "vm-memory/backend-mmap",
-    "vhost-rs/vhost-user-slave",
-    "vhost-user-backend",
-]
+virtiofs = ["fuse-rs/vhost-user-fs", "vm-memory/backend-mmap", "vhost-rs/vhost-user-slave", "vhost-user-backend"]
 
 [workspace]
 members = ["api", "app", "error", "rafs", "storage", "utils"]

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,6 @@ fusedev:
 	$(call static_check,$@,target-$@)
 
 PACKAGES = rafs storage
-PACKAGES += upgrade-manager
 
 # If virtiofs test must be performed, only run binary part
 # Use same traget to avoid re-compile for differnt targets like gnu and musl

--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,9 @@ docker-nydus-smoke: docker-static
 
 
 NYDUSIFY_PATH = /nydus-rs/contrib/nydusify
+# TODO: Nydusify smoke has to be time consuming for a while since it relies on musl nydusd and nydus-image.
+# So musl compliation must be involved.
+# And docker-in-docker deployment invovles image buiding?
 docker-nydusify-smoke: docker-static
 	$(call build_golang,$(NYDUSIFY_PATH),make build-smoke)
 	docker build -t nydusify-smoke misc/nydusify-smoke

--- a/misc/nydus-smoke/Dockerfile
+++ b/misc/nydus-smoke/Dockerfile
@@ -1,10 +1,12 @@
-FROM clux/muslrust:1.52.1
+FROM rust:1.52.1
+ARG ARCH=x86_64
 
+RUN mkdir /root/.cargo/
+RUN rustup component add rustfmt && rustup component add clippy
+
+ENV CARGO_HOME=/root/.cargo
 RUN apt update && apt install -y tree
 
 WORKDIR /nydus-rs
 
-CMD rustup component add clippy && \
-  rustup component add rustfmt && \
-  rustup target add x86_64-unknown-linux-musl && \
-  make static-test
+CMD make fusedev-release smoke

--- a/tests/builder.rs
+++ b/tests/builder.rs
@@ -17,9 +17,8 @@ pub struct Builder<'a> {
 }
 
 pub fn new<'a>(work_dir: &'a Path, whiteout_spec: &'a str) -> Builder<'a> {
-    let builder = std::env::var("NYDUS_IMAGE").unwrap_or_else(|_| {
-        String::from("./target-fusedev/x86_64-unknown-linux-musl/release/nydus-image")
-    });
+    let builder = std::env::var("NYDUS_IMAGE")
+        .unwrap_or_else(|_| String::from("./target-fusedev/release/nydus-image"));
     Builder {
         builder,
         work_dir,

--- a/tests/nydusd.rs
+++ b/tests/nydusd.rs
@@ -73,9 +73,8 @@ pub fn new(
         .write_all(config.as_bytes())
         .unwrap();
 
-    let nydusd = std::env::var("NYDUSD").unwrap_or_else(|_| {
-        String::from("./target-fusedev/x86_64-unknown-linux-musl/release/nydusd")
-    });
+    let nydusd =
+        std::env::var("NYDUSD").unwrap_or_else(|_| String::from("./target-fusedev/release/nydusd"));
 
     Nydusd {
         nydusd,
@@ -132,6 +131,7 @@ impl Nydusd {
     pub fn check(&self, expect_texture: &str, mount_path: &str) {
         let mount_path = self.work_dir.join(mount_path);
 
+        // TODO: Lower `tree` does not support option `-J`, we should check return code from here.
         let tree_ret = exec(format!("tree -a -J -v {:?}", mount_path).as_str(), true).unwrap();
         let md5_ret = exec(
             format!("find {:?} -type f -exec md5sum {{}} + | sort", mount_path).as_str(),


### PR DESCRIPTION
Now makefile uses both gnu and musl targets and compile for virtiofs feature of static. This is not necessary.