### PR TITLE
Backend: fix registry authorization

### DIFF
--- a/storage/src/backend/oss.rs
+++ b/storage/src/backend/oss.rs
@@ -202,7 +202,7 @@ impl BlobBackend for Oss {
 
         let resp = self
             .request
-            .call::<&[u8]>(Method::HEAD, url.as_str(), None, headers, true)
+            .call::<&[u8]>(Method::HEAD, url.as_str(), None, None, headers, true)
             .map_err(OssError::Request)?;
 
         let content_length = resp
@@ -239,7 +239,7 @@ impl BlobBackend for Oss {
         // Safe because the the call() is a synchronous operation.
         let mut resp = self
             .request
-            .call::<&[u8]>(Method::GET, url.as_str(), None, headers, true)
+            .call::<&[u8]>(Method::GET, url.as_str(), None, None, headers, true)
             .map_err(OssError::Request)?;
 
         Ok(resp
@@ -259,7 +259,7 @@ impl BlobBackend for Oss {
 
         // Safe because the the call() is a synchronous operation.
         self.request
-            .call::<&[u8]>(Method::POST, url.as_str(), None, headers, true)
+            .call::<&[u8]>(Method::POST, url.as_str(), None, None, headers, true)
             .map_err(OssError::Request)?;
 
         Ok(buf.len())

--- a/storage/src/backend/request.rs
+++ b/storage/src/backend/request.rs
@@ -196,6 +196,7 @@ impl Request {
         client: &Client,
         method: Method,
         url: &str,
+        query: &Option<Vec<(&str, &str)>>,
         data: Option<ReqBody<R>>,
         headers: HeaderMap,
         catch_status: bool,
@@ -214,7 +215,10 @@ impl Request {
             data.is_some(),
         );
 
-        let rb = client.request(method, url).headers(headers);
+        let mut rb = client.request(method, url).headers(headers);
+        if let Some(q) = query.as_ref() {
+            rb = rb.query(q);
+        }
 
         let ret;
         if let Some(data) = data {
@@ -249,6 +253,7 @@ impl Request {
         &self,
         method: Method,
         url: &str,
+        query: Option<Vec<(&str, &str)>>,
         data: Option<ReqBody<R>>,
         headers: HeaderMap,
         catch_status: bool,
@@ -264,6 +269,7 @@ impl Request {
                     &proxy.client,
                     method.clone(),
                     url,
+                    &query,
                     data_cloned,
                     headers.clone(),
                     catch_status,
@@ -292,6 +298,7 @@ impl Request {
             &self.client,
             method,
             url,
+            &query,
             data,
             headers,
             catch_status,


### PR DESCRIPTION
On harbor or ghcr registry implementation, token service only accept
HTTP GET request and must put auth string to the header.

The information needed for getting token needs to be placed both in
the query and in the body to be compatible with different registry
implementations, which have been tested on these platforms:
docker hub, harbor, github ghcr, aliyun acr.

Signed-off-by: Yan Song <imeoer@linux.alibaba.com>