### PR TITLE
Add capability of prefetch for rafs v6 format

### DIFF
--- a/rafs/src/fs.rs
+++ b/rafs/src/fs.rs
@@ -464,9 +464,7 @@ impl Rafs {
         let prefetch_all = self.prefetch_all;
 
         let _ = std::thread::spawn(move || {
-            if sb.meta.is_v5() {
-                Self::do_prefetch_v5(reader, prefetch_files, prefetch_all, sb, device);
-            }
+            Self::do_prefetch(reader, prefetch_files, prefetch_all, sb, device);
         });
     }
 
@@ -479,7 +477,7 @@ impl Rafs {
         self.sb.superblock.root_ino()
     }
 
-    fn do_prefetch_v5(
+    fn do_prefetch(
         mut reader: RafsIoReader,
         prefetch_files: Option<Vec<PathBuf>>,
         prefetch_all: bool,

--- a/rafs/src/lib.rs
+++ b/rafs/src/lib.rs
@@ -134,7 +134,7 @@ pub trait RafsIoWrite: Write + Seek + 'static {
     }
 
     /// Seek the writer to the `offset`.
-    fn seek_to_offset(&mut self, offset: u64) -> Result<u64> {
+    fn seek_offset(&mut self, offset: u64) -> Result<u64> {
         self.seek(SeekFrom::Start(offset)).map_err(|e| {
             error!("Seeking to offset {} from start fails, {}", offset, e);
             e

--- a/rafs/src/metadata/direct_v6.rs
+++ b/rafs/src/metadata/direct_v6.rs
@@ -917,7 +917,37 @@ impl RafsInode for OndiskInodeWrapper {
         &self,
         descendants: &mut Vec<Arc<dyn RafsInode>>,
     ) -> Result<usize> {
-        todo!()
+        if !self.is_dir() {
+            return Err(enotdir!());
+        }
+
+        let mut child_dirs: Vec<Arc<dyn RafsInode>> = Vec::new();
+
+        // EROFS packs dot and dotdot, so skip them two.
+        self.walk_children_inodes(2, &mut |inode: Option<Arc<dyn RafsInode>>,
+                                           name: OsString,
+                                           ino,
+                                           offset| {
+            // Safe to unwrap since it must have child inode.
+            if let Some(child_inode) = inode {
+                if child_inode.is_dir() {
+                    trace!("Got dir {:?}", child_inode.name());
+                    child_dirs.push(child_inode);
+                } else if !child_inode.is_empty_size() && child_inode.is_reg() {
+                    descendants.push(child_inode);
+                }
+                Ok(PostWalkAction::Continue)
+            } else {
+                Ok(PostWalkAction::Continue)
+            }
+        })
+        .unwrap();
+
+        for d in child_dirs {
+            d.collect_descendants_inodes(descendants)?;
+        }
+
+        Ok(0)
     }
 
     fn alloc_bio_vecs(&self, offset: u64, size: usize, user_io: bool) -> Result<Vec<BlobIoVec>> {

--- a/rafs/src/metadata/direct_v6.rs
+++ b/rafs/src/metadata/direct_v6.rs
@@ -878,7 +878,8 @@ impl RafsInode for OndiskInodeWrapper {
 
     /// Check whether the inode is a hardlink.
     fn is_hardlink(&self) -> bool {
-        todo!()
+        let inode = self.disk_inode();
+        inode.nlink() > 1 && self.is_reg()
     }
 
     /// Get inode number of the parent directory.

--- a/rafs/src/metadata/layout/v6.rs
+++ b/rafs/src/metadata/layout/v6.rs
@@ -300,8 +300,11 @@ pub struct RafsV6SuperBlockExt {
     s_blob_table_size: u32,
     /// chunk size
     s_chunk_size: u32,
+    s_prefetch_table_offset: u64,
+    s_prefetch_table_size: u32,
+    s_padding: u32,
     /// Reserved
-    s_reserved: [u8; 232],
+    s_reserved: [u8; 216],
 }
 
 impl_bootstrap_converter!(RafsV6SuperBlockExt);
@@ -393,6 +396,18 @@ impl RafsV6SuperBlockExt {
         u64
     );
     impl_pub_getter_setter!(blob_table_size, set_blob_table_size, s_blob_table_size, u32);
+    impl_pub_getter_setter!(
+        prefetch_table_size,
+        set_prefetch_table_size,
+        s_prefetch_table_size,
+        u32
+    );
+    impl_pub_getter_setter!(
+        prefetch_table_offset,
+        set_prefetch_table_offset,
+        s_prefetch_table_offset,
+        u64
+    );
 }
 
 impl RafsStore for RafsV6SuperBlockExt {
@@ -412,7 +427,10 @@ impl Default for RafsV6SuperBlockExt {
             s_blob_table_offset: u64::to_le(0),
             s_blob_table_size: u32::to_le(0),
             s_chunk_size: u32::to_le(0),
-            s_reserved: [0u8; 232],
+            s_prefetch_table_offset: u64::to_le(0),
+            s_prefetch_table_size: u32::to_le(0),
+            s_padding: u32::to_le(0),
+            s_reserved: [0u8; 216],
         }
     }
 }
@@ -1637,6 +1655,75 @@ impl RafsXAttrs {
             RAFSV6_XATTR_TYPES[pos].index,
             RAFSV6_XATTR_TYPES[pos].prefix_len,
         ))
+    }
+}
+
+#[derive(Clone, Default, Debug)]
+pub struct RafsV6PrefetchTable {
+    /// List of inode numbers for prefetch.
+    /// Note: It's not inode index of inodes table being stored here.
+    pub inodes: Vec<u32>,
+}
+
+impl RafsV6PrefetchTable {
+    /// Create a new instance of `RafsV6PrefetchTable`.
+    pub fn new() -> RafsV6PrefetchTable {
+        RafsV6PrefetchTable { inodes: vec![] }
+    }
+
+    /// Get content size of the inode prefetch table.
+    pub fn size(&self) -> usize {
+        self.len() * size_of::<u64>()
+    }
+
+    /// Get number of entries in the prefetch table.
+    pub fn len(&self) -> usize {
+        self.inodes.len()
+    }
+
+    /// Check whether the inode prefetch table is empty.
+    pub fn is_empty(&self) -> bool {
+        self.inodes.is_empty()
+    }
+
+    /// Add an inode into the inode prefetch table.
+    pub fn add_entry(&mut self, ino: u32) {
+        self.inodes.push(ino);
+    }
+
+    /// Store the inode prefetch table to a writer.
+    pub fn store(&mut self, w: &mut dyn RafsIoWrite) -> Result<usize> {
+        // Sort prefetch table by inode index, hopefully, it can save time when mounting rafs
+        // Because file data is dumped in the order of inode index.
+        self.inodes.sort_unstable();
+
+        let (_, data, _) = unsafe { self.inodes.align_to::<u8>() };
+        w.write_all(data.as_ref())?;
+
+        // OK. Let's see if we have to align... :-(
+        // let cur_len = self.inodes.len() * size_of::<u32>();
+
+        Ok(data.len())
+    }
+
+    /// Load a inode prefetch table from a reader.
+    ///
+    /// Note: Generally, prefetch happens after loading bootstrap, so with methods operating
+    /// files with changing their offset won't bring errors. But we still use `pread` now so as
+    /// to make this method more stable and robust. Even dup(2) can't give us a separated file struct.
+    pub fn load_prefetch_table_from(
+        &mut self,
+        r: &mut RafsIoReader,
+        offset: u64,
+        entries: usize,
+    ) -> Result<usize> {
+        self.inodes = vec![0u32; entries];
+
+        let (_, data, _) = unsafe { self.inodes.align_to_mut::<u8>() };
+        r.seek_to_offset(offset)?;
+        r.read_exact(data)?;
+
+        Ok(data.len())
     }
 }
 

--- a/rafs/src/metadata/layout/v6.rs
+++ b/rafs/src/metadata/layout/v6.rs
@@ -412,9 +412,9 @@ impl RafsV6SuperBlockExt {
 
 impl RafsStore for RafsV6SuperBlockExt {
     fn store(&self, w: &mut dyn RafsIoWrite) -> Result<usize> {
-        w.seek_to_offset((EROFS_SUPER_OFFSET + EROFS_SUPER_BLOCK_SIZE) as u64)?;
+        w.seek_offset((EROFS_SUPER_OFFSET + EROFS_SUPER_BLOCK_SIZE) as u64)?;
         w.write_all(self.as_ref())?;
-        w.seek_to_offset(EROFS_BLOCK_SIZE as u64)?;
+        w.seek_offset(EROFS_BLOCK_SIZE as u64)?;
 
         Ok(EROFS_BLOCK_SIZE as usize - (EROFS_SUPER_OFFSET + EROFS_SUPER_BLOCK_SIZE) as usize)
     }

--- a/rafs/src/metadata/mod.rs
+++ b/rafs/src/metadata/mod.rs
@@ -553,15 +553,16 @@ impl RafsSuper {
 
     /// Convert a file path to an inode number.
     pub fn ino_from_path(&self, f: &Path) -> Result<u64> {
+        let root_ino = self.superblock.root_ino();
         if f == Path::new("/") {
-            return Ok(ROOT_ID);
+            return Ok(root_ino);
         }
 
         if !f.starts_with("/") {
             return Err(einval!());
         }
 
-        let mut parent = self.get_inode(ROOT_ID, self.validate_digest)?;
+        let mut parent = self.get_inode(root_ino, self.validate_digest)?;
 
         let entries = f
             .components()

--- a/rafs/src/metadata/mod.rs
+++ b/rafs/src/metadata/mod.rs
@@ -637,6 +637,8 @@ impl RafsSuper {
             Ok(())
         } else if self.meta.is_v5() {
             self.prefetch_data_v5(r, fetcher).map(|_| ())
+        } else if self.meta.is_v6() {
+            self.prefetch_data_v6(r, fetcher).map(|_| ())
         } else {
             Err(RafsError::Prefetch(
                 "Unknown filesystem version, prefetch disabled".to_string(),
@@ -711,7 +713,12 @@ impl RafsSuper {
             for i in descendants.iter() {
                 Self::prefetch_inode(i, head_desc, hardlinks, try_prefetch)?;
             }
-        } else if !inode.is_empty_size() {
+        } else if !inode.is_empty_size() && inode.is_reg() {
+            // An empty regular file will also be packed into nydus image,
+            // then it has a size of zero.
+            // Moreover, for rafs v5, symlink has size of zero but non-zero size
+            // for symlink size. For rafs v6, symlink size is also represented by i_size.
+            // So we have to restrain the condition here.
             Self::prefetch_inode(&inode, head_desc, hardlinks, try_prefetch)?;
         }
 

--- a/src/bin/nydus-image/core/bootstrap.rs
+++ b/src/bin/nydus-image/core/bootstrap.rs
@@ -543,9 +543,22 @@ impl Bootstrap {
 
         let blob_table_entries = blob_table.entries.len();
 
+        let (prefetch_table_offset, prefetch_table_size) = if ctx.prefetch.len() > 0 {
+            // Prefetch table is very close to blob devices table
+            let offset = blob_table_offset + blob_table_size;
+            let size = ctx.prefetch.len() * size_of::<u64>() as u32;
+            trace!("prefetch table locates at offset {} size {}", offset, size);
+            (offset, size)
+        } else {
+            (0, 0)
+        };
+
         let orig_meta_addr = bootstrap_ctx.nodes[0].offset;
         let meta_addr = if blob_table_size > 0 {
-            align_offset(blob_table_offset + blob_table_size, EROFS_BLOCK_SIZE as u64)
+            align_offset(
+                blob_table_offset + blob_table_size + prefetch_table_size as u64,
+                EROFS_BLOCK_SIZE as u64,
+            )
         } else {
             orig_meta_addr
         };
@@ -613,7 +626,28 @@ impl Bootstrap {
             Result<()>
         )?;
 
-        // Erofs does not have inode table, so we lose the chance to decide if this
+        // `Node` offset might be updated during above inodes dumping. So `get_prefetch_table` after it.
+        let prefetch_table = ctx
+            .prefetch
+            .get_rafsv6_prefetch_table(&bootstrap_ctx.nodes, meta_addr);
+
+        if let Some(mut pt) = prefetch_table {
+            // Device slots are very close to extended super block.
+            ext_sb.set_prefetch_table_offset(prefetch_table_offset);
+            ext_sb.set_prefetch_table_size(prefetch_table_size);
+            bootstrap_writer
+                .seek_to_offset(prefetch_table_offset as u64)
+                .context("failed seek to prefetch table offset")?;
+
+            pt.store(&mut bootstrap_writer).unwrap();
+
+            bootstrap_writer.file.seek(SeekFrom::Start(ext_sb_offset))?;
+            ext_sb
+                .store(&mut bootstrap_writer)
+                .context("failed to revise extended SB")?;
+        }
+
+        // EROFS does not have inode table, so we lose the chance to decide if this
         // image has xattr. So we have to rewrite extended super block.
         if ctx.has_xattr {
             ext_sb.set_has_xattr();

--- a/src/bin/nydus-image/core/bootstrap.rs
+++ b/src/bin/nydus-image/core/bootstrap.rs
@@ -597,8 +597,8 @@ impl Bootstrap {
 
         // dump devtslot
         bootstrap_writer
-            .seek_to_offset(EROFS_DEVTABLE_OFFSET as u64)
-            .context("failed to seek to devtslot")?;
+            .seek_offset(EROFS_DEVTABLE_OFFSET as u64)
+            .context("failed to seek devtslot")?;
         for slot in devtable.iter() {
             slot.store(&mut bootstrap_writer)
                 .context("failed to store device slot")?;
@@ -606,7 +606,7 @@ impl Bootstrap {
 
         // Dump blob table
         bootstrap_writer
-            .seek_to_offset(blob_table_offset as u64)
+            .seek_offset(blob_table_offset as u64)
             .context("failed seek for extended blob table offset")?;
         blob_table
             .store(&mut bootstrap_writer)
@@ -636,8 +636,8 @@ impl Bootstrap {
             ext_sb.set_prefetch_table_offset(prefetch_table_offset);
             ext_sb.set_prefetch_table_size(prefetch_table_size);
             bootstrap_writer
-                .seek_to_offset(prefetch_table_offset as u64)
-                .context("failed seek to prefetch table offset")?;
+                .seek_offset(prefetch_table_offset as u64)
+                .context("failed seek prefetch table offset")?;
 
             pt.store(&mut bootstrap_writer).unwrap();
 


### PR DESCRIPTION
Rafs v6 now has the capability of prefetch with this patch set merged if it would.
By design, it places a prefetch table very closely to blob devices table on v6 extended block when creating v6 nydus image.
The `nydus-image` command line user interface is exactly the same with v5 style. Each file that needs to be prefetched will have its `nid` persisted into the prefetch table.
When nydusd starts, the prefetching files will be found from the prefetch table and the files' contents will be downloaded in ahead of time.