### PR TITLE
improve passthroughfs when running together with rafs

### DIFF
--- a/rafs/src/fs.rs
+++ b/rafs/src/fs.rs
@@ -664,6 +664,17 @@ impl FileSystem for Rafs {
         r
     }
 
+    fn open(
+        &self,
+        _ctx: &Context,
+        _inode: Self::Inode,
+        _flags: u32,
+        _fuse_flags: u32,
+    ) -> Result<(Option<Self::Handle>, OpenOptions)> {
+        // Keep cache since we are readonly
+        Ok((None, OpenOptions::KEEP_CACHE))
+    }
+
     fn release(
         &self,
         _ctx: &Context,
@@ -791,6 +802,16 @@ impl FileSystem for Rafs {
             rec.mark_success(0);
             r
         })
+    }
+
+    fn opendir(
+        &self,
+        _ctx: &Context,
+        _inode: Self::Inode,
+        _flags: u32,
+    ) -> Result<(Option<Self::Handle>, OpenOptions)> {
+        // Cache dir since we are readonly
+        Ok((None, OpenOptions::CACHE_DIR))
     }
 
     fn releasedir(&self, _ctx: &Context, _inode: u64, _flags: u32, _handle: u64) -> Result<()> {

--- a/src/bin/nydusd/daemon.rs
+++ b/src/bin/nydusd/daemon.rs
@@ -299,7 +299,7 @@ pub trait NydusDaemon: DaemonStateMachineSubscriber {
         }
         let backend = fs_backend_factory(&cmd)?;
         let index = self.get_vfs().mount(backend, &cmd.mountpoint)?;
-        info!("rafs mounted at {}", &cmd.mountpoint);
+        info!("{} mounted at {}", &cmd.fs_type, &cmd.mountpoint);
         self.backend_collection().add(&cmd.mountpoint, &cmd)?;
 
         // Add mounts opaque to UpgradeManager

--- a/src/bin/nydusd/main.rs
+++ b/src/bin/nydusd/main.rs
@@ -231,6 +231,13 @@ fn main() -> Result<()> {
                 .default_value("/")
                 .required(false)
                 .global(true),
+        )
+        .arg(
+            Arg::with_name("hybrid-mode").long("hybrid-mode")
+            .help("run nydusd in rafs and passthroughfs hybrid mode")
+            .required(false)
+            .takes_value(false)
+            .global(true)
         );
 
     #[cfg(feature = "fusedev")]
@@ -349,6 +356,12 @@ fn main() -> Result<()> {
     } else {
         None
     };
+
+    // Enable all options required by passthroughfs
+    if cmd_arguments_parsed.is_present("hybrid-mode") {
+        opts.no_open = false;
+        opts.killpriv_v2 = true;
+    }
 
     let vfs = Vfs::new(opts);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,7 @@ pub enum NydusError {
 
 pub type Result<T> = std::result::Result<T, NydusError>;
 
-#[derive(Clone, Serialize, PartialEq, Deserialize)]
+#[derive(Clone, Debug, Serialize, PartialEq, Deserialize)]
 pub enum FsBackendType {
     Rafs,
     PassthroughFs,
@@ -36,6 +36,12 @@ impl FromStr for FsBackendType {
                 o
             ))),
         }
+    }
+}
+
+impl Display for FsBackendType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
     }
 }
 


### PR DESCRIPTION
When running passthrougfs together with rafs in the same vfs instance, we need to make sure that necessary passthroughfs options are enabled rather than using the default vfs options.