### PR TITLE
misc: update top image list

### DIFF
--- a/misc/top_images/image_list.txt
+++ b/misc/top_images/image_list.txt
@@ -22,7 +22,6 @@ debian
 sonarqube
 wordpress
 influxdb
-elasticsearch
 tomcat
 amazonlinux
 maven
@@ -42,9 +41,6 @@ adminer
 ghost
 java
 kong
-kibana
 solr
 sentry
-logstash
 zookeeper
-jenkins


### PR DESCRIPTION
some images do not have `latest` label. Let's drop them.