### PR TITLE
nydusctl can command nydusd to attach a rafs backend

### DIFF
--- a/api/src/http_endpoint.rs
+++ b/api/src/http_endpoint.rs
@@ -89,8 +89,8 @@ pub type HttpResult = std::result::Result<Response, HttpError>;
 pub enum ApiRequest {
     DaemonInfo,
     Events,
-    Mount((String, ApiMountCmd)),
-    Remount((String, ApiMountCmd)),
+    Mount(String, ApiMountCmd),
+    Remount(String, ApiMountCmd),
     Umount(String),
     ConfigureDaemon(DaemonConf),
     ExportGlobalMetrics(Option<String>),
@@ -285,12 +285,12 @@ impl EndpointHandler for MountHandler {
         match (req.method(), req.body.as_ref()) {
             (Method::Post, Some(body)) => {
                 let cmd = parse_body(body)?;
-                let r = kicker(ApiRequest::Mount((mountpoint, cmd)));
+                let r = kicker(ApiRequest::Mount(mountpoint, cmd));
                 Ok(convert_to_response(r, HttpError::Mount))
             }
             (Method::Put, Some(body)) => {
                 let cmd = parse_body(body)?;
-                let r = kicker(ApiRequest::Remount((mountpoint, cmd)));
+                let r = kicker(ApiRequest::Remount(mountpoint, cmd));
                 Ok(convert_to_response(r, HttpError::Mount))
             }
             (Method::Delete, None) => {

--- a/src/bin/nydusctl/client.rs
+++ b/src/bin/nydusctl/client.rs
@@ -20,14 +20,24 @@ impl NydusdClient {
         }
     }
 
-    fn build_uri(&self, path: &str) -> HyperUri {
-        let endpoint = format!("/api/v1/{}", path);
+    fn build_uri(&self, path: &str, query: Option<Vec<(&str, &str)>>) -> HyperUri {
+        let mut endpoint = format!("/api/v1/{}", path);
+
+        if let Some(q) = query {
+            let mut params = String::new();
+            for p in q {
+                params.push_str(&format!("{}={}", p.0, p.1))
+            }
+
+            endpoint.push_str(&format!("?{}", params));
+        }
+
         Uri::new(&self.sock_path, endpoint.as_str()).into()
     }
 
     pub async fn get(&self, path: &str) -> Result<Value> {
         let client = Client::unix();
-        let uri = self.build_uri(path);
+        let uri = self.build_uri(path, None);
         let response = client.get(uri).await?;
         let sc = response.status().as_u16();
         let buf = hyper::body::to_bytes(response).await?;
@@ -42,7 +52,7 @@ impl NydusdClient {
 
     pub async fn put(&self, path: &str, data: Option<String>) -> Result<()> {
         let client = Client::unix();
-        let uri = self.build_uri(path);
+        let uri = self.build_uri(path, None);
         let (body, _) = if let Some(d) = data {
             let l = d.len();
             (d.into(), l)
@@ -52,6 +62,72 @@ impl NydusdClient {
 
         let req = Request::builder()
             .method(Method::PUT)
+            .header(header::USER_AGENT, "nydusctl")
+            .uri(uri)
+            .body(body)?;
+        let response = client.request(req).await?;
+        let sc = response.status().as_u16();
+        let buf = hyper::body::to_bytes(response).await?;
+
+        if sc >= 400 {
+            let b: serde_json::Value =
+                serde_json::from_slice(&buf).map_err(|e| anyhow!("deserialize: {}", e))?;
+            bail!("Request failed. {:?}", b);
+        }
+
+        Ok(())
+    }
+
+    pub async fn post(
+        &self,
+        path: &str,
+        data: Option<String>,
+        query: Option<Vec<(&str, &str)>>,
+    ) -> Result<()> {
+        let client = Client::unix();
+        let uri = self.build_uri(path, query);
+        let (body, _) = if let Some(d) = data {
+            let l = d.len();
+            (d.into(), l)
+        } else {
+            (Body::empty(), 0)
+        };
+
+        let req = Request::builder()
+            .method(Method::POST)
+            .header(header::USER_AGENT, "nydusctl")
+            .uri(uri)
+            .body(body)?;
+        let response = client.request(req).await?;
+        let sc = response.status().as_u16();
+        let buf = hyper::body::to_bytes(response).await?;
+
+        if sc >= 400 {
+            let b: serde_json::Value =
+                serde_json::from_slice(&buf).map_err(|e| anyhow!("deserialize: {}", e))?;
+            bail!("Request failed. {:?}", b);
+        }
+
+        Ok(())
+    }
+
+    pub async fn delete(
+        &self,
+        path: &str,
+        data: Option<String>,
+        query: Option<Vec<(&str, &str)>>,
+    ) -> Result<()> {
+        let client = Client::unix();
+        let uri = self.build_uri(path, query);
+        let (body, _) = if let Some(d) = data {
+            let l = d.len();
+            (d.into(), l)
+        } else {
+            (Body::empty(), 0)
+        };
+
+        let req = Request::builder()
+            .method(Method::DELETE)
             .header(header::USER_AGENT, "nydusctl")
             .uri(uri)
             .body(body)?;

--- a/src/bin/nydusctl/commands.rs
+++ b/src/bin/nydusctl/commands.rs
@@ -83,8 +83,11 @@ Persister Buffer:       {buffered}
                 files = m["underlying_files"],
                 directory = m["store_path"],
                 requests = m["prefetch_mr_count"],
-                avg_prefetch_size = m["prefetch_data_amount"].as_u64().unwrap()
-                    / m["prefetch_mr_count"].as_u64().unwrap(),
+                avg_prefetch_size = m["prefetch_data_amount"]
+                    .as_u64()
+                    .unwrap()
+                    .checked_div(m["prefetch_mr_count"].as_u64().unwrap())
+                    .unwrap_or_default(),
                 workers = m["prefetch_workers"],
                 unmerged_blocks = m["prefetch_unmerged_chunks"],
                 buffered = m["buffered_backend_size"],

--- a/src/bin/nydusctl/commands.rs
+++ b/src/bin/nydusctl/commands.rs
@@ -356,3 +356,41 @@ Prefetch Merging Size:  {merging_size}
         Ok(())
     }
 }
+
+pub(crate) struct CommandMount {}
+
+impl CommandMount {
+    pub async fn execute(
+        &self,
+        _raw: bool,
+        client: &NydusdClient,
+        params: Option<CommandParams>,
+    ) -> Result<()> {
+        let p = params.unwrap();
+        let (source, mountpoint, fs_type) = (&p["source"], &p["mountpoint"], &p["type"]);
+        let config = std::fs::read_to_string(&p["config"]).unwrap();
+        let cmd = json!({"source": source, "fs_type": fs_type, "config": config}).to_string();
+
+        client
+            .post("mount", Some(cmd), Some(vec![("mountpoint", mountpoint)]))
+            .await
+    }
+}
+
+pub(crate) struct CommandUmount {}
+
+impl CommandUmount {
+    pub async fn execute(
+        &self,
+        _raw: bool,
+        client: &NydusdClient,
+        params: Option<CommandParams>,
+    ) -> Result<()> {
+        let p = params.unwrap();
+        let mountpoint = &p["mountpoint"];
+
+        client
+            .delete("mount", None, Some(vec![("mountpoint", &mountpoint)]))
+            .await
+    }
+}

--- a/src/bin/nydusd/api_server_glue.rs
+++ b/src/bin/nydusd/api_server_glue.rs
@@ -70,8 +70,8 @@ impl ApiServer {
         let resp = match request {
             ApiRequest::DaemonInfo => self.daemon_info(),
             ApiRequest::Events => Self::events(),
-            ApiRequest::Mount((mountpoint, info)) => self.do_mount(mountpoint, info),
-            ApiRequest::Remount((mountpoint, info)) => self.do_remount(mountpoint, info),
+            ApiRequest::Mount(mountpoint, info) => self.do_mount(mountpoint, info),
+            ApiRequest::Remount(mountpoint, info) => self.do_remount(mountpoint, info),
             ApiRequest::Umount(mountpoint) => self.do_umount(mountpoint),
             ApiRequest::ConfigureDaemon(conf) => self.configure_daemon(conf),
             ApiRequest::ExportGlobalMetrics(id) => Self::export_global_metrics(id),


### PR DESCRIPTION
nydusctl as a nydusd client send HTTP API to nydusd to command it attach one or more rafs banckends.
It can also detach the rafs backend it just attached.