### PR TITLE
nydusd: fix a race window when shutdown http server

### DIFF
--- a/api/src/http.rs
+++ b/api/src/http.rs
@@ -511,6 +511,7 @@ pub fn start_http_thread(
     let mut pool = Poll::new()?;
     let waker = Waker::new(pool.registry(), EXIT_TOKEN)?;
     let waker = Arc::new(waker);
+    let waker2 = waker.clone();
     let mut server = HttpServer::new(socket_path).map_err(|e| {
         if let ServerError::IOError(e) = e {
             e
@@ -575,6 +576,8 @@ pub fn start_http_thread(
             }
 
             info!("http-server thread exits");
+            // Keep the waker alive until the poll loop exits.
+            drop(waker2);
             Ok(())
         })?;
 

--- a/src/bin/nydusd/api_server_glue.rs
+++ b/src/bin/nydusd/api_server_glue.rs
@@ -402,22 +402,24 @@ impl ApiServerController {
     pub fn stop(&mut self) {
         // Signal the HTTP router thread to exit, which will then notify the HTTP handler thread.
         if let Some(waker) = self.waker.take() {
-            let _ = waker.wake();
-        }
-        if let Some(t) = self.http_handler_thread.take() {
-            if let Err(e) = t.join() {
-                error!(
-                    "Failed to join the HTTP handler thread, execution error. {:?}",
-                    e
-                );
+            if let Err(e) = waker.wake() {
+                error!("Failed to signal http router thread for exiting, {}", e);
             }
-        }
-        if let Some(t) = self.http_router_thread.take() {
-            if let Err(e) = t.join() {
-                error!(
-                    "Failed to join the HTTP router thread, execution error. {:?}",
-                    e
-                );
+            if let Some(t) = self.http_router_thread.take() {
+                if let Err(e) = t.join() {
+                    error!(
+                        "Failed to join the HTTP router thread, execution error. {:?}",
+                        e
+                    );
+                }
+            }
+            if let Some(t) = self.http_handler_thread.take() {
+                if let Err(e) = t.join() {
+                    error!(
+                        "Failed to join the HTTP handler thread, execution error. {:?}",
+                        e
+                    );
+                }
             }
         }
     }

--- a/src/bin/nydusd/main.rs
+++ b/src/bin/nydusd/main.rs
@@ -179,7 +179,7 @@ impl DaemonController {
                 }
 
                 if event.is_readable() && event.token() == Token(1) {
-                    if self.active.load(Ordering::Acquire) {
+                    if !self.active.load(Ordering::Acquire) {
                         return;
                     } else if self.singleton_mode.load(Ordering::Acquire) {
                         self.active.store(false, Ordering::Relaxed);


### PR DESCRIPTION
The mio waker must be alive to get the notification delivered,
otherwise the inflight notification may get dropped silently.

Also fix a bug in the way to detect daemon working state.

Signed-off-by: Liu Jiang <gerry@linux.alibaba.com>