### PR TITLE
snapshotter: pass auth from docker config

### DIFF
--- a/contrib/nydus-snapshotter/config/daemonconfig.go
+++ b/contrib/nydus-snapshotter/config/daemonconfig.go
@@ -117,7 +117,7 @@ func NewDaemonConfig(cfg DaemonConfig, imageID string, vpcRegistry bool, labels 
 		if vpcRegistry {
 			registryHost = registry.ConvertToVPCHost(registryHost)
 		}
-		keyChain := auth.FromLabels(labels)
+		keyChain := auth.GetRegistryKeyChain(registryHost, labels)
 		// If no auth is provided, don't touch auth from provided nydusd configuration file.
 		// We don't validate the original nydusd auth from configuration file since it can be empty
 		// when repository is public.

--- a/contrib/nydus-snapshotter/go.mod
+++ b/contrib/nydus-snapshotter/go.mod
@@ -5,6 +5,7 @@ go 1.14
 require (
 	github.com/containerd/containerd v1.4.12
 	github.com/containerd/continuity v0.0.0-20200928162600-f2cc35102c2a
+	github.com/docker/cli v20.10.0-beta1.0.20201029214301-1d20b15adc38+incompatible
 	github.com/dragonflyoss/image-service/contrib/nydusify v0.0.0-20210518022841-c17fb49cce7c
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e

--- a/contrib/nydus-snapshotter/pkg/auth/docker.go
+++ b/contrib/nydus-snapshotter/pkg/auth/docker.go
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2021. Ant Group. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package auth
+
+import (
+	"os"
+
+	dockerconfig "github.com/docker/cli/cli/config"
+)
+
+const (
+	dockerHost          = "https://index.docker.io/v1/"
+	convertedDockerHost = "registry-1.docker.io"
+)
+
+// FromDockerConfig finds auth for a given host in docker's config.json settings.
+func FromDockerConfig(host string) *PassKeyChain {
+	if len(host) == 0 {
+		return nil
+	}
+
+	// The host of docker hub image will be converted to `registry-1.docker.io` in:
+	// github.com/containerd/containerd/remotes/docker/registry.go
+	// But we need use the key `https://index.docker.io/v1/` to find auth from docker config.
+	if host == convertedDockerHost {
+		host = dockerHost
+	}
+
+	// TODO: log to default logger
+	config := dockerconfig.LoadDefaultConfigFile(os.Stderr)
+	authConfig, err := config.GetAuthConfig(host)
+	if err != nil {
+		return nil
+	}
+
+	// Do not return empty auth. It makes caller life easier.
+	if len(authConfig.Username) == 0 || len(authConfig.Password) == 0 {
+		return nil
+	}
+
+	return &PassKeyChain{
+		Username: authConfig.Username,
+		Password: authConfig.Password,
+	}
+}

--- a/contrib/nydus-snapshotter/pkg/auth/docker_test.go
+++ b/contrib/nydus-snapshotter/pkg/auth/docker_test.go
@@ -1,0 +1,95 @@
+/*
+ * Copyright (c) 2021. Ant Group. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package auth
+
+import (
+	"encoding/base64"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	testConfigFmt = `
+{
+        "auths": {
+                "%s": {
+                        "auth": "%s"
+                },
+                "%s": {
+                        "auth": "%s"
+                }
+        }
+}
+`
+	dockerUser = "dockeruserfoobar"
+	dockerPass = "dockerpassfoobar"
+	extraHost  = "reg.docker.alibaba-cloud.com"
+	extraUser  = "extrauserfoobar"
+	extraPass  = "extrapassfoobar"
+
+	configFile = "config.json"
+)
+
+var oldDockerConfig = os.Getenv("DOCKER_CONFIG")
+
+func setupDockerConfig() (string, error) {
+	dir, err := ioutil.TempDir("", "testdocker-")
+	if err != nil {
+		return "", err
+	}
+	os.Setenv("DOCKER_CONFIG", dir)
+
+	err = ioutil.WriteFile(filepath.Join(dir, configFile),
+		[]byte(fmt.Sprintf(testConfigFmt, dockerHost, base64.StdEncoding.EncodeToString([]byte(dockerUser+":"+dockerPass)),
+			extraHost, base64.StdEncoding.EncodeToString([]byte(extraUser+":"+extraPass)))),
+		0600)
+	if err != nil {
+		os.RemoveAll(dir)
+		return "", err
+	}
+
+	return dir, nil
+}
+
+func TestDockerCred(t *testing.T) {
+	assert := assert.New(t)
+
+	dir, err := setupDockerConfig()
+	assert.Nil(err)
+	defer func() {
+		os.RemoveAll(dir)
+		os.Setenv("DOCKER_CONFIG", oldDockerConfig)
+	}()
+
+	// Empty host should get empty auth
+	auth := FromDockerConfig("")
+	assert.Nil(auth)
+
+	// Unmatching host should get empty auth
+	auth = FromDockerConfig("foo")
+	assert.Nil(auth)
+
+	auth = FromDockerConfig(dockerHost)
+	assert.NotNil(auth)
+	assert.Equal(auth.Username, dockerUser)
+	assert.Equal(auth.Password, dockerPass)
+
+	auth = FromDockerConfig(convertedDockerHost)
+	assert.NotNil(auth)
+	assert.Equal(auth.Username, dockerUser)
+	assert.Equal(auth.Password, dockerPass)
+
+	auth = FromDockerConfig(extraHost)
+	assert.NotNil(auth)
+	assert.Equal(auth.Username, extraUser)
+	assert.Equal(auth.Password, extraPass)
+}

--- a/contrib/nydus-snapshotter/pkg/auth/keychain.go
+++ b/contrib/nydus-snapshotter/pkg/auth/keychain.go
@@ -79,6 +79,17 @@ func FromLabels(labels map[string]string) *PassKeyChain {
 	}
 }
 
+// GetRegistryKeyChain get image pull kaychain from (ordered):
+// 1. username and secrets labels
+// 2. docker config
+func GetRegistryKeyChain(host string, labels map[string]string) *PassKeyChain {
+	kc := FromLabels(labels)
+	if kc != nil {
+		return kc
+	}
+	return FromDockerConfig(host)
+}
+
 func (kc PassKeyChain) Resolve(target authn.Resource) (authn.Authenticator, error) {
 	return authn.FromConfig(kc.toAuthConfig()), nil
 }


### PR DESCRIPTION
So that if there is a docker config.json setup, we can reuse it.
