### PR TITLE
A series of changes for supporting diff build cache

### DIFF
--- a/contrib/nydusify/pkg/checker/checker.go
+++ b/contrib/nydusify/pkg/checker/checker.go
@@ -116,6 +116,7 @@ func (checker *Checker) Check(ctx context.Context) error {
 		&rule.BootstrapRule{
 			Parsed:          targetParsed,
 			NydusImagePath:  checker.NydusImagePath,
+			BackendType:     checker.BackendType,
 			BootstrapPath:   filepath.Join(checker.WorkDir, "nydus_bootstrap"),
 			DebugOutputPath: filepath.Join(checker.WorkDir, "nydus_bootstrap_debug.json"),
 		},

--- a/contrib/nydusify/pkg/checker/rule/manifest.go
+++ b/contrib/nydusify/pkg/checker/rule/manifest.go
@@ -6,7 +6,6 @@ package rule
 
 import (
 	"encoding/json"
-	"fmt"
 	"reflect"
 
 	"github.com/pkg/errors"
@@ -66,37 +65,17 @@ func (rule *ManifestRule) Validate() error {
 	}
 
 	layers := rule.TargetParsed.NydusImage.Manifest.Layers
-	blobListInAnnotation := []string{}
-	blobListInLayer := []string{}
 	for i, layer := range layers {
 		if i == len(layers)-1 {
 			if layer.Annotations[utils.LayerAnnotationNydusBootstrap] != "true" {
 				return errors.New("invalid bootstrap layer in nydus image manifest")
-			}
-			// Check blob list in annotation
-			blobListStr, ok := layer.Annotations[utils.LayerAnnotationNydusBlobIDs]
-			if !ok {
-				return errors.New("invalid blob list in annotation of nydus image manifest")
-			}
-			if err := json.Unmarshal([]byte(blobListStr), &blobListInAnnotation); err != nil {
-				return errors.Wrap(err, "failed to unmarshal blob list in annotation of nydus image manifest")
 			}
 		} else {
 			if layer.MediaType != utils.MediaTypeNydusBlob ||
 				layer.Annotations[utils.LayerAnnotationNydusBlob] != "true" {
 				return errors.New("invalid blob layer in nydus image manifest")
 			}
-			blobListInLayer = append(blobListInLayer, layer.Digest.Hex())
 		}
-	}
-
-	// Compare the blob list differences between bootstrap layer annotation
-	// and manifest layers.
-	if rule.BackendType == "registry" && !reflect.DeepEqual(blobListInAnnotation, blobListInLayer) {
-		return fmt.Errorf(
-			"unmatched blob list between in annotation and layers: %v != %v",
-			blobListInAnnotation, blobListInLayer,
-		)
 	}
 
 	// Check Nydus image config with OCI image

--- a/rafs/src/lib.rs
+++ b/rafs/src/lib.rs
@@ -79,7 +79,7 @@ impl RafsIoRead for File {}
 pub type RafsIoWriter = Box<dyn RafsIoWrite>;
 
 /// A helper trait for RafsIoWriter.
-pub trait RafsIoWrite: Write + Seek {
+pub trait RafsIoWrite: Write + Seek + 'static {
     fn as_any(&self) -> &dyn Any;
 
     fn validate_alignment(&mut self, size: usize, alignment: usize) -> Result<usize> {

--- a/rafs/src/metadata/cached_v5.rs
+++ b/rafs/src/metadata/cached_v5.rs
@@ -733,7 +733,7 @@ mod cached_tests {
     };
     use crate::metadata::layout::{RafsXAttrs, RAFS_ROOT_INODE};
     use crate::metadata::{RafsInode, RafsStore, RafsSuperMeta};
-    use crate::{RafsIoReader, RafsIoWriter};
+    use crate::{BufWriter, RafsIoReader};
 
     #[test]
     fn test_load_inode() {
@@ -744,7 +744,7 @@ mod cached_tests {
             .read(true)
             .open("/tmp/buf_1")
             .unwrap();
-        let mut writer = Box::new(f.try_clone().unwrap()) as RafsIoWriter;
+        let mut writer = BufWriter::new(f.try_clone().unwrap());
         let mut reader = Box::new(f.try_clone().unwrap()) as RafsIoReader;
 
         let mut ondisk_inode = RafsV5Inode::new();
@@ -815,7 +815,7 @@ mod cached_tests {
             .read(true)
             .open("/tmp/buf_2")
             .unwrap();
-        let mut writer = Box::new(f.try_clone().unwrap()) as RafsIoWriter;
+        let mut writer = BufWriter::new(f.try_clone().unwrap());
         let mut reader = Box::new(f.try_clone().unwrap()) as RafsIoReader;
         let file_name = OsString::from("c_inode_2");
         let symlink_name = OsString::from("c_inode_1");
@@ -856,7 +856,7 @@ mod cached_tests {
             .read(true)
             .open("/tmp/buf_3")
             .unwrap();
-        let mut writer = Box::new(f.try_clone().unwrap()) as RafsIoWriter;
+        let mut writer = BufWriter::new(f.try_clone().unwrap());
         let mut reader = Box::new(f.try_clone().unwrap()) as RafsIoReader;
         let file_name = OsString::from("c_inode_3");
         let mut ondisk_inode = RafsV5Inode::new();

--- a/rafs/src/metadata/direct_v5.rs
+++ b/rafs/src/metadata/direct_v5.rs
@@ -530,7 +530,10 @@ impl RafsInode for OndiskInodeWrapper {
         if inode.is_reg() {
             let chunks = (inode.i_size + chunk_size - 1) / chunk_size;
             if !inode.has_hole() && chunks != inode.i_child_count as u64 {
-                return Err(einval!("invalid chunk count"));
+                return Err(einval!(format!(
+                    "invalid chunk count, ino {}, expected {}, actual {}",
+                    inode.i_ino, chunks, inode.i_child_count,
+                )));
             }
             let size = inode.size()
                 + xattr_size

--- a/rafs/src/metadata/md_v5.rs
+++ b/rafs/src/metadata/md_v5.rs
@@ -53,7 +53,7 @@ impl RafsSuper {
         Ok(true)
     }
 
-    pub(crate) fn store_v5(&self, w: &mut RafsIoWriter) -> Result<usize> {
+    pub(crate) fn store_v5(&self, w: &mut dyn RafsIoWrite) -> Result<usize> {
         let mut sb = RafsV5SuperBlock::new();
 
         sb.set_magic(self.meta.magic);

--- a/rafs/src/metadata/md_v6.rs
+++ b/rafs/src/metadata/md_v6.rs
@@ -53,7 +53,7 @@ impl RafsSuper {
 mod tests {
     use super::*;
     use crate::metadata::RafsStore;
-    use crate::RafsIoWriter;
+    use crate::BufWriter;
     use std::fs::OpenOptions;
     use std::io::Write;
     use vmm_sys_util::tempfile::TempFile;
@@ -107,7 +107,7 @@ mod tests {
             .open(t_file.as_path())
             .unwrap();
         let sb = RafsV6SuperBlock::new();
-        let mut writer = Box::new(file) as RafsIoWriter;
+        let mut writer = BufWriter::new(file);
         sb.store(&mut writer).unwrap();
 
         let file = OpenOptions::new()

--- a/rafs/src/metadata/mod.rs
+++ b/rafs/src/metadata/mod.rs
@@ -28,7 +28,7 @@ use storage::device::{BlobChunkInfo, BlobInfo, BlobIoVec};
 use self::layout::{XattrName, XattrValue, RAFS_SUPER_VERSION_V5, RAFS_SUPER_VERSION_V6};
 use self::noop::NoopSuperBlock;
 use crate::fs::{RafsConfig, RAFS_DEFAULT_ATTR_TIMEOUT, RAFS_DEFAULT_ENTRY_TIMEOUT};
-use crate::{RafsError, RafsIoReader, RafsIoWriter, RafsResult};
+use crate::{RafsError, RafsIoReader, RafsIoWrite, RafsResult};
 
 pub mod cached_v5;
 pub mod direct_v5;
@@ -203,7 +203,7 @@ pub trait RafsInode: Any {
 /// Trait to store Rafs meta block and validate alignment.
 pub trait RafsStore {
     /// Write the Rafs filesystem metadata to a writer.
-    fn store(&self, w: &mut RafsIoWriter) -> Result<usize>;
+    fn store(&self, w: &mut dyn RafsIoWrite) -> Result<usize>;
 }
 
 bitflags! {
@@ -470,7 +470,7 @@ impl RafsSuper {
     }
 
     /// Store RAFS metadata to backend storage.
-    pub fn store(&self, w: &mut RafsIoWriter) -> Result<usize> {
+    pub fn store(&self, w: &mut dyn RafsIoWrite) -> Result<usize> {
         if self.meta.is_v5() {
             return self.store_v5(w);
         }

--- a/src/bin/nydus-image/builder/directory.rs
+++ b/src/bin/nydus-image/builder/directory.rs
@@ -165,6 +165,6 @@ impl Builder for DirectoryBuilder {
         }
 
         bootstrap_mgr.add(bootstrap_ctx);
-        BuildOutput::new(&blob_mgr, &bootstrap_mgr, 0)
+        BuildOutput::new(&blob_mgr, &bootstrap_mgr)
     }
 }

--- a/src/bin/nydus-image/builder/mod.rs
+++ b/src/bin/nydus-image/builder/mod.rs
@@ -4,7 +4,7 @@
 
 use anyhow::Result;
 
-use crate::core::context::{BlobManager, BootstrapContext, BuildContext};
+use crate::core::context::{BlobManager, BootstrapManager, BuildContext};
 
 pub(crate) use diff::DiffBuilder;
 pub(crate) use directory::DirectoryBuilder;
@@ -18,7 +18,7 @@ pub(crate) trait Builder {
     fn build(
         &mut self,
         build_ctx: &mut BuildContext,
-        bootstrap_ctx: &mut BootstrapContext,
+        bootstrap_mgr: &mut BootstrapManager,
         blob_mgr: &mut BlobManager,
     ) -> Result<(Vec<String>, u64)>;
 }

--- a/src/bin/nydus-image/builder/mod.rs
+++ b/src/bin/nydus-image/builder/mod.rs
@@ -4,7 +4,7 @@
 
 use anyhow::Result;
 
-use crate::core::context::{BlobManager, BootstrapManager, BuildContext};
+use crate::core::context::{BlobManager, BootstrapManager, BuildContext, BuildOutput};
 
 pub(crate) use diff::DiffBuilder;
 pub(crate) use directory::DirectoryBuilder;
@@ -20,5 +20,5 @@ pub(crate) trait Builder {
         build_ctx: &mut BuildContext,
         bootstrap_mgr: &mut BootstrapManager,
         blob_mgr: &mut BlobManager,
-    ) -> Result<(Vec<String>, u64)>;
+    ) -> Result<BuildOutput>;
 }

--- a/src/bin/nydus-image/builder/stargz.rs
+++ b/src/bin/nydus-image/builder/stargz.rs
@@ -656,6 +656,6 @@ impl Builder for StargzBuilder {
         }
 
         bootstrap_mgr.add(bootstrap_ctx);
-        BuildOutput::new(&blob_mgr, &bootstrap_mgr, 0)
+        BuildOutput::new(&blob_mgr, &bootstrap_mgr)
     }
 }

--- a/src/bin/nydus-image/core/blob.rs
+++ b/src/bin/nydus-image/core/blob.rs
@@ -41,10 +41,7 @@ impl Blob {
                         .dump_blob(ctx, blob_ctx, blob_index, chunk_dict)
                         .context("failed to dump blob chunks")?;
                     if idx < prefetch_entries {
-                        debug!("[{}]\treadahead {}", node.overlay, node);
                         blob_ctx.blob_readahead_size += size;
-                    } else {
-                        debug!("[{}]\t{}", node.overlay, node);
                     }
                 }
                 self.dump_meta_data(blob_ctx)?;

--- a/src/bin/nydus-image/core/blob.rs
+++ b/src/bin/nydus-image/core/blob.rs
@@ -22,14 +22,14 @@ impl Blob {
     }
 
     /// Dump blob file and generate chunks
-    pub fn dump<T: ChunkDict>(
+    pub fn dump<'a, T: ChunkDict>(
         &mut self,
         ctx: &BuildContext,
-        blob_ctx: &mut BlobContext,
+        blob_ctx: &'a mut BlobContext,
         blob_index: u32,
         nodes: &mut Vec<Node>,
         chunk_dict: &mut T,
-    ) -> Result<()> {
+    ) -> Result<bool> {
         match ctx.source_type {
             SourceType::Directory | SourceType::Diff => {
                 let (inodes, prefetch_entries) = blob_ctx
@@ -76,20 +76,12 @@ impl Blob {
             blob_ctx.blob_id = format!("{:x}", blob_ctx.blob_hash.clone().finalize());
         }
 
-        Ok(())
-    }
+        blob_ctx.set_blob_readahead_size(ctx);
+        blob_ctx.flush()?;
 
-    pub fn flush(self, blob_ctx: &mut BlobContext) -> Result<()> {
-        let blob_id = if blob_ctx.compressed_blob_size > 0 {
-            Some(blob_ctx.blob_id.as_str())
-        } else {
-            None
-        };
-        if let Some(writer) = blob_ctx.writer.take() {
-            writer.release(blob_id)?;
-        }
+        let blob_exists = blob_ctx.compressed_blob_size > 0;
 
-        Ok(())
+        Ok(blob_exists)
     }
 
     fn dump_meta_data(&mut self, blob_ctx: &mut BlobContext) -> Result<()> {

--- a/src/bin/nydus-image/core/context.rs
+++ b/src/bin/nydus-image/core/context.rs
@@ -194,12 +194,9 @@ impl ArtifactBufferWriter {
 
         if let Some(n) = name {
             if let ArtifactStorage::FileDir(s) = &self.storage {
-                // NOTE: File with same name will be deleted ahead of time.
-                // So each newly generated blob can be stored.
                 let might_exist_path = Path::new(s).join(n);
                 if might_exist_path.exists() {
-                    remove_file(&might_exist_path)
-                        .with_context(|| format!("failed to remove blob {:?}", might_exist_path))?;
+                    return Ok(());
                 }
 
                 // Safe to unwrap as `FileDir` must have `tmp_file` created.

--- a/src/bin/nydus-image/core/context.rs
+++ b/src/bin/nydus-image/core/context.rs
@@ -17,11 +17,15 @@ use std::sync::Arc;
 use anyhow::{Context, Error, Result};
 use nydus_utils::digest;
 use nydus_utils::div_round_up;
+use rafs::metadata::layout::v5::RafsV5BlobTable;
+use rafs::metadata::layout::v6::RafsV6BlobTable;
 use rafs::metadata::layout::v6::EROFS_BLOCK_SIZE;
+use rafs::metadata::RafsSuperFlags;
 use rafs::metadata::{Inode, RAFS_DEFAULT_CHUNK_SIZE, RAFS_MAX_CHUNK_SIZE};
 use rafs::{RafsIoReader, RafsIoWrite};
 use sha2::{Digest, Sha256};
 use storage::compress;
+use storage::device::BlobFeatures;
 use storage::device::BlobInfo;
 use storage::meta::{BlobChunkInfoOndisk, BlobMetaHeaderOndisk};
 use vmm_sys_util::tempfile::TempFile;
@@ -29,7 +33,7 @@ use vmm_sys_util::tempfile::TempFile;
 use super::chunk_dict::{ChunkDict, HashChunkDict};
 use super::layout::BlobLayout;
 use super::node::{ChunkWrapper, Node, WhiteoutSpec};
-use super::prefetch::Prefetch;
+use super::prefetch::{Prefetch, PrefetchPolicy};
 
 // TODO: select BufWriter capacity by performance testing.
 pub const BUF_WRITER_CAPACITY: usize = 2 << 17;
@@ -83,6 +87,15 @@ pub enum ArtifactStorage {
 impl Default for ArtifactStorage {
     fn default() -> Self {
         Self::SingleFile(PathBuf::new())
+    }
+}
+
+impl ArtifactStorage {
+    fn get_path(&self, name: &str) -> PathBuf {
+        match self {
+            Self::SingleFile(path) => path.to_path_buf(),
+            Self::FileDir(base) => base.join(name),
+        }
     }
 }
 
@@ -284,6 +297,15 @@ impl BlobContext {
         self.chunk_size = chunk_size;
     }
 
+    pub fn set_blob_readahead_size(&mut self, ctx: &BuildContext) {
+        if (self.compressed_blob_size > 0
+            || (ctx.source_type == SourceType::StargzIndex && !self.blob_id.is_empty()))
+            && ctx.prefetch.policy != PrefetchPolicy::Blob
+        {
+            self.blob_readahead_size = 0;
+        }
+    }
+
     pub fn set_meta_info_enabled(&mut self, enable: bool) {
         self.blob_meta_info_enabled = enable;
     }
@@ -321,6 +343,20 @@ impl BlobContext {
             Ok(index)
         }
     }
+
+    pub fn flush(&mut self) -> Result<()> {
+        let blob_id = if self.compressed_blob_size > 0 {
+            Some(self.blob_id.as_str())
+        } else {
+            None
+        };
+
+        if let Some(writer) = self.writer.take() {
+            writer.release(blob_id)?;
+        }
+
+        Ok(())
+    }
 }
 
 impl From<&BlobInfo> for BlobContext {
@@ -336,10 +372,14 @@ impl From<&BlobInfo> for BlobContext {
     }
 }
 
-/// BlobManager stores all blob related information during build,
-/// the vector index will be as the blob index.
+/// BlobManager stores all blob related information during build.
 pub struct BlobManager {
-    pub blobs: Vec<BlobContext>,
+    /// Some layers may not have a blob (only have metadata), so Option
+    /// is used here, the vector index will be as the layer index.
+    ///
+    /// We can get blob index for a layer by using:
+    /// self.blobs.iter().flatten().collect()[layer_index];
+    blobs: Vec<Option<BlobContext>>,
     /// Chunk dictionary from reference image or base layer.
     pub chunk_dict_ref: Arc<dyn ChunkDict>,
     /// Chunk dictionary to hold new chunks from the upper layer.
@@ -363,17 +403,12 @@ impl BlobManager {
         self.chunk_dict_ref.clone()
     }
 
-    /// Get blob context for current layer
-    pub fn current(&mut self) -> Option<&mut BlobContext> {
-        self.blobs.last_mut()
-    }
-
     /// Allocate a blob index sequentially.
     ///
     /// This should be paired with Self::add() and keep in consistence.
     pub fn alloc_index(&self) -> Result<u32> {
         // Rafs v6 only supports 256 blobs.
-        u8::try_from(self.blobs.len())
+        u8::try_from(self.blobs.iter().flatten().count())
             .map(|v| v as u32)
             .with_context(|| Error::msg("too many blobs"))
     }
@@ -381,27 +416,57 @@ impl BlobManager {
     /// Add a blob context to manager
     ///
     /// This should be paired with Self::alloc_index() and keep in consistence.
-    pub fn add(&mut self, blob_ctx: BlobContext) {
+    pub fn add(&mut self, blob_ctx: Option<BlobContext>) {
         self.blobs.push(blob_ctx);
+    }
+
+    pub fn len(&self) -> usize {
+        self.blobs.len()
+    }
+
+    /// Only get valid (non-empty) blobs.
+    pub fn get_blobs(&self) -> Vec<&BlobContext> {
+        self.blobs.iter().flatten().collect()
+    }
+
+    pub fn get_blobs_from(&self, skip: usize) -> Vec<&BlobContext> {
+        self.blobs.iter().skip(skip).flatten().collect()
+    }
+
+    pub fn get_last_blob(&self) -> Option<&BlobContext> {
+        self.blobs.last().unwrap_or(&None).as_ref()
     }
 
     pub fn from_blob_table(&mut self, blob_table: Vec<Arc<BlobInfo>>) {
         self.blobs = blob_table
             .iter()
-            .map(|entry| BlobContext::from(entry.as_ref()))
+            .map(|entry| Some(BlobContext::from(entry.as_ref())))
             .collect();
     }
 
-    fn get_blob_idx_by_id(&self, id: &str) -> Option<u32> {
-        for i in 0..self.blobs.len() {
-            if self.blobs[i].blob_id.eq(id) {
-                return Some(i as u32);
+    pub fn get_blob_idx_by_id(&self, id: &str) -> Option<u32> {
+        for (idx, blob) in self.get_blobs().iter().enumerate() {
+            if blob.blob_id.eq(id) {
+                return Some(idx as u32);
             }
         }
         None
     }
 
-    /// extend blobs which belong to ChunkDict and setup real_blob_idx map
+    pub fn get_blob_idx_by_layer_idx(&self, layer_idx: u32) -> Option<u32> {
+        let mut blob_idx = 0u32;
+        for (idx, blob) in self.blobs.iter().enumerate() {
+            if blob.is_some() {
+                if idx == layer_idx as usize {
+                    return Some(blob_idx);
+                }
+                blob_idx += 1;
+            }
+        }
+        None
+    }
+
+    /// Extend blobs which belong to ChunkDict and setup real_blob_idx map
     /// should call this function after import parent bootstrap
     /// otherwise will break blobs order
     pub fn extend_blob_table_from_chunk_dict(&mut self) -> Result<()> {
@@ -413,7 +478,7 @@ impl BlobManager {
                     .set_real_blob_idx(blob.blob_index(), real_idx);
             } else {
                 let idx = self.alloc_index()?;
-                self.add(BlobContext::from(blob.as_ref()));
+                self.add(Some(BlobContext::from(blob.as_ref())));
                 self.chunk_dict_ref
                     .set_real_blob_idx(blob.blob_index(), idx);
             }
@@ -421,18 +486,110 @@ impl BlobManager {
 
         Ok(())
     }
+
+    pub fn to_blob_table_v5(
+        &self,
+        build_ctx: &BuildContext,
+        up_idx: Option<usize>,
+    ) -> Result<RafsV5BlobTable> {
+        let mut blob_table = RafsV5BlobTable::new();
+        let up_idx = up_idx.unwrap_or(self.blobs.len() - 1) as usize;
+
+        for (idx, ctx) in self.blobs.iter().enumerate() {
+            if let Some(ctx) = ctx {
+                let blob_id = ctx.blob_id.clone();
+                let blob_readahead_size = u32::try_from(ctx.blob_readahead_size)?;
+                let chunk_count = ctx.chunk_count;
+                let decompressed_blob_size = ctx.decompressed_blob_size;
+                let compressed_blob_size = ctx.compressed_blob_size;
+                let blob_features = BlobFeatures::empty();
+                let mut flags = RafsSuperFlags::empty();
+                match build_ctx.fs_version {
+                    RafsVersion::V5 => {
+                        flags |= RafsSuperFlags::from(build_ctx.compressor);
+                        flags |= RafsSuperFlags::from(build_ctx.digester);
+                    }
+                    RafsVersion::V6 => todo!(),
+                }
+                blob_table.add(
+                    blob_id,
+                    0,
+                    blob_readahead_size,
+                    ctx.chunk_size,
+                    chunk_count,
+                    decompressed_blob_size,
+                    compressed_blob_size,
+                    blob_features,
+                    flags,
+                );
+            }
+            if idx == up_idx {
+                break;
+            }
+        }
+
+        Ok(blob_table)
+    }
+
+    pub fn to_blob_table_v6(
+        &self,
+        build_ctx: &BuildContext,
+        up_idx: Option<usize>,
+    ) -> Result<RafsV6BlobTable> {
+        let mut blob_table = RafsV6BlobTable::new();
+        let up_idx = up_idx.unwrap_or(self.blobs.len() - 1) as usize;
+
+        for (idx, ctx) in self.blobs.iter().enumerate() {
+            if let Some(ctx) = ctx {
+                let blob_id = ctx.blob_id.clone();
+                let blob_readahead_size = u32::try_from(ctx.blob_readahead_size)?;
+                let chunk_count = ctx.chunk_count;
+                let decompressed_blob_size = ctx.decompressed_blob_size;
+                let compressed_blob_size = ctx.compressed_blob_size;
+                let blob_features = BlobFeatures::empty();
+                let mut flags = RafsSuperFlags::empty();
+                match build_ctx.fs_version {
+                    RafsVersion::V5 => todo!(),
+                    RafsVersion::V6 => {
+                        flags |= RafsSuperFlags::from(build_ctx.compressor);
+                        flags |= RafsSuperFlags::from(build_ctx.digester);
+                    }
+                }
+                blob_table.add(
+                    blob_id,
+                    0,
+                    blob_readahead_size,
+                    ctx.chunk_size,
+                    chunk_count,
+                    decompressed_blob_size,
+                    compressed_blob_size,
+                    blob_features,
+                    flags,
+                    ctx.blob_meta_header,
+                );
+                if idx == up_idx {
+                    break;
+                }
+            }
+        }
+
+        Ok(blob_table)
+    }
 }
 
 /// BootstrapContext is used to hold inmemory data of bootstrap during build.
 pub struct BootstrapContext {
+    /// This build has a parent bootstrap.
     pub layered: bool,
     /// Cache node index for hardlinks, HashMap<(real_inode, dev), Vec<index>>.
     pub lower_inode_map: HashMap<(Inode, u64), Vec<u64>>,
     pub upper_inode_map: HashMap<(Inode, u64), Vec<u64>>,
     /// Store all nodes in ascendant ordor, indexed by (node.index - 1).
     pub nodes: Vec<Node>,
-    /// current position to write in f_bootstrap
+    /// Current position to write in f_bootstrap
     pub offset: u64,
+    /// Bootstrap file name, only be used for diff build.
+    pub name: String,
     /// Bootstrap file writer.
     storage: ArtifactStorage,
 }
@@ -445,6 +602,7 @@ impl BootstrapContext {
             upper_inode_map: HashMap::new(),
             nodes: Vec::new(),
             offset: EROFS_BLOCK_SIZE,
+            name: String::new(),
             storage,
         })
     }
@@ -466,6 +624,10 @@ pub struct BootstrapManager {
     /// Parent bootstrap file reader.
     pub f_parent_bootstrap: Option<RafsIoReader>,
     bootstrap_storage: ArtifactStorage,
+    /// The vector index will be as the layer index.
+    /// We can get the bootstrap of a layer by using:
+    /// self.bootstraps[layer_index];
+    bootstraps: Vec<BootstrapContext>,
 }
 
 impl BootstrapManager {
@@ -476,6 +638,7 @@ impl BootstrapManager {
         Self {
             f_parent_bootstrap,
             bootstrap_storage,
+            bootstraps: Vec::new(),
         }
     }
 
@@ -484,6 +647,22 @@ impl BootstrapManager {
             self.bootstrap_storage.clone(),
             self.f_parent_bootstrap.is_some(),
         )
+    }
+
+    pub fn add(&mut self, bootstrap_ctx: BootstrapContext) {
+        self.bootstraps.push(bootstrap_ctx);
+    }
+
+    pub fn get_bootstraps(&self) -> Vec<String> {
+        self.bootstraps.iter().map(|b| b.name.to_owned()).collect()
+    }
+
+    pub fn get_last_bootstrap(&self) -> Option<String> {
+        self.bootstraps.last().map(|b| b.name.to_owned())
+    }
+
+    pub fn get_bootstrap_path(&self, name: &str) -> PathBuf {
+        self.bootstrap_storage.get_path(name)
     }
 }
 
@@ -563,5 +742,44 @@ impl BuildContext {
 
     pub fn set_chunk_size(&mut self, chunk_size: u32) {
         self.chunk_size = chunk_size;
+    }
+}
+
+/// BuildOutput represents the output in this build.
+#[derive(Default, Debug, Clone)]
+pub struct BuildOutput {
+    /// Blob ids for all layer, index equals blob index.
+    pub blobs: Vec<String>,
+    /// Bootstrap names for all layer in this build, index equals layer index.
+    pub bootstraps: Vec<String>,
+    /// The size of output blob in this build.
+    pub blob_size: Option<u64>,
+    /// The name of output bootstrap in this build, for the bootstrap
+    /// of last layer in diff build.
+    pub bootstrap_name: String,
+}
+
+impl BuildOutput {
+    pub fn new(
+        blob_mgr: &BlobManager,
+        bootstrap_mgr: &BootstrapManager,
+        skip: usize,
+    ) -> Result<BuildOutput> {
+        let blobs = blob_mgr
+            .get_blobs_from(skip)
+            .iter()
+            .map(|b| b.blob_id.to_owned())
+            .collect();
+        let bootstraps = bootstrap_mgr.get_bootstraps();
+        let blob_size = blob_mgr.get_last_blob().map(|b| b.compressed_blob_size);
+        let bootstrap_name = bootstrap_mgr
+            .get_last_bootstrap()
+            .ok_or_else(|| anyhow!("can't get last bootstrap"))?;
+        Ok(Self {
+            blobs,
+            bootstraps,
+            blob_size,
+            bootstrap_name,
+        })
     }
 }

--- a/src/bin/nydus-image/core/node.rs
+++ b/src/bin/nydus-image/core/node.rs
@@ -401,11 +401,6 @@ impl Node {
                 chunk_size,
                 is_compressed,
             )?;
-            trace!(
-                "\t\tbuilding chunk: {} compressor {}",
-                chunk,
-                ctx.compressor,
-            );
 
             blob_ctx.add_chunk_meta_info(&chunk)?;
             chunk_dict.add_chunk(chunk.clone());
@@ -419,7 +414,13 @@ impl Node {
         Ok(blob_size)
     }
 
-    pub fn dump_bootstrap_v5(&self, f_bootstrap: &mut dyn RafsIoWrite) -> Result<usize> {
+    pub fn dump_bootstrap_v5(
+        &self,
+        ctx: &BuildContext,
+        f_bootstrap: &mut dyn RafsIoWrite,
+    ) -> Result<usize> {
+        debug!("[{}]\t{}", self.overlay, self);
+
         let mut node_size = 0;
         if let InodeWrapper::V5(raw_inode) = &self.inode {
             // Dump inode info
@@ -453,6 +454,7 @@ impl Node {
                     .store(f_bootstrap)
                     .context("failed to dump chunk info to bootstrap")?;
                 node_size += chunk_size;
+                trace!("\t\tchunk: {} compressor {}", chunk, ctx.compressor,);
             }
 
             Ok(node_size)
@@ -1102,7 +1104,6 @@ impl Node {
             d_size,
             self.v6_datalayout
         );
-        // assert_ne!(self.offset, 8105024);
     }
 }
 


### PR DESCRIPTION
In buildkit/harbor-acceld scenario, nydus-image need to dump blobs and bootstraps for every layer, the last bootstrap file of layer will be used as final metadata of a Nydus image, and other bootstraps of lower layer will be used as cache files in buildkit to speed up image build on next.

Commits:

Builder: fix blob race in diff build
Nydusify: relax blob list check in checker
Builder: fix invalid blob reference in diff build
Builder: some fixups for diff build cache
Builder: implement diff build cache
Builder: introduce artifact storage