### PR TITLE
snapshottoer: pass mount type "fuse.nydus-overlayfs"

### DIFF
--- a/contrib/nydus-snapshotter/cmd/containerd-nydus-grpc/pkg/command/flags.go
+++ b/contrib/nydus-snapshotter/cmd/containerd-nydus-grpc/pkg/command/flags.go
@@ -47,6 +47,7 @@ type Args struct {
 	MetricsFile          string
 	EnableStargz         bool
 	DisableCacheManager  bool
+	EnableNydusOverlayFS bool
 }
 
 type Flags struct {
@@ -168,6 +169,12 @@ func buildFlags(args *Args) []cli.Flag {
 			Usage:       "whether to disable blob cache manager",
 			Destination: &args.DisableCacheManager,
 		},
+		&cli.BoolFlag{
+			Name:        "enable-nydus-overlayfs",
+			Value:       false,
+			Usage:       "whether to disable nydus-overlayfs to mount",
+			Destination: &args.EnableNydusOverlayFS,
+		},
 	}
 }
 
@@ -218,6 +225,7 @@ func Validate(args *Args, cfg *config.Config) error {
 	cfg.MetricsFile = args.MetricsFile
 	cfg.EnableStargz = args.EnableStargz
 	cfg.DisableCacheManager = args.DisableCacheManager
+	cfg.EnableNydusOverlayFS = args.EnableNydusOverlayFS
 
 	d, err := time.ParseDuration(args.GCPeriod)
 	if err != nil {

--- a/contrib/nydus-snapshotter/config/config.go
+++ b/contrib/nydus-snapshotter/config/config.go
@@ -48,6 +48,7 @@ type Config struct {
 	LogDir               string        `toml:"log_dir"`
 	LogToStdout          bool          `toml:"log_to_stdout"`
 	DisableCacheManager  bool          `toml:"disable_cache_manager"`
+	EnableNydusOverlayFS bool          `toml:"enable_nydus_overlayfs"`
 }
 
 func (c *Config) FillupWithDefaults() error {

--- a/contrib/nydus-snapshotter/pkg/daemon/config.go
+++ b/contrib/nydus-snapshotter/pkg/daemon/config.go
@@ -87,6 +87,16 @@ func WithRootMountPoint(rootMountPoint string) NewDaemonOpt {
 	}
 }
 
+func WithCustomMountPoint(customMountPoint string) NewDaemonOpt {
+	return func(d *Daemon) error {
+		if err := os.MkdirAll(customMountPoint, 0755); err != nil {
+			return errors.Wrapf(err, "failed to create customMountPoint %s", customMountPoint)
+		}
+		d.CustomMountPoint = &customMountPoint
+		return nil
+	}
+}
+
 func WithSnapshotDir(dir string) NewDaemonOpt {
 	return func(d *Daemon) error {
 		d.SnapshotDir = dir

--- a/contrib/nydus-snapshotter/pkg/daemon/daemon.go
+++ b/contrib/nydus-snapshotter/pkg/daemon/daemon.go
@@ -11,11 +11,10 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/pkg/errors"
-
 	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/config"
 	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/nydussdk"
 	"github.com/dragonflyoss/image-service/contrib/nydus-snapshotter/pkg/nydussdk/model"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -26,19 +25,20 @@ const (
 type NewDaemonOpt func(d *Daemon) error
 
 type Daemon struct {
-	ID             string
-	SnapshotID     string
-	ConfigDir      string
-	SocketDir      string
-	LogDir         string
-	LogLevel       string
-	LogToStdout    bool
-	SnapshotDir    string
-	Pid            int
-	ImageID        string
-	DaemonMode     string
-	ApiSock        *string
-	RootMountPoint *string
+	ID               string
+	SnapshotID       string
+	ConfigDir        string
+	SocketDir        string
+	LogDir           string
+	LogLevel         string
+	LogToStdout      bool
+	SnapshotDir      string
+	Pid              int
+	ImageID          string
+	DaemonMode       string
+	ApiSock          *string
+	RootMountPoint   *string
+	CustomMountPoint *string
 }
 
 func (d *Daemon) SharedMountPoint() string {
@@ -49,6 +49,13 @@ func (d *Daemon) MountPoint() string {
 	if d.RootMountPoint != nil {
 		return filepath.Join("/", d.SnapshotID, "fs")
 	}
+	if d.CustomMountPoint != nil {
+		return *d.CustomMountPoint
+	}
+	return filepath.Join(d.SnapshotDir, d.SnapshotID, "fs")
+}
+
+func (d *Daemon) OldMountPoint() string {
 	return filepath.Join(d.SnapshotDir, d.SnapshotID, "fs")
 }
 

--- a/contrib/nydus-snapshotter/pkg/filesystem/nydus/fs.go
+++ b/contrib/nydus-snapshotter/pkg/filesystem/nydus/fs.go
@@ -344,7 +344,7 @@ func (fs *filesystem) createNewDaemon(snapshotID string, imageID string) (*daemo
 		d   *daemon.Daemon
 		err error
 	)
-
+	customMountPoint := filepath.Join(fs.SnapshotRoot(), snapshotID, "mnt")
 	if d, err = daemon.NewDaemon(
 		daemon.WithSnapshotID(snapshotID),
 		daemon.WithSocketDir(fs.SocketRoot()),
@@ -354,6 +354,7 @@ func (fs *filesystem) createNewDaemon(snapshotID string, imageID string) (*daemo
 		daemon.WithImageID(imageID),
 		daemon.WithLogLevel(fs.logLevel),
 		daemon.WithLogToStdout(fs.logToStdout),
+		daemon.WithCustomMountPoint(customMountPoint),
 	); err != nil {
 		return nil, err
 	}

--- a/contrib/nydus-snapshotter/pkg/process/manager.go
+++ b/contrib/nydus-snapshotter/pkg/process/manager.go
@@ -208,8 +208,13 @@ func (m *Manager) DestroyDaemon(d *daemon.Daemon) error {
 			log.L.Errorf("failed to process wait, %v", err)
 		}
 	}
-	if err := m.mounter.Umount(d.MountPoint()); err != nil && err != syscall.EINVAL {
-		return errors.Wrap(err, fmt.Sprintf("failed to umount mountpoint %s", d.MountPoint()))
+	// for backward compatible, here umount <snapshotdir>/<id>/fs and <snapshotdir>/<id>/mnt
+	// if mountpoint not exist, Umount will return nil
+	mps := []string{d.MountPoint(), d.OldMountPoint()}
+	for _, mp := range mps {
+		if err := m.mounter.Umount(mp); err != nil && err != syscall.EINVAL {
+			return errors.Wrap(err, fmt.Sprintf("failed to umount mountpoint %s", mp))
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
For the unified usage of runc and kata, this pr add mount type "fuse.nydus-overlayfs"
with options=append(overlayOptions, nydusOption), In containerd, it will use mount helper
"nydus-overlayfs" to do the real mount

In runc case, nydus-overlayfs will ignore nydusOption and do the overlay
mount in containerd + runc-shim

In kata case, nydus-overlayfs will ignore nydusOption and do the overlay
mount in containerd, and parse the nydusOption in kata-shim

Signed-off-by: luodaowen.backend <luodaowen.backend@bytedance.com>