### PR TITLE
Backend: support skip_verify option

### DIFF
--- a/docs/containerd-env-setup.md
+++ b/docs/containerd-env-setup.md
@@ -30,6 +30,7 @@ $ sudo cat > /etc/nydusd-config.json << EOF
       "type": "registry",
       "config": {
         "scheme": "http",
+        "skip_verify": false,
         "timeout": 5,
         "connect_timeout": 5,
         "retry_limit": 2,

--- a/docs/nydusd.md
+++ b/docs/nydusd.md
@@ -179,8 +179,13 @@ We are working on enabling cloud-hypervisor support for nydus.
       "type": "registry",
       "config": {
         ...
+        // Registry url scheme, https or http
         "scheme": "http",
+        // Registry hostname with format `$host:$port`
         "host": "my-registry:5000",
+        // Skip SSL certificate validation for HTTPS scheme
+        "skip_verify": false,
+        // Use format `$namespace/$repo` (no image tag)
         "repo": "test/repo",
         // Username and password for auth
         // base64(username:password), optional

--- a/storage/src/backend/connection.rs
+++ b/storage/src/backend/connection.rs
@@ -277,6 +277,10 @@ impl Connection {
             .connect_timeout(connect_timeout)
             .redirect(Policy::none());
 
+        if config.skip_verify {
+            cb = cb.danger_accept_invalid_certs(true);
+        }
+
         if !proxy.is_empty() {
             cb = cb.proxy(reqwest::Proxy::all(proxy).map_err(|e| einval!(e))?)
         }

--- a/storage/src/backend/mod.rs
+++ b/storage/src/backend/mod.rs
@@ -55,9 +55,13 @@ pub type BackendResult<T> = std::result::Result<T, BackendError>;
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(default)]
 pub struct ProxyConfig {
+    /// Access remote storage backend via P2P proxy, e.g. Dragonfly dfdaemon server URL.
     url: String,
+    /// Endpoint of P2P proxy health checking.
     ping_url: String,
+    /// Fallback to remote storage backend if P2P proxy ping failed.
     fallback: bool,
+    /// Interval of P2P proxy health checking, in seconds.
     check_interval: u64,
 }
 
@@ -76,9 +80,15 @@ impl Default for ProxyConfig {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(default)]
 pub struct CommonConfig {
+    /// Enable HTTP proxy for the read request.
     proxy: ProxyConfig,
+    /// Skip SSL certificate validation for HTTPS scheme.
+    skip_verify: bool,
+    /// Drop the read request once http request timeout, in seconds.
     timeout: u64,
+    /// Drop the read request once http connection timeout, in seconds.
     connect_timeout: u64,
+    /// Retry count when read request failed.
     retry_limit: u8,
 }
 
@@ -86,6 +96,7 @@ impl Default for CommonConfig {
     fn default() -> Self {
         Self {
             proxy: ProxyConfig::default(),
+            skip_verify: false,
             timeout: 5,
             connect_timeout: 5,
             retry_limit: 0,


### PR DESCRIPTION
Add `skip_verify: true` option to enable skipping SSL certificate validation
for HTTPS scheme, and add some comments for other options.

Signed-off-by: Yan Song <imeoer@linux.alibaba.com>