### PR TITLE
Use Caret to specify dependency versions.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,31 +23,31 @@ path = "src/lib.rs"
 rlimit = "0.3.0"
 log = "0.4.8"
 libc = "0.2"
-vmm-sys-util = ">=0.9.0"
+vmm-sys-util = "0.9.0"
 clap = "2.33"
 flexi_logger = { version = "0.17" }
 # pin regex to fix RUSTSEC-2022-0013
-regex = ">=1.5.5"
-serde = { version = ">=1.0.27", features = ["serde_derive", "rc"] }
+regex = "1.5.5"
+serde = { version = "1.0.110", features = ["serde_derive", "rc"] }
 serde_json = "1.0.51"
 serde_with = { version = "1.6.0", features = ["macros"] }
 sha2 = "0.9.1"
 lazy_static = "1.4.0"
 xattr = "0.2.2"
-nix = ">=0.23.0"
+nix = "0.23.1"
 anyhow = "1.0.35"
-base64 = { version = ">=0.12.0" }
+base64 = "0.13.0"
 rust-fsm = "0.6.0"
 vm-memory = { version = "0.7.0", features = ["backend-mmap"], optional = true }
 chrono = "0.4.19"
 openssl = { version = "0.10.38", features = ["vendored"] }
 hyperlocal = "0.8.0"
-tokio = { version = ">=1.13.1", features = ["macros"] }
+tokio = { version = "1.16.1", features = ["macros"] }
 hyper = "0.14.11"
 # pin openssl-src to bring in fix for RUSTSEC-2021-0098 and RUSTSEC-2022-0014
 openssl-src = "=111.18.0"
 # pin rand_core to bring in fix for RUSTSEC-2021-0023
-rand_core = ">=0.6.2"
+rand_core = "0.6.2"
 
 fuse-backend-rs = { version = "0.4.0", optional = true }
 vhost = { version = "0.3.0", features = ["vhost-user-slave"], optional = true }
@@ -69,7 +69,7 @@ event-manager = "0.2.1"
 
 [dev-dependencies]
 sendfd = "0.3.3"
-vmm-sys-util = ">=0.9.0"
+vmm-sys-util = "0.9.0"
 env_logger = "0.8.2"
 rand = "0.8.5"
 

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -11,10 +11,10 @@ license = "Apache-2.0 OR BSD-3-Clause"
 lazy_static = "1.4.0"
 log = "0.4.8"
 dbs-uhttp = { version = "0.2.0" }
-serde = { version = ">=1.0.27", features = ["rc"] }
-serde_derive = ">=1.0.27"
-serde_json = ">=1.0.9"
-vmm-sys-util = ">=0.9.0"
+serde = { version = "1.0.110", features = ["rc"] }
+serde_derive = "1.0.110"
+serde_json = "1.0.53"
+vmm-sys-util = "0.9.0"
 url = "2.1.1"
 http = "0.2.1"
 nydus-utils = { path = "../utils" }

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -14,11 +14,11 @@ built = { version = "=0.4.3", features = ["chrono", "git2"] }
 
 [dependencies]
 # pin regex to fix RUSTSEC-2022-0013
-regex = ">=1.5.5"
+regex = "1.5.5"
 flexi_logger = { version = "0.17" }
 libc = "0.2"
 log = "0.4"
-nix = ">=0.23.0"
-serde = { version = ">=1.0.27", features = ["serde_derive"] }
+nix = "0.23.1"
+serde = { version = "1.0.110", features = ["serde_derive"] }
 
 nydus-error = { version = "0.2", path = "../error" }

--- a/blobfs/Cargo.toml
+++ b/blobfs/Cargo.toml
@@ -9,8 +9,8 @@ license = "Apache-2.0 OR BSD-3-Clause"
 
 [dependencies]
 log = "0.4.8"
-serde = { version = ">=1.0.27", features = ["serde_derive", "rc"] }
-serde_json = ">=1.0.9"
+serde = { version = "1.0.110", features = ["serde_derive", "rc"] }
+serde_json = "1.0.53"
 serde_with = { version = "1.6.0", features = ["macros"] }
 libc = "0.2"
 vm-memory = { version = "0.7.0" }

--- a/error/Cargo.toml
+++ b/error/Cargo.toml
@@ -13,5 +13,5 @@ backtrace = "0.3"
 httpdate = "1.0"
 libc = "0.2"
 log = "0.4"
-serde = { version = ">=1.0.27", features = ["serde_derive", "rc"] }
-serde_json = ">=1.0.9"
+serde = { version = "1.0.110", features = ["serde_derive", "rc"] }
+serde_json = "1.0.53"

--- a/rafs/Cargo.toml
+++ b/rafs/Cargo.toml
@@ -9,8 +9,8 @@ license = "Apache-2.0 OR BSD-3-Clause"
 anyhow = "1.0.35"
 # pin arc-swap because 1.x version of ArcSwapAny does not implement Clone
 arc-swap = "=0.4"
-base64 = { version = ">=0.12.0", optional = true }
-bitflags = ">=1.1.0"
+base64 = { version = "0.13.0", optional = true }
+bitflags = "1.2.1"
 blake3 = "1.0"
 flate2 = { version = "1.0", features = ["miniz-sys"], default-features = false }
 futures = "0.3"
@@ -19,9 +19,9 @@ lazy_static = "1.4.0"
 libc = "0.2"
 log = "0.4"
 lz4-sys = "1.9.2"
-nix = ">=0.23.0"
-serde = { version = ">=1.0.27", features = ["serde_derive", "rc"] }
-serde_json = ">=1.0.9"
+nix = "0.23.1"
+serde = { version = "1.0.110", features = ["serde_derive", "rc"] }
+serde_json = "1.0.53"
 serde_with = { version = "1.6.0", features = ["macros"] }
 sha2 = { version = "0.9.1" }
 sha-1 = { version = "0.9.1", optional = true }
@@ -35,7 +35,7 @@ nydus-error = { path = "../error" }
 storage = { path = "../storage", features = ["backend-localfs"] }
 
 [dev-dependencies]
-vmm-sys-util = ">=0.9.0"
+vmm-sys-util = "0.9.0"
 assert_matches = "1.5.0"
 
 [features]

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -9,8 +9,8 @@ license = "Apache-2.0 OR BSD-3-Clause"
 anyhow = "1.0.35"
 # pin arc-swap because 1.x version of ArcSwapAny does not implement Clone
 arc-swap = "=0.4"
-base64 = { version = ">=0.12.0", optional = true }
-bitflags = ">=1.1.0"
+base64 = { version = "0.13.0", optional = true }
+bitflags = "1.2.1"
 futures = "0.3"
 governor = "0.4"
 hmac = { version = "0.8.1", optional = true }
@@ -18,18 +18,18 @@ httpdate = { version = "1.0", optional = true }
 lazy_static = "1.4.0"
 libc = "0.2"
 log = "0.4.8"
-nix = ">=0.23.0"
+nix = "0.23.1"
 reqwest = { version = "0.11.0", features = ["blocking", "json"], optional = true }
-serde = { version = ">=1.0.27", features = ["serde_derive", "rc"] }
-serde_json = ">=1.0.9"
+serde = { version = "1.0.110", features = ["serde_derive", "rc"] }
+serde_json = "1.0.53"
 serde_with = { version = "1.6.0", features = ["macros"] }
 sha2 = { version = "0.9.1", optional = true }
 sha-1 = { version = "0.9.1", optional = true }
 spmc = "0.3.0"
-tokio = { version = ">=1.13.1", features = ["rt-multi-thread"] }
+tokio = { version = "1.16.1", features = ["rt-multi-thread"] }
 url = { version = "2.1.1", optional = true }
 vm-memory = "0.7.0"
-vmm-sys-util = ">=0.9.0"
+vmm-sys-util = "0.9.0"
 fuse-backend-rs = { version = "0.4.0" }
 
 nydus-utils = { path = "../utils" }


### PR DESCRIPTION
When compiling dragonball-sandbox, an error is reported:                                                        
```                                                                                                             
Error:   --> /home/runner/.cargo/git/checkouts/image-service-7b544e3856b79dd7/cba6aa9/storage/src/utils.rs:27:26
   |                                                                                                            
27 |         match preadv(fd, iovec, offset as off64_t).map_err(|_| last_error!()) {                            
   |                          ^^^^^ types differ in mutability                                                  
   |                                                                                                            
   = note: expected mutable reference `&mut [IoSliceMut<'_>]`                                                   
                      found reference `&[IoVec<&mut [u8]>]`                                                     
```                                                                                                             
This is because when dragonball-sandbox compiles storage, nix uses `0.24.0`.                                    
                                                                                                                
The `preadv` of `0.24.0` is signed as below (https://docs.rs/nix/0.24.0/nix/sys/uio/fn.preadv.html),            
different from the 0.23.1 we are using                                                                          
now (https://docs.rs/nix/0.23.1/nix/sys/uio/fn.preadv.html).                                                    
```                                                                                                             
pub fn preadv(                                                                                                  
    fd: RawFd,                                                                                                  
    iov: &mut [IoSliceMut<'_>],                                                                                 
    offset: off_t                                                                                               
) -> Result<usize>                                                                                              
```                                                                                                             
                                                                                                                
So we should use `Caret requirements` to avoid version compatibility issues.                                    
See                                                                                                             
`https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html`                                        
for details.                                                                                                    
                                                                                                                
According to cargo's definition of [API                                                                         
compatibility](https://github.com/rust-lang/cargo/blob/master/src/doc/src/reference/semver.md).                 
Cargo uses the convention that only changes in the left-most non-zero component                                 
are considered incompatible.                                                                                    
                                                                                                                
This patch modifies `Comparison requirements` to `Caret requirements`,                                          
and the version number is based on the version that Cargo.lock now depends on.                                  
                                                                                                                
Signed-off-by: wllenyj <wllenyj@linux.alibaba.com>                                                              