### PR TITLE
nydusd-virtiofs: Implement set_state/get_state to avoid panicking

### DIFF
--- a/src/bin/nydusctl/commands.rs
+++ b/src/bin/nydusctl/commands.rs
@@ -9,7 +9,7 @@ use std::time::Duration;
 use crate::client::NydusdClient;
 use anyhow::Result;
 
-use nydus::FsBackendDesc;
+use nydus::{FsBackendDesc, FsBackendType};
 use rafs::fs::RafsConfig;
 
 type CommandParams = HashMap<String, String>;
@@ -340,19 +340,33 @@ Profile:                {profile}
                     profile = version_info["profile"],
                 );
 
-                for f in backend_list.values() {
-                    let backend: FsBackendDesc = serde_json::from_value(f.clone()).unwrap();
-                    let fs: RafsConfig = serde_json::from_value(backend.config.clone()).unwrap();
-                    print!(
-                        r#"
-Mode:                   {meta_mode}
-Prefetch:               {enabled}
-Prefetch Merging Size:  {merging_size}
+                if !backend_list.is_empty() {
+                    println!("Backend list:")
+                }
+
+                for (mount_point, backend_obj) in backend_list {
+                    let backend: FsBackendDesc =
+                        serde_json::from_value(backend_obj.clone()).unwrap();
+                    println!("  {}", mount_point);
+                    println!("    type:                   {}", backend.backend_type);
+                    println!("    mountpoint:             {}", backend.mountpoint);
+                    println!("    mounted_time:           {}", backend.mounted_time);
+                    match backend.backend_type {
+                        FsBackendType::PassthroughFs => {}
+                        FsBackendType::Rafs => {
+                            let fs: RafsConfig =
+                                serde_json::from_value(backend.config.unwrap().clone()).unwrap();
+                            print!(
+                                r#"    Mode:                   {meta_mode}
+    Prefetch:               {enabled}
+    Prefetch Merging Size:  {merging_size}
 "#,
-                        meta_mode = fs.mode,
-                        enabled = fs.fs_prefetch.enable,
-                        merging_size = fs.fs_prefetch.merging_size,
-                    );
+                                meta_mode = fs.mode,
+                                enabled = fs.fs_prefetch.enable,
+                                merging_size = fs.fs_prefetch.merging_size,
+                            );
+                        }
+                    }
                 }
             }
         }

--- a/src/bin/nydusctl/commands.rs
+++ b/src/bin/nydusctl/commands.rs
@@ -333,7 +333,8 @@ impl CommandDaemon {
                     r#"
 Version:                {version}
 Status:                 {state}
-Profile:                {profile}"#,
+Profile:                {profile}
+"#,
                     version = version_info["package_ver"],
                     state = i["state"],
                     profile = version_info["profile"],

--- a/src/bin/nydusd/daemon.rs
+++ b/src/bin/nydusd/daemon.rs
@@ -205,11 +205,11 @@ impl FsBackendCollection {
                     "auth",
                     "token"
                 );
-                config
+                Some(config)
             }
             FsBackendType::PassthroughFs => {
                 // Passthrough Fs has no config ever input.
-                serde_json::Value::Null
+                None
             }
         };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,5 +60,5 @@ pub struct FsBackendDesc {
     pub mountpoint: String,
     #[serde_as(as = "DisplayFromStr")]
     pub mounted_time: DateTime<Local>,
-    pub config: serde_json::Value,
+    pub config: Option<serde_json::Value>,
 }


### PR DESCRIPTION
Implement set_state/get_state to avoid panicking when `nydusctl  info` is called.

Fixes: #294 

With this PR:

## nydusd-virtiofs

```bash
$ ~/nydusctl --sock $sock info

Version:                "2.0.0-rc.0"
Status:                 "RUNNING"
Profile:                "debug"
Backend list:
  /containers
    type:                   PassthroughFs
    mountpoint:             /containers
    mounted_time:           2022-01-30 13:46:49.241122388 +08:00
```
## nydusd-fusedev

```bash
$ ~/nydusctl --sock $sock info

Version:                "1.0.0"
Status:                 "RUNNING"
Profile:                "release"
Backend list:
  /134/fs
    type:                   Rafs
    mountpoint:             /134/fs
    mounted_time:           2022-01-30 12:53:36.566015398 +08:00
    Mode:                   direct
    Prefetch:               true
    Prefetch Merging Size:  0
```