### PR TITLE
Load blob cache object information from command line

### DIFF
--- a/api/src/http_endpoint_v2.rs
+++ b/api/src/http_endpoint_v2.rs
@@ -32,12 +32,12 @@ fn convert_to_response<O: FnOnce(ApiError) -> HttpError>(api_resp: ApiResponse, 
                 FsFilesPatterns(d) => success_response(Some(d)),
                 FsGlobalMetrics(d) => success_response(Some(d)),
 
-                /*
-                       FsBackendInfo(d) => success_response(Some(d)),
-                       InflightMetrics(d) => success_response(Some(d)),
-                */
+                // Nydus API v1
+                FsBackendInfo(d) => success_response(Some(d)),
+                InflightMetrics(d) => success_response(Some(d)),
+
+                // Nydus API v2
                 BlobObjectList(d) => success_response(Some(d)),
-                _ => panic!("Unexpected response message from API service"),
             }
         }
         Err(e) => {

--- a/docs/samples/boostrap_blob_cache_entry.json
+++ b/docs/samples/boostrap_blob_cache_entry.json
@@ -1,0 +1,17 @@
+{
+  "type": "bootstrap",
+  "id": "bootstrap1",
+  "domain_id": "userid1",
+  "config": {
+    "id": "factory1",
+    "backend_type": "localfs",
+    "backend_config": {
+      "blob_file": "bootstrap1",
+      "dir": "/tmp/nydus"
+    },
+    "cache_type": "fscache",
+    "cache_config": {
+      "work_dir": "/tmp/nydus"
+    }
+  }
+}

--- a/rafs/src/metadata/mod.rs
+++ b/rafs/src/metadata/mod.rs
@@ -468,9 +468,16 @@ impl RafsSuper {
     }
 
     /// Load Rafs super block from a metadata file.
-    pub fn load_from_metadata(path: &str, mode: RafsMode, validate_digest: bool) -> Result<Self> {
+    pub fn load_from_metadata<P: AsRef<Path>>(
+        path: P,
+        mode: RafsMode,
+        validate_digest: bool,
+    ) -> Result<Self> {
         // open bootstrap file
-        let file = OpenOptions::new().read(true).write(false).open(path)?;
+        let file = OpenOptions::new()
+            .read(true)
+            .write(false)
+            .open(path.as_ref())?;
         let mut rs = RafsSuper {
             mode,
             validate_digest,

--- a/src/bin/nydusd/blob_cache.rs
+++ b/src/bin/nydusd/blob_cache.rs
@@ -10,28 +10,76 @@ use std::sync::{Arc, Mutex, MutexGuard};
 use storage::device::BlobInfo;
 use storage::factory::FactoryConfig;
 
+pub const BLOB_CACHE_TYPE_BOOTSTRAP: &str = "bootstrap";
+pub const BLOB_CACHE_TYPE_DATA_BLOB: &str = "datablob";
+
+/// Configuration for a blob to be cached.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct BlobCacheConfigEntry {
+    /// Domain id for the blob.
+    /// #[serde(default)]
+    pub domain_id: String,
+    /// Blob id.
+    #[serde(rename = "id")]
+    pub blob_id: String,
+    /// Type of blob object, bootstrap or data blob.
+    #[serde(rename = "type")]
+    pub blob_type: String,
+    /// Configuration information to generate blob cache object.
+    #[serde(rename = "config")]
+    pub blob_config: FactoryConfig,
+    /// Optional path for bootstrap blob.
+    #[serde(default, rename = "path")]
+    pub blob_path: Option<String>,
+}
+
+impl BlobCacheConfigEntry {
+    pub fn validate(&self) -> Result<()> {
+        match self.blob_type.as_str() {
+            BLOB_CACHE_TYPE_BOOTSTRAP => {
+                if self.blob_path.is_none() {
+                    Err(einval!("`path` is needed for a bootstrap blob"))
+                } else {
+                    Ok(())
+                }
+            }
+            BLOB_CACHE_TYPE_DATA_BLOB => {
+                todo!();
+            }
+            _ => Err(einval!("invalid blob type from `BlobCacheConfigEntry")),
+        }
+    }
+}
+
+/// Configuration for a list of blobs to be cached.
+#[derive(Debug, Default, Deserialize, Serialize)]
+pub struct BlobCacheConfigList {
+    /// List of blob configuration entries.
+    pub blobs: Vec<BlobCacheConfigEntry>,
+}
+
 #[derive(Clone)]
-pub struct FsCacheBootstrapConfig {
+pub struct BlobCacheConfigBootstrap {
     blob_id: String,
     scoped_blob_id: String,
     path: String,
     factory_config: Arc<FactoryConfig>,
 }
 
-impl FsCacheBootstrapConfig {
+impl BlobCacheConfigBootstrap {
     pub fn path(&self) -> &str {
         &self.path
     }
 }
 
 #[derive(Clone)]
-pub struct FsCacheDataBlobConfig {
+pub struct BlobCacheConfigDataBlob {
     blob_info: Arc<BlobInfo>,
     scoped_blob_id: String,
     factory_config: Arc<FactoryConfig>,
 }
 
-impl FsCacheDataBlobConfig {
+impl BlobCacheConfigDataBlob {
     pub fn blob_info(&self) -> &Arc<BlobInfo> {
         &self.blob_info
     }
@@ -42,19 +90,19 @@ impl FsCacheDataBlobConfig {
 }
 
 #[derive(Clone)]
-pub enum FsCacheObjectConfig {
-    DataBlob(Arc<FsCacheDataBlobConfig>),
-    Bootstrap(Arc<FsCacheBootstrapConfig>),
+pub enum BlobCacheObjectConfig {
+    DataBlob(Arc<BlobCacheConfigDataBlob>),
+    Bootstrap(Arc<BlobCacheConfigBootstrap>),
 }
 
-impl FsCacheObjectConfig {
+impl BlobCacheObjectConfig {
     fn new_data_blob(
         domain_id: String,
         blob_info: Arc<BlobInfo>,
         factory_config: Arc<FactoryConfig>,
     ) -> Self {
         let scoped_blob_id = domain_id + "-" + blob_info.blob_id();
-        FsCacheObjectConfig::DataBlob(Arc::new(FsCacheDataBlobConfig {
+        BlobCacheObjectConfig::DataBlob(Arc::new(BlobCacheConfigDataBlob {
             blob_info,
             scoped_blob_id,
             factory_config,
@@ -68,7 +116,7 @@ impl FsCacheObjectConfig {
         factory_config: Arc<FactoryConfig>,
     ) -> Self {
         let scoped_blob_id = domain_id + "-" + &blob_id;
-        FsCacheObjectConfig::Bootstrap(Arc::new(FsCacheBootstrapConfig {
+        BlobCacheObjectConfig::Bootstrap(Arc::new(BlobCacheConfigBootstrap {
             blob_id,
             scoped_blob_id,
             path,
@@ -78,15 +126,15 @@ impl FsCacheObjectConfig {
 
     fn get_key(&self) -> &str {
         match self {
-            FsCacheObjectConfig::Bootstrap(o) => &o.scoped_blob_id,
-            FsCacheObjectConfig::DataBlob(o) => &o.scoped_blob_id,
+            BlobCacheObjectConfig::Bootstrap(o) => &o.scoped_blob_id,
+            BlobCacheObjectConfig::DataBlob(o) => &o.scoped_blob_id,
         }
     }
 }
 
 #[derive(Default)]
 struct BlobCacheState {
-    id_to_config_map: HashMap<String, FsCacheObjectConfig>,
+    id_to_config_map: HashMap<String, BlobCacheObjectConfig>,
 }
 
 /// Struct to maintain cached file objects.
@@ -116,7 +164,7 @@ impl BlobCacheMgr {
         blob_info: Arc<BlobInfo>,
         factory_config: Arc<FactoryConfig>,
     ) -> Result<()> {
-        let config = FsCacheObjectConfig::new_data_blob(domain_id, blob_info, factory_config);
+        let config = BlobCacheObjectConfig::new_data_blob(domain_id, blob_info, factory_config);
         let mut state = self.get_state();
         if state.id_to_config_map.contains_key(config.get_key()) {
             Err(Error::new(
@@ -148,7 +196,7 @@ impl BlobCacheMgr {
         factory_config: Arc<FactoryConfig>,
     ) -> Result<()> {
         let rs = RafsSuper::load_from_metadata(path, RafsMode::Direct, true)?;
-        let config = FsCacheObjectConfig::new_bootstrap_blob(
+        let config = BlobCacheObjectConfig::new_bootstrap_blob(
             domain_id.clone(),
             id.to_string(),
             path.to_string(),
@@ -167,7 +215,7 @@ impl BlobCacheMgr {
                 .insert(config.get_key().to_string(), config);
             // Try to add the referenced data blob object if it doesn't exist yet.
             for bi in rs.superblock.get_blob_infos() {
-                let data_blob = FsCacheObjectConfig::new_data_blob(
+                let data_blob = BlobCacheObjectConfig::new_data_blob(
                     domain_id.clone(),
                     bi,
                     factory_config.clone(),
@@ -182,12 +230,169 @@ impl BlobCacheMgr {
         }
     }
 
-    pub fn get_config(&self, key: &str) -> Option<FsCacheObjectConfig> {
+    /// Add a list of bootstrap and/or data blobs.
+    pub fn add_blob_list(&self, blobs: &BlobCacheConfigList) -> Result<()> {
+        for entry in blobs.blobs.iter() {
+            if let Err(e) = entry.validate() {
+                warn!("Invalid blob config entry: {:?}", entry);
+                return Err(e);
+            }
+            if entry.blob_type == BLOB_CACHE_TYPE_BOOTSTRAP
+                && entry.blob_config.cache.cache_type == "fscache"
+                && entry.blob_path.is_some()
+            {
+                let path = entry.blob_path.as_ref().unwrap();
+                if let Err(e) = self.add_bootstrap_object(
+                    entry.domain_id.clone(),
+                    &entry.blob_id,
+                    path,
+                    Arc::new(entry.blob_config.clone()),
+                ) {
+                    warn!("Failed to add bootstrap entry: {:?}", entry);
+                    return Err(e);
+                }
+            } else {
+                warn!("Unsupported blob config entry: {:?}", entry);
+                return Err(einval!("unsupported blob configuration entry"));
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Get blob configuration for blob with `key`.
+    pub fn get_config(&self, key: &str) -> Option<BlobCacheObjectConfig> {
         self.get_state().id_to_config_map.get(key).cloned()
     }
 
     #[inline]
     fn get_state(&self) -> MutexGuard<BlobCacheState> {
         self.state.lock().unwrap()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_blob_cache_entry() {
+        let config = r#"
+        {
+            "domain_id": "domain1",
+            "id": "blob1",
+            "type": "bootstrap",
+            "path": "/tmp/file1",
+            "config": {
+                "id": "factory1",
+                "backend": {
+                    "type": "oss",
+                    "config": {
+                        "endpoint": "test",
+                        "access_key_id": "test",
+                        "access_key_secret": "test",
+                        "bucket_name": "antsys-nydus",
+                        "object_prefix":"nydus_v2/",
+                        "scheme": "http"
+                    }
+                },
+                "cache": {
+                    "type": "fscache",
+                    "compressed": false,
+                    "config": {}
+                }
+            }
+          }"#;
+        let mut entry: BlobCacheConfigEntry = serde_json::from_str(config).unwrap();
+
+        assert_eq!(&entry.domain_id, "domain1");
+        assert_eq!(&entry.blob_id, "blob1");
+        assert_eq!(&entry.blob_type, "bootstrap");
+        assert_eq!(entry.blob_path, Some("/tmp/file1".to_string()));
+        assert_eq!(&entry.blob_config.id, "factory1");
+        assert_eq!(&entry.blob_config.backend.backend_type, "oss");
+        assert_eq!(&entry.blob_config.cache.cache_type, "fscache");
+        assert_eq!(entry.blob_config.cache.cache_compressed, false);
+        assert!(entry.blob_config.backend.backend_config.is_object());
+        entry.validate().unwrap();
+
+        let path = entry.blob_path.take();
+        entry.validate().unwrap_err();
+        entry.blob_path = path;
+        entry.validate().unwrap();
+        entry.blob_type = "unknown".to_string();
+        entry.validate().unwrap_err();
+    }
+
+    #[test]
+    fn test_blob_cache_list() {
+        let config = r#"
+         {
+            "blobs" : [
+                {
+                    "domain_id": "domain1",
+                    "id": "blob1",
+        		    "type": "bootstrap",
+        		    "path": "/tmp/file1",
+        		    "config": {
+        			    "id": "factory1",
+        			    "backend": {
+        				    "type": "oss",
+        				    "config": {
+        					    "endpoint": "test",
+        					    "access_key_id": "test",
+        					    "access_key_secret": "test",
+        					    "bucket_name": "antsys-nydus",
+        					    "object_prefix": "nydus_v2/",
+        					    "scheme": "http"
+        				    }
+        			    },
+        			    "cache": {
+        				    "type": "fscache",
+        				    "compressed": false,
+        				    "config": {}
+        			    }
+        		    }
+        	    },
+        	    {
+                    "domain_id": "domain1",
+                    "id": "blob2",
+        		    "type": "bootstrap",
+        		    "path": "/tmp/file2",
+        		    "config": {
+        			    "id": "factory2",
+        			    "backend": {
+        				    "type": "oss",
+        				    "config": {
+        					    "endpoint": "test",
+        					    "access_key_id": "test",
+        					    "access_key_secret": "test",
+        					    "bucket_name": "antsys-nydus",
+        					    "object_prefix": "nydus_v2/",
+        					    "scheme": "http"
+        				    }
+        			    },
+        			    "cache": {
+        				    "type": "fscache",
+        				    "compressed": false,
+        				    "config": {}
+        			    }
+        		    }
+        	    }
+            ]
+         }"#;
+        let list: BlobCacheConfigList = serde_json::from_str(config).unwrap();
+
+        assert_eq!(list.blobs.len(), 2);
+        assert_eq!(&list.blobs[0].blob_type, "bootstrap");
+        assert_eq!(list.blobs[0].blob_path, Some("/tmp/file1".to_string()));
+        assert_eq!(&list.blobs[0].blob_config.id, "factory1");
+        assert_eq!(&list.blobs[0].blob_config.backend.backend_type, "oss");
+        assert_eq!(&list.blobs[0].blob_config.cache.cache_type, "fscache");
+        assert_eq!(list.blobs[0].blob_config.cache.cache_compressed, false);
+        assert!(list.blobs[0].blob_config.backend.backend_config.is_object());
+        list.blobs[0].validate().unwrap();
+        assert_eq!(list.blobs[1].blob_path, Some("/tmp/file2".to_string()));
+        list.blobs[1].validate().unwrap();
     }
 }

--- a/src/bin/nydusd/fs_cache.rs
+++ b/src/bin/nydusd/fs_cache.rs
@@ -21,7 +21,7 @@ use storage::cache::BlobCache;
 use storage::factory::BLOB_FACTORY;
 
 use crate::blob_cache::{
-    BlobCacheMgr, FsCacheBootstrapConfig, FsCacheDataBlobConfig, FsCacheObjectConfig,
+    BlobCacheConfigBootstrap, BlobCacheConfigDataBlob, BlobCacheMgr, BlobCacheObjectConfig,
 };
 
 ioctl_write_int!(fscache_cread, 0x98, 1);
@@ -232,7 +232,7 @@ enum FsCacheObject {
 #[derive(Default)]
 struct FsCacheState {
     fd_to_object_map: HashMap<u32, FsCacheObject>,
-    fd_to_config_map: HashMap<u32, Arc<FsCacheDataBlobConfig>>,
+    fd_to_config_map: HashMap<u32, Arc<BlobCacheConfigDataBlob>>,
     blob_cache_mgr: Arc<BlobCacheMgr>,
 }
 
@@ -407,10 +407,10 @@ impl FsCacheHandler {
         let msg = match config {
             None => format!("cinit {},{}", hdr.id, -libc::ENOENT),
             Some(info) => match info {
-                FsCacheObjectConfig::DataBlob(config) => {
+                BlobCacheObjectConfig::DataBlob(config) => {
                     self.handle_open_data_blob(hdr, msg, config)
                 }
-                FsCacheObjectConfig::Bootstrap(config) => {
+                BlobCacheObjectConfig::Bootstrap(config) => {
                     self.handle_open_bootstrap(hdr, msg, config)
                 }
             },
@@ -422,7 +422,7 @@ impl FsCacheHandler {
         &self,
         hdr: &FsCacheMsgHeader,
         msg: &FsCacheMsgOpen,
-        config: Arc<FsCacheDataBlobConfig>,
+        config: Arc<BlobCacheConfigDataBlob>,
     ) -> String {
         match self.create_data_blob_object(&config, hdr.id, msg.fd) {
             Err(s) => s,
@@ -447,7 +447,7 @@ impl FsCacheHandler {
     /// way to share blob/chunkamp files with filecache manager.
     fn create_data_blob_object(
         &self,
-        config: &FsCacheDataBlobConfig,
+        config: &BlobCacheConfigDataBlob,
         id: u32,
         fd: u32,
     ) -> std::result::Result<(Arc<dyn BlobCache>, u64), String> {
@@ -476,7 +476,7 @@ impl FsCacheHandler {
         &self,
         hdr: &FsCacheMsgHeader,
         msg: &FsCacheMsgOpen,
-        config: Arc<FsCacheBootstrapConfig>,
+        config: Arc<BlobCacheConfigBootstrap>,
     ) -> String {
         let mut state = self.get_state();
         if state.fd_to_object_map.contains_key(&msg.fd) {
@@ -597,7 +597,7 @@ impl FsCacheHandler {
     }
 
     #[inline]
-    fn get_config(&self, key: &str) -> Option<FsCacheObjectConfig> {
+    fn get_config(&self, key: &str) -> Option<BlobCacheObjectConfig> {
         self.get_state().blob_cache_mgr.get_config(key)
     }
 }

--- a/src/bin/nydusd/fs_cache.rs
+++ b/src/bin/nydusd/fs_cache.rs
@@ -403,10 +403,9 @@ impl FsCacheHandler {
 
     fn handle_open_request(&self, hdr: &FsCacheMsgHeader, msg: &FsCacheMsgOpen) {
         let key = msg.volume_key.clone() + "-" + &msg.cookie_key;
-        let config = self.get_config(&key);
-        let msg = match config {
+        let msg = match self.get_config(&key) {
             None => format!("cinit {},{}", hdr.id, -libc::ENOENT),
-            Some(info) => match info {
+            Some(cfg) => match cfg {
                 BlobCacheObjectConfig::DataBlob(config) => {
                     self.handle_open_data_blob(hdr, msg, config)
                 }
@@ -485,12 +484,20 @@ impl FsCacheHandler {
 
         match OpenOptions::new().read(true).open(config.path()) {
             Err(e) => {
-                warn!("Failed to open bootstrap file {}, {}", config.path(), e);
+                warn!(
+                    "Failed to open bootstrap file {}, {}",
+                    config.path().display(),
+                    e
+                );
                 format!("copen {},{}", hdr.id, -libc::ENOENT)
             }
             Ok(f) => match f.metadata() {
                 Err(e) => {
-                    warn!("Failed to open bootstrap file {}, {}", config.path(), e);
+                    warn!(
+                        "Failed to open bootstrap file {}, {}",
+                        config.path().display(),
+                        e
+                    );
                     format!("copen {},{}", hdr.id, -libc::ENOENT)
                 }
                 Ok(md) => {

--- a/src/bin/nydusd/main.rs
+++ b/src/bin/nydusd/main.rs
@@ -316,9 +316,15 @@ fn append_services_subcmd_options(app: App<'static, 'static>) -> App<'static, 's
             Arg::with_name("fscache")
                 .long("fscache")
                 .short("F")
-                .help("Control device for fscache, which also enables fscache service")
+                .help("Working directory fscache driver to cache files")
+                .takes_value(true),
+        )
+        .arg(
+            Arg::with_name("fscache-tag")
+                .long("fscache-tag")
+                .help("Fscache tag to identify the fs daemon instance")
                 .takes_value(true)
-                .default_value("/dev/cachefiles"),
+                .requires("fscache"),
         );
 
     app.subcommand(subcmd)

--- a/src/bin/nydusd/main.rs
+++ b/src/bin/nydusd/main.rs
@@ -16,7 +16,8 @@ extern crate lazy_static;
 extern crate nix;
 #[macro_use]
 extern crate nydus_error;
-extern crate core;
+#[macro_use]
+extern crate serde;
 
 #[cfg(feature = "fusedev")]
 use std::convert::TryInto;

--- a/src/bin/nydusd/main.rs
+++ b/src/bin/nydusd/main.rs
@@ -16,8 +16,6 @@ extern crate lazy_static;
 extern crate nix;
 #[macro_use]
 extern crate nydus_error;
-#[macro_use]
-extern crate serde;
 
 #[cfg(feature = "fusedev")]
 use std::convert::TryInto;

--- a/src/bin/nydusd/main.rs
+++ b/src/bin/nydusd/main.rs
@@ -673,6 +673,7 @@ fn process_daemon_arguments(
     _apisock: Option<&str>,
     bti: BuildTimeInfo,
 ) -> Result<()> {
+    info!("Start Nydus in daemon mode!");
     let daemon = create_daemon(subargs, bti)?;
     DAEMON_CONTROLLER.set_daemon(daemon);
     Ok(())

--- a/src/bin/nydusd/service_controller.rs
+++ b/src/bin/nydusd/service_controller.rs
@@ -17,7 +17,7 @@ use crate::daemon::{
     DaemonError, DaemonResult, DaemonState, DaemonStateMachineContext, DaemonStateMachineInput,
     DaemonStateMachineSubscriber,
 };
-use crate::{FsService, NydusDaemon, SubCmdArgs};
+use crate::{DAEMON_CONTROLLER, FsService, NydusDaemon, SubCmdArgs};
 
 pub struct ServiceContoller {
     bti: BuildTimeInfo,
@@ -70,6 +70,8 @@ impl ServiceContoller {
     }
 
     fn initialize_blob_cache(&self, config: &Option<serde_json::Value>) -> Result<()> {
+        DAEMON_CONTROLLER.set_blob_cache_mgr(self.blob_cache_mgr.clone());
+
         // Create blob cache objects configured by the configuration file.
         if let Some(config) = config {
             if let Some(config1) = config.as_object() {

--- a/src/bin/nydusd/service_controller.rs
+++ b/src/bin/nydusd/service_controller.rs
@@ -9,9 +9,10 @@ use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
 use std::sync::mpsc::{channel, Receiver, Sender};
 use std::sync::{Arc, Mutex};
 
+use nydus_api::http::BlobCacheList;
 use nydus_app::BuildTimeInfo;
 
-use crate::blob_cache::{BlobCacheConfigList, BlobCacheMgr};
+use crate::blob_cache::BlobCacheMgr;
 use crate::daemon::{
     DaemonError, DaemonResult, DaemonState, DaemonStateMachineContext, DaemonStateMachineInput,
     DaemonStateMachineSubscriber,
@@ -73,7 +74,7 @@ impl ServiceContoller {
         if let Some(config) = config {
             if let Some(config1) = config.as_object() {
                 if config1.contains_key("blobs") {
-                    if let Ok(v) = serde_json::from_value::<BlobCacheConfigList>(config.clone()) {
+                    if let Ok(v) = serde_json::from_value::<BlobCacheList>(config.clone()) {
                         if let Err(e) = self.blob_cache_mgr.add_blob_list(&v) {
                             error!("Failed to add blob list: {}", e);
                             return Err(e);

--- a/storage/src/backend/localfs.rs
+++ b/storage/src/backend/localfs.rs
@@ -58,18 +58,21 @@ fn default_readahead_sec() -> u32 {
 }
 
 /// Configuration information for localfs storage backend.
+///
+/// This structure is externally visible through configuration file and HTTP API, please keep them
+/// stable.
 #[derive(Clone, Deserialize, Serialize)]
-struct LocalFsConfig {
+pub struct LocalFsConfig {
     #[serde(default)]
-    readahead: bool,
+    pub readahead: bool,
     #[serde(default = "default_readahead_sec")]
-    readahead_sec: u32,
+    pub readahead_sec: u32,
     #[serde(default)]
-    blob_file: String,
+    pub blob_file: String,
     #[serde(default)]
-    dir: String,
+    pub dir: String,
     #[serde(default)]
-    alt_dirs: Vec<String>,
+    pub alt_dirs: Vec<String>,
 }
 
 struct LocalFsEntry {

--- a/storage/src/backend/mod.rs
+++ b/storage/src/backend/mod.rs
@@ -30,6 +30,9 @@ pub mod oss;
 #[cfg(feature = "backend-registry")]
 pub mod registry;
 
+#[cfg(feature = "backend-localfs")]
+pub use localfs::LocalFsConfig;
+
 /// Error codes related to storage backend operations.
 #[derive(Debug)]
 pub enum BackendError {

--- a/storage/src/backend/mod.rs
+++ b/storage/src/backend/mod.rs
@@ -52,13 +52,20 @@ pub enum BackendError {
 pub type BackendResult<T> = std::result::Result<T, BackendError>;
 
 /// Configuration information for network proxy.
+///
+/// This structure is externally visible through configuration file and HTTP API, please keep them
+/// stable.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(default)]
 pub struct ProxyConfig {
-    url: String,
-    ping_url: String,
-    fallback: bool,
-    check_interval: u64,
+    /// URL for proxy server
+    pub url: String,
+    /// URL for keep alive.
+    pub ping_url: String,
+    /// Fallback to normal connection without proxy.
+    pub fallback: bool,
+    /// Time interval to check for keepalive.
+    pub check_interval: u64,
 }
 
 impl Default for ProxyConfig {
@@ -73,13 +80,20 @@ impl Default for ProxyConfig {
 }
 
 /// Generic configuration for storage backends.
+///
+/// This structure is externally visible through configuration file and HTTP API, please keep them
+/// stable.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(default)]
 pub struct CommonConfig {
-    proxy: ProxyConfig,
-    timeout: u64,
-    connect_timeout: u64,
-    retry_limit: u8,
+    /// Configuration information for network proxy.
+    pub proxy: ProxyConfig,
+    /// Timeout value for data communication.
+    pub timeout: u64,
+    /// Timeout value for connection setup.
+    pub connect_timeout: u64,
+    /// Number of times to retry connection.
+    pub retry_limit: u8,
 }
 
 impl Default for CommonConfig {

--- a/storage/src/cache/filecache/mod.rs
+++ b/storage/src/cache/filecache/mod.rs
@@ -25,12 +25,18 @@ fn default_work_dir() -> String {
     ".".to_string()
 }
 
+/// Configuration information for file cache.
+///
+/// This structure is externally visible through configuration file and HTTP API, please keep them
+/// stable.
 #[derive(Clone, Debug, Deserialize, Serialize)]
-struct FileCacheConfig {
+pub struct FileCacheConfig {
+    /// Working directory to keep cached files.
     #[serde(default = "default_work_dir")]
-    work_dir: String,
+    pub work_dir: String,
+    /// Legacy: disable index mapping, keep it as false when possible.
     #[serde(default)]
-    disable_indexed_map: bool,
+    pub disable_indexed_map: bool,
 }
 
 impl FileCacheConfig {

--- a/storage/src/cache/fscache/mod.rs
+++ b/storage/src/cache/fscache/mod.rs
@@ -24,10 +24,15 @@ fn default_work_dir() -> String {
     ".".to_string()
 }
 
+/// Configuration information for fscache.
+///
+/// This structure is externally visible through configuration file and HTTP API, please keep them
+/// stable.
 #[derive(Clone, Debug, Deserialize, Serialize)]
-struct FsCacheConfig {
+pub struct FsCacheConfig {
+    /// Working directory to keep cached files.
     #[serde(default = "default_work_dir")]
-    work_dir: String,
+    pub work_dir: String,
 }
 
 impl FsCacheConfig {

--- a/storage/src/cache/mod.rs
+++ b/storage/src/cache/mod.rs
@@ -43,8 +43,8 @@ mod worker;
 pub mod state;
 
 pub use dummycache::DummyCacheMgr;
-pub use filecache::FileCacheMgr;
-pub use fscache::FsCacheMgr;
+pub use filecache::{FileCacheConfig, FileCacheMgr};
+pub use fscache::{FsCacheConfig, FsCacheMgr};
 
 /// Timeout in milli-seconds to retrieve blob data from backend storage.
 pub const SINGLE_INFLIGHT_WAIT_TIMEOUT: u64 = 2000;

--- a/storage/src/cache/mod.rs
+++ b/storage/src/cache/mod.rs
@@ -117,7 +117,7 @@ impl<'a, F: FnMut(BlobIoRange)> BlobIoMergeState<'a, F> {
 }
 
 /// Configuration information for blob data prefetching.
-#[derive(Clone, Default, Eq, Hash, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, Hash, PartialEq)]
 pub struct BlobPrefetchConfig {
     /// Whether to enable blob data prefetching.
     pub enable: bool,

--- a/storage/src/factory.rs
+++ b/storage/src/factory.rs
@@ -49,6 +49,9 @@ lazy_static! {
 }
 
 /// Configuration information for storage backend.
+///
+/// This structure is externally visible through configuration file and HTTP API, please keep them
+/// stable.
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct BackendConfig {
     /// Type of storage backend.
@@ -86,6 +89,9 @@ impl BackendConfig {
 }
 
 /// Configuration information for blob cache manager.
+///
+/// This structure is externally visible through configuration file and HTTP API, please keep them
+/// stable.
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct CacheConfig {
     /// Type of blob cache.
@@ -106,6 +112,9 @@ pub struct CacheConfig {
 }
 
 /// Configuration information to create blob cache manager.
+///
+/// This structure is externally visible through configuration file and HTTP API, please keep them
+/// stable.
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct FactoryConfig {
     /// Id of the factory.

--- a/storage/src/factory.rs
+++ b/storage/src/factory.rs
@@ -86,7 +86,7 @@ impl BackendConfig {
 }
 
 /// Configuration information for blob cache manager.
-#[derive(Clone, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct CacheConfig {
     /// Type of blob cache.
     #[serde(default, rename = "type")]
@@ -106,7 +106,7 @@ pub struct CacheConfig {
 }
 
 /// Configuration information to create blob cache manager.
-#[derive(Clone, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct FactoryConfig {
     /// Id of the factory.
     #[serde(default)]
@@ -126,6 +126,7 @@ struct BlobCacheMgrKey {
 #[allow(clippy::derive_hash_xor_eq)]
 impl Hash for BlobCacheMgrKey {
     fn hash<H: Hasher>(&self, state: &mut H) {
+        self.config.id.hash(state);
         self.config.backend.backend_type.hash(state);
         self.config.cache.cache_type.hash(state);
         self.config.cache.prefetch_config.hash(state);


### PR DESCRIPTION
The PR enhance the nydusd main to load cached blob object configuration information from configuration file, so those
blob objects may be used to support fscache.