### PR TITLE
rafs: only append more chunks to last bio when amplify io

### DIFF
--- a/rafs/src/fs.rs
+++ b/rafs/src/fs.rs
@@ -696,6 +696,7 @@ impl FileSystem for Rafs {
         }
 
         let start = self.ios.latency_start();
+
         for desc in descs.iter_mut() {
             debug_assert!(desc.validate());
             debug_assert!(!desc.bi_vec.is_empty());

--- a/rafs/src/metadata/layout/v5.rs
+++ b/rafs/src/metadata/layout/v5.rs
@@ -1207,9 +1207,9 @@ impl RafsXAttrs {
     }
 }
 
-/// Allocate a group of `BlobIoVec` to handle blob io to range `offset..ofset + size`.
+/// Allocate a group of `BlobIoVec` to handle blob io to range `offset..(offset+size)`.
 ///
-/// The range `offset..ofset + size` may be backed by multiple blobs, so a group of `BlobIoVec` will
+/// The range `offset..(offset+size)` may be backed by multiple blobs, so a group of `BlobIoVec` will
 /// be returned on success, each one covers a continuous range on a single blob.
 pub(crate) fn rafsv5_alloc_bio_vecs<I: RafsInode + RafsV5InodeChunkOps + RafsV5InodeOps>(
     inode: &I,


### PR DESCRIPTION
Amplified IO chunks should be appended to the last Desc rather
than creating a new desc comprising several chunks.
Other wise it will consume IO buffers provided by upper layer.
Moreover, two descs can't be merged before issuing to backend storage.

Signed-off-by: Changwei Ge <chge@linux.alibaba.com>