### PR TITLE
Rafs: validate metadata stored in bootstrap

### DIFF
--- a/rafs/src/metadata/md_v6.rs
+++ b/rafs/src/metadata/md_v6.rs
@@ -29,7 +29,7 @@ impl RafsSuper {
 
         let mut ext_sb = RafsV6SuperBlockExt::new();
         ext_sb.load(r)?;
-        ext_sb.validate(end)?;
+        ext_sb.validate()?;
         self.meta.chunk_size = ext_sb.chunk_size();
         self.meta.blob_table_offset = ext_sb.blob_table_offset();
         self.meta.blob_table_size = ext_sb.blob_table_size();

--- a/storage/src/meta/mod.rs
+++ b/storage/src/meta/mod.rs
@@ -38,7 +38,7 @@ const BLOB_CHUNK_UNCOMP_OFFSET_MASK: u64 = 0xfff_ffff_f000;
 const BLOB_CHUNK_SIZE_MASK: u64 = 0xf_ffff;
 const BLOB_CHUNK_SIZE_SHIFT: u64 = 44;
 const FILE_SUFFIX: &str = "blob.meta";
-const BLOB_FEATURE_4K_ALIGNED: u32 = 0x1;
+pub const BLOB_FEATURE_4K_ALIGNED: u32 = 0x1;
 
 /// Blob metadata on disk format.
 #[repr(C)]


### PR DESCRIPTION
This adds more sanity checks for metadata read from bootstrap in order
to prevent malicious images.

Signed-off-by: Liu Bo <bo.liu@linux.alibaba.com>