### PR TITLE
cargo: update fuse-backend-rs dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -488,13 +488,14 @@ dependencies = [
 
 [[package]]
 name = "fuse-backend-rs"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c29edd681312df94a2c7a44e4f2de824d1a037728e87a7f7896d1d08cc0f012a"
+checksum = "ff1447465e2b0d1f40830f9cb214b16845d5e06e7e6ac2ad1f1896b17a64d623"
 dependencies = [
  "arc-swap 1.5.0",
  "bitflags",
  "caps",
+ "lazy_static",
  "libc",
  "log",
  "nix 0.22.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ openssl-src = ">=111.16.0"
 rand_core = ">=0.6.2"
 
 event-manager = "0.2.1"
-fuse-backend-rs = { version = "0.2.0", optional = true }
+fuse-backend-rs = { version = "0.3.0", optional = true }
 vhost = { version = "0.3.0", features = ["vhost-user-slave"], optional = true }
 vhost-user-backend = { version = "0.1.0", optional = true }
 virtio-bindings = { version = "0.1", features = ["virtio-v5_0_0"], optional = true }

--- a/blobfs/Cargo.toml
+++ b/blobfs/Cargo.toml
@@ -14,7 +14,7 @@ serde_json = ">=1.0.9"
 serde_with = { version = "1.6.0", features = ["macros"] }
 libc = "0.2"
 vm-memory = { version = "0.7.0" }
-fuse-backend-rs = { version = "0.2.0" }
+fuse-backend-rs = { version = "0.3.0" }
 
 rafs = { path = "../rafs" }
 nydus-error = { path = "../error" }

--- a/rafs/Cargo.toml
+++ b/rafs/Cargo.toml
@@ -28,7 +28,7 @@ sha-1 = { version = "0.9.1", optional = true }
 spmc = "0.3.0"
 url = { version = "2.1.1", optional = true }
 vm-memory = "0.7.0"
-fuse-backend-rs = { version = "0.2.0" }
+fuse-backend-rs = { version = "0.3.0" }
 
 nydus-utils = { path = "../utils" }
 nydus-error = { path = "../error" }

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -32,7 +32,7 @@ tokio = { version = ">=1.13.1", features = ["rt-multi-thread"] }
 url = { version = "2.1.1", optional = true }
 vm-memory = "0.7.0"
 vmm-sys-util = ">=0.9.0"
-fuse-backend-rs = { version = "0.2.0" }
+fuse-backend-rs = { version = "0.3.0" }
 
 nydus-utils = { path = "../utils" }
 nydus-error = { path = "../error" }

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -15,7 +15,7 @@ sha2 = "0.9.1"
 blake3 = "1.0"
 serde = { version = ">=1.0.27", features = ["serde_derive", "rc"] }
 serde_json = ">=1.0.9"
-fuse-backend-rs = { version = "0.2.0" }
+fuse-backend-rs = { version = "0.3.0" }
 
 nydus-error = "0.1"
 


### PR DESCRIPTION
Use 0.3.0 to bring in fix about ioctl API.

Signed-off-by: Peng Tao <bergwolf@hyper.sh>