### PR TITLE
docs: update containerd env setup docs

### DIFF
--- a/contrib/ctr-remote/cmd/main.go
+++ b/contrib/ctr-remote/cmd/main.go
@@ -58,7 +58,7 @@ func main() {
 		}
 	}
 	if err := app.Run(os.Args); err != nil {
-		fmt.Fprintf(os.Stderr, "ctr: %v\n", err)
+		fmt.Fprintf(os.Stderr, "ctr-remote: %v\n", err)
 		os.Exit(1)
 	}
 }

--- a/docs/containerd-env-setup.md
+++ b/docs/containerd-env-setup.md
@@ -15,7 +15,7 @@ sudo cp nydusify containerd-nydus-grpc /usr/local/bin
 
 Nydus provides a containerd remote snapshotter `containerd-nydus-grpc` to prepare container rootfs with nydus formatted images. To start it, first save a nydusd config to `/etc/nydusd-config.json`:
 ```bash
-$ cat > /etc/nydusd-config.json << EOL
+$ sudo cat > /etc/nydusd-config.json << EOL
 {
   "device": {
     "backend": {
@@ -47,15 +47,21 @@ EOL
 ```
 
 Then start `containerd-nydus-grpc` remote snapshotter:
+
 ```bash
-/usr/local/bin/containerd-nydus-grpc --nydusd-path /usr/local/bin/nydusd \
+sudo /usr/local/bin/containerd-nydus-grpc \
     --config-path /etc/nydusd-config.json \
+    --shared-daemon \
     --log-level debug \
     --root /var/lib/containerd/io.containerd.snapshotter.v1.nydus \
     --cache-dir /var/lib/nydus/cache \
-    --address /run/containerd/containerd-nydus-grpc.sock
+    --address /run/containerd/containerd-nydus-grpc.sock \
+    --nydusd-path /usr/local/bin/nydusd \
+    --nydusimg-path /usr/local/bin/nydus-image
 ```
-`cache-dir` argument represent the blob cache root dir, if unset, it will be set `root` + "/cache". It overrides the `work_dir` option in nydusd-config.json.
+
+`cache-dir` argument represent the blob cache root dir, if unset, it will be set `root` + "/cache". It overrides the `work_dir` option in `nydusd-config.json`.
+
 ## Configure and Start containerd
 
 Nydus uses two features of containerd:
@@ -63,6 +69,7 @@ Nydus uses two features of containerd:
 * snapshotter annotations
 
 To set them up, add something like the following to your containerd config (default to `/etc/containerd/config.toml`):
+
 ```toml
 [proxy_plugins]
   [proxy_plugins.nydus]
@@ -75,28 +82,30 @@ To set them up, add something like the following to your containerd config (defa
 ```
 
 Then restart containerd, e.g.:
-```base
-systemctl restart containerd
+
+```bash
+sudo systemctl restart containerd
 ```
 
 ## Start A Local Registry Container
 
 ```bash
-docker run -d --restart=always -p 5000:5000 registry
+sudo docker run -d --restart=always -p 5000:5000 registry
 ```
 
 ## Convert An Image To Nydus Format
 
 ```bash
-nydusify convert --nydus-image /usr/local/bin/nydus-image --source ubuntu --target localhost:5000/ubuntu-nydus
+sudo nydusify convert --nydus-image /usr/local/bin/nydus-image --source ubuntu --target localhost:5000/ubuntu-nydus
 ```
 
 ## Create New Pods With Nydus Format Image
 
-For example, use the following `cat pod-config.yaml` and `container-config.yaml`
+For example, use the following `nydus-sandbox.yaml` and `nydus-container.yaml`
 
-```
-$ cat pod-config.yaml
+`nydus-sandbox.yaml`:
+
+```yaml
 metadata:
   attempt: 1
   name: nydus-sandbox
@@ -110,8 +119,9 @@ annotations:
   "io.containerd.osfeature": "nydus.remoteimage.v1"
 ```
 
-```
-$cat container-config.yaml
+`nydus-container.yaml`:
+
+```yaml
 metadata:
   name: nydus-container
 image:
@@ -125,29 +135,31 @@ log_path: container.1.log
 
 To create a new pod with the just converted nydus image:
 
-```
-$ crictl run container-config.yaml pod-config.yaml
-77f5a5c87d37dde96afbd6a950fbff49402a95073b11f952aa3a572c7113d151
-$ crictl ps
-CONTAINER           IMAGE                                 CREATED             STATE               NAME                ATTEMPT             POD ID
-77f5a5c87d37d       localhost:5000/ubuntu-nydus:latest   8 seconds ago       Running             nydus-container     0                   0f3aefac561b3
+```bash
+$ sudo crictl pull localhost:5000/ubuntu-nydus:latest
+$ pod=`sudo crictl runp nydus-sandbox.yaml`
+$ container=`sudo crictl create $pod nydus-container.yaml nydus-sandbox.yaml`
+$ sudo crictl start $container
+$ sudo crictl ps
+CONTAINER ID        IMAGE                                CREATED             STATE               NAME                      ATTEMPT             POD ID
+f4a6c6dc47e34       localhost:5000/ubuntu-nydus:latest   9 seconds ago       Running             nydus-container           0                   21b91779d551e
 ```
 
-## Test Nydus with ctr-remote
+## Test Nydus with `ctr-remote`
 
-You can also use ctr-remote to run container with converted nydus image, pull image: 
+You can also use `ctr-remote` to run containers with converted nydus image, pull image:
 
-```
-$ ctr-remote image rpull --plain-http localhost:5000/ubuntu-nydus:latest
-fetching sha256:1a406a70... application/vnd.oci.image.manifest.v1+json
-fetching sha256:206058bb... application/vnd.oci.image.config.v1+json
-fetching sha256:6eb834fa... application/vnd.oci.image.layer.v1.tar+gzip
+```bash
+$ sudo ctr-remote image rpull --plain-http localhost:5000/ubuntu-nydus:latest
+fetching sha256:9523a2de... application/vnd.oci.image.manifest.v1+json
+fetching sha256:a2cdb40d... application/vnd.oci.image.config.v1+json
+fetching sha256:18059446... application/vnd.oci.image.layer.v1.tar+gzip
 ```
 
 Next run container:
 
-```
-$ ctr-remote run --rm -t --snapshotter=nydus localhost:5000/ubuntu-nydus:latest test /bin/bash
+```bash
+$ sudo ctr-remote run --rm -t --snapshotter=nydus localhost:5000/ubuntu-nydus:latest test /bin/bash
 /# ps -ef 
 UID          PID    PPID  C STIME TTY          TIME CMD
 root           1       0  0 13:45 pts/0    00:00:00 /bin/bash

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -36,7 +36,7 @@ Nydus offers a powerful tool that converts an OCI image into a nydus image easil
 Use a command like the following to start the registry container:
 
 ```bash
-$ docker run -d -p 5000:5000 --restart=always --name registry registry:2
+$ sudo docker run -d -p 5000:5000 --restart=always --name registry registry:2
 ```
 
 The registry is now ready to use. Please refer to [docker document](https://docs.docker.com/registry/deploying) for more details.
@@ -47,7 +47,7 @@ You can pull an image from Docker Hub and push it to your local registry. The fo
 
 ```bash
 # workdir: nydus-rs/contrib/nydusify
-  $ sudo nydusify convert \
+$ sudo nydusify convert \
   --nydus-image /path/to/nydus-image \
   --source ubuntu:16.04 \
   --target localhost:5000/ubuntu:16.04-nydus
@@ -93,7 +93,7 @@ The Nydus image is converted layer by layer automatically under the `tmp` direct
 
 ```bash
 # workdir: nydus-rs/contrib/nydusify
-$sudo tree tmp -L 4
+$ sudo tree tmp -L 4
 tmp
 ├── blobs
 │   ├── 00d151e7d392e68e2c756a6fc42640006ddc0a98d37dba3f90a7b73f63188bbd
@@ -111,14 +111,11 @@ tmp
 └── source
 ```
 
-Tips: The local registry is an http server, therefore, we set the `target-insecure=true`. Otherwise, we will meet a FATA with `http: server gave HTTP response to HTTPS client`.
-
 After you have converted the image format, we could use `nydusd` to parse it and expose a FUSE mount point for containers to access.
 
-The `Nydusd` runs with a container image registry as a storage backend. Therefore, the registry backend is configured with the following json file.
+The `Nydusd` runs with a container image registry as a storage backend. Therefore, the registry backend is configured with the following json file(`registry.json`).
 
 ```json
-$ cat registry.json
 {
   "device": {
     "backend": {
@@ -159,33 +156,13 @@ $ sudo ls  ./mnt/
 bin  boot  dev  etc  home  lib  lib64  media  mnt  opt  proc  root  run  sbin  srv  sys  tmp  usr  var
 ```
 
-To verify your `Nydusd` setup, try accessing a file in the mounted directory.
-
-```bash
-# workdir: nydus-rs
-$ sudo cat  ./mnt/etc/bash.bashrc
-# System-wide .bashrc file for interactive bash(1) shells.
-
-# To enable the settings / commands in this file for login shells as well,
-# this file has to be sourced in /etc/profile.
-
-# If not running interactively, don't do anything
-[ -z "$PS1" ] && return
-
-# check the window size after each command and, if necessary,
-# update the values of LINES and COLUMNS.
-shopt -s checkwinsize
-...
-
-```
-
 ## Build Nydus Image From Directory Source
 
 Nydus also offers a `nydus-image` tool to convert an unpacked container image into a Nydus format image. For multiple layers of an image, you need to manually and recursively convert them from the lowest layer, one layer at a time.
 The layers of an image could be rendered by the following command.
 
 ```bash
-$ docker inspect ubuntu:16.04
+$ sudo docker inspect ubuntu:16.04
 ...
 "GraphDriver": {
             "Data": {


### PR DESCRIPTION
This commit contains:

- Use sudo for all commands.
- Fix containerd-nydus-grpc/crictl commands options/sub-commands
- Fix ctr-remote' name printed in stderr
  if this command failed.

Signed-off-by: bin liu <liubin0329@gmail.com>