### PR TITLE
nydus: depend on an alias of fuse_rs - fuse_backend_rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ chrono = "0.4.19"
 openssl = { version = "0.10.35", features = ["vendored"] }
 
 event-manager = { git = "https://github.com/rust-vmm/event-manager.git", tag = "v0.2.0" }
-fuse-rs = { git = "https://github.com/cloud-hypervisor/fuse-backend-rs.git", optional = true, rev = "cfd2cca" }
+fuse-backend-rs = { git = "https://github.com/cloud-hypervisor/fuse-backend-rs.git", optional = true, rev = "cfd2cca", package = "fuse-rs" }
 vhost-rs = { git = "https://github.com/cloud-hypervisor/vhost.git", branch = "dragonball", package = "vhost", optional = true }
 vhost-user-backend = { git = "https://github.com/cloud-hypervisor/vhost-user-backend.git", package = "vhost_user_backend", rev = "78757bfa", optional = true }
 hyperlocal = "0.8.0"
@@ -61,8 +61,8 @@ vmm-sys-util = "0.6.0"
 env_logger = "0.8.2"
 
 [features]
-fusedev = ["nydus-utils/fusedev", "fuse-rs/fusedev"]
-virtiofs = ["fuse-rs/vhost-user-fs", "vm-memory/backend-mmap", "vhost-rs/vhost-user-slave", "vhost-user-backend"]
+fusedev = ["nydus-utils/fusedev", "fuse-backend-rs/fusedev"]
+virtiofs = ["fuse-backend-rs/vhost-user-fs", "vm-memory/backend-mmap", "vhost-rs/vhost-user-slave", "vhost-user-backend"]
 
 [workspace]
 members = ["api", "app", "error", "rafs", "storage", "utils"]

--- a/rafs/Cargo.toml
+++ b/rafs/Cargo.toml
@@ -27,7 +27,7 @@ spmc = "0.3.0"
 url = { version = "2.1.1", optional = true }
 vm-memory = ">=0.2.0"
 
-fuse-rs = { git = "https://github.com/cloud-hypervisor/fuse-backend-rs.git", rev = "cfd2cca" }
+fuse-backend-rs = { git = "https://github.com/cloud-hypervisor/fuse-backend-rs.git", rev = "cfd2cca", package = "fuse-rs" }
 
 nydus-utils = { path = "../utils" }
 nydus-error = "0.1"
@@ -38,8 +38,8 @@ vmm-sys-util = "0.6.0"
 assert_matches = "1.5.0"
 
 [features]
-fusedev = ["fuse-rs/fusedev"]
-virtio-fs = ["fuse-rs/virtiofs"]
-vhost-user-fs = ["fuse-rs/vhost-user-fs"]
+fusedev = ["fuse-backend-rs/fusedev"]
+virtio-fs = ["fuse-backend-rs/virtiofs"]
+vhost-user-fs = ["fuse-backend-rs/vhost-user-fs"]
 backend-oss = ["storage/backend-oss"]
 backend-registry = ["storage/backend-registry"]

--- a/rafs/src/fs.rs
+++ b/rafs/src/fs.rs
@@ -20,9 +20,9 @@ use std::time::{Duration, SystemTime};
 use nix::unistd::{getegid, geteuid};
 use serde::Deserialize;
 
-use fuse_rs::abi::linux_abi::Attr;
-use fuse_rs::api::filesystem::*;
-use fuse_rs::api::BackendFileSystem;
+use fuse_backend_rs::abi::linux_abi::Attr;
+use fuse_backend_rs::api::filesystem::*;
+use fuse_backend_rs::api::BackendFileSystem;
 
 use crate::metadata::{
     layout::RAFS_ROOT_INODE, Inode, RafsInode, RafsSuper, RAFS_DEFAULT_BLOCK_SIZE,

--- a/rafs/src/metadata/cached_v5.rs
+++ b/rafs/src/metadata/cached_v5.rs
@@ -16,8 +16,8 @@ use std::mem::size_of;
 use std::os::unix::ffi::OsStrExt;
 use std::sync::Arc;
 
-use fuse_rs::abi::linux_abi;
-use fuse_rs::api::filesystem::Entry;
+use fuse_backend_rs::abi::linux_abi;
+use fuse_backend_rs::api::filesystem::Entry;
 
 use crate::metadata::layout::v5::{
     rafsv5_alloc_bio_desc, rafsv5_validate_digest, RafsBlobEntry, RafsChunkFlags, RafsChunkInfo,

--- a/rafs/src/metadata/layout/mod.rs
+++ b/rafs/src/metadata/layout/mod.rs
@@ -9,7 +9,7 @@ use std::io::Result;
 use std::mem::size_of;
 use std::os::unix::ffi::OsStrExt;
 
-use fuse_rs::abi::linux_abi::ROOT_ID;
+use fuse_backend_rs::abi::linux_abi::ROOT_ID;
 
 pub const RAFS_SUPER_VERSION_V4: u32 = 0x400;
 pub const RAFS_SUPER_VERSION_V5: u32 = 0x500;

--- a/rafs/src/metadata/mod.rs
+++ b/rafs/src/metadata/mod.rs
@@ -18,8 +18,8 @@ use std::time::Duration;
 use serde::Serialize;
 use serde_with::{serde_as, DisplayFromStr};
 
-use fuse_rs::abi::linux_abi::Attr;
-use fuse_rs::api::filesystem::{Entry, ROOT_ID};
+use fuse_backend_rs::abi::linux_abi::Attr;
+use fuse_backend_rs::api::filesystem::{Entry, ROOT_ID};
 use nydus_utils::digest::{self, RafsDigest};
 use storage::compress;
 use storage::device::{RafsBioDesc, RafsBlobEntry, RafsChunkInfo};

--- a/rafs/src/mock/mock_inode.rs
+++ b/rafs/src/mock/mock_inode.rs
@@ -9,8 +9,8 @@ use std::io::Result;
 use std::os::unix::ffi::OsStrExt;
 use std::sync::Arc;
 
-use fuse_rs::abi::linux_abi;
-use fuse_rs::api::filesystem::Entry;
+use fuse_backend_rs::abi::linux_abi;
+use fuse_backend_rs::api::filesystem::Entry;
 
 use storage::device::RafsBioDesc;
 

--- a/src/bin/nydusd/daemon.rs
+++ b/src/bin/nydusd/daemon.rs
@@ -23,11 +23,11 @@ use std::thread;
 use std::{error, fmt, io};
 
 use event_manager::{EventOps, EventSubscriber, Events};
-use fuse_rs::api::{vfs::VfsError, BackendFileSystem, Vfs};
-use fuse_rs::passthrough::{Config, PassthroughFs};
+use fuse_backend_rs::api::{vfs::VfsError, BackendFileSystem, Vfs};
+use fuse_backend_rs::passthrough::{Config, PassthroughFs};
 #[cfg(feature = "virtiofs")]
-use fuse_rs::transport::Error as FuseTransportError;
-use fuse_rs::Error as VhostUserFsError;
+use fuse_backend_rs::transport::Error as FuseTransportError;
+use fuse_backend_rs::Error as VhostUserFsError;
 
 use vmm_sys_util::{epoll::EventSet, eventfd::EventFd};
 

--- a/src/bin/nydusd/fusedev.rs
+++ b/src/bin/nydusd/fusedev.rs
@@ -23,12 +23,12 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use nix::sys::stat::{major, minor};
 use serde::Serialize;
 
-use fuse_rs::api::{
+use fuse_backend_rs::api::{
     server::{MetricsHook, Server},
     Vfs,
 };
 
-use fuse_rs::abi::linux_abi::{InHeader, OutHeader};
+use fuse_backend_rs::abi::linux_abi::{InHeader, OutHeader};
 use vmm_sys_util::eventfd::EventFd;
 
 use crate::upgrade::{self, FailoverPolicy, UpgradeManager};
@@ -100,7 +100,7 @@ impl FuseServer {
                     .handle_message(reader, writer, None, Some(metrics_hook))
                 {
                     match e {
-                        fuse_rs::Error::EncodeMessage(_ebadf) => {
+                        fuse_backend_rs::Error::EncodeMessage(_ebadf) => {
                             return Err(eio!("fuse session has been shut down"));
                         }
                         _ => {

--- a/src/bin/nydusd/main.rs
+++ b/src/bin/nydusd/main.rs
@@ -33,7 +33,7 @@ use nix::sys::signal;
 use rlimit::{rlim, Resource};
 
 use clap::{App, Arg};
-use fuse_rs::api::{Vfs, VfsOptions};
+use fuse_backend_rs::api::{Vfs, VfsOptions};
 
 use event_manager::{EventManager, EventSubscriber, SubscriberOps};
 use vmm_sys_util::eventfd::EventFd;

--- a/src/bin/nydusd/virtiofs.rs
+++ b/src/bin/nydusd/virtiofs.rs
@@ -14,8 +14,8 @@ use std::thread;
 
 use libc::EFD_NONBLOCK;
 
-use fuse_rs::api::{server::Server, Vfs};
-use fuse_rs::transport::{FsCacheReqHandler, Reader, Writer};
+use fuse_backend_rs::api::{server::Server, Vfs};
+use fuse_backend_rs::transport::{FsCacheReqHandler, Reader, Writer};
 
 use vhost_rs::vhost_user::{message::*, Listener, SlaveFsCacheReq};
 use vhost_user_backend::{VhostUserBackend, VhostUserDaemon, Vring};

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -31,7 +31,7 @@ httpdate = { version = "1.0", optional = true }
 reqwest = { version = "0.11.0", features = ["blocking", "json"], optional = true }
 tokio = { version = "1.5.0", features = ["rt-multi-thread"] }
 
-fuse-rs = { git = "https://github.com/cloud-hypervisor/fuse-backend-rs.git", rev = "cfd2cca" }
+fuse-backend-rs = { git = "https://github.com/cloud-hypervisor/fuse-backend-rs.git", rev = "cfd2cca", package = "fuse-rs" }
 
 nydus-utils = { path = "../utils" }
 nydus-error = "0.1"

--- a/storage/src/device.rs
+++ b/storage/src/device.rs
@@ -9,8 +9,8 @@ use std::io;
 use std::io::Error;
 use std::sync::Arc;
 
-use fuse_rs::api::filesystem::{ZeroCopyReader, ZeroCopyWriter};
-use fuse_rs::transport::FileReadWriteVolatile;
+use fuse_backend_rs::api::filesystem::{ZeroCopyReader, ZeroCopyWriter};
+use fuse_backend_rs::transport::FileReadWriteVolatile;
 use vm_memory::{Bytes, VolatileSlice};
 
 use crate::cache::RafsCache;

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -14,7 +14,7 @@ sha2 = "0.9.1"
 blake3 = "0.3.6"
 serde = { version = ">=1.0.27", features = ["serde_derive", "rc"] }
 serde_json = ">=1.0.9"
-fuse-rs = { git = "https://github.com/cloud-hypervisor/fuse-backend-rs.git", optional = true, rev = "cfd2cca" }
+fuse-backend-rs = { git = "https://github.com/cloud-hypervisor/fuse-backend-rs.git", optional = true, rev = "cfd2cca", package = "fuse-rs" }
 
 # used by fuse.rs, should be moved into fuse-backend-rs
 nix = "0.17"
@@ -24,4 +24,4 @@ vmm-sys-util = "0.6"
 nydus-error = "0.1"
 
 [features]
-fusedev = ["fuse-rs/fusedev"]
+fusedev = ["fuse-backend-rs/fusedev"]

--- a/utils/src/fuse.rs
+++ b/utils/src/fuse.rs
@@ -19,7 +19,7 @@ use nix::poll::{poll, PollFd, PollFlags};
 use nix::unistd::{close, dup, getgid, getuid, read};
 use nix::Error as nixError;
 
-use fuse_rs::transport::{FuseBuf, Reader, Writer};
+use fuse_backend_rs::transport::{FuseBuf, Reader, Writer};
 use vmm_sys_util::eventfd::EventFd;
 
 /// These follows definition from libfuse


### PR DESCRIPTION
fuse-rs crate has changed its package name to fuse-backend-rs,
in order to keep consistent with it and reduce code confliction
when pushing patches from different repositories, we import
dependency by its alias.

Signed-off-by: Changwei Ge <chge@linux.alibaba.com>