### PR TITLE
storage: fscache: hide useless chunk map

### DIFF
--- a/storage/src/cache/fscache/mod.rs
+++ b/storage/src/cache/fscache/mod.rs
@@ -201,7 +201,7 @@ impl FileCacheEntry {
 
         let blob_file_path = format!("{}/{}", mgr.work_dir, blob_info.blob_id());
         let chunk_map = Arc::new(BlobStateMap::from(IndexedChunkMap::new(
-            &blob_file_path,
+            "",
             blob_info.chunk_count(),
         )?));
         let reader = mgr

--- a/storage/src/cache/state/indexed_chunk_map.rs
+++ b/storage/src/cache/state/indexed_chunk_map.rs
@@ -35,7 +35,11 @@ pub struct IndexedChunkMap {
 impl IndexedChunkMap {
     /// Create a new instance of `IndexedChunkMap`.
     pub fn new(blob_path: &str, chunk_count: u32) -> Result<Self> {
-        let filename = format!("{}.{}", blob_path, FILE_SUFFIX);
+        let filename = if !blob_path.is_empty() {
+            format!("{}.{}", blob_path, FILE_SUFFIX)
+        } else {
+            "".to_string()
+        };
 
         PersistMap::open(&filename, chunk_count, true).map(|map| IndexedChunkMap { map })
     }


### PR DESCRIPTION
At least, fscache doesn't have any real requirement on chunk map.
Let's drop it directly instead.

Signed-off-by: Gao Xiang \<hsiangkao@linux.alibaba.com\>