### PR TITLE
Builder: make repeatable for root directory

### DIFF
--- a/rafs/src/fs.rs
+++ b/rafs/src/fs.rs
@@ -411,8 +411,8 @@ impl Rafs {
             attr.gid = self.i_gid;
         }
 
-        // Older rafs image doesn't include mtime, in such case we use
-        // runtime timestamp.
+        // Older rafs image or the root inode doesn't include mtime, in such cases
+        // we use runtime timestamp.
         if attr.mtime == 0 {
             attr.atime = self.i_time;
             attr.ctime = self.i_time;


### PR DESCRIPTION
Usually the root directory is created by the build tool (nydusify/buildkit/acceld)
and the mtime of the root directory is different for each build, which makes it
completely impossible to achieve repeatable builds, especially in a tar build scenario
(blob + bootstrap in one tar layer), which causes the layer hash to change and wastes
registry storage space, so the mtime of the root directory is forced to be ignored.

Signed-off-by: Yan Song <imeoer@linux.alibaba.com>