### PR TITLE
storage: support direct IO for fscache

### DIFF
--- a/storage/src/cache/cachedfile.rs
+++ b/storage/src/cache/cachedfile.rs
@@ -60,6 +60,8 @@ pub(crate) struct FileCacheEntry {
     pub(crate) is_direct_chunkmap: bool,
     // The blob is for an stargz image.
     pub(crate) is_stargz: bool,
+    // True if direct IO is enabled for the `self.file`, supported for fscache only.
+    pub(crate) dio_enabled: bool,
     // Data from the file cache should be validated before use.
     pub(crate) need_validate: bool,
     pub(crate) prefetch_config: Arc<AsyncPrefetchConfig>,
@@ -375,7 +377,7 @@ impl FileCacheEntry {
             let blob_size = (blob_end - blob_offset) as usize;
 
             match self.read_chunks(blob_offset, blob_size, &chunks[start_idx..=end_idx]) {
-                Ok(v) => {
+                Ok(mut v) => {
                     total_size += blob_size;
                     trace!(
                         "range persist chunk start {} {} pending {} {}",
@@ -390,10 +392,14 @@ impl FileCacheEntry {
                         } else {
                             chunks[idx].uncompress_offset()
                         };
+                        let buf = &mut v[idx - start_idx];
+                        if self.dio_enabled {
+                            self.adjust_buffer_for_dio(buf)
+                        }
                         trace!("persist_chunk idx {}", idx);
-                        Self::persist_chunk(&self.file, offset, &v[idx - start_idx]).map_err(
-                            |e| eio!(format!("do_fetch_chunk failed to persist {:?}", e)),
-                        )?;
+                        Self::persist_chunk(&self.file, offset, &buf).map_err(|e| {
+                            eio!(format!("do_fetch_chunk failed to persist {:?}", e))
+                        })?;
                     }
 
                     bitmap
@@ -412,6 +418,14 @@ impl FileCacheEntry {
             Err(eio!("failed to read data from storage backend"))
         } else {
             Ok(total_size)
+        }
+    }
+
+    fn adjust_buffer_for_dio(&self, buf: &mut Vec<u8>) {
+        debug_assert!(buf.capacity() % 0x1000 == 0);
+        if buf.len() != buf.capacity() {
+            // Padding with 0 for direct IO.
+            buf.resize(buf.capacity(), 0);
         }
     }
 }

--- a/storage/src/cache/filecache/mod.rs
+++ b/storage/src/cache/filecache/mod.rs
@@ -261,6 +261,7 @@ impl FileCacheEntry {
             is_compressed,
             is_direct_chunkmap,
             is_stargz,
+            dio_enabled: false,
             need_validate,
             prefetch_config,
         })

--- a/storage/src/cache/fscache/mod.rs
+++ b/storage/src/cache/fscache/mod.rs
@@ -237,6 +237,7 @@ impl FileCacheEntry {
             is_compressed: false,
             is_direct_chunkmap: true,
             is_stargz: false,
+            dio_enabled: true,
             need_validate: mgr.validate,
             prefetch_config,
         })

--- a/storage/src/utils.rs
+++ b/storage/src/utils.rs
@@ -224,9 +224,11 @@ pub fn readahead(fd: libc::c_int, mut offset: u64, end: u64) {
 /// A customized buf allocator that avoids zeroing
 pub fn alloc_buf(size: usize) -> Vec<u8> {
     debug_assert!(size < isize::MAX as usize);
-    let layout = Layout::from_size_align(size, 0x1000).unwrap();
+    let layout = Layout::from_size_align(size, 0x1000)
+        .unwrap()
+        .pad_to_align();
     let ptr = unsafe { alloc(layout) };
-    unsafe { Vec::from_raw_parts(ptr, size, size) }
+    unsafe { Vec::from_raw_parts(ptr, size, layout.size()) }
 }
 
 /// Check hash of data matches provided one


### PR DESCRIPTION
Enhance cachefiles to support direct IO for fscahce, but direct IO is
not supported for filecache yet. We may enhance it to support filecache
on demand.

Signed-off-by: Liu Jiang <gerry@linux.alibaba.com>