### PR TITLE
add global log level option for nydusify

### DIFF
--- a/contrib/nydusify/pkg/packer/packer.go
+++ b/contrib/nydusify/pkg/packer/packer.go
@@ -13,7 +13,6 @@ import (
 	"github.com/dragonflyoss/image-service/contrib/nydusify/pkg/build"
 	"github.com/dragonflyoss/image-service/contrib/nydusify/pkg/checker/tool"
 	"github.com/dragonflyoss/image-service/contrib/nydusify/pkg/compactor"
-	"github.com/dragonflyoss/image-service/contrib/nydusify/pkg/utils"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -22,7 +21,6 @@ import (
 const (
 	nydusBinaryName  = "nydus-image"
 	defaultOutputDir = "./.nydus-build-output"
-	defaultLogLevel  = "info"
 )
 
 var (
@@ -32,7 +30,7 @@ var (
 )
 
 type Opt struct {
-	LogLevel       string
+	LogLevel       logrus.Level
 	NydusImagePath string
 	OutputDir      string
 	BackendConfig  *BackendConfig
@@ -357,16 +355,9 @@ func blobFileName(meta string) string {
 	return fmt.Sprintf("%s.blob", strings.TrimSuffix(meta, filepath.Ext(meta)))
 }
 
-func initLogger(logLevel string) (*logrus.Logger, error) {
-	if utils.IsEmptyString(logLevel) {
-		logLevel = defaultLogLevel
-	}
-	level, err := logrus.ParseLevel(logLevel)
-	if err != nil {
-		return nil, err
-	}
+func initLogger(logLevel logrus.Level) (*logrus.Logger, error) {
 	logger := logrus.New()
-	logger.SetLevel(level)
+	logger.SetLevel(logLevel)
 	logger.SetFormatter(&logrus.TextFormatter{
 		FullTimestamp: true,
 	})

--- a/contrib/nydusify/pkg/packer/packer_test.go
+++ b/contrib/nydusify/pkg/packer/packer_test.go
@@ -31,7 +31,7 @@ func TestNew(t *testing.T) {
 	tmpDir, tearDown := setUpTmpDir(t)
 	defer tearDown()
 	_, err := New(Opt{
-		LogLevel:       "info",
+		LogLevel:       logrus.InfoLevel,
 		OutputDir:      tmpDir,
 		NydusImagePath: filepath.Join(tmpDir, "nydus-image"),
 	})
@@ -56,7 +56,7 @@ func TestPacker_Pack(t *testing.T) {
 	tmpDir, tearDown := setUpTmpDir(t)
 	defer tearDown()
 	p, err := New(Opt{
-		LogLevel:       "info",
+		LogLevel:       logrus.InfoLevel,
 		OutputDir:      tmpDir,
 		NydusImagePath: filepath.Join(tmpDir, "nydus-image"),
 	})

--- a/docs/nydusify.md
+++ b/docs/nydusify.md
@@ -6,7 +6,7 @@ The Nydusify CLI tool supports:
 
 ### Get binaries from release page
 
-Get `nydus-image`, `nydusd` and `nydusify` binaries from [release](https://github.com/dragonflyoss/image-service/releases/latest) page and install them to system PATH like `/usr/bin` or /usr/local/bin`.
+Get `nydus-image`, `nydusd` and `nydusify` binaries from [release](https://github.com/dragonflyoss/image-service/releases/latest) page and install them to system PATH like `/usr/bin` or `/usr/local/bin`.
 
 ## Basic Usage
 


### PR DESCRIPTION
Add --log-level option and -D as global options for
pack/convert/check subcommands.

The -D is the shortcut for --log-level debug,
and will have the highest priority.

Signed-off-by: bin liu <bin@hyper.sh>