### PR TITLE
fscache: implement blob unregister api

### DIFF
--- a/api/src/http.rs
+++ b/api/src/http.rs
@@ -106,7 +106,7 @@ pub struct BlobCacheList {
 
 #[derive(Clone, Deserialize, Debug)]
 pub struct BlobObjectParam {
-    pub blob_id: String,
+    pub domain_id: String,
 }
 
 #[derive(Debug)]
@@ -259,7 +259,7 @@ pub enum HttpError {
     // Blob cache management related errors (v2)
     /// Failed to create blob object
     CreateBlobObject(ApiError),
-    /// Failed to create blob object
+    /// Failed to delete blob object
     DeleteBlobObject(ApiError),
     /// Failed to list existing blob objects
     GetBlobObjects(ApiError),


### PR DESCRIPTION
```
fscache: implement blob unregister api

Add `DELETE /api/v2/blobs?domain_id=?` api to support remove (unregister)
fscache blob cache config, including bootstrap and its blob items.

fscache: refactor blob cache state

Simplify BlobCacheState methods to make code cleaner.
```