### PR TITLE
nydusd: fix thread-num validation

### DIFF
--- a/src/bin/nydusd/main.rs
+++ b/src/bin/nydusd/main.rs
@@ -263,7 +263,7 @@ fn main() -> Result<()> {
                 .global(true)
                 .validator(|v| {
                     if let Ok(t) = v.parse::<i32>() {
-                        if t > 0 || t > 1024 {
+                        if t > 0 && t <= 1024 {
                             Ok(())
                         } else {
                             Err("Invalid working thread number {}, valid values: [1-1024]"


### PR DESCRIPTION
The acceptable range for thread-num should be [1-2024], but now
this option can be set larger than 1024.

Signed-off-by: bin liu <bin@hyper.sh>