### PR TITLE
rafs: rename is_all_chunk_ready to all_chunks_ready

### DIFF
--- a/rafs/src/fs.rs
+++ b/rafs/src/fs.rs
@@ -676,7 +676,7 @@ impl FileSystem for Rafs {
 
         // Try to amplify user io for Rafs v5, to improve performance.
         if self.sb.meta.is_v5() && size < self.amplify_io {
-            let all_chunks_ready = self.device.is_all_chunk_ready(&descs);
+            let all_chunks_ready = self.device.all_chunks_ready(&descs);
             if !all_chunks_ready {
                 let chunk_size = self.metadata().chunk_size as u64;
                 let next_chunk_base = (offset + (size as u64) + chunk_size) & !chunk_size;

--- a/storage/src/device.rs
+++ b/storage/src/device.rs
@@ -920,7 +920,7 @@ impl BlobDevice {
     }
 
     /// Check all chunks related to the blob io vector are ready.
-    pub fn is_all_chunk_ready(&self, io_vecs: &[BlobIoVec]) -> bool {
+    pub fn all_chunks_ready(&self, io_vecs: &[BlobIoVec]) -> bool {
         for io_vec in io_vecs.iter() {
             if let Some(blob) = self.get_blob_by_iovec(io_vec) {
                 let chunk_map = blob.get_chunk_map();


### PR DESCRIPTION
This fixes a trivial grammer mistake.

Signed-off-by: Changwei Ge <chge@linux.alibaba.com>