### PR TITLE
fix(nydus-snapshotter): fix p.Wait() return err when destroy nydusd

### DIFF
--- a/contrib/nydus-snapshotter/pkg/process/manager.go
+++ b/contrib/nydus-snapshotter/pkg/process/manager.go
@@ -8,6 +8,7 @@ package process
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -194,8 +195,10 @@ func (m *Manager) DestroyDaemon(d *daemon.Daemon) error {
 			return err
 		}
 		_, err = p.Wait()
-		if err != nil {
-			return err
+		// if nydus-snapshotter restart, it will break the relationship between nydusd and
+		// nydus-snapshotter, p.Wait() will return err, so here should exclude this case
+		if err != nil && !stderrors.Is(err, syscall.ECHILD) {
+			log.L.Errorf("failed to process wait, %v", err)
 		}
 	}
 	if err := m.mounter.Umount(d.MountPoint()); err != nil && err != syscall.EINVAL {


### PR DESCRIPTION
When nydus-snapshotter restart, it will break the relationship between nydusd and
nydus-snapshotter, so p.Wait() will return err. This pr fix the err by judge the err type

Signed-off-by: luodaowen.backend <luodaowen.backend@bytedance.com>