### PR TITLE
Fix app version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1113,21 +1113,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nydus-app"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91166e11340319bb872baba7546649218eb2454db54cb9c1b9f9ec922c66e390"
-dependencies = [
- "built",
- "flexi_logger",
- "libc",
- "log",
- "nix",
- "nydus-error 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde",
-]
-
-[[package]]
 name = "nydus-error"
 version = "0.1.0"
 dependencies = [
@@ -1173,7 +1158,7 @@ dependencies = [
  "log",
  "nix",
  "nydus-api",
- "nydus-app 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nydus-app",
  "nydus-error 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "nydus-utils",
  "openssl",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ tokio = { version = "1.9.0", features = ["macros"] }
 hyper = "0.14.11"
 
 nydus-api = { path = "api" }
-nydus-app = "0.1"
+nydus-app = { path = "app" }
 nydus-error = "0.1"
 nydus-utils = { path = "utils" }
 rafs = { path = "rafs", features = ["backend-registry", "backend-oss"] }

--- a/app/build.rs
+++ b/app/build.rs
@@ -3,5 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 fn main() {
+    println!("cargo:rerun-if-changed=../git/HEAD");
     built::write_built_file().expect("Failed to acquire build-time information");
 }


### PR DESCRIPTION
App version has a part of git commit id. But it only changes when `nydus-app` crate has to be re-compiled. So when perform `nydusd --version`, the output git commit id might not be the HEAD commit id.