### PR TITLE
Improve nydusctl CLI tool

### DIFF
--- a/api/openapi/nydus-rs.yaml
+++ b/api/openapi/nydus-rs.yaml
@@ -480,12 +480,6 @@ components:
           type: integer
         prefetch_workers:
           type: integer
-        prefetch_policy:
-          type: array
-          items:
-            type: string
-        prefetch_total_size:
-          type: integer
         prefetch_mr_count:
           type: integer
         prefetch_unmerged_chunks:

--- a/api/src/http_endpoint.rs
+++ b/api/src/http_endpoint.rs
@@ -174,6 +174,13 @@ struct ErrorMessage {
     message: String,
 }
 
+impl From<ErrorMessage> for Vec<u8> {
+    fn from(msg: ErrorMessage) -> Self {
+        // Safe to unwrap since `ErrorMessage` must succeed in serialization
+        serde_json::to_vec(&msg).unwrap()
+    }
+}
+
 pub fn error_response(error: HttpError, status: StatusCode) -> Response {
     let mut response = Response::new(Version::Http11, status);
 
@@ -181,8 +188,7 @@ pub fn error_response(error: HttpError, status: StatusCode) -> Response {
         code: "UNDEFINED".to_string(),
         message: format!("{:?}", error),
     };
-    response.set_body(Body::new(serde_json::to_string(&err_msg).unwrap()));
-
+    response.set_body(Body::new(err_msg));
     response
 }
 

--- a/src/bin/nydusctl/client.rs
+++ b/src/bin/nydusctl/client.rs
@@ -58,9 +58,10 @@ impl NydusdClient {
         let response = client.request(req).await?;
         let sc = response.status().as_u16();
         let buf = hyper::body::to_bytes(response).await?;
-        let b = serde_json::from_slice(&buf).map_err(|e| anyhow!("deserialize: {}", e))?;
 
         if sc >= 400 {
+            let b: serde_json::Value =
+                serde_json::from_slice(&buf).map_err(|e| anyhow!("deserialize: {}", e))?;
             bail!("Request failed. {:?}", b);
         }
 

--- a/src/bin/nydusctl/commands.rs
+++ b/src/bin/nydusctl/commands.rs
@@ -63,16 +63,31 @@ impl CommandBlobcache {
         } else {
             print!(
                 r#"
-Partial Hits:       {partial_hits}
-Whole Hits:         {whole_hits}
-Total Read:         {total_read}
-Prefetch Amount:    {prefetch_amount} = {prefetch_amount_kb}KB
+Partial Hits:           {partial_hits}
+Whole Hits:             {whole_hits}
+Total Read:             {total_read}
+Directory:              {directory}
+Files:                  {files}
+Prefetch Workers:       {workers}
+Prefetch Amount:        {prefetch_amount} = {prefetch_amount_kb} KB
+Prefetch Requests:      {requests}
+Prefetch Average Size:  {avg_prefetch_size} Bytes
+Prefetch Unmerged:      {unmerged_blocks}
+Persister Buffer:       {buffered}
 "#,
                 partial_hits = m["partial_hits"],
                 whole_hits = m["whole_hits"],
                 total_read = m["total"],
                 prefetch_amount = m["prefetch_data_amount"],
                 prefetch_amount_kb = m["prefetch_data_amount"].as_u64().unwrap() / 1024,
+                files = m["underlying_files"],
+                directory = m["store_path"],
+                requests = m["prefetch_mr_count"],
+                avg_prefetch_size = m["prefetch_data_amount"].as_u64().unwrap()
+                    / m["prefetch_mr_count"].as_u64().unwrap(),
+                workers = m["prefetch_workers"],
+                unmerged_blocks = m["prefetch_unmerged_chunks"],
+                buffered = m["buffered_backend_size"],
             );
         }
 

--- a/src/bin/nydusctl/main.rs
+++ b/src/bin/nydusctl/main.rs
@@ -6,6 +6,8 @@
 extern crate clap;
 #[macro_use]
 extern crate anyhow;
+#[macro_use]
+extern crate lazy_static;
 
 use std::collections::HashMap;
 

--- a/src/bin/nydusctl/main.rs
+++ b/src/bin/nydusctl/main.rs
@@ -37,15 +37,21 @@ async fn main() -> Result<()> {
                 .takes_value(false)
                 .global(false),
         )
-        .subcommand(SubCommand::with_name("info").help("Get nydusd working status"))
+        .subcommand(SubCommand::with_name("info").about("Get nydusd working status"))
         .subcommand(
             SubCommand::with_name("set")
-                .help("Configure nydusd")
+                .about(
+                    "Configure nydusd parameters in format: set KIND VALUE where KIND can be \"log-level\"",
+                )
+                .help(
+                    r#"Acceptable Items:
+        log-level: trace, debug, info, warn, error"#,
+                )
                 .arg(
                     Arg::with_name("KIND")
                         .help("what item to configure")
                         .required(true)
-                        .possible_values(&["log_level"])
+                        .possible_values(&["log-level"])
                         .takes_value(true)
                         .index(1),
                 )
@@ -59,7 +65,9 @@ async fn main() -> Result<()> {
         )
         .subcommand(
             SubCommand::with_name("metrics")
-                .help("Configure nydusd")
+                .about(
+                    "Query nydus metrics. Possible metrics category: fsstats; blobcache; backend",
+                )
                 .arg(
                     Arg::with_name("category")
                         .help("Show the category of metrics: blobcache, backend, fsstats")

--- a/utils/src/metrics.rs
+++ b/utils/src/metrics.rs
@@ -686,18 +686,18 @@ pub struct BlobcacheMetrics {
     // Cache hit percentage = (partial_hits + whole_hits) / total
     pub partial_hits: BasicMetric,
     pub whole_hits: BasicMetric,
+    // How many `read` requests are processed by the blobcache instance.
+    // This metric will be helpful when comparing with cache hits times.
     pub total: BasicMetric,
     // Scale of blobcache. Blobcache does not evict entries.
     // Means the number of chunks in ready status.
     pub entries_count: BasicMetric,
-    // In unit of Bytes
-    pub prefetch_data_amount: BasicMetric,
-    pub prefetch_workers: AtomicUsize,
-    pub prefetch_policy: Mutex<HashSet<String>>,
     // Together with below two fields, we can figure out average merging size thus
     // to estimate the possibility to merge backend IOs.
-    pub prefetch_total_size: BasicMetric,
+    // In unit of Bytes
+    pub prefetch_data_amount: BasicMetric,
     pub prefetch_mr_count: BasicMetric,
+    pub prefetch_workers: AtomicUsize,
     pub prefetch_unmerged_chunks: BasicMetric,
     pub buffered_backend_size: BasicMetric,
 }


### PR DESCRIPTION
Let CLI tool `nydusctl` print more debug/trace information exported from nydusd
Trim unused metircs.
Fix a bug that error message from nydusd http response body can't be parsed.