### PR TITLE
Builder: support tar build

### DIFF
--- a/rafs/src/metadata/mod.rs
+++ b/rafs/src/metadata/mod.rs
@@ -468,7 +468,7 @@ impl RafsSuper {
     }
 
     /// Load Rafs super block from a metadata file.
-    pub fn load_from_metadata(path: &str, mode: RafsMode, validate_digest: bool) -> Result<Self> {
+    pub fn load_from_metadata(path: &Path, mode: RafsMode, validate_digest: bool) -> Result<Self> {
         // open bootstrap file
         let file = OpenOptions::new().read(true).write(false).open(path)?;
         let mut rs = RafsSuper {

--- a/rafs/src/metadata/mod.rs
+++ b/rafs/src/metadata/mod.rs
@@ -483,7 +483,7 @@ impl RafsSuper {
         Ok(rs)
     }
 
-    pub fn load_chunk_dict_from_metadata(path: &str) -> Result<Self> {
+    pub fn load_chunk_dict_from_metadata(path: &Path) -> Result<Self> {
         // open bootstrap file
         let file = OpenOptions::new().read(true).write(false).open(path)?;
         let mut rs = RafsSuper {

--- a/src/bin/nydus-image/builder/diff.rs
+++ b/src/bin/nydus-image/builder/diff.rs
@@ -305,7 +305,7 @@ fn dump_blob(
     blob_nodes: &mut Vec<Node>,
     chunk_dict: Arc<dyn ChunkDict>,
 ) -> Result<(Option<BlobContext>, ChunkMap)> {
-    let mut blob_ctx = BlobContext::new(blob_id, blob_storage)?;
+    let mut blob_ctx = BlobContext::new(blob_id, blob_storage, ctx.blob_offset)?;
     blob_ctx.set_chunk_dict(chunk_dict);
     blob_ctx.set_chunk_size(ctx.chunk_size);
     blob_ctx.set_meta_info_enabled(ctx.fs_version == RafsVersion::V6);

--- a/src/bin/nydus-image/builder/diff.rs
+++ b/src/bin/nydus-image/builder/diff.rs
@@ -136,7 +136,7 @@ use crate::core::context::{
 use crate::core::node::{ChunkSource, ChunkWrapper, Node, NodeChunk, Overlay};
 use crate::core::tree::Tree;
 use nydus_utils::digest::RafsDigest;
-use rafs::metadata::layout::{RafsBlobTable, RAFS_ROOT_INODE};
+use rafs::metadata::layout::RAFS_ROOT_INODE;
 use rafs::metadata::{RafsInode, RafsMode, RafsSuper};
 use storage::device::BlobChunkInfo;
 
@@ -653,14 +653,7 @@ impl DiffBuilder {
 
         // Dump bootstrap file
         let blob_table = blob_mgr.to_blob_table(ctx)?;
-        match blob_table {
-            RafsBlobTable::V5(table) => {
-                bootstrap.dump_rafsv5(ctx, bootstrap_ctx, &table)?;
-            }
-            RafsBlobTable::V6(table) => {
-                bootstrap.dump_rafsv6(ctx, bootstrap_ctx, &table)?;
-            }
-        };
+        bootstrap.dump(ctx, bootstrap_ctx, &blob_table)?;
         bootstrap_ctx.blobs = blob_mgr
             .get_blobs()
             .iter()

--- a/src/bin/nydus-image/builder/diff.rs
+++ b/src/bin/nydus-image/builder/diff.rs
@@ -523,14 +523,16 @@ impl DiffBuilder {
                                                         path: &Path|
              -> Result<()> {
                 let mut chunks = Vec::new();
-                inode.walk_chunks(&mut |cki: &dyn BlobChunkInfo| -> Result<()> {
-                    let chunk = ChunkWrapper::from_chunk_info(cki);
-                    chunks.push(NodeChunk {
-                        source: ChunkSource::Parent,
-                        inner: chunk,
-                    });
-                    Ok(())
-                })?;
+                if inode.is_reg() {
+                    inode.walk_chunks(&mut |cki: &dyn BlobChunkInfo| -> Result<()> {
+                        let chunk = ChunkWrapper::from_chunk_info(cki);
+                        chunks.push(NodeChunk {
+                            source: ChunkSource::Parent,
+                            inner: chunk,
+                        });
+                        Ok(())
+                    })?;
+                }
                 self.chunk_map
                     .insert(path.to_path_buf(), (chunks, inode.get_digest()));
                 Ok(())

--- a/src/bin/nydus-image/builder/diff.rs
+++ b/src/bin/nydus-image/builder/diff.rs
@@ -854,7 +854,6 @@ pub mod tests {
 
     use super::*;
     use nydus_utils::exec;
-    use storage::RAFS_DEFAULT_CHUNK_SIZE;
 
     fn create_dir(path: &Path) {
         fs::create_dir_all(path).unwrap();
@@ -995,10 +994,7 @@ pub mod tests {
             (Overlay::UpperAddition, PathBuf::from("/test-1-symlink")),
             (Overlay::UpperAddition, PathBuf::from("/test-2")),
         ];
-        let ctx = BuildContext {
-            chunk_size: RAFS_DEFAULT_CHUNK_SIZE as u32,
-            ..Default::default()
-        };
+        let ctx = BuildContext::default();
         let nodes = walk_diff(&ctx, None, lower_dir.clone(), lower_dir.clone()).unwrap();
         for (i, node) in nodes.into_iter().enumerate() {
             println!("lower node: {:?} {:?}", node.overlay, node.target());

--- a/src/bin/nydus-image/builder/directory.rs
+++ b/src/bin/nydus-image/builder/directory.rs
@@ -130,7 +130,11 @@ impl Builder for DirectoryBuilder {
         )?;
 
         // Dump blob file
-        let mut blob_ctx = BlobContext::new(ctx.blob_id.clone(), ctx.blob_storage.clone())?;
+        let mut blob_ctx = BlobContext::new(
+            ctx.blob_id.clone(),
+            ctx.blob_storage.clone(),
+            ctx.blob_offset,
+        )?;
         blob_ctx.set_chunk_dict(blob_mgr.get_chunk_dict());
         blob_ctx.set_chunk_size(ctx.chunk_size);
         blob_ctx.set_meta_info_enabled(ctx.fs_version == RafsVersion::V6);

--- a/src/bin/nydus-image/builder/directory.rs
+++ b/src/bin/nydus-image/builder/directory.rs
@@ -16,7 +16,6 @@ use crate::core::context::{
 };
 use crate::core::node::{Node, Overlay};
 use crate::core::tree::Tree;
-use rafs::metadata::layout::RafsBlobTable;
 
 struct FilesystemTreeBuilder {}
 
@@ -159,10 +158,7 @@ impl Builder for DirectoryBuilder {
 
         // Dump bootstrap file
         let blob_table = blob_mgr.to_blob_table(ctx)?;
-        match blob_table {
-            RafsBlobTable::V5(table) => bootstrap.dump_rafsv5(ctx, &mut bootstrap_ctx, &table)?,
-            RafsBlobTable::V6(table) => bootstrap.dump_rafsv6(ctx, &mut bootstrap_ctx, &table)?,
-        }
+        bootstrap.dump(ctx, &mut bootstrap_ctx, &blob_table)?;
 
         bootstrap_mgr.add(bootstrap_ctx);
         BuildOutput::new(&blob_mgr, &bootstrap_mgr)

--- a/src/bin/nydus-image/builder/stargz.rs
+++ b/src/bin/nydus-image/builder/stargz.rs
@@ -574,7 +574,7 @@ impl StargzBuilder {
         let mut decompressed_blob_size = 0u64;
         let mut compressed_blob_size = 0u64;
         let blob_index = blob_mgr.alloc_index()?;
-        let mut blob_ctx = BlobContext::new(ctx.blob_id.clone(), ctx.blob_storage.clone())?;
+        let mut blob_ctx = BlobContext::new(ctx.blob_id.clone(), ctx.blob_storage.clone(), 0)?;
         blob_ctx.set_chunk_dict(blob_mgr.get_chunk_dict());
         blob_ctx.set_chunk_size(ctx.chunk_size);
 

--- a/src/bin/nydus-image/builder/stargz.rs
+++ b/src/bin/nydus-image/builder/stargz.rs
@@ -649,10 +649,10 @@ impl Builder for StargzBuilder {
 
         // Dump bootstrap file
         let blob_table = blob_mgr.to_blob_table(ctx)?;
-        match blob_table {
-            RafsBlobTable::V5(table) => bootstrap.dump_rafsv5(ctx, &mut bootstrap_ctx, &table)?,
-            RafsBlobTable::V6(_) => todo!(),
+        if let RafsBlobTable::V6(_) = blob_table {
+            todo!();
         }
+        bootstrap.dump(ctx, &mut bootstrap_ctx, &blob_table)?;
 
         bootstrap_mgr.add(bootstrap_ctx);
         BuildOutput::new(&blob_mgr, &bootstrap_mgr)

--- a/src/bin/nydus-image/core/blob_compact.rs
+++ b/src/bin/nydus-image/core/blob_compact.rs
@@ -516,7 +516,7 @@ impl BlobCompactor {
                 }
                 State::Rebuild(cs) => {
                     let blob_storage = ArtifactStorage::FileDir(PathBuf::from(dir));
-                    let mut blob_ctx = BlobContext::new(String::from(""), Some(blob_storage))?;
+                    let mut blob_ctx = BlobContext::new(String::from(""), Some(blob_storage), 0)?;
                     blob_ctx.set_meta_info_enabled(self.is_v6());
                     let blob_idx = self.new_blob_mgr.alloc_index()?;
                     let new_chunks = cs.dump(
@@ -556,6 +556,7 @@ impl BlobCompactor {
         let mut build_ctx = BuildContext::new(
             "".to_string(),
             false,
+            0,
             rs.meta.get_compressor(),
             rs.meta.get_digester(),
             rs.meta.explicit_uidgid(),

--- a/src/bin/nydus-image/core/blob_compact.rs
+++ b/src/bin/nydus-image/core/blob_compact.rs
@@ -551,8 +551,7 @@ impl BlobCompactor {
         backend: Arc<dyn BlobBackend + Send + Sync>,
         cfg: &Config,
     ) -> Result<Option<BuildOutput>> {
-        let rs =
-            RafsSuper::load_from_metadata(s_boostrap.to_str().unwrap(), RafsMode::Direct, true)?;
+        let rs = RafsSuper::load_from_metadata(&s_boostrap, RafsMode::Direct, true)?;
         info!("load bootstrap {:?} successfully", s_boostrap);
         let mut build_ctx = BuildContext::new(
             "".to_string(),

--- a/src/bin/nydus-image/core/blob_compact.rs
+++ b/src/bin/nydus-image/core/blob_compact.rs
@@ -14,7 +14,6 @@ use crate::core::tree::Tree;
 use anyhow::Result;
 use nydus_utils::digest::RafsDigest;
 use nydus_utils::try_round_up_4k;
-use rafs::metadata::layout::RafsBlobTable;
 use rafs::metadata::{RafsMode, RafsSuper};
 use serde::{Deserialize, Serialize};
 use sha2::Digest;
@@ -599,14 +598,7 @@ impl BlobCompactor {
         std::mem::swap(&mut bootstrap_ctx.nodes, &mut compactor.nodes);
         // blobs have already been dumped, dump bootstrap only
         let blob_table = compactor.new_blob_mgr.to_blob_table(&build_ctx)?;
-        match blob_table {
-            RafsBlobTable::V5(table) => {
-                bootstrap.dump_rafsv5(&mut build_ctx, &mut bootstrap_ctx, &table)?;
-            }
-            RafsBlobTable::V6(table) => {
-                bootstrap.dump_rafsv6(&mut build_ctx, &mut bootstrap_ctx, &table)?;
-            }
-        };
+        bootstrap.dump(&mut build_ctx, &mut bootstrap_ctx, &blob_table)?;
         bootstrap_mgr.add(bootstrap_ctx);
         Ok(Some(BuildOutput::new(
             &compactor.new_blob_mgr,

--- a/src/bin/nydus-image/core/bootstrap.rs
+++ b/src/bin/nydus-image/core/bootstrap.rs
@@ -67,13 +67,8 @@ impl Bootstrap {
         // user to pass the source root as prefetch hint. Check it here.
         ctx.prefetch.insert_if_need(&tree.node);
 
-        let inode_map = if tree.node.overlay.is_lower_layer() {
-            &mut bootstrap_ctx.lower_inode_map
-        } else {
-            &mut bootstrap_ctx.upper_inode_map
-        };
-        inode_map.insert(
-            (tree.node.src_ino, tree.node.src_dev),
+        bootstrap_ctx.inode_map.insert(
+            (tree.node.layer_idx, tree.node.src_ino, tree.node.src_dev),
             vec![tree.node.index],
         );
 
@@ -121,8 +116,7 @@ impl Bootstrap {
         )?;
 
         // Clear all cached states for next upper layer build.
-        bootstrap_ctx.lower_inode_map.clear();
-        bootstrap_ctx.upper_inode_map.clear();
+        bootstrap_ctx.inode_map.clear();
         ctx.prefetch.clear();
 
         Ok(tree)
@@ -170,12 +164,11 @@ impl Bootstrap {
             // Hardlink handle, all hardlink nodes' ino, nlink should be the same,
             // because the real_ino may be conflicted between different layers,
             // so we need to find hardlink node index list in the layer where the node is located.
-            let inode_map = if child.node.overlay.is_lower_layer() {
-                &mut bootstrap_ctx.lower_inode_map
-            } else {
-                &mut bootstrap_ctx.upper_inode_map
-            };
-            if let Some(indexes) = inode_map.get_mut(&(child.node.src_ino, child.node.src_dev)) {
+            if let Some(indexes) = bootstrap_ctx.inode_map.get_mut(&(
+                child.node.layer_idx,
+                child.node.src_ino,
+                child.node.src_dev,
+            )) {
                 let nlink = indexes.len() as u32 + 1;
                 let first_index = indexes[0];
                 child.node.inode.set_ino(first_index);
@@ -189,8 +182,8 @@ impl Bootstrap {
                 child.node.inode.set_ino(index);
                 child.node.inode.set_nlink(1);
                 // Store inode real ino
-                inode_map.insert(
-                    (child.node.src_ino, child.node.src_dev),
+                bootstrap_ctx.inode_map.insert(
+                    (child.node.layer_idx, child.node.src_ino, child.node.src_dev),
                     vec![child.node.index],
                 );
             }
@@ -413,8 +406,7 @@ impl Bootstrap {
 
         // Set super block
         let mut super_block = RafsV5SuperBlock::new();
-        let inodes_count =
-            (bootstrap_ctx.lower_inode_map.len() + bootstrap_ctx.upper_inode_map.len()) as u64;
+        let inodes_count = bootstrap_ctx.inode_map.len() as u64;
         super_block.set_inodes_count(inodes_count);
         super_block.set_inode_table_offset(super_block_size as u64);
         super_block.set_inode_table_entries(inode_table_entries);

--- a/src/bin/nydus-image/core/bootstrap.rs
+++ b/src/bin/nydus-image/core/bootstrap.rs
@@ -17,6 +17,7 @@ use rafs::metadata::layout::v6::{
     align_offset, calculate_nid, RafsV6BlobTable, RafsV6Device, RafsV6SuperBlock,
     RafsV6SuperBlockExt, EROFS_BLOCK_SIZE, EROFS_DEVTABLE_OFFSET, EROFS_INODE_SLOT_SIZE,
 };
+use rafs::metadata::layout::RafsBlobTable;
 use rafs::RafsIoWrite;
 
 use rafs::metadata::layout::RAFS_ROOT_INODE;
@@ -364,8 +365,20 @@ impl Bootstrap {
         }
     }
 
+    pub fn dump(
+        &mut self,
+        ctx: &mut BuildContext,
+        bootstrap_ctx: &mut BootstrapContext,
+        blob_table: &RafsBlobTable,
+    ) -> Result<()> {
+        match blob_table {
+            RafsBlobTable::V5(table) => self.dump_rafsv5(ctx, bootstrap_ctx, &table),
+            RafsBlobTable::V6(table) => self.dump_rafsv6(ctx, bootstrap_ctx, &table),
+        }
+    }
+
     /// Dump bootstrap and blob file, return (Vec<blob_id>, blob_size)
-    pub fn dump_rafsv5(
+    fn dump_rafsv5(
         &mut self,
         ctx: &mut BuildContext,
         bootstrap_ctx: &mut BootstrapContext,
@@ -498,7 +511,7 @@ impl Bootstrap {
     }
 
     /// Dump bootstrap and blob file, return (Vec<blob_id>, blob_size)
-    pub fn dump_rafsv6(
+    fn dump_rafsv6(
         &mut self,
         ctx: &mut BuildContext,
         bootstrap_ctx: &mut BootstrapContext,

--- a/src/bin/nydus-image/core/context.rs
+++ b/src/bin/nydus-image/core/context.rs
@@ -599,9 +599,8 @@ impl BlobManager {
 pub struct BootstrapContext {
     /// This build has a parent bootstrap.
     pub layered: bool,
-    /// Cache node index for hardlinks, HashMap<(real_inode, dev), Vec<index>>.
-    pub lower_inode_map: HashMap<(Inode, u64), Vec<u64>>,
-    pub upper_inode_map: HashMap<(Inode, u64), Vec<u64>>,
+    /// Cache node index for hardlinks, HashMap<(layer_index, real_inode, dev), Vec<index>>.
+    pub inode_map: HashMap<(u16, Inode, u64), Vec<u64>>,
     /// Store all nodes in ascendant ordor, indexed by (node.index - 1).
     pub nodes: Vec<Node>,
     /// Current position to write in f_bootstrap
@@ -617,8 +616,7 @@ impl BootstrapContext {
     pub fn new(storage: ArtifactStorage, layered: bool) -> Result<Self> {
         Ok(Self {
             layered,
-            lower_inode_map: HashMap::new(),
-            upper_inode_map: HashMap::new(),
+            inode_map: HashMap::new(),
             nodes: Vec::new(),
             offset: EROFS_BLOCK_SIZE,
             name: String::new(),

--- a/src/bin/nydus-image/core/context.rs
+++ b/src/bin/nydus-image/core/context.rs
@@ -678,7 +678,7 @@ impl BootstrapManager {
     }
 }
 
-#[derive(Default, Clone)]
+#[derive(Clone)]
 pub struct BuildContext {
     /// Blob id (user specified or sha256(blob)).
     pub blob_id: String,
@@ -756,6 +756,29 @@ impl BuildContext {
 
     pub fn set_chunk_size(&mut self, chunk_size: u32) {
         self.chunk_size = chunk_size;
+    }
+}
+
+impl Default for BuildContext {
+    fn default() -> Self {
+        Self {
+            blob_id: String::new(),
+            aligned_chunk: false,
+            compressor: compress::Algorithm::default(),
+            digester: digest::Algorithm::default(),
+            explicit_uidgid: true,
+            whiteout_spec: WhiteoutSpec::default(),
+
+            chunk_size: RAFS_DEFAULT_CHUNK_SIZE as u32,
+            fs_version: RafsVersion::default(),
+
+            source_type: SourceType::default(),
+            source_path: PathBuf::new(),
+
+            prefetch: Prefetch::default(),
+            blob_storage: None,
+            has_xattr: true,
+        }
     }
 }
 

--- a/src/bin/nydus-image/core/node.rs
+++ b/src/bin/nydus-image/core/node.rs
@@ -224,6 +224,8 @@ pub struct Node {
     pub(crate) target: PathBuf,
     /// Parsed version of `target`.
     pub(crate) target_vec: Vec<OsString>,
+    /// Layer index where node located.
+    pub layer_idx: u16,
     /// Last status change time of the file, in nanoseconds.
     pub ctime: i64,
     /// Used by rafsv6 inode datalayout
@@ -285,6 +287,7 @@ impl Node {
             symlink: None,
             xattrs: RafsXAttrs::default(),
             explicit_uidgid,
+            layer_idx: 0,
             ctime: 0,
             offset: 0,
             dirents: Vec::new(),

--- a/src/bin/nydus-image/core/node.rs
+++ b/src/bin/nydus-image/core/node.rs
@@ -103,6 +103,8 @@ pub enum WhiteoutSpec {
     Oci,
     /// "whiteouts and opaque directories" in https://www.kernel.org/doc/Documentation/filesystems/overlayfs.txt
     Overlayfs,
+    /// No whiteout spec, which will build all `.wh.*` and `.wh..wh..opq` files into bootstrap.
+    None,
 }
 
 impl Default for WhiteoutSpec {
@@ -118,6 +120,7 @@ impl FromStr for WhiteoutSpec {
         match s {
             "oci" => Ok(Self::Oci),
             "overlayfs" => Ok(Self::Overlayfs),
+            "none" => Ok(Self::None),
             _ => Err(anyhow!("invalid whiteout spec")),
         }
     }
@@ -1021,6 +1024,9 @@ impl Node {
                 } else if self.is_overlayfs_opaque(spec) {
                     return Some(WhiteoutType::OverlayFsOpaque);
                 }
+            }
+            WhiteoutSpec::None => {
+                return None;
             }
         }
 

--- a/src/bin/nydus-image/core/node.rs
+++ b/src/bin/nydus-image/core/node.rs
@@ -15,7 +15,6 @@ use std::os::linux::fs::MetadataExt;
 use std::os::unix::ffi::OsStrExt;
 use std::path::{Component, Path, PathBuf};
 use std::str::FromStr;
-use std::sync::Arc;
 
 use anyhow::{Context, Error, Result};
 use nix::sys::stat;
@@ -47,7 +46,7 @@ use super::chunk_dict::ChunkDict;
 use super::context::{BlobContext, BootstrapContext, BuildContext, RafsVersion};
 use super::tree::Tree;
 
-const ROOT_PATH_NAME: &[u8] = &[b'/'];
+pub const ROOT_PATH_NAME: &[u8] = &[b'/'];
 
 /// Prefix for OCI whiteout file.
 pub const OCISPEC_WHITEOUT_PREFIX: &str = ".wh.";
@@ -1199,7 +1198,7 @@ impl InodeWrapper {
         }
     }
 
-    pub fn from_inode_info(inode: &Arc<dyn RafsInode>) -> Self {
+    pub fn from_inode_info(inode: &dyn RafsInode) -> Self {
         if let Some(inode) = inode.as_any().downcast_ref::<CachedInodeV5>() {
             InodeWrapper::V5(to_rafsv5_inode(inode))
         } else if let Some(inode) = inode.as_any().downcast_ref::<OndiskInodeWrapper>() {

--- a/src/bin/nydus-image/core/tree.rs
+++ b/src/bin/nydus-image/core/tree.rs
@@ -17,7 +17,6 @@
 
 use std::ffi::OsStr;
 use std::ffi::OsString;
-use std::os::unix::ffi::OsStrExt;
 use std::path::PathBuf;
 
 use anyhow::Result;
@@ -27,7 +26,6 @@ use rafs::metadata::{Inode, RafsInode, RafsSuper};
 use super::chunk_dict::ChunkDict;
 use super::node::{
     ChunkSource, ChunkWrapper, InodeWrapper, Node, NodeChunk, Overlay, WhiteoutSpec, WhiteoutType,
-    ROOT_PATH_NAME,
 };
 
 /// An in-memory tree structure to maintain information and topology of filesystem nodes.

--- a/src/bin/nydus-image/core/tree.rs
+++ b/src/bin/nydus-image/core/tree.rs
@@ -350,6 +350,7 @@ impl<'a> MetadataTreeBuilder<'a> {
             chunks,
             symlink,
             xattrs,
+            layer_idx: 0,
             ctime: 0,
             offset: 0,
             dirents: Vec::<(u64, OsString, u32)>::new(),

--- a/src/bin/nydus-image/main.rs
+++ b/src/bin/nydus-image/main.rs
@@ -38,6 +38,7 @@ use crate::core::context::{
 use crate::core::node::{self, WhiteoutSpec};
 use crate::core::prefetch::Prefetch;
 use crate::core::tree;
+use crate::merge::Merger;
 use crate::trace::{EventTracerClass, TimingTracerClass, TraceClass};
 use crate::validator::Validator;
 use storage::factory::{BackendConfig, BlobFactory};
@@ -47,6 +48,7 @@ mod trace;
 mod builder;
 mod core;
 mod inspect;
+mod merge;
 mod stat;
 mod validator;
 
@@ -323,6 +325,24 @@ fn prepare_cmd_args(bti_string: String) -> ArgMatches<'static> {
                 )
         )
         .subcommand(
+            SubCommand::with_name("merge")
+                .about("Merge multiple bootstraps into a overlaid bootstrap")
+                .arg(
+                    Arg::with_name("bootstrap")
+                        .long("bootstrap")
+                        .short("B")
+                        .help("output path of nydus overlaid bootstrap")
+                        .required(true)
+                        .takes_value(true),
+                )
+                .arg(
+                    Arg::with_name("SOURCE")
+                        .help("bootstrap paths (allow one or more)")
+                        .required(true)
+                        .multiple(true),
+                )
+        )
+        .subcommand(
             SubCommand::with_name("check")
                 .about("Validates nydus image's filesystem metadata")
                 .arg(
@@ -505,6 +525,8 @@ fn main() -> Result<()> {
 
     if let Some(matches) = cmd.subcommand_matches("create") {
         Command::create(matches, &build_info)
+    } else if let Some(matches) = cmd.subcommand_matches("merge") {
+        Command::merge(matches)
     } else if let Some(matches) = cmd.subcommand_matches("check") {
         Command::check(matches, &build_info)
     } else if let Some(matches) = cmd.subcommand_matches("inspect") {
@@ -648,6 +670,15 @@ impl Command {
         OutputSerializer::dump(matches, build_output, &build_info)?;
 
         Ok(())
+    }
+
+    fn merge(matches: &clap::ArgMatches) -> Result<()> {
+        let source_bootstrap_paths: Vec<PathBuf> = matches
+            .values_of("SOURCE")
+            .map(|paths| paths.map(PathBuf::from).collect())
+            .unwrap();
+        let target_bootstrap_path = Self::get_bootstrap(&matches)?;
+        Merger::merge(source_bootstrap_paths, target_bootstrap_path.to_path_buf())
     }
 
     fn compact(matches: &clap::ArgMatches, build_info: &BuildTimeInfo) -> Result<()> {

--- a/src/bin/nydus-image/main.rs
+++ b/src/bin/nydus-image/main.rs
@@ -135,6 +135,20 @@ impl OutputSerializer {
 }
 
 fn prepare_cmd_args(bti_string: String) -> ArgMatches<'static> {
+    let arg_chunk_dict = Arg::with_name("chunk-dict")
+        .long("chunk-dict")
+        .short("M")
+        .help("Specify a chunk dictionary for chunk deduplication")
+        .takes_value(true);
+    let arg_prefetch_policy = Arg::with_name("prefetch-policy")
+        .long("prefetch-policy")
+        .short("P")
+        .help("blob data prefetch policy")
+        .takes_value(true)
+        .required(false)
+        .default_value("none")
+        .possible_values(&["fs", "blob", "none"]);
+
     // TODO: Try to use yaml to define below options
     App::new("")
         .version(bti_string.as_str())
@@ -247,14 +261,7 @@ fn prepare_cmd_args(bti_string: String) -> ArgMatches<'static> {
                         .required(false),
                 )
                 .arg(
-                    Arg::with_name("prefetch-policy")
-                        .long("prefetch-policy")
-                        .short("P")
-                        .help("blob data prefetch policy")
-                        .takes_value(true)
-                        .required(false)
-                        .default_value("none")
-                        .possible_values(&["fs", "blob", "none"]),
+                    arg_prefetch_policy.clone(),
                 )
                 .arg(
                     Arg::with_name("repeatable")
@@ -310,11 +317,7 @@ fn prepare_cmd_args(bti_string: String) -> ArgMatches<'static> {
                         .takes_value(true)
                 )
                 .arg(
-                    Arg::with_name("chunk-dict")
-                        .long("chunk-dict")
-                        .short("M")
-                        .help("Specify a chunk dictionary for chunk deduplication")
-                        .takes_value(true)
+                    arg_chunk_dict.clone(),
                 )
                 .arg(
                     Arg::with_name("backend-type")
@@ -343,21 +346,10 @@ fn prepare_cmd_args(bti_string: String) -> ArgMatches<'static> {
                         .takes_value(true),
                 )
                 .arg(
-                    Arg::with_name("chunk-dict")
-                        .long("chunk-dict")
-                        .short("M")
-                        .help("Specify a chunk dictionary for chunk deduplication")
-                        .takes_value(true)
+                    arg_chunk_dict,
                 )
                 .arg(
-                    Arg::with_name("prefetch-policy")
-                        .long("prefetch-policy")
-                        .short("P")
-                        .help("blob data prefetch policy")
-                        .takes_value(true)
-                        .required(false)
-                        .default_value("none")
-                        .possible_values(&["fs", "blob", "none"]),
+                    arg_prefetch_policy,
                 )
                 .arg(
                     Arg::with_name("SOURCE")

--- a/src/bin/nydus-image/main.rs
+++ b/src/bin/nydus-image/main.rs
@@ -296,6 +296,13 @@ fn prepare_cmd_args(bti_string: String) -> ArgMatches<'static> {
                         .takes_value(false)
                 )
                 .arg(
+                    Arg::with_name("blob-offset")
+                        .long("blob-offset")
+                        .help("add an offset for compressed blob (is only used to put the blob in the tarball)")
+                        .default_value("0")
+                        .takes_value(true)
+                )
+                .arg(
                     Arg::with_name("blob-dir")
                         .long("blob-dir")
                         .short("D")
@@ -547,6 +554,7 @@ impl Command {
     fn create(matches: &clap::ArgMatches, build_info: &BuildTimeInfo) -> Result<()> {
         let blob_id = Self::get_blob_id(&matches)?;
         let chunk_size = Self::get_chunk_size(&matches)?;
+        let blob_offset = Self::get_blob_offset(&matches)?;
         let parent_bootstrap = Self::get_parent_bootstrap(&matches)?;
         let source_path = PathBuf::from(matches.value_of("SOURCE").unwrap());
         let extra_paths: Vec<PathBuf> = matches
@@ -600,6 +608,7 @@ impl Command {
         let mut build_ctx = BuildContext::new(
             blob_id,
             aligned_chunk,
+            blob_offset,
             compressor,
             digester,
             !repeatable,
@@ -915,6 +924,13 @@ impl Command {
                 }
                 Ok(chunk_size)
             }
+        }
+    }
+
+    fn get_blob_offset(matches: &clap::ArgMatches) -> Result<u64> {
+        match matches.value_of("blob-offset") {
+            None => Ok(0),
+            Some(v) => u64::from_str_radix(v, 10).context(format!("invalid blob offset {}", v)),
         }
     }
 

--- a/src/bin/nydus-image/main.rs
+++ b/src/bin/nydus-image/main.rs
@@ -277,7 +277,7 @@ fn prepare_cmd_args(bti_string: String) -> ArgMatches<'static> {
                         .takes_value(true)
                         .required(true)
                         .default_value("oci")
-                        .possible_values(&["oci", "overlayfs"])
+                        .possible_values(&["oci", "overlayfs", "none"])
                 )
                 .arg(
                     Arg::with_name("output-json")

--- a/src/bin/nydus-image/main.rs
+++ b/src/bin/nydus-image/main.rs
@@ -250,7 +250,7 @@ fn prepare_cmd_args(bti_string: String) -> ArgMatches<'static> {
                     Arg::with_name("prefetch-policy")
                         .long("prefetch-policy")
                         .short("P")
-                        .help("prefetch policy:")
+                        .help("blob data prefetch policy")
                         .takes_value(true)
                         .required(false)
                         .default_value("none")
@@ -353,7 +353,7 @@ fn prepare_cmd_args(bti_string: String) -> ArgMatches<'static> {
                     Arg::with_name("prefetch-policy")
                         .long("prefetch-policy")
                         .short("P")
-                        .help("prefetch policy:")
+                        .help("blob data prefetch policy")
                         .takes_value(true)
                         .required(false)
                         .default_value("none")
@@ -705,9 +705,10 @@ impl Command {
         } else {
             None
         };
-        let prefetch = Self::get_prefetch(matches)?;
-        let mut ctx = BuildContext::default();
-        ctx.prefetch = prefetch;
+        let mut ctx = BuildContext {
+            prefetch: Self::get_prefetch(matches)?,
+            ..Default::default()
+        };
         Merger::merge(
             &mut ctx,
             source_bootstrap_paths,
@@ -964,7 +965,9 @@ impl Command {
     fn get_blob_offset(matches: &clap::ArgMatches) -> Result<u64> {
         match matches.value_of("blob-offset") {
             None => Ok(0),
-            Some(v) => u64::from_str_radix(v, 10).context(format!("invalid blob offset {}", v)),
+            Some(v) => v
+                .parse::<u64>()
+                .context(format!("invalid blob offset {}", v)),
         }
     }
 

--- a/src/bin/nydus-image/main.rs
+++ b/src/bin/nydus-image/main.rs
@@ -350,6 +350,16 @@ fn prepare_cmd_args(bti_string: String) -> ArgMatches<'static> {
                         .takes_value(true)
                 )
                 .arg(
+                    Arg::with_name("prefetch-policy")
+                        .long("prefetch-policy")
+                        .short("P")
+                        .help("prefetch policy:")
+                        .takes_value(true)
+                        .required(false)
+                        .default_value("none")
+                        .possible_values(&["fs", "blob", "none"]),
+                )
+                .arg(
                     Arg::with_name("SOURCE")
                         .help("bootstrap paths (allow one or more)")
                         .required(true)
@@ -606,11 +616,7 @@ impl Command {
             }
         }
 
-        let prefetch_policy = matches
-            .value_of("prefetch-policy")
-            .unwrap_or_default()
-            .parse()?;
-        let prefetch = Prefetch::new(prefetch_policy)?;
+        let prefetch = Self::get_prefetch(matches)?;
 
         let mut build_ctx = BuildContext::new(
             blob_id,
@@ -699,7 +705,11 @@ impl Command {
         } else {
             None
         };
+        let prefetch = Self::get_prefetch(matches)?;
+        let mut ctx = BuildContext::default();
+        ctx.prefetch = prefetch;
         Merger::merge(
+            &mut ctx,
             source_bootstrap_paths,
             target_bootstrap_path.to_path_buf(),
             chunk_dict_path,
@@ -941,6 +951,14 @@ impl Command {
                 Ok(chunk_size)
             }
         }
+    }
+
+    fn get_prefetch(matches: &clap::ArgMatches) -> Result<Prefetch> {
+        let prefetch_policy = matches
+            .value_of("prefetch-policy")
+            .unwrap_or_default()
+            .parse()?;
+        Prefetch::new(prefetch_policy)
     }
 
     fn get_blob_offset(matches: &clap::ArgMatches) -> Result<u64> {

--- a/src/bin/nydus-image/merge.rs
+++ b/src/bin/nydus-image/merge.rs
@@ -1,0 +1,88 @@
+// Copyright (C) 2022 Nydus Developers. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+
+use rafs::metadata::layout::RAFS_ROOT_INODE;
+use rafs::metadata::{RafsInode, RafsMode, RafsSuper};
+
+use crate::core::bootstrap::Bootstrap;
+use crate::core::chunk_dict::HashChunkDict;
+use crate::core::context::ArtifactStorage;
+use crate::core::context::{BlobContext, BlobManager, BootstrapContext, BuildContext};
+use crate::core::node::{ChunkSource, Overlay, WhiteoutSpec};
+use crate::core::tree::{MetadataTreeBuilder, Tree};
+
+pub struct Merger {}
+
+impl Merger {
+    pub fn merge(sources: Vec<PathBuf>, target: PathBuf) -> Result<()> {
+        if sources.is_empty() {
+            bail!("please provide at least one source bootstrap");
+        }
+
+        let mut dict = HashChunkDict::default();
+
+        let mut tree: Option<Tree> = None;
+        let mut blob_mgr = BlobManager::new();
+
+        let mut blob_idx = 0u32;
+        for source in sources {
+            let rs = RafsSuper::load_from_metadata(&source, RafsMode::Direct, true)?;
+
+            let blobs = rs.superblock.get_blob_infos();
+            if blobs.len() > 0 {
+                let mut blob_ctx = BlobContext::from(blobs[0].as_ref(), ChunkSource::Parent);
+                let blob_id = source.file_name().unwrap().to_str().unwrap();
+                blob_ctx.blob_id = blob_id.to_owned();
+                blob_mgr.add(blob_ctx);
+            }
+
+            if let Some(tree) = &mut tree {
+                let mut nodes = Vec::new();
+                rs.walk_inodes(RAFS_ROOT_INODE, None, &mut |inode: &dyn RafsInode,
+                                                            path: &Path|
+                 -> Result<()> {
+                    let mut node = MetadataTreeBuilder::parse_node(&rs, inode, path.to_path_buf())?;
+                    for chunk in &mut node.chunks {
+                        chunk.inner.set_blob_index(blob_idx);
+                    }
+                    node.overlay = Overlay::UpperAddition;
+                    match node.whiteout_type(WhiteoutSpec::Oci) {
+                        Some(_) => {
+                            nodes.insert(0, node.clone());
+                        }
+                        _ => {
+                            nodes.push(node.clone());
+                        }
+                    }
+                    Ok(())
+                })?;
+                for node in &nodes {
+                    tree.apply(node, true, WhiteoutSpec::Oci)?;
+                }
+            } else {
+                tree = Some(Tree::from_bootstrap(&rs, &mut dict)?);
+            }
+
+            if blobs.len() > 0 {
+                blob_idx += 1;
+            }
+        }
+
+        // Safe to unwrap because source bootstrap is at least one.
+        let mut tree = tree.unwrap();
+        let mut bootstrap = Bootstrap::new()?;
+        let storage = ArtifactStorage::SingleFile(target.clone());
+        let mut bootstrap_ctx = BootstrapContext::new(storage, false)?;
+        let mut ctx = BuildContext::default();
+        bootstrap.build(&mut ctx, &mut bootstrap_ctx, &mut tree)?;
+        let blob_table = blob_mgr.to_blob_table(&ctx)?;
+        bootstrap.dump(&mut ctx, &mut bootstrap_ctx, &blob_table)?;
+
+        Ok(())
+    }
+}

--- a/src/bin/nydus-image/merge.rs
+++ b/src/bin/nydus-image/merge.rs
@@ -21,6 +21,7 @@ pub struct Merger {}
 
 impl Merger {
     pub fn merge(
+        ctx: &mut BuildContext,
         sources: Vec<PathBuf>,
         target: PathBuf,
         chunk_dict: Option<PathBuf>,
@@ -97,10 +98,9 @@ impl Merger {
         let mut bootstrap = Bootstrap::new()?;
         let storage = ArtifactStorage::SingleFile(target.clone());
         let mut bootstrap_ctx = BootstrapContext::new(storage, false)?;
-        let mut ctx = BuildContext::default();
-        bootstrap.build(&mut ctx, &mut bootstrap_ctx, &mut tree)?;
+        bootstrap.build(ctx, &mut bootstrap_ctx, &mut tree)?;
         let blob_table = blob_mgr.to_blob_table(&ctx)?;
-        bootstrap.dump(&mut ctx, &mut bootstrap_ctx, &blob_table)?;
+        bootstrap.dump(ctx, &mut bootstrap_ctx, &blob_table)?;
 
         Ok(())
     }

--- a/src/bin/nydus-image/merge.rs
+++ b/src/bin/nydus-image/merge.rs
@@ -8,10 +8,10 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 
+use nydus_utils::compress;
 use nydus_utils::digest::{self};
 use rafs::metadata::layout::RAFS_ROOT_INODE;
 use rafs::metadata::{RafsInode, RafsMode, RafsSuper, RafsSuperMeta};
-use storage::compress;
 
 use crate::core::bootstrap::Bootstrap;
 use crate::core::chunk_dict::HashChunkDict;

--- a/src/bin/nydus-image/stat.rs
+++ b/src/bin/nydus-image/stat.rs
@@ -7,7 +7,7 @@ use std::fs::OpenOptions;
 use std::path::Path;
 use std::sync::atomic::Ordering;
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result};
 use rafs::metadata::{RafsMode, RafsSuper};
 use serde::Serialize;
 
@@ -158,12 +158,7 @@ impl ImageStat {
     }
 
     pub fn stat(&mut self, path: &Path, is_base: bool) -> Result<()> {
-        let p = match path.to_str() {
-            None => bail!("invalid path to nydus image metadata blob"),
-            Some(v) => v,
-        };
-
-        let rs = RafsSuper::load_from_metadata(p, RafsMode::Direct, false)?;
+        let rs = RafsSuper::load_from_metadata(path, RafsMode::Direct, false)?;
         let mut dict = HashChunkDict::default();
         let mut hardlinks = HashSet::new();
         let tree =

--- a/src/bin/nydus-image/validator.rs
+++ b/src/bin/nydus-image/validator.rs
@@ -6,7 +6,7 @@
 
 use std::path::Path;
 
-use anyhow::{Context, Error, Result};
+use anyhow::{Context, Result};
 use rafs::metadata::{RafsMode, RafsSuper};
 
 use crate::tree::Tree;
@@ -17,10 +17,7 @@ pub struct Validator {
 
 impl Validator {
     pub fn new(bootstrap_path: &Path) -> Result<Self> {
-        let path = bootstrap_path
-            .to_str()
-            .ok_or_else(|| Error::msg("bootstrap path is invalid"))?;
-        let sb = RafsSuper::load_from_metadata(path, RafsMode::Direct, true)?;
+        let sb = RafsSuper::load_from_metadata(bootstrap_path, RafsMode::Direct, true)?;
 
         Ok(Self { sb })
     }

--- a/tests/diff.rs
+++ b/tests/diff.rs
@@ -228,6 +228,7 @@ fn integration_test_diff_build_with_chunk_dict() {
         &snapshot_dir_4,
     ));
     let expected_chunk_dict_bootstrap = IntoIter::new([
+        (PathBuf::from("/"), vec![]),
         (
             PathBuf::from("/file-1"),
             vec![
@@ -324,21 +325,23 @@ fn integration_test_diff_build_with_chunk_dict() {
     let mut reader = Box::new(file) as RafsIoReader;
     rs.load(&mut reader).unwrap();
     let mut actual = HashMap::new();
+    let blobs = rs.superblock.get_blob_infos();
     rs.walk_inodes(RAFS_ROOT_INODE, None, &mut |inode: &dyn RafsInode,
                                                 path: &Path|
      -> Result<()> {
         let mut chunks = Vec::new();
-        let blobs = rs.superblock.get_blob_infos();
-        inode
-            .walk_chunks(&mut |chunk: &dyn BlobChunkInfo| -> Result<()> {
-                chunks.push((
-                    chunk.blob_index(),
-                    blobs[chunk.blob_index() as usize].blob_id().to_string(),
-                    format!("{}", chunk.chunk_id()),
-                ));
-                Ok(())
-            })
-            .unwrap();
+        if inode.is_reg() {
+            inode
+                .walk_chunks(&mut |chunk: &dyn BlobChunkInfo| -> Result<()> {
+                    chunks.push((
+                        chunk.blob_index(),
+                        blobs[chunk.blob_index() as usize].blob_id().to_string(),
+                        format!("{}", chunk.chunk_id()),
+                    ));
+                    Ok(())
+                })
+                .unwrap();
+        }
         actual.insert(path.to_path_buf(), chunks);
         Ok(())
     })
@@ -386,6 +389,7 @@ fn integration_test_diff_build_with_chunk_dict() {
         &snapshot_dir_6,
     ));
     let expected_bootstrap = IntoIter::new([
+        (PathBuf::from("/"), vec![]),
         (
             PathBuf::from("/file-8"),
             vec![
@@ -460,21 +464,23 @@ fn integration_test_diff_build_with_chunk_dict() {
     let mut reader = Box::new(file) as RafsIoReader;
     rs.load(&mut reader).unwrap();
     let mut actual = HashMap::new();
+    let blobs = rs.superblock.get_blob_infos();
     rs.walk_inodes(RAFS_ROOT_INODE, None, &mut |inode: &dyn RafsInode,
                                                 path: &Path|
      -> Result<()> {
         let mut chunks = Vec::new();
-        let blobs = rs.superblock.get_blob_infos();
-        inode
-            .walk_chunks(&mut |chunk: &dyn BlobChunkInfo| -> Result<()> {
-                chunks.push((
-                    chunk.blob_index(),
-                    blobs[chunk.blob_index() as usize].blob_id().to_string(),
-                    format!("{}", chunk.chunk_id()),
-                ));
-                Ok(())
-            })
-            .unwrap();
+        if inode.is_reg() {
+            inode
+                .walk_chunks(&mut |chunk: &dyn BlobChunkInfo| -> Result<()> {
+                    chunks.push((
+                        chunk.blob_index(),
+                        blobs[chunk.blob_index() as usize].blob_id().to_string(),
+                        format!("{}", chunk.chunk_id()),
+                    ));
+                    Ok(())
+                })
+                .unwrap();
+        }
         actual.insert(path.to_path_buf(), chunks);
         Ok(())
     })
@@ -539,6 +545,7 @@ fn integration_test_diff_build_with_chunk_dict() {
     ));
 
     let expected_bootstrap = IntoIter::new([
+        (PathBuf::from("/"), vec![]),
         (
             PathBuf::from("/file-1"),
             vec![
@@ -678,21 +685,23 @@ fn integration_test_diff_build_with_chunk_dict() {
     let mut reader = Box::new(file) as RafsIoReader;
     rs.load(&mut reader).unwrap();
     let mut actual = HashMap::new();
+    let blobs = rs.superblock.get_blob_infos();
     rs.walk_inodes(RAFS_ROOT_INODE, None, &mut |inode: &dyn RafsInode,
                                                 path: &Path|
      -> Result<()> {
         let mut chunks = Vec::new();
-        let blobs = rs.superblock.get_blob_infos();
-        inode
-            .walk_chunks(&mut |chunk: &dyn BlobChunkInfo| -> Result<()> {
-                chunks.push((
-                    chunk.blob_index(),
-                    blobs[chunk.blob_index() as usize].blob_id().to_string(),
-                    format!("{}", chunk.chunk_id()),
-                ));
-                Ok(())
-            })
-            .unwrap();
+        if inode.is_reg() {
+            inode
+                .walk_chunks(&mut |chunk: &dyn BlobChunkInfo| -> Result<()> {
+                    chunks.push((
+                        chunk.blob_index(),
+                        blobs[chunk.blob_index() as usize].blob_id().to_string(),
+                        format!("{}", chunk.chunk_id()),
+                    ));
+                    Ok(())
+                })
+                .unwrap();
+        }
         actual.insert(path.to_path_buf(), chunks);
         Ok(())
     })


### PR DESCRIPTION
Introduce a new build mode named tar build in nydusify and builder (nydus-image).

In order to correspond to the OCI image layer, we need a new build mode, that is
to convert the OCI-formatted tar stream directly into a nydus-formatted tar stream.

The nydus tar stream contains blob and bootstrap files, and the workflow is divided
into two steps, Convert and Merge.

Convert: converts each layer of the OCI tar stream to a nydus tar stream.
Merge: reads the bootstrap files from each layer of the nydus tar stream and merges
them into a final bootstrap.

Support merge sub-command in builder, it will be used in [converter](https://github.com/containerd/nydus-snapshotter/pull/34) package, and this
package will be imported by acceleration-service and buildkit to support the conversion
or build of nydus image.