### PR TITLE
api: add path for metadata blob

### DIFF
--- a/api/src/http.rs
+++ b/api/src/http.rs
@@ -70,6 +70,9 @@ pub struct BlobCacheEntryConfig {
     /// One of `FileCacheConfig`, `FsCacheConfig`, or empty.
     #[serde(default)]
     pub cache_config: Value,
+    /// Optional file path for metadata blobs.
+    #[serde(default)]
+    pub metadata_path: Option<String>,
 }
 
 /// Blob cache object type for nydus/rafs bootstrap blob.

--- a/docs/samples/boostrap_blob_cache_entry.json
+++ b/docs/samples/boostrap_blob_cache_entry.json
@@ -6,12 +6,12 @@
     "id": "factory1",
     "backend_type": "localfs",
     "backend_config": {
-      "blob_file": "bootstrap1",
       "dir": "/tmp/nydus"
     },
     "cache_type": "fscache",
     "cache_config": {
       "work_dir": "/tmp/nydus"
-    }
+    },
+    "metadata_file": "/tmp/nydus/bootstrap1"
   }
 }

--- a/src/bin/nydusd/api_server_glue.rs
+++ b/src/bin/nydusd/api_server_glue.rs
@@ -299,7 +299,10 @@ impl ApiServer {
             None => Err(ApiError::DaemonAbnormal(DaemonErrorKind::Unsupported)),
             Some(mgr) => {
                 if let Err(e) = mgr.add_blob_entry(entry) {
-                    Err(ApiError::DaemonAbnormal(DaemonErrorKind::Other(format!("{}", e))))
+                    Err(ApiError::DaemonAbnormal(DaemonErrorKind::Other(format!(
+                        "{}",
+                        e
+                    ))))
                 } else {
                     Ok(ApiResponsePayload::Empty)
                 }

--- a/src/bin/nydusd/service_controller.rs
+++ b/src/bin/nydusd/service_controller.rs
@@ -17,7 +17,7 @@ use crate::daemon::{
     DaemonError, DaemonResult, DaemonState, DaemonStateMachineContext, DaemonStateMachineInput,
     DaemonStateMachineSubscriber,
 };
-use crate::{DAEMON_CONTROLLER, FsService, NydusDaemon, SubCmdArgs};
+use crate::{FsService, NydusDaemon, SubCmdArgs, DAEMON_CONTROLLER};
 
 pub struct ServiceContoller {
     bti: BuildTimeInfo,

--- a/storage/src/backend/mod.rs
+++ b/storage/src/backend/mod.rs
@@ -25,13 +25,16 @@ use crate::StorageError;
 pub mod connection;
 #[cfg(feature = "backend-localfs")]
 pub mod localfs;
-#[cfg(feature = "backend-oss")]
-pub mod oss;
-#[cfg(feature = "backend-registry")]
-pub mod registry;
-
 #[cfg(feature = "backend-localfs")]
 pub use localfs::LocalFsConfig;
+#[cfg(feature = "backend-oss")]
+pub mod oss;
+#[cfg(feature = "backend-oss")]
+pub use oss::OssConfig;
+#[cfg(feature = "backend-registry")]
+pub mod registry;
+#[cfg(feature = "backend-registry")]
+pub use registry::RegistryConfig;
 
 /// Error codes related to storage backend operations.
 #[derive(Debug)]

--- a/storage/src/backend/oss.rs
+++ b/storage/src/backend/oss.rs
@@ -41,20 +41,24 @@ impl From<OssError> for BackendError {
     }
 }
 
+/// OSS configuration information to access blobs.
+///
+/// This structure is externally visible through configuration file and HTTP API, please keep them
+/// stable.
 #[derive(Clone, Deserialize, Serialize)]
-struct OssConfig {
-    endpoint: String,
-    access_key_id: String,
-    access_key_secret: String,
-    bucket_name: String,
+pub struct OssConfig {
+    pub endpoint: String,
+    pub access_key_id: String,
+    pub access_key_secret: String,
+    pub bucket_name: String,
     #[serde(default = "default_http_scheme")]
-    scheme: String,
+    pub scheme: String,
     /// Prefix object_prefix to OSS object key, for example the simulation of subdirectory:
     /// - object_key: sha256:xxx
     /// - object_prefix: nydus/
     /// - object_key with object_prefix: nydus/sha256:xxx
     #[serde(default)]
-    object_prefix: String,
+    pub object_prefix: String,
 }
 
 // `OssState` is almost identical to `OssConfig`, but let's keep them separated.

--- a/storage/src/backend/registry.rs
+++ b/storage/src/backend/registry.rs
@@ -94,24 +94,28 @@ impl HashCache {
     }
 }
 
+/// Container registry configuration information to access blobs.
+///
+/// This structure is externally visible through configuration file and HTTP API, please keep them
+/// stable.
 #[derive(Clone, Deserialize, Serialize)]
-struct RegistryConfig {
+pub struct RegistryConfig {
     #[serde(default = "default_http_scheme")]
-    scheme: String,
-    host: String,
-    repo: String,
+    pub scheme: String,
+    pub host: String,
+    pub repo: String,
     // Base64_encoded(username:password), the field should be
     // sent to registry auth server to get a bearer token.
     #[serde(default)]
-    auth: Option<String>,
+    pub auth: Option<String>,
     // The field is a bearer token to be sent to registry
     // to authorize registry requests.
     #[serde(default)]
-    registry_token: Option<String>,
+    pub registry_token: Option<String>,
     #[serde(default)]
-    blob_url_scheme: String,
+    pub blob_url_scheme: String,
     #[serde(default)]
-    blob_redirected_host: String,
+    pub blob_redirected_host: String,
 }
 
 #[derive(Clone, Deserialize)]


### PR DESCRIPTION
The blob manager needs a path to manage metadata blobs, so add one.

Signed-off-by: Liu Jiang <gerry@linux.alibaba.com>