### PR TITLE
Nydus image

### DIFF
--- a/src/bin/nydus-image/builder/diff.rs
+++ b/src/bin/nydus-image/builder/diff.rs
@@ -706,9 +706,13 @@ impl DiffBuilder {
             let ctx = Arc::new(ctx.clone());
             let hint_path_idx = idx + base;
             let hint_path = paths[hint_path_idx].clone();
+            let snapshot_path = paths[idx].clone();
             let chunk_dict = chunk_dict.clone();
             let worker = thread::spawn(move || -> Result<(Option<BlobContext>, ChunkMap)> {
-                info!("[{}] diff building with hint {:?}", idx, hint_path);
+                info!(
+                    "[{}: {:?}] diff building with hint {:?}",
+                    idx, snapshot_path, hint_path
+                );
 
                 let snapshot_idx = idx as u32;
                 let mut blob_nodes = walk_all(ctx.as_ref(), hint_path.clone(), hint_path)?;

--- a/src/bin/nydus-image/main.rs
+++ b/src/bin/nydus-image/main.rs
@@ -19,7 +19,7 @@ use std::fs::{self, metadata, DirEntry, File, OpenOptions};
 use std::path::{Path, PathBuf};
 
 use anyhow::{bail, Context, Result};
-use clap::{App, Arg, SubCommand};
+use clap::{App, Arg, ArgMatches, SubCommand};
 use nix::unistd::{getegid, geteuid};
 use serde::{Deserialize, Serialize};
 
@@ -132,11 +132,9 @@ impl OutputSerializer {
     }
 }
 
-fn main() -> Result<()> {
-    let (bti_string, build_info) = BuildTimeInfo::dump(crate_version!());
-
+fn prepare_cmd_args(bti_string: String) -> ArgMatches<'static> {
     // TODO: Try to use yaml to define below options
-    let cmd = App::new("")
+    App::new("")
         .version(bti_string.as_str())
         .author(crate_authors!())
         .about("Build or inspect RAFS filesystems for nydus accelerated container images.")
@@ -470,7 +468,13 @@ fn main() -> Result<()> {
                 .required(false)
                 .global(true),
         )
-        .get_matches();
+        .get_matches()
+}
+
+fn main() -> Result<()> {
+    let (bti_string, build_info) = BuildTimeInfo::dump(crate_version!());
+
+    let cmd = prepare_cmd_args(bti_string);
 
     // Safe to unwrap because it has a default value and possible values are defined.
     let level = cmd.value_of("log-level").unwrap().parse().unwrap();


### PR DESCRIPTION
commit 0c0fa920b09dd6e2e592d8ee67cd712974fd2379 (HEAD -> gh-master-nydus-image, gh/nydus-image)
Author: gexuyang <gexuyang@linux.alibaba.com>
Date:   Wed Mar 9 16:16:46 2022 +0800

    nydus-image: add log info in diff build

    Signed-off-by: gexuyang <gexuyang@linux.alibaba.com>

commit ab9cce788bdd335300e8eee0b7846ee351231e97
Author: gexuyang <gexuyang@linux.alibaba.com>
Date:   Wed Mar 9 15:47:49 2022 +0800

    nydus-image: add log-file to set log output

    Signed-off-by: gexuyang <gexuyang@linux.alibaba.com>

commit 804dc4a95fbbef41d42363e1f10acbbf040630f3
Author: gexuyang <gexuyang@linux.alibaba.com>
Date:   Wed Mar 9 15:16:34 2022 +0800

    refactor: nydus-image: prepare ArgMatches in a new function

    The main function is too long to understand its logic. Refactor its
    ArgMatches logic by extracting it into a new function

    Signed-off-by: gexuyang <gexuyang@linux.alibaba.com>