### PR TITLE
nydusd: graceful state machine thread shutdown

### DIFF
--- a/api/src/http.rs
+++ b/api/src/http.rs
@@ -429,6 +429,7 @@ pub fn start_http_thread(
                     Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
                     Err(e) => {
                         error!("http server poll events failed, {}", e);
+                        exit_api_server(api_notifier, &to_api);
                         return Err(e);
                     }
                     Ok(_) => {}

--- a/src/bin/nydusd/api_server_glue.rs
+++ b/src/bin/nydusd/api_server_glue.rs
@@ -10,9 +10,6 @@ use std::sync::mpsc::{Receiver, Sender};
 use std::sync::Arc;
 use std::thread::JoinHandle;
 
-use nix::sys::signal::{kill, SIGTERM};
-use nix::unistd::Pid;
-
 use nydus::{FsBackendType, NydusError};
 use nydus_api::http::{
     ApiError, ApiMountCmd, ApiRequest, ApiResponse, ApiResponsePayload, ApiResult, DaemonConf,
@@ -232,9 +229,6 @@ impl ApiServer {
                 error!("wait for fuse service failed {:}", e);
                 ApiError::DaemonAbnormal(e.into())
             })?;
-
-        // Should be reliable since this Api server works under event manager.
-        kill(Pid::this(), SIGTERM).unwrap_or_else(|e| error!("Send signal error. {}", e));
 
         Ok(ApiResponsePayload::Empty)
     }

--- a/src/bin/nydusd/main.rs
+++ b/src/bin/nydusd/main.rs
@@ -62,8 +62,8 @@ pub fn exit_daemon() {
     let daemon = FUSE_DAEMON.lock().expect("Not posioned lock");
     if let Some(daemon) = daemon.deref() {
         daemon
-            .disconnect()
-            .unwrap_or_else(|e| error!("disconnect daemon failed, {}", e));
+            .stop()
+            .unwrap_or_else(|e| error!("exit daemon failed, {}", e));
     }
 }
 


### PR DESCRIPTION
When exiting, make sure we wait for the state machine thread to quit.

A few changes were applied:
1. exit_daemon() should call daemon.stop() so that it can result in
    different daemon action depending on the current state. Then in a normal
    workflow, nydusd would just umount and quit. But when in Interrupted,
    nydusd just dies directly without doing any umount etc.
2. Quit the state machine thread upon EXIT (TerminateFuseService) event.
3. Wait for the state machine thread together when waiting for the fuse
    service threads.
4. Nydusd should just die when getting EXIT message in INIT state.
5. Only send Stop event if state is not INTERRUPTED or STOPPED.
    Otherwise there is no state machine thread to handle it.
6. Init and Interrupted should always be able to stop as well.
