### PR TITLE
cargo: update openssl-src dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1269,9 +1269,9 @@ checksum = "77af24da69f9d9341038eba93a073b1fdaaa1b788221b00a69bce9e762cb32de"
 
 [[package]]
 name = "openssl-src"
-version = "111.17.0+1.1.1m"
+version = "111.18.0+1.1.1n"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05d6a336abd10814198f66e2a91ccd7336611f30334119ca8ce300536666fcf4"
+checksum = "7897a926e1e8d00219127dc020130eca4292e5ca666dd592480d72c3eca2ff6c"
 dependencies = [
  "cc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,8 +44,8 @@ openssl = { version = "0.10.38", features = ["vendored"] }
 hyperlocal = "0.8.0"
 tokio = { version = ">=1.13.1", features = ["macros"] }
 hyper = "0.14.11"
-# pin openssl-src to bring in fix for RUSTSEC-2021-0098
-openssl-src = ">=111.16.0"
+# pin openssl-src to bring in fix for RUSTSEC-2021-0098 and RUSTSEC-2022-0014
+openssl-src = "=111.18.0"
 # pin rand_core to bring in fix for RUSTSEC-2021-0023
 rand_core = ">=0.6.2"
 


### PR DESCRIPTION
To bring in fix for RUSTSEC-2022-0014.
