### PR TITLE
nydus-image: fix wrongly calculated prefetch table size

### DIFF
--- a/rafs/src/metadata/layout/v6.rs
+++ b/rafs/src/metadata/layout/v6.rs
@@ -1673,7 +1673,7 @@ impl RafsV6PrefetchTable {
 
     /// Get content size of the inode prefetch table.
     pub fn size(&self) -> usize {
-        self.len() * size_of::<u64>()
+        self.len() * size_of::<u32>()
     }
 
     /// Get number of entries in the prefetch table.

--- a/src/bin/nydus-image/core/bootstrap.rs
+++ b/src/bin/nydus-image/core/bootstrap.rs
@@ -546,7 +546,8 @@ impl Bootstrap {
         let (prefetch_table_offset, prefetch_table_size) = if ctx.prefetch.len() > 0 {
             // Prefetch table is very close to blob devices table
             let offset = blob_table_offset + blob_table_size;
-            let size = ctx.prefetch.len() * size_of::<u64>() as u32;
+            // Each prefetched file has is nid of `u32` filled into prefetch table.
+            let size = ctx.prefetch.len() * size_of::<u32>() as u32;
             trace!("prefetch table locates at offset {} size {}", offset, size);
             (offset, size)
         } else {


### PR DESCRIPTION
Nid in prefetch table is of u32, so prefetch table should be
files_count * size_of::<u32>()

Signed-off-by: Changwei Ge <chge@linux.alibaba.com>