### PR TITLE
Slightly improve nydus-image inspect 

### DIFF
--- a/src/bin/nydus-image/inspect.rs
+++ b/src/bin/nydus-image/inspect.rs
@@ -339,11 +339,17 @@ Blocks:             {blocks}"#,
                         let path = self.path_from_ino(inode.i_parent).unwrap();
                         println!(
                             r#"
-    {:width$} Parent Path {:width$}
+    File: {:width$} Parent Path: {:width$}
+    Compressed Offset: {}, Compressed Size: {}
+    Decompressed Offset: {}, Decompressed Size: {}
     Chunk ID: {:50}, Blob ID: {}
 "#,
                             name.to_string_lossy(),
                             path.to_string_lossy(),
+                            c.compress_offset,
+                            c.compress_size,
+                            c.decompress_offset,
+                            c.decompress_size,
                             c.block_id,
                             if let Ok(ref blob) = self.blobs_table.get(c.blob_index) {
                                 &blob.blob_id

--- a/src/bin/nydus-image/inspect.rs
+++ b/src/bin/nydus-image/inspect.rs
@@ -659,9 +659,12 @@ impl Executor {
         inspector: &mut RafsInspector,
         input: String,
     ) -> std::result::Result<Option<Value>, ExecuteError> {
-        let mut raw = input.strip_suffix("\n").unwrap_or(&input).split(' ');
+        let mut raw = input
+            .strip_suffix("\n")
+            .unwrap_or(&input)
+            .split_ascii_whitespace();
         let cmd = raw.next().unwrap();
-        let args = raw.next();
+        let args = raw.next().map(|a| a.trim());
 
         debug!("execute {:?} {:?}", cmd, args);
 


### PR DESCRIPTION
Let nydus-image inspect tool print more information when debug the nydus image
 Fix command parsing panic when more than one whitespaces input