### PR TITLE
cargo: dump package version to 1.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1197,7 +1197,7 @@ dependencies = [
 
 [[package]]
 name = "nydus-rs"
-version = "1.0.0"
+version = "1.1.1"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nydus-rs"
-version = "1.0.0"
+version = "1.1.1"
 authors = ["The Nydus Developers"]
 edition = "2018"
 
@@ -36,7 +36,6 @@ nix = "0.17"
 anyhow = "1.0.35"
 base64 = { version = ">=0.12.0" }
 rust-fsm = "0.6.0"
-vm-memory = { version = "0.6.0", features = ["backend-mmap"], optional = true }
 chrono = "0.4.19"
 openssl = { version = "0.10.35", features = ["vendored"] }
 hyperlocal = "0.8.0"
@@ -44,6 +43,7 @@ tokio = { version = "1.9.0", features = ["macros"] }
 hyper = "0.14.11"
 
 event-manager = "0.2.1"
+vm-memory = { version = "0.6.0", features = ["backend-mmap"], optional = true }
 fuse-backend-rs = { git = "https://github.com/cloud-hypervisor/fuse-backend-rs.git", rev = "afc7b69", optional = true }
 vhost = { version = "0.2.0", features = ["vhost-user-slave"], optional = true }
 vhost-user-backend = { git = "https://github.com/rust-vmm/vhost-user-backend", rev = "3242b37", optional = true }


### PR DESCRIPTION
Let's dump the version of nydus and prepare for releasing v1.1.1