### PR TITLE
Small improvement for snapshotter

### DIFF
--- a/contrib/nydus-snapshotter/.golangci.yml
+++ b/contrib/nydus-snapshotter/.golangci.yml
@@ -1,0 +1,23 @@
+# https://golangci-lint.run/usage/configuration#config-file
+
+linters:
+  enable:
+    - structcheck
+    - varcheck
+    - staticcheck
+    - unconvert
+    - gofmt
+    - goimports
+    - revive
+    - ineffassign
+    - vet
+    - unused
+    - misspell
+  disable:
+    - errcheck
+
+run:
+  deadline: 4m
+  skip-dirs:
+    - misc
+

--- a/contrib/nydus-snapshotter/Makefile
+++ b/contrib/nydus-snapshotter/Makefile
@@ -25,6 +25,9 @@ clear:
 vet:
 	go vet $(PACKAGES)
 
+check: vet
+	golangci-lint run
+
 .PHONY: test
 test: vet
 	go test -v -mod=mod -cover ${PACKAGES}

--- a/contrib/nydus-snapshotter/cmd/containerd-nydus-grpc/pkg/logging/setup.go
+++ b/contrib/nydus-snapshotter/cmd/containerd-nydus-grpc/pkg/logging/setup.go
@@ -19,8 +19,9 @@ func SetUp(logLevel string) error {
 		return err
 	}
 	logrus.SetLevel(lvl)
-	logrus.SetFormatter(&logrus.JSONFormatter{
+	logrus.SetFormatter(&logrus.TextFormatter{
 		TimestampFormat: log.RFC3339NanoFixed,
+		FullTimestamp:   true,
 	})
 	return nil
 }


### PR DESCRIPTION
1. Use `golangci-lint` tool to perform static check to get code neater
2. Don't use json format log for snapshotter anymore since it is not friendly for human read and debug