### PR TITLE
Bump version to 2.0.0-rc.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1215,7 +1215,7 @@ dependencies = [
 
 [[package]]
 name = "nydus-rs"
-version = "1.0.0"
+version = "2.0.0-rc.0"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nydus-rs"
-version = "1.0.0"
+version = "2.0.0-rc.0"
 authors = ["The Nydus Developers"]
 edition = "2018"
 


### PR DESCRIPTION
Release `v2.0.0-rc.0` for building release binaries.

Signed-off-by: Yan Song <imeoer@linux.alibaba.com>