### PR TITLE
action/ci: add stable-1.x branch to CI target branches list

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: ["*"]
   pull_request:
-    branches: [master]
+    branches: [master, stable-1.x]
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
So we can perform smoke test against PRs for stable-1.x updates.