### PR TITLE
add golangci-lint tool for ctr-remote tool

### DIFF
--- a/contrib/ctr-remote/.golangci.yml
+++ b/contrib/ctr-remote/.golangci.yml
@@ -1,0 +1,23 @@
+# https://golangci-lint.run/usage/configuration#config-file
+
+linters:
+  enable:
+    - structcheck
+    - varcheck
+    - staticcheck
+    - unconvert
+    - gofmt
+    - goimports
+    - revive
+    - ineffassign
+    - vet
+    - unused
+    - misspell
+  disable:
+    - errcheck
+
+run:
+  deadline: 4m
+  skip-dirs:
+    - misc
+

--- a/contrib/ctr-remote/Makefile
+++ b/contrib/ctr-remote/Makefile
@@ -17,4 +17,5 @@ static-release:
 .PHONY: test
 test: build
 	go vet $(PACKAGES)
+	golangci-lint run
 	go test -v -cover ${PACKAGES}


### PR DESCRIPTION
Add a `golangci-lint` rule definition file together with adding a static check step into its Makefile.

This PR partly addresses #252 

