### PR TITLE
cache: commit region for internal IO if hits gzip format

### DIFF
--- a/storage/src/cache/filecache/cache_entry.rs
+++ b/storage/src/cache/filecache/cache_entry.rs
@@ -575,9 +575,12 @@ impl FileCacheEntry {
                         req.tags[i].clone(),
                         Some(req.chunks[i].clone()),
                     )?;
-                } else if !is_ready {
+                } else {
+                    state.commit();
                     // On slow path, don't try to handle internal(read amplification) IO.
-                    self.chunk_map.clear_pending(chunk.as_base());
+                    if !is_ready {
+                        self.chunk_map.clear_pending(chunk.as_base());
+                    }
                 }
             } else {
                 let tag = if let BlobIoTag::User(ref s) = req.tags[i] {


### PR DESCRIPTION
Internal IO can't be loaded from compressed cache file.
Just skip this region.

Signed-off-by: Changwei Ge <chge@linux.alibaba.com>