### PR TITLE
cargo: use event-manger from crate.io

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,7 +420,8 @@ dependencies = [
 [[package]]
 name = "event-manager"
 version = "0.2.1"
-source = "git+https://github.com/rust-vmm/event-manager.git?tag=v0.2.1#3fa29497b397bfbe613cbc142b426da198a36a01"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "377fa591135fbe23396a18e2655a6d5481bf7c5823cdfa3cc81b01a229cbe640"
 dependencies = [
  "libc",
  "vmm-sys-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ hyperlocal = "0.8.0"
 tokio = { version = "1.9.0", features = ["macros"] }
 hyper = "0.14.11"
 
-event-manager = { git = "https://github.com/rust-vmm/event-manager.git", tag = "v0.2.1" }
+event-manager = "0.2.1"
 fuse-backend-rs = { git = "https://github.com/cloud-hypervisor/fuse-backend-rs.git", rev = "afc7b69", optional = true }
 vhost = { version = "0.2.0", features = ["vhost-user-slave"], optional = true }
 vhost-user-backend = { git = "https://github.com/rust-vmm/vhost-user-backend", rev = "3242b37", optional = true }


### PR DESCRIPTION
Instead of getting it from github.
