### PR TITLE
Utilize golangci-lint to perform static check for nydus-overlayfs

### DIFF
--- a/contrib/nydus-overlayfs/.golangci.yml
+++ b/contrib/nydus-overlayfs/.golangci.yml
@@ -1,0 +1,23 @@
+# https://golangci-lint.run/usage/configuration#config-file
+
+linters:
+  enable:
+    - structcheck
+    - varcheck
+    - staticcheck
+    - unconvert
+    - gofmt
+    - goimports
+    - revive
+    - ineffassign
+    - vet
+    - unused
+    - misspell
+  disable:
+    - errcheck
+
+run:
+  deadline: 4m
+  skip-dirs:
+    - misc
+

--- a/contrib/nydus-overlayfs/Makefile
+++ b/contrib/nydus-overlayfs/Makefile
@@ -19,4 +19,5 @@ static-release:
 .PHONY: test
 test: build
 	go vet $(PACKAGES)
+	golangci-lint run
 	go test -v -cover ${PACKAGES}


### PR DESCRIPTION
Add a `golangci-lint` rule definition file into and trigger corresponding static check in its Makefile.
This PR partly addressed #252 
