### PR TITLE
makefile: correct cargo clippy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ endef
 
 define static_check
 	# Cargo will skip checking if it is already checked
-	cargo clippy --features=$(1) --workspace --bins --tests --target-dir target-$(1) -- -Dclippy::all
+	cargo clippy --features=$(1) --workspace --bins --tests --target-dir target-$(1) -- -Dwarnings
 endef
 
 .PHONY: all .release_version .format .musl_target build release static-release fusedev-release virtiofs-release virtiofs fusedev


### PR DESCRIPTION
Per https://github.com/rust-lang/rust-clippy/#travis-ci, we should
use -Dwarnings to fail CI upon both clippy warnings and rustc warnings.
Right now rustc warnings are silently ignored.
