### PR TITLE
stroage: avoid stale chunkmap state for fscache

### DIFF
--- a/storage/src/cache/filecache/mod.rs
+++ b/storage/src/cache/filecache/mod.rs
@@ -286,6 +286,7 @@ impl FileCacheEntry {
             Arc::new(BlobStateMap::from(IndexedChunkMap::new(
                 blob_file,
                 blob_info.chunk_count(),
+                true,
             )?))
         };
 

--- a/storage/src/cache/fscache/mod.rs
+++ b/storage/src/cache/fscache/mod.rs
@@ -203,6 +203,7 @@ impl FileCacheEntry {
         let chunk_map = Arc::new(BlobStateMap::from(IndexedChunkMap::new(
             &blob_file_path,
             blob_info.chunk_count(),
+            false,
         )?));
         let reader = mgr
             .backend

--- a/storage/src/cache/state/blob_state_map.rs
+++ b/storage/src/cache/state/blob_state_map.rs
@@ -456,13 +456,13 @@ pub(crate) mod tests {
         let skip_index = 77;
 
         let indexed_chunk_map1 = Arc::new(BlobStateMap::from(
-            IndexedChunkMap::new(&blob_path, chunk_count).unwrap(),
+            IndexedChunkMap::new(&blob_path, chunk_count, true).unwrap(),
         ));
         let indexed_chunk_map2 = Arc::new(BlobStateMap::from(
-            IndexedChunkMap::new(&blob_path, chunk_count).unwrap(),
+            IndexedChunkMap::new(&blob_path, chunk_count, true).unwrap(),
         ));
         let indexed_chunk_map3 = Arc::new(BlobStateMap::from(
-            IndexedChunkMap::new(&blob_path, chunk_count).unwrap(),
+            IndexedChunkMap::new(&blob_path, chunk_count, true).unwrap(),
         ));
 
         let now = Instant::now();
@@ -552,7 +552,7 @@ pub(crate) mod tests {
         }
 
         let indexed_chunk_map =
-            BlobStateMap::from(IndexedChunkMap::new(&blob_path, chunk_count).unwrap());
+            BlobStateMap::from(IndexedChunkMap::new(&blob_path, chunk_count, true).unwrap());
         let now = Instant::now();
         iterate(&chunks, &indexed_chunk_map as &dyn ChunkMap, chunk_count);
         let elapsed1 = now.elapsed().as_millis();
@@ -585,7 +585,7 @@ pub(crate) mod tests {
         // indexed ChunkMap
         let tmp_file = TempFile::new().unwrap();
         let index_map = Arc::new(BlobStateMap::from(
-            IndexedChunkMap::new(tmp_file.as_path().to_str().unwrap(), 10).unwrap(),
+            IndexedChunkMap::new(tmp_file.as_path().to_str().unwrap(), 10, true).unwrap(),
         ));
         index_map
             .check_ready_and_mark_pending(chunk_1.as_ref())
@@ -676,7 +676,7 @@ pub(crate) mod tests {
     fn test_inflight_tracer_race() {
         let tmp_file = TempFile::new().unwrap();
         let map = Arc::new(BlobStateMap::from(
-            IndexedChunkMap::new(tmp_file.as_path().to_str().unwrap(), 10).unwrap(),
+            IndexedChunkMap::new(tmp_file.as_path().to_str().unwrap(), 10, true).unwrap(),
         ));
 
         let chunk_4: Arc<dyn BlobChunkInfo> = Arc::new({
@@ -744,7 +744,7 @@ pub(crate) mod tests {
     fn test_inflight_tracer_timeout() {
         let tmp_file = TempFile::new().unwrap();
         let map = Arc::new(BlobStateMap::from(
-            IndexedChunkMap::new(tmp_file.as_path().to_str().unwrap(), 10).unwrap(),
+            IndexedChunkMap::new(tmp_file.as_path().to_str().unwrap(), 10, true).unwrap(),
         ));
 
         let chunk_4: Arc<dyn BlobChunkInfo> = Arc::new({
@@ -788,7 +788,7 @@ pub(crate) mod tests {
     fn test_inflight_tracer_race_range() {
         let tmp_file = TempFile::new().unwrap();
         let map = Arc::new(BlobStateMap::from(
-            IndexedChunkMap::new(tmp_file.as_path().to_str().unwrap(), 10).unwrap(),
+            IndexedChunkMap::new(tmp_file.as_path().to_str().unwrap(), 10, true).unwrap(),
         ));
 
         assert_eq!(map.is_range_all_ready(), false);

--- a/storage/src/cache/state/indexed_chunk_map.rs
+++ b/storage/src/cache/state/indexed_chunk_map.rs
@@ -34,17 +34,17 @@ pub struct IndexedChunkMap {
 
 impl IndexedChunkMap {
     /// Create a new instance of `IndexedChunkMap`.
-    pub fn new(blob_path: &str, chunk_count: u32) -> Result<Self> {
+    pub fn new(blob_path: &str, chunk_count: u32, persist: bool) -> Result<Self> {
         let filename = format!("{}.{}", blob_path, FILE_SUFFIX);
 
-        PersistMap::open(&filename, chunk_count, true).map(|map| IndexedChunkMap { map })
+        PersistMap::open(&filename, chunk_count, true, persist).map(|map| IndexedChunkMap { map })
     }
 
     /// Create a new instance of `IndexedChunkMap` from an existing chunk map file.
     pub fn open(blob_info: &BlobInfo, workdir: &str) -> Result<Self> {
         let filename = format!("{}/{}.{}", workdir, blob_info.blob_id(), FILE_SUFFIX);
 
-        PersistMap::open(&filename, blob_info.chunk_count(), false)
+        PersistMap::open(&filename, blob_info.chunk_count(), false, true)
             .map(|map| IndexedChunkMap { map })
     }
 }
@@ -159,7 +159,7 @@ mod tests {
         let blob_path = dir.as_path().join("blob-1");
         let blob_path = blob_path.as_os_str().to_str().unwrap().to_string();
 
-        assert!(IndexedChunkMap::new(&blob_path, 0).is_err());
+        assert!(IndexedChunkMap::new(&blob_path, 0, false).is_err());
 
         let cache_path = format!("{}.{}", blob_path, FILE_SUFFIX);
         let mut file = OpenOptions::new()
@@ -179,7 +179,7 @@ mod tests {
         let chunk = MockChunkInfo::new();
         assert_eq!(chunk.id(), 0);
 
-        assert!(IndexedChunkMap::new(&blob_path, 1).is_err());
+        assert!(IndexedChunkMap::new(&blob_path, 1, true).is_err());
     }
 
     #[test]
@@ -188,7 +188,7 @@ mod tests {
         let blob_path = dir.as_path().join("blob-1");
         let blob_path = blob_path.as_os_str().to_str().unwrap().to_string();
 
-        assert!(IndexedChunkMap::new(&blob_path, 0).is_err());
+        assert!(IndexedChunkMap::new(&blob_path, 0, true).is_err());
 
         let cache_path = format!("{}.{}", blob_path, FILE_SUFFIX);
         let _file = OpenOptions::new()
@@ -207,7 +207,7 @@ mod tests {
         let chunk = MockChunkInfo::new();
         assert_eq!(chunk.id(), 0);
 
-        let map = IndexedChunkMap::new(&blob_path, 1).unwrap();
+        let map = IndexedChunkMap::new(&blob_path, 1, true).unwrap();
         assert_eq!(map.map.not_ready_count.load(Ordering::Acquire), 1);
         assert_eq!(map.map.count, 1);
         assert_eq!(map.map.size, 0x1001);
@@ -223,7 +223,7 @@ mod tests {
         let blob_path = dir.as_path().join("blob-1");
         let blob_path = blob_path.as_os_str().to_str().unwrap().to_string();
 
-        assert!(IndexedChunkMap::new(&blob_path, 0).is_err());
+        assert!(IndexedChunkMap::new(&blob_path, 0, true).is_err());
 
         let cache_path = format!("{}.{}", blob_path, FILE_SUFFIX);
         let file = OpenOptions::new()
@@ -243,7 +243,7 @@ mod tests {
         let chunk = MockChunkInfo::new();
         assert_eq!(chunk.id(), 0);
 
-        let map = IndexedChunkMap::new(&blob_path, 1).unwrap();
+        let map = IndexedChunkMap::new(&blob_path, 1, true).unwrap();
         assert_eq!(map.map.not_ready_count.load(Ordering::Acquire), 1);
         assert_eq!(map.map.count, 1);
         assert_eq!(map.map.size, 0x1001);
@@ -259,7 +259,7 @@ mod tests {
         let blob_path = dir.as_path().join("blob-1");
         let blob_path = blob_path.as_os_str().to_str().unwrap().to_string();
 
-        assert!(IndexedChunkMap::new(&blob_path, 0).is_err());
+        assert!(IndexedChunkMap::new(&blob_path, 0, true).is_err());
 
         let cache_path = format!("{}.{}", blob_path, FILE_SUFFIX);
         let mut file = OpenOptions::new()
@@ -289,7 +289,7 @@ mod tests {
         let chunk = MockChunkInfo::new();
         assert_eq!(chunk.id(), 0);
 
-        let map = IndexedChunkMap::new(&blob_path, 1).unwrap();
+        let map = IndexedChunkMap::new(&blob_path, 1, true).unwrap();
         assert_eq!(map.is_range_all_ready(), true);
         assert_eq!(map.map.count, 1);
         assert_eq!(map.map.size, 0x1001);
@@ -304,7 +304,7 @@ mod tests {
         let blob_path = dir.as_path().join("blob-1");
         let blob_path = blob_path.as_os_str().to_str().unwrap().to_string();
 
-        assert!(IndexedChunkMap::new(&blob_path, 0).is_err());
+        assert!(IndexedChunkMap::new(&blob_path, 0, true).is_err());
 
         let cache_path = format!("{}.{}", blob_path, FILE_SUFFIX);
         let mut file = OpenOptions::new()
@@ -334,7 +334,7 @@ mod tests {
         let chunk = MockChunkInfo::new();
         assert_eq!(chunk.id(), 0);
 
-        let map = IndexedChunkMap::new(&blob_path, 1).unwrap();
+        let map = IndexedChunkMap::new(&blob_path, 1, true).unwrap();
         assert_eq!(map.map.not_ready_count.load(Ordering::Acquire), 1);
         assert_eq!(map.map.count, 1);
         assert_eq!(map.map.size, 0x1001);

--- a/storage/src/cache/state/persist_map.rs
+++ b/storage/src/cache/state/persist_map.rs
@@ -49,7 +49,7 @@ pub(crate) struct PersistMap {
 }
 
 impl PersistMap {
-    pub fn open(filename: &str, chunk_count: u32, create: bool) -> Result<Self> {
+    pub fn open(filename: &str, chunk_count: u32, create: bool, persist: bool) -> Result<Self> {
         if chunk_count == 0 {
             return Err(einval!("chunk count should be greater than 0"));
         }
@@ -58,6 +58,7 @@ impl PersistMap {
             .read(true)
             .write(create)
             .create(create)
+            .truncate(!persist)
             .open(filename)
             .map_err(|err| {
                 einval!(format!(
@@ -157,6 +158,9 @@ impl PersistMap {
         }
 
         readahead(fd, 0, expected_size);
+        if !persist {
+            let _ = std::fs::remove_file(filename);
+        }
 
         Ok(Self {
             count: chunk_count,

--- a/storage/src/cache/state/range_map.rs
+++ b/storage/src/cache/state/range_map.rs
@@ -28,7 +28,7 @@ impl BlobRangeMap {
         let filename = format!("{}.{}", blob_path, FILE_SUFFIX);
         debug_assert!(shift < 64);
 
-        PersistMap::open(&filename, count, true).map(|map| BlobRangeMap { shift, map })
+        PersistMap::open(&filename, count, true, true).map(|map| BlobRangeMap { shift, map })
     }
 
     /// Create a new instance of `BlobRangeMap` from an existing chunk map file.
@@ -36,7 +36,7 @@ impl BlobRangeMap {
         let filename = format!("{}/{}.{}", workdir, blob_id, FILE_SUFFIX);
         debug_assert!(shift < 64);
 
-        PersistMap::open(&filename, count, false).map(|map| BlobRangeMap { shift, map })
+        PersistMap::open(&filename, count, false, true).map(|map| BlobRangeMap { shift, map })
     }
 
     pub(crate) fn get_range(&self, start: u64, count: u64) -> Result<(u32, u32)> {


### PR DESCRIPTION
The fscache driver maintains its own data ready state. On startup stale
chunkmap may cause data corrupt for fscache, so clean stale chunkmap
on startup.

Signed-off-by: Liu Jiang <gerry@linux.alibaba.com>