### PR TITLE
update fuse-backend-rs to 0.4.0.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -265,7 +265,16 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0a89e2ae426ea83155dccf10c0fa6b1463ef6d5fcb44cee0b224a408fa640a62"
 dependencies = [
- "core-foundation-sys",
+ "core-foundation-sys 0.8.2",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "065a5d7ffdcbc8fa145d6f0746f3555025b9097a9e9cda59f7467abae670c78d"
+dependencies = [
  "libc",
 ]
 
@@ -362,6 +371,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "diskarbitration-sys"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f82432ae94d42f160b6e17389d6e1c1eee29827b99ad32d35a0a96bb98bedb5"
+dependencies = [
+ "core-foundation-sys 0.2.3",
+ "libc",
 ]
 
 [[package]]
@@ -488,16 +507,19 @@ dependencies = [
 
 [[package]]
 name = "fuse-backend-rs"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff1447465e2b0d1f40830f9cb214b16845d5e06e7e6ac2ad1f1896b17a64d623"
+checksum = "0c3be1c08fddde81df5502239ce031cca69529a444f259da3252dec67d99f324"
 dependencies = [
  "arc-swap 1.5.0",
  "bitflags",
  "caps",
+ "core-foundation-sys 0.2.3",
+ "diskarbitration-sys",
  "lazy_static",
  "libc",
  "log",
+ "mio 0.8.2",
  "nix 0.22.2",
  "vhost",
  "virtio-queue",
@@ -1649,7 +1671,7 @@ checksum = "23a2ac85147a3a11d77ecf1bc7166ec0b92febfa4461c37944e180f319ece467"
 dependencies = [
  "bitflags",
  "core-foundation",
- "core-foundation-sys",
+ "core-foundation-sys 0.8.2",
  "libc",
  "security-framework-sys",
 ]
@@ -1660,7 +1682,7 @@ version = "2.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9dd14d83160b528b7bfd66439110573efcfbe281b17fc2ca9f39f550d619c7e"
 dependencies = [
- "core-foundation-sys",
+ "core-foundation-sys 0.8.2",
  "libc",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ openssl-src = "=111.18.0"
 rand_core = ">=0.6.2"
 
 event-manager = "0.2.1"
-fuse-backend-rs = { version = "0.3.0", optional = true }
+fuse-backend-rs = { version = "0.4.0", optional = true }
 vhost = { version = "0.3.0", features = ["vhost-user-slave"], optional = true }
 vhost-user-backend = { version = "0.1.0", optional = true }
 virtio-bindings = { version = "0.1", features = ["virtio-v5_0_0"], optional = true }

--- a/blobfs/Cargo.toml
+++ b/blobfs/Cargo.toml
@@ -14,7 +14,7 @@ serde_json = ">=1.0.9"
 serde_with = { version = "1.6.0", features = ["macros"] }
 libc = "0.2"
 vm-memory = { version = "0.7.0" }
-fuse-backend-rs = { version = "0.3.0" }
+fuse-backend-rs = { version = "0.4.0" }
 
 rafs = { path = "../rafs" }
 nydus-error = { path = "../error" }

--- a/rafs/Cargo.toml
+++ b/rafs/Cargo.toml
@@ -28,7 +28,7 @@ sha-1 = { version = "0.9.1", optional = true }
 spmc = "0.3.0"
 url = { version = "2.1.1", optional = true }
 vm-memory = "0.7.0"
-fuse-backend-rs = { version = "0.3.0" }
+fuse-backend-rs = { version = "0.4.0" }
 
 nydus-utils = { path = "../utils" }
 nydus-error = { path = "../error" }

--- a/rafs/src/fs.rs
+++ b/rafs/src/fs.rs
@@ -30,7 +30,7 @@ use std::time::{Duration, SystemTime};
 use nix::unistd::{getegid, geteuid};
 use serde::Deserialize;
 
-use fuse_backend_rs::abi::linux_abi::Attr;
+use fuse_backend_rs::abi::fuse_abi::Attr;
 use fuse_backend_rs::api::filesystem::*;
 use fuse_backend_rs::api::BackendFileSystem;
 use nydus_utils::metrics::{self, FopRecorder, StatsFop::*};

--- a/rafs/src/metadata/cached_v5.rs
+++ b/rafs/src/metadata/cached_v5.rs
@@ -18,7 +18,7 @@ use std::os::unix::ffi::OsStrExt;
 use std::str::FromStr;
 use std::sync::Arc;
 
-use fuse_backend_rs::abi::linux_abi;
+use fuse_backend_rs::abi::fuse_abi;
 use fuse_backend_rs::api::filesystem::Entry;
 use nydus_utils::digest::Algorithm;
 use nydus_utils::{digest::RafsDigest, ByteSize};
@@ -399,8 +399,8 @@ impl RafsInode for CachedInodeV5 {
     }
 
     #[inline]
-    fn get_attr(&self) -> linux_abi::Attr {
-        linux_abi::Attr {
+    fn get_attr(&self) -> fuse_abi::Attr {
+        fuse_abi::Attr {
             ino: self.i_ino,
             size: self.i_size,
             blocks: self.i_blocks,

--- a/rafs/src/metadata/layout/mod.rs
+++ b/rafs/src/metadata/layout/mod.rs
@@ -12,7 +12,7 @@ use std::io::Result;
 use std::mem::size_of;
 use std::os::unix::ffi::OsStrExt;
 
-use fuse_backend_rs::abi::linux_abi::ROOT_ID;
+use fuse_backend_rs::abi::fuse_abi::ROOT_ID;
 use nydus_utils::ByteSize;
 
 use crate::metadata::layout::v5::RAFSV5_ALIGNMENT;

--- a/rafs/src/metadata/mod.rs
+++ b/rafs/src/metadata/mod.rs
@@ -17,7 +17,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 use std::time::Duration;
 
-use fuse_backend_rs::abi::linux_abi::Attr;
+use fuse_backend_rs::abi::fuse_abi::Attr;
 use fuse_backend_rs::api::filesystem::{Entry, ROOT_ID};
 use nydus_utils::digest::{self, RafsDigest};
 use serde::Serialize;

--- a/rafs/src/mock/mock_inode.rs
+++ b/rafs/src/mock/mock_inode.rs
@@ -10,7 +10,7 @@ use std::io::Result;
 use std::os::unix::ffi::OsStrExt;
 use std::sync::Arc;
 
-use fuse_backend_rs::abi::linux_abi;
+use fuse_backend_rs::abi::fuse_abi;
 use fuse_backend_rs::api::filesystem::Entry;
 use nydus_utils::{digest::RafsDigest, ByteSize};
 
@@ -94,8 +94,8 @@ impl RafsInode for MockInode {
     }
 
     #[inline]
-    fn get_attr(&self) -> linux_abi::Attr {
-        linux_abi::Attr {
+    fn get_attr(&self) -> fuse_abi::Attr {
+        fuse_abi::Attr {
             ino: self.i_ino,
             size: self.i_size,
             blocks: self.i_blocks,

--- a/src/bin/nydusd/fusedev.rs
+++ b/src/bin/nydusd/fusedev.rs
@@ -20,7 +20,7 @@ use std::sync::{
 use std::thread::{self, JoinHandle};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use fuse_backend_rs::abi::linux_abi::{InHeader, OutHeader};
+use fuse_backend_rs::abi::fuse_abi::{InHeader, OutHeader};
 use fuse_backend_rs::api::server::{MetricsHook, Server};
 use fuse_backend_rs::api::Vfs;
 use fuse_backend_rs::transport::fusedev::{FuseChannel, FuseSession};
@@ -97,10 +97,10 @@ struct FuseServer {
 }
 
 impl FuseServer {
-    fn new(server: Arc<Server<Arc<Vfs>>>, se: &FuseSession, evtfd: EventFd) -> Result<FuseServer> {
+    fn new(server: Arc<Server<Arc<Vfs>>>, se: &FuseSession, _evtfd: EventFd) -> Result<FuseServer> {
         Ok(FuseServer {
             server,
-            ch: se.new_channel(evtfd)?,
+            ch: se.new_channel()?,
         })
     }
 

--- a/src/bin/nydusd/virtiofs.rs
+++ b/src/bin/nydusd/virtiofs.rs
@@ -26,7 +26,7 @@ use virtio_bindings::bindings::virtio_ring::{
     VIRTIO_RING_F_EVENT_IDX, VIRTIO_RING_F_INDIRECT_DESC,
 };
 use virtio_queue::DescriptorChain;
-use vm_memory::{GuestAddressSpace, GuestMemoryAtomic, GuestMemoryLoadGuard, GuestMemoryMmap};
+use vm_memory::{GuestMemoryAtomic, GuestMemoryLoadGuard, GuestMemoryMmap};
 use vmm_sys_util::epoll::EventSet;
 use vmm_sys_util::eventfd::EventFd;
 
@@ -96,11 +96,6 @@ impl VhostUserFsBackend {
     // to handle it.
     fn process_queue(&mut self, vring_state: &mut MutexGuard<VringState>) -> Result<bool> {
         let mut used_any = false;
-        let mem = self
-            .mem
-            .as_ref()
-            .ok_or(DaemonError::NoMemoryConfigured)?
-            .memory();
 
         let avail_chains: Vec<DescriptorChain<GuestMemoryLoadGuard<GuestMemoryMmap>>> = vring_state
             .get_queue_mut()
@@ -113,10 +108,12 @@ impl VhostUserFsBackend {
 
             let head_index = chain.head_index();
 
+            let mem = chain.memory();
+
             let reader =
-                Reader::new(&mem, chain.clone()).map_err(DaemonError::InvalidDescriptorChain)?;
+                Reader::new(mem, chain.clone()).map_err(DaemonError::InvalidDescriptorChain)?;
             let writer =
-                Writer::new(&mem, chain.clone()).map_err(DaemonError::InvalidDescriptorChain)?;
+                Writer::new(mem, chain.clone()).map_err(DaemonError::InvalidDescriptorChain)?;
 
             self.server
                 .handle_message(

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -32,7 +32,7 @@ tokio = { version = ">=1.13.1", features = ["rt-multi-thread"] }
 url = { version = "2.1.1", optional = true }
 vm-memory = "0.7.0"
 vmm-sys-util = ">=0.9.0"
-fuse-backend-rs = { version = "0.3.0" }
+fuse-backend-rs = { version = "0.4.0" }
 
 nydus-utils = { path = "../utils" }
 nydus-error = { path = "../error" }

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -15,7 +15,7 @@ sha2 = "0.9.1"
 blake3 = "1.0"
 serde = { version = ">=1.0.27", features = ["serde_derive", "rc"] }
 serde_json = ">=1.0.9"
-fuse-backend-rs = { version = "0.3.0" }
+fuse-backend-rs = { version = "0.4.0" }
 
 nydus-error = { version = "0.2", path = "../error" }
 


### PR DESCRIPTION
In the new version of fuse-backend-rs, the
`fuse_backend_rs::abi::linux_abi` mod has been replaced with
`fuse_backend_rs::abi::fuse_abi`.

Signed-off-by: wllenyj <wllenyj@linux.alibaba.com>
