### PR TITLE
nydusd: handle api server mio poll error

### DIFF
--- a/api/src/http.rs
+++ b/api/src/http.rs
@@ -425,7 +425,10 @@ pub fn start_http_thread(
             'wait: loop {
                 match pool.poll(&mut events, None) {
                     Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
-                    Err(e) => return Err(e),
+                    Err(e) => {
+                        error!("http server poll events failed, {}", e);
+                        return Err(e);
+                    }
                     Ok(_) => {}
                 }
 


### PR DESCRIPTION
We should exit the api server thread when poll fails on non EINTR errors.
Otherwise we may enter a busy loop.
