### PR TITLE
Finalize single worker fscache support

### DIFF
--- a/contrib/docker-nydus-graphdriver/Dockerfile
+++ b/contrib/docker-nydus-graphdriver/Dockerfile
@@ -7,7 +7,7 @@ RUN CGO_ENABLED=0 GOOS=linux go build -v .
 
 FROM alpine:3.13.6
 RUN mkdir -p /plugin; mkdir -p /nydus
-ARG NYDUSD_PATH=./nydusd
+#ARG NYDUSD_PATH=./nydusd
 COPY --from=0 /app/nydus_graphdriver /plugin/nydus_graphdriver
-COPY ${NYDUSD_PATH} /nydus
+#COPY ${NYDUSD_PATH} /nydus
 ENTRYPOINT [ "/plugin/nydus_graphdriver" ]

--- a/contrib/docker-nydus-graphdriver/config.json
+++ b/contrib/docker-nydus-graphdriver/config.json
@@ -24,20 +24,5 @@
       }
     ]
   },
-  "PropagatedMount": "/home",
-  "Mounts": [
-    {
-      "Name": "NYDUS_CONFIG",
-      "Source": "/var/lib/nydus/config.json",
-      "Destination": "/nydus/config.json",
-      "Type": "none",
-      "Options": [
-        "bind",
-        "ro"
-      ],
-      "Settable": [
-        "source"
-      ]
-    }
-  ]
+  "PropagatedMount": "/home"
 }

--- a/contrib/docker-nydus-graphdriver/plugin/nydus/glue.go
+++ b/contrib/docker-nydus-graphdriver/plugin/nydus/glue.go
@@ -13,10 +13,12 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	"golang.org/x/sys/unix"
 )
 
 const (
@@ -86,6 +88,17 @@ func getDaemonStatus(socket string) error {
 		return errors.Errorf("nydus is not ready. current stat %s", info.State)
 	}
 
+	return nil
+}
+
+func (nydus *Nydus) MountErofs(fsid string, devices []string, mountpoint string) error {
+	mount := unix.Mount
+
+	opts := "fsid=" + fsid + ",device=" + strings.Join(devices, ",device=")
+	logrus.Infof("Mount erofs with %s", opts)
+	if e := mount("erofs", mountpoint, "erofs", 0, opts); e != nil {
+		return errors.Wrapf(e, "failed to mount erofs")
+	}
 	return nil
 }
 

--- a/contrib/docker-nydus-graphdriver/plugin/nydus/nydus.go
+++ b/contrib/docker-nydus-graphdriver/plugin/nydus/nydus.go
@@ -258,8 +258,10 @@ func (d *Driver) Get(id, mountLabel string) (fs containerfs.ContainerFS, retErr 
 		return
 	}
 
+	newlowers := make([]string, 0)
 	for _, l := range lowers {
 		if l == id {
+			newlowers = append(newlowers, id)
 			break
 		}
 
@@ -297,11 +299,11 @@ func (d *Driver) Get(id, mountLabel string) (fs containerfs.ContainerFS, retErr 
 		// Relative path
 		nydusRelaMountpoint := path.Join(l, nydusDirName)
 		if _, err := os.Stat(path.Join(d.home, nydusRelaMountpoint)); err == nil {
-			lowers = append(lowers, nydusRelaMountpoint)
+			newlowers = append(newlowers, nydusRelaMountpoint)
 		} else {
 			diffDir := path.Join(l, "diff")
 			if _, err := os.Stat(diffDir); err == nil {
-				lowers = append(lowers, diffDir)
+				newlowers = append(newlowers, diffDir)
 			}
 		}
 	}
@@ -330,7 +332,7 @@ func (d *Driver) Get(id, mountLabel string) (fs containerfs.ContainerFS, retErr 
 
 	upperDir := path.Join(id, diffDirName)
 	workDir := path.Join(id, workDirName)
-	opts := "lowerdir=" + strings.Join(lowers, ":") + ",upperdir=" + upperDir + ",workdir=" + workDir
+	opts := "lowerdir=" + strings.Join(newlowers, ":") + ",upperdir=" + upperDir + ",workdir=" + workDir
 
 	mountData := label.FormatMountLabel(opts, mountLabel)
 	mount := unix.Mount

--- a/src/bin/nydusd/blob_cache.rs
+++ b/src/bin/nydusd/blob_cache.rs
@@ -179,6 +179,7 @@ impl BlobCacheMgr {
                 .insert(config.get_key().to_string(), config);
             // Try to add the referenced data blob object if it doesn't exist yet.
             for bi in rs.superblock.get_blob_infos() {
+                debug!("Found blob {} on domain {}", &bi.blob_id(), domain_id);
                 let data_blob = BlobCacheObjectConfig::new_data_blob(
                     domain_id.to_string(),
                     bi,


### PR DESCRIPTION
Step I. prepare a json file:
{
  "type": "bootstrap",
  "id": "aa229b3a8eeeacf0bfbb17a6415fa6a817583d99c4b590fc6b56a50f49e8957c",
  "domain_id": "aa229b3a8eeeacf0bfbb17a6415fa6a817583d99c4b590fc6b56a50f49e8957c",
  "config": {
    "id": "factory1",
    "backend_type": "registry",
    "backend_config": {
      "scheme": "https",
      "host": "index.docker.io",
      "repo": "hsiangkao/ubuntu"
    },
    "cache_type": "fscache",
    "cache_config": {
      "work_dir": "/var/lib/containerd-nydus-grpc/cachedir"
    },
    "metadata_path": "/root/ubuntu-20.04.image.boot"
  }
}

Step II.
docker poll docker.io/hsiangkao/ubuntu:20.04-rafs-v6-docker
and copy image.boot as /root/ubuntu-20.04.img.boot

Step III.
cargo build --target x86_64-unknown-linux-gnu --features=fusedev --release --target-dir target-fusedev --bin nydusd
mkdir /root/fscache
target-fusedev/x86_64-unknown-linux-gnu/release/nydusd daemon -F /root/fscache -A /tmp/nydus.sock

Step IV.
curl --http1.1 --unix-socket /tmp/nydus.sock -XPUT -d "@[json file]" http://localhost/api/v2/blobs
mount -t erofs -ofsid=aa229b3a8eeeacf0bfbb17a6415fa6a817583d99c4b590fc6b56a50f49e8957c,device=aae220288dc01b26a0d69ef553a32d274b258aff545d798e04f91045e00b3666 nodev mnt

Signed-off-by: Gao Xiang \<hsiangkao@linux.alibaba.com\>