### PR TITLE
release: include an example nydusd config in the release tarball

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,7 @@ jobs:
         sudo mv target-fusedev/x86_64-unknown-linux-musl/release/nydus-image .
         sudo mv target-fusedev/x86_64-unknown-linux-musl/release/nydusctl .
         sudo mv target-virtiofs/x86_64-unknown-linux-musl/release/nydusd nydusd-virtiofs
+        sudo cp -r misc/configs .
         sudo chown -R $(id -un):$(id -gn) .
     - name: store-artifacts
       uses: actions/upload-artifact@v2
@@ -41,6 +42,7 @@ jobs:
           nydusd-virtiofs
           nydus-image
           nydusctl
+          configs
   build-contrib:
     runs-on: ubuntu-latest
     steps:

--- a/misc/configs/nydusd-config.json
+++ b/misc/configs/nydusd-config.json
@@ -1,0 +1,27 @@
+{
+  "device": {
+    "backend": {
+      "type": "registry",
+      "config": {
+        "scheme": "http",
+        "timeout": 5,
+        "connect_timeout": 5,
+        "retry_limit": 0
+      }
+    },
+    "cache": {
+      "type": "blobcache",
+      "config": {
+        "work_dir": "/cache"
+      }
+    }
+  },
+  "mode": "direct",
+  "digest_validate": false,
+  "iostats_files": true,
+  "enable_xattr": true,
+  "fs_prefetch": {
+    "enable": true,
+    "threads_count": 4
+  }
+}


### PR DESCRIPTION
So that user can just use it in normal use cases.