### PR TITLE
blobcache: check chunks continuity by their compressed size

### DIFF
--- a/storage/src/cache/blobcache.rs
+++ b/storage/src/cache/blobcache.rs
@@ -727,9 +727,8 @@ impl BlobCache {
                     if i != 0 && self.compressor() != compress::Algorithm::GZip {
                         let prior_cki = &req.chunks[i - 1];
                         assert!(
-                            chunk.decompress_offset()
-                                == prior_cki.decompress_offset()
-                                    + prior_cki.decompress_size() as u64
+                            chunk.compress_offset()
+                                == prior_cki.compress_offset() + prior_cki.compress_size() as u64
                         )
                     }
 


### PR DESCRIPTION
Building nydus image with --chunk-aligned option set, decompressed_offset +
decompressed_size = next_decompressed_offset can't be ruled.
So we use compressed part now.

Signed-off-by: Changwei Ge <chge@linux.alibaba.com>