### PR TITLE
Introduce nydusd - a tool to query nydusd working status

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -683,6 +683,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "hmac"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -716,15 +722,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.3.4"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd179ae861f0c2e53da70d892f5f3029f9594be0c41dc5269cd371691b1dc2f9"
-
-[[package]]
-name = "httpdate"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
+checksum = "acd94fdbe1d4ff688b67b04eee2e17bd50995534a61539e45adfefb45e5e5503"
 
 [[package]]
 name = "httpdate"
@@ -740,9 +740,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.4"
+version = "0.14.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8e946c2b1349055e0b72ae281b238baf1a3ea7307c7e9f9d64673bdd9c26ac7"
+checksum = "15d1cfb9e4f68655fa04c01f59edb405b6074a0f7118ea881e5026e4a1cd8593"
 dependencies = [
  "bytes 1.1.0",
  "futures-channel",
@@ -752,9 +752,9 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
- "httpdate 0.3.2",
+ "httpdate",
  "itoa",
- "pin-project",
+ "pin-project-lite",
  "socket2",
  "tokio",
  "tower-service",
@@ -773,6 +773,19 @@ dependencies = [
  "native-tls",
  "tokio",
  "tokio-native-tls",
+]
+
+[[package]]
+name = "hyperlocal"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fafdf7b2b2de7c9784f76e02c0935e65a8117ec3b768644379983ab333ac98c"
+dependencies = [
+ "futures-util",
+ "hex",
+ "hyper",
+ "pin-project",
+ "tokio",
 ]
 
 [[package]]
@@ -1113,7 +1126,7 @@ name = "nydus-error"
 version = "0.1.0"
 dependencies = [
  "backtrace",
- "httpdate 1.0.1",
+ "httpdate",
  "libc",
  "log",
  "serde",
@@ -1127,7 +1140,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c75f391a670e94e64594ff3e58178eb2be60ba0abd5e5b1b1e93a6ab2d9a844"
 dependencies = [
  "backtrace",
- "httpdate 1.0.1",
+ "httpdate",
  "libc",
  "log",
  "serde",
@@ -1147,6 +1160,8 @@ dependencies = [
  "event-manager",
  "flexi_logger",
  "fuse-rs",
+ "hyper",
+ "hyperlocal",
  "lazy_static",
  "libc",
  "log",
@@ -1165,6 +1180,7 @@ dependencies = [
  "serde_with",
  "sha2",
  "storage",
+ "tokio",
  "vhost",
  "vhost_user_backend",
  "vm-memory",
@@ -1766,11 +1782,10 @@ checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "socket2"
-version = "0.3.19"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "122e570113d28d773067fab24266b66753f6ea915758651696b6e35e49f88d6e"
+checksum = "5dc90fe6c7be1a323296982db1836d1ea9e47b6839496dde9a541bc496df3516"
 dependencies = [
- "cfg-if 1.0.0",
  "libc",
  "winapi",
 ]
@@ -1794,7 +1809,7 @@ dependencies = [
  "futures",
  "governor",
  "hmac",
- "httpdate 1.0.1",
+ "httpdate",
  "libc",
  "log",
  "lz4-sys",
@@ -1811,7 +1826,7 @@ dependencies = [
  "tokio",
  "url",
  "vm-memory",
- "vmm-sys-util 0.6.0",
+ "vmm-sys-util 0.9.0",
 ]
 
 [[package]]
@@ -1939,7 +1954,19 @@ dependencies = [
  "mio",
  "num_cpus",
  "pin-project-lite",
+ "tokio-macros",
  "winapi",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54473be61f4ebe4efd09cec9bd5d16fa51d70ea0192213d754d2d500457db110"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2080,7 +2107,7 @@ source = "git+https://github.com/cloud-hypervisor/vhost.git?branch=dragonball#42
 dependencies = [
  "bitflags",
  "libc",
- "vmm-sys-util 0.6.0",
+ "vmm-sys-util 0.9.0",
 ]
 
 [[package]]
@@ -2263,9 +2290,9 @@ dependencies = [
 
 [[package]]
 name = "winapi"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8093091eeb260906a183e6ae1abdba2ef5ef2257a21801128899c3fc699229c6"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
 dependencies = [
  "winapi-i686-pc-windows-gnu",
  "winapi-x86_64-pc-windows-gnu",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -920,9 +920,10 @@ checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
 [[package]]
 name = "micro_http"
 version = "0.2.0"
-source = "git+https://github.com/cloud-hypervisor/micro-http.git#af72318b755620f9c1b99b319bc2e4e942b91b2f"
+source = "git+https://github.com/cloud-hypervisor/micro-http.git?branch=master#f4405cb5afb092e86204c26d589e8c9448721bf0"
 dependencies = [
- "epoll",
+ "libc",
+ "vmm-sys-util 0.9.0",
 ]
 
 [[package]]
@@ -2139,6 +2140,16 @@ name = "vmm-sys-util"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c40b8c9abb58cec48e0e39dfbe83ff1cfed17d89df28f0fa74f5e88021ae56b"
+dependencies = [
+ "bitflags",
+ "libc",
+]
+
+[[package]]
+name = "vmm-sys-util"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "733537bded03aaa93543f785ae997727b30d1d9f4a03b7861d23290474242e11"
 dependencies = [
  "bitflags",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,10 @@ panic = "abort"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
+[[bin]]
+name = "nydusd"
+path = "src/bin/nydusd/main.rs"
+
 [dependencies]
 rlimit = "0.3.0"
 log = "0.4.8"
@@ -35,6 +39,9 @@ event-manager = { git = "https://github.com/rust-vmm/event-manager.git", tag = "
 fuse-rs = { git = "https://github.com/cloud-hypervisor/fuse-backend-rs.git", optional = true, rev = "cfd2cca" }
 vhost-rs = { git = "https://github.com/cloud-hypervisor/vhost.git", branch = "dragonball", package = "vhost", optional = true }
 vhost-user-backend = { git = "https://github.com/cloud-hypervisor/vhost-user-backend.git", package = "vhost_user_backend", rev = "78757bfa", optional = true }
+hyperlocal = "0.8.0"
+tokio = { version = "1.9.0", features = ["macros"] }
+hyper = "0.14.11"
 
 nydus-api = { path = "api" }
 nydus-app = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,11 @@ panic = "abort"
 name = "nydusd"
 path = "src/bin/nydusd/main.rs"
 
+[lib]
+name = "nydus"
+path = "src/lib.rs"
+
+
 [dependencies]
 rlimit = "0.3.0"
 log = "0.4.8"

--- a/api/src/http.rs
+++ b/api/src/http.rs
@@ -203,7 +203,7 @@ pub fn start_http_thread(
             epoll::ctl(
                 epoll_fd,
                 epoll::ControlOptions::EPOLL_CTL_ADD,
-                server.epoll_fd(),
+                server.epoll().as_raw_fd(),
                 epoll::Event::new(epoll::Events::EPOLLIN, EVENT_UNIX_SOCKET),
             )?;
 

--- a/rafs/src/fs.rs
+++ b/rafs/src/fs.rs
@@ -63,12 +63,12 @@ fn default_prefetch_all() -> bool {
 #[derive(Clone, Default, Deserialize)]
 pub struct FsPrefetchControl {
     #[serde(default)]
-    enable: bool,
+    pub enable: bool,
     #[serde(default = "default_threads_count")]
-    threads_count: usize,
+    pub threads_count: usize,
     #[serde(default = "default_merging_size")]
     // In unit of Bytes
-    merging_size: usize,
+    pub merging_size: usize,
     #[serde(default)]
     // In unit of Bytes. It sets a limit to prefetch bandwidth usage in order to
     // reduce congestion with normal user IO.
@@ -78,7 +78,7 @@ pub struct FsPrefetchControl {
     //                        it will be raised to the chunk size.
     bandwidth_rate: u32,
     #[serde(default = "default_prefetch_all")]
-    prefetch_all: bool,
+    pub prefetch_all: bool,
 }
 
 /// Not everything can be safely exported from configuration.

--- a/src/bin/nydusctl/client.rs
+++ b/src/bin/nydusctl/client.rs
@@ -1,0 +1,69 @@
+// Copyright 2020 Ant Group. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use std::path::PathBuf;
+
+use anyhow::Result;
+use hyper::{header, Body, Client, Method, Request, Uri as HyperUri};
+use hyperlocal::{UnixClientExt, Uri};
+use serde_json::{self, Value};
+
+pub struct NydusdClient {
+    sock_path: PathBuf,
+}
+
+impl NydusdClient {
+    pub fn new(sock: &str) -> Self {
+        Self {
+            sock_path: sock.to_string().into(),
+        }
+    }
+
+    fn build_uri(&self, path: &str) -> HyperUri {
+        let endpoint = format!("/api/v1/{}", path);
+        Uri::new(&self.sock_path, endpoint.as_str()).into()
+    }
+
+    pub async fn get(&self, path: &str) -> Result<Value> {
+        let client = Client::unix();
+        let uri = self.build_uri(path);
+        let response = client.get(uri).await?;
+        let sc = response.status().as_u16();
+        let buf = hyper::body::to_bytes(response).await?;
+        let b = serde_json::from_slice(&buf).map_err(|e| anyhow!("deserialize: {}", e))?;
+
+        if sc >= 400 {
+            bail!("Request failed. {:?}", b);
+        }
+
+        Ok(b)
+    }
+
+    pub async fn put(&self, path: &str, data: Option<String>) -> Result<()> {
+        let client = Client::unix();
+        let uri = self.build_uri(path);
+        let (body, _) = if let Some(d) = data {
+            let l = d.len();
+            (d.into(), l)
+        } else {
+            (Body::empty(), 0)
+        };
+
+        let req = Request::builder()
+            .method(Method::PUT)
+            .header(header::USER_AGENT, "nydusctl")
+            .uri(uri)
+            .body(body)?;
+        let response = client.request(req).await?;
+        let sc = response.status().as_u16();
+        let buf = hyper::body::to_bytes(response).await?;
+        let b = serde_json::from_slice(&buf).map_err(|e| anyhow!("deserialize: {}", e))?;
+
+        if sc >= 400 {
+            bail!("Request failed. {:?}", b);
+        }
+
+        Ok(())
+    }
+}

--- a/src/bin/nydusctl/commands.rs
+++ b/src/bin/nydusctl/commands.rs
@@ -1,0 +1,204 @@
+// Copyright 2020 Ant Group. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashMap;
+use std::thread::sleep;
+use std::time::Duration;
+
+use crate::client::NydusdClient;
+use anyhow::Result;
+
+use nydus::FsBackendDesc;
+use rafs::fs::RafsConfig;
+
+type CommandParams = HashMap<String, String>;
+
+pub(crate) struct CommandBlobcache {}
+
+impl CommandBlobcache {
+    pub async fn execute(
+        &self,
+        raw: bool,
+        client: &NydusdClient,
+        _params: Option<CommandParams>,
+    ) -> Result<()> {
+        let metrics = client.get("metrics/blobcache").await?;
+        let m = metrics.as_object().unwrap();
+
+        if raw {
+            println!("{}", metrics.to_string());
+        } else {
+            print!(
+                r#"
+Partial Hits:       {partial_hits}
+Whole Hits:         {whole_hits}
+Total Read:         {total_read}
+Prefetch Amount:    {prefetch_amount} = {prefetch_amount_kb}KB
+"#,
+                partial_hits = m["partial_hits"],
+                whole_hits = m["whole_hits"],
+                total_read = m["total"],
+                prefetch_amount = m["prefetch_data_amount"],
+                prefetch_amount_kb = m["prefetch_data_amount"].as_u64().unwrap() / 1024,
+            );
+        }
+
+        Ok(())
+    }
+}
+
+pub(crate) struct CommandBackend {}
+
+impl CommandBackend {
+    pub async fn execute(
+        &self,
+        raw: bool,
+        client: &NydusdClient,
+        params: Option<CommandParams>,
+    ) -> Result<()> {
+        let metrics = client.get("metrics/backend").await?;
+
+        let interval: Option<Result<u32>> =
+            params.and_then(|p| p.get("interval").cloned()).map(|i| {
+                i.parse()
+                    .map_err(|e| anyhow!("Invalid interval input. {}", e))
+            });
+
+        if let Some(Err(e)) = interval {
+            return Err(e);
+        } else if let Some(Ok(i)) = interval {
+            let mut last_record = metrics;
+            loop {
+                sleep(Duration::from_secs(i as u64));
+
+                let newest = client.get("metrics/backend").await?;
+
+                let delta = newest["read_amount_total"].as_u64().unwrap()
+                    - last_record["read_amount_total"].as_u64().unwrap();
+                let bw = delta / i as u64 / 1024;
+
+                println!("Backend read bandwidth {}KB/S", bw);
+
+                last_record = newest;
+            }
+        }
+
+        if raw {
+            println!("{}", metrics.to_string());
+        } else {
+            let m = metrics.as_object().unwrap();
+            print!(
+                r#"
+Backend Type:       {backend_type}
+Read Amount:        {read_amount} Bytes ({read_count_mb} MB)
+Read Count:         {read_count}
+Read Errors:        {read_errors}
+"#,
+                backend_type = m["backend_type"],
+                read_amount = m["read_amount_total"],
+                read_count = m["read_count"],
+                read_count_mb = m["read_amount_total"].as_f64().unwrap() / 1024.0 / 1024.0,
+                read_errors = m["read_errors"],
+            );
+        }
+
+        Ok(())
+    }
+}
+
+pub(crate) struct CommandFsStats {}
+
+impl CommandFsStats {
+    pub async fn execute(
+        &self,
+        raw: bool,
+        client: &NydusdClient,
+        _params: Option<CommandParams>,
+    ) -> Result<()> {
+        let metrics = client.get("metrics").await?;
+        let m = metrics.as_object().unwrap();
+        let fop_counter = m["fop_hits"].as_array().unwrap();
+        if raw {
+            println!("{}", metrics.to_string());
+        } else {
+            print!(
+                r#"
+FOP Counters:
+Getattr({}) Readlink({}) Open({}) Release({}) Read({}) Statfs({}) Getxattr({}) Listxattr({})
+Opendir({}) Lookup({}) Readdir({}) Readdirplus({}) Access({}) Forget({}) BatchForget({})
+"#,
+                fop_counter[0],
+                fop_counter[1],
+                fop_counter[2],
+                fop_counter[3],
+                fop_counter[4],
+                fop_counter[5],
+                fop_counter[6],
+                fop_counter[7],
+                fop_counter[8],
+                fop_counter[9],
+                fop_counter[10],
+                fop_counter[11],
+                fop_counter[12],
+                fop_counter[13],
+                fop_counter[14],
+            );
+        }
+
+        Ok(())
+    }
+}
+
+pub(crate) struct CommandDaemon {}
+
+impl CommandDaemon {
+    pub async fn execute(
+        &self,
+        raw: bool,
+        client: &NydusdClient,
+        params: Option<CommandParams>,
+    ) -> Result<()> {
+        if let Some(p) = params {
+            let data = serde_json::to_string(&p)?;
+            client.put("daemon", Some(data)).await?;
+        } else {
+            let info = client.get("daemon").await?;
+            let i = info.as_object().unwrap();
+
+            let backend_list = i["backend_collection"].as_object().unwrap();
+
+            if raw {
+                println!("{}", info.to_string());
+            } else {
+                let version_info = &i["version"];
+                print!(
+                    r#"
+Version:                {version}
+Status:                 {state}
+Profile:                {profile}"#,
+                    version = version_info["package_ver"],
+                    state = i["state"],
+                    profile = version_info["profile"],
+                );
+
+                for f in backend_list.values() {
+                    let backend: FsBackendDesc = serde_json::from_value(f.clone()).unwrap();
+                    let fs: RafsConfig = serde_json::from_value(backend.config.clone()).unwrap();
+                    print!(
+                        r#"
+Mode:                   {meta_mode}
+Prefetch:               {enabled}
+Prefetch Merging Size:  {merging_size}
+"#,
+                        meta_mode = fs.mode,
+                        enabled = fs.fs_prefetch.enable,
+                        merging_size = fs.fs_prefetch.merging_size,
+                    );
+                }
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/src/bin/nydusctl/main.rs
+++ b/src/bin/nydusctl/main.rs
@@ -1,0 +1,130 @@
+// Copyright 2020 Ant Group. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#[macro_use(crate_authors, crate_version)]
+extern crate clap;
+#[macro_use]
+extern crate anyhow;
+
+use std::collections::HashMap;
+
+use anyhow::Result;
+use clap::{App, Arg, SubCommand};
+
+mod client;
+mod commands;
+
+use commands::{CommandBackend, CommandBlobcache, CommandDaemon, CommandFsStats};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let cmd = App::new("A client to query and configure nydusd")
+        .version(crate_version!())
+        .author(crate_authors!())
+        .arg(
+            Arg::with_name("sock")
+                .long("sock")
+                .help("Unix domain socket path")
+                .takes_value(true)
+                .required(true)
+                .global(false),
+        )
+        .arg(
+            Arg::with_name("raw")
+                .long("raw")
+                .help("Output plain json")
+                .takes_value(false)
+                .global(false),
+        )
+        .subcommand(SubCommand::with_name("info").help("Get nydusd working status"))
+        .subcommand(
+            SubCommand::with_name("set")
+                .help("Configure nydusd")
+                .arg(
+                    Arg::with_name("KIND")
+                        .help("what item to configure")
+                        .required(true)
+                        .possible_values(&["log_level"])
+                        .takes_value(true)
+                        .index(1),
+                )
+                .arg(
+                    Arg::with_name("VALUE")
+                        .help("what item to configure")
+                        .required(true)
+                        .takes_value(true)
+                        .index(2),
+                ),
+        )
+        .subcommand(
+            SubCommand::with_name("metrics")
+                .help("Configure nydusd")
+                .arg(
+                    Arg::with_name("category")
+                        .help("Show the category of metrics: blobcache, backend, fsstats")
+                        .required(true)
+                        .possible_values(&["blobcache", "backend", "fsstats"])
+                        .takes_value(true)
+                        .index(1),
+                )
+                .arg(
+                    Arg::with_name("interval")
+                        .long("interval")
+                        .short("I")
+                        .required(false)
+                        .takes_value(true),
+                ),
+        )
+        .get_matches();
+
+    // Safe to unwrap because it is required by Clap
+    let sock = cmd.value_of("sock").unwrap();
+    let raw = cmd.is_present("raw");
+    let client = client::NydusdClient::new(sock);
+
+    if cmd.subcommand_matches("info").is_some() {
+        let cmd = CommandDaemon {};
+        cmd.execute(raw, &client, None).await?;
+    }
+
+    if let Some(matches) = cmd.subcommand_matches("set") {
+        // Safe to unwrap since the below two arguments are required by clap.
+        let kind = matches.value_of("KIND").unwrap().to_string();
+        let value = matches.value_of("VALUE").unwrap().to_string();
+        let mut items = HashMap::new();
+        items.insert(kind, value);
+
+        let cmd = CommandDaemon {};
+        cmd.execute(raw, &client, Some(items)).await?;
+    }
+
+    if let Some(matches) = cmd.subcommand_matches("metrics") {
+        // Safe to unwrap as it is required by clap
+        let category = matches.value_of("category").unwrap();
+
+        let mut context = HashMap::new();
+
+        matches
+            .value_of("interval")
+            .map(|i| context.insert("interval".to_string(), i.to_string()));
+
+        match category {
+            "blobcache" => {
+                let cmd = CommandBlobcache {};
+                cmd.execute(raw, &client, None).await?
+            }
+            "backend" => {
+                let cmd = CommandBackend {};
+                cmd.execute(raw, &client, Some(context)).await?
+            }
+            "fsstats" => {
+                let cmd = CommandFsStats {};
+                cmd.execute(raw, &client, None).await?
+            }
+            _ => println!("Illegal category"),
+        }
+    }
+
+    Ok(())
+}

--- a/src/bin/nydusd/main.rs
+++ b/src/bin/nydusd/main.rs
@@ -41,7 +41,8 @@ use nydus_api::http::start_http_thread;
 use nydus_app::{dump_program_info, setup_logging, BuildTimeInfo};
 
 mod daemon;
-use daemon::{DaemonError, FsBackendMountCmd, FsBackendType, NydusDaemonSubscriber};
+use daemon::{DaemonError, FsBackendMountCmd, NydusDaemonSubscriber};
+use nydus::FsBackendType;
 
 #[cfg(feature = "virtiofs")]
 mod virtiofs;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,56 @@
+// Copyright 2021 Ant Group. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fmt::{self, Display};
+use std::str::FromStr;
+
+use chrono::{self, DateTime, Local};
+use serde::{Deserialize, Serialize};
+use serde_with::{serde_as, DisplayFromStr};
+
+extern crate serde_json;
+
+#[allow(dead_code)]
+#[derive(Debug)]
+pub enum NydusError {
+    InvalidArguments(String),
+}
+
+pub type Result<T> = std::result::Result<T, NydusError>;
+
+#[derive(Clone, Serialize, PartialEq, Deserialize)]
+pub enum FsBackendType {
+    Rafs,
+    PassthroughFs,
+}
+
+impl FromStr for FsBackendType {
+    type Err = NydusError;
+    fn from_str(s: &str) -> Result<FsBackendType> {
+        match s {
+            "rafs" => Ok(FsBackendType::Rafs),
+            "passthrough_fs" => Ok(FsBackendType::PassthroughFs),
+            o => Err(NydusError::InvalidArguments(format!(
+                "Fs backend type only accepts 'rafs' and 'passthrough_fs', but {} was specified",
+                o
+            ))),
+        }
+    }
+}
+
+impl Display for NydusError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+#[serde_as]
+#[derive(Serialize, Clone, Deserialize)]
+pub struct FsBackendDesc {
+    pub backend_type: FsBackendType,
+    pub mountpoint: String,
+    #[serde_as(as = "DisplayFromStr")]
+    pub mounted_time: DateTime<Local>,
+    pub config: serde_json::Value,
+}


### PR DESCRIPTION
`nydusctl` is a newly added executive binary.
It communicates with `nydusd` via HTTP API over UDS. It can
- show nydusd work status
- export io metrics to user 
- configure nydusd dynamically.