### PR TITLE
snapshotter: don't touch original nydusd auth if no auth in labels

### DIFF
--- a/contrib/nydus-snapshotter/config/daemonconfig.go
+++ b/contrib/nydus-snapshotter/config/daemonconfig.go
@@ -120,10 +120,15 @@ func NewDaemonConfig(cfg DaemonConfig, imageID string, vpcRegistry bool, labels 
 			registryHost = registry.ConvertToVPCHost(registryHost)
 		}
 		keyChain := auth.FromLabels(labels)
-		if keyChain.TokenBase() {
-			cfg.Device.Backend.Config.RegistryToken = keyChain.Password
-		} else {
-			cfg.Device.Backend.Config.Auth = keyChain.ToBase64()
+		// If no auth is provided, don't touch auth from provided nydusd configuration file.
+		// We don't validate the original nydusd auth from configuration file since it can be empty
+		// when repository is public.
+		if keyChain != nil {
+			if keyChain.TokenBase() {
+				cfg.Device.Backend.Config.RegistryToken = keyChain.Password
+			} else {
+				cfg.Device.Backend.Config.Auth = keyChain.ToBase64()
+			}
 		}
 		cfg.Device.Backend.Config.Host = registryHost
 		cfg.Device.Backend.Config.Repo = image.Repo

--- a/contrib/nydus-snapshotter/pkg/auth/keychain_test.go
+++ b/contrib/nydus-snapshotter/pkg/auth/keychain_test.go
@@ -15,28 +15,27 @@ import (
 )
 
 func TestFromLabels(t *testing.T) {
-	labels := map[string]string {
+	labels := map[string]string{
 		label.ImagePullUsername: "mock",
-		label.ImagePullSecret: "mock",
+		label.ImagePullSecret:   "mock",
 	}
 	kc := FromLabels(labels)
 	assert.Equal(t, kc.Username, "mock")
 	assert.Equal(t, kc.Password, "mock")
 	assert.Equal(t, "bW9jazptb2Nr", kc.ToBase64())
 
-	kc, err := FromBase64("bW9jazptb2Nr")
+	kc1, err := FromBase64("bW9jazptb2Nr")
 	assert.Nil(t, err)
-	assert.Equal(t, kc.Username, "mock")
-	assert.Equal(t, kc.Password, "mock")
+	assert.Equal(t, kc1.Username, "mock")
+	assert.Equal(t, kc1.Password, "mock")
 
-	labels = map[string]string {}
+	labels = map[string]string{}
 	kc = FromLabels(labels)
-	assert.Equal(t, "", kc.ToBase64())
+	assert.Nil(t, kc)
 
-	labels = map[string]string {
+	labels = map[string]string{
 		label.ImagePullSecret: "mock",
 	}
 	kc = FromLabels(labels)
-	assert.True(t, kc.TokenBase())
-	assert.Equal(t, "mock", kc.Password)
+	assert.Nil(t, kc)
 }


### PR DESCRIPTION
Nydusd must pull data from registry with auth if the repo is private.
Snapshotter only fetches auth from labels and if no auth in the labels,
it will use empty string to replace the original auth.

This causes nydusd lossing auth to access registry.

Signed-off-by: Changwei Ge <chge@linux.alibaba.com>