### PR TITLE
action: support multiple arch releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
   schedule:
     # Run daily sanity check at 23:08 clock UTC
     - cron: "8 23 * * *"
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always
@@ -48,6 +49,7 @@ jobs:
             ./target-fusedev
             ./target-virtiofs
           cache-on-failure: true
+          key: ${{ runner.os }}-cargo-amd64
       - name: Cache Docker Layers
         uses: satackey/action-docker-layer-caching@v0.0.11
         # Ignore the failure of a step and avoid terminating the job.

--- a/.github/workflows/convert.yml
+++ b/.github/workflows/convert.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     # Do conversion every day at 00:03 clock UTC
     - cron: "3 0 * * *"
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
   schedule:
     # Run daily sanity check at 22:08 clock UTC
     - cron: "8 22 * * *"
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always
@@ -14,6 +15,9 @@ env:
 jobs:
   build-nydus-rs:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
     steps:
     - uses: actions/checkout@v2
     - name: Cache cargo
@@ -23,19 +27,24 @@ jobs:
           ./target-fusedev
           ./target-virtiofs
         cache-on-failure: true
+        key: ${{ runner.os }}-cargo-${{ matrix.arch }}
     - name: Build nydus-rs
       run: |
-        make docker-static
-        sudo mv target-fusedev/x86_64-unknown-linux-musl/release/nydusd nydusd-fusedev
-        sudo mv target-fusedev/x86_64-unknown-linux-musl/release/nydus-image .
-        sudo mv target-fusedev/x86_64-unknown-linux-musl/release/nydusctl .
-        sudo mv target-virtiofs/x86_64-unknown-linux-musl/release/nydusd nydusd-virtiofs
+        declare -A rust_arch_map=( ["amd64"]="x86_64" ["arm64"]="aarch64")
+        arch=${rust_arch_map[${{ matrix.arch }}]}
+        cargo install cross
+        rustup component add rustfmt && rustup component add clippy
+        make -e ARCH=$arch -e CARGO=cross static-release
+        sudo mv target-fusedev/$arch-unknown-linux-musl/release/nydusd nydusd-fusedev
+        sudo mv target-fusedev/$arch-unknown-linux-musl/release/nydus-image .
+        sudo mv target-fusedev/$arch-unknown-linux-musl/release/nydusctl .
+        sudo mv target-virtiofs/$arch-unknown-linux-musl/release/nydusd nydusd-virtiofs
         sudo cp -r misc/configs .
         sudo chown -R $(id -un):$(id -gn) . ~/.cargo/
     - name: store-artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: nydus-artifacts
+        name: nydus-artifacts-${{ matrix.arch }}
         path: |
           nydusd-fusedev
           nydusd-virtiofs
@@ -44,6 +53,9 @@ jobs:
           configs
   build-contrib:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
     env:
       DOCKER: false
     steps:
@@ -60,7 +72,7 @@ jobs:
           ${{ runner.os }}-go
     - name: build contrib go components
       run: |
-        make all-contrib-static-release
+        make -e GOARCH=${{ matrix.arch }} all-contrib-static-release
         sudo mv contrib/ctr-remote/bin/ctr-remote .
         sudo mv contrib/docker-nydus-graphdriver/bin/nydus_graphdriver .
         sudo mv contrib/nydusify/cmd/nydusify .
@@ -68,7 +80,7 @@ jobs:
     - name: store-artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: nydus-artifacts
+        name: nydus-artifacts-${{ matrix.arch }}
         path: |
           ctr-remote
           nydus_graphdriver
@@ -77,6 +89,9 @@ jobs:
           containerd-nydus-grpc
   upload-artifacts:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
     needs: [build-nydus-rs, build-contrib]
     steps:
     - uses: actions/checkout@v2
@@ -89,13 +104,13 @@ jobs:
     - name: download artifacts
       uses: actions/download-artifact@v2
       with:
-        name: nydus-artifacts
+        name: nydus-artifacts-${{ matrix.arch }}
         path: nydus-static
     - name: upload artifacts
       if: ${{ github.event_name == 'push' }}
       run: |
         tag=$(echo $GITHUB_REF | cut -d/ -f3-)
-        tarball="nydus-static-$tag-x86_64.tgz"
+        tarball="nydus-static-$tag-linux-${{ matrix.arch }}.tgz"
         chmod +x nydus-static/*
         tar cf - nydus-static | gzip > ${tarball}
         echo "tag=$tag" >> $GITHUB_ENV

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1230,7 +1230,6 @@ dependencies = [
  "nydus-error",
  "nydus-utils",
  "openssl",
- "openssl-src",
  "rafs",
  "rand",
  "rand_core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,8 +44,6 @@ openssl = { version = "0.10.38", features = ["vendored"] }
 hyperlocal = "0.8.0"
 tokio = { version = "1.16.1", features = ["macros"] }
 hyper = "0.14.11"
-# pin openssl-src to bring in fix for RUSTSEC-2021-0098 and RUSTSEC-2022-0014
-openssl-src = "=111.18.0"
 # pin rand_core to bring in fix for RUSTSEC-2021-0023
 rand_core = "0.6.2"
 

--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,15 @@ all: build
 TEST_WORKDIR_PREFIX ?= "/tmp"
 DOCKER ?= "true"
 
-current_dir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
-ARCH := $(shell uname -p)
+ARCH ?= $(shell uname -p)
+CARGO ?= $(shell which cargo)
+CARGO_BUILD_GEARS = -v ~/.ssh/id_rsa:/root/.ssh/id_rsa -v ~/.cargo/git:/root/.cargo/git -v ~/.cargo/registry:/root/.cargo/registry
+SUDO = $(shell which sudo)
 
+FUSEDEV_COMMON = --target-dir ${current_dir}/target-fusedev --features=fusedev --release
+VIRIOFS_COMMON = --target-dir ${current_dir}/target-virtiofs --features=virtiofs --release
+
+current_dir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 env_go_path := $(shell go env GOPATH 2> /dev/null)
 go_path := $(if $(env_go_path),$(env_go_path),"$(HOME)/go")
 
@@ -14,9 +20,6 @@ go_path := $(if $(env_go_path),$(env_go_path),"$(HOME)/go")
 # then mitigate the impact of docker hub rate limit, for example:
 # env DIND_CACHE_DIR=/path/to/host/var-lib-docker make docker-nydusify-smoke
 dind_cache_mount := $(if $(DIND_CACHE_DIR),-v $(DIND_CACHE_DIR):/var/lib/docker,)
-
-FUSEDEV_COMMON = --target-dir target-fusedev --features=fusedev --release
-VIRIOFS_COMMON = --target-dir target-virtiofs --features=virtiofs --release
 
 # Functions
 
@@ -36,12 +39,12 @@ endef
 # Build nydus respecting different features
 # $(1) is the specified feature. [fusedev, virtiofs]
 define build_nydus
-	cargo build --features=$(1) --target-dir target-$(1) $(CARGO_BUILD_FLAGS)
+	${CARGO} build --features=$(1) --target-dir ${current_dir}/target-$(1) $(CARGO_BUILD_FLAGS)
 endef
 
 define static_check
 	# Cargo will skip checking if it is already checked
-	cargo clippy --features=$(1) --workspace --bins --tests --target-dir target-$(1) -- -Dwarnings
+	${CARGO} clippy --features=$(1) --workspace --bins --tests --target-dir ${current_dir}/target-$(1) -- -Dwarnings
 endef
 
 .PHONY: all .release_version .format .musl_target build release static-release fusedev-release virtiofs-release virtiofs fusedev
@@ -50,7 +53,7 @@ endef
 	$(eval CARGO_BUILD_FLAGS += --release)
 
 .format:
-	cargo fmt -- --check
+	${CARGO} fmt -- --check
 
 .musl_target:
 	$(eval CARGO_BUILD_FLAGS += --target ${ARCH}-unknown-linux-musl)
@@ -73,32 +76,27 @@ fusedev:
 	$(call static_check,$@,target-$@)
 
 clean:
-	cargo clean
-	cargo clean --target-dir target-virtiofs
-	cargo clean --target-dir target-fusedev
+	${CARGO} clean
+	${CARGO} clean --target-dir ${current_dir}/target-virtiofs
+	${CARGO} clean --target-dir ${current_dir}/target-fusedev
 
 # If virtiofs test must be performed, only run binary part
 # Use same traget to avoid re-compile for differnt targets like gnu and musl
 ut:
-	TEST_WORKDIR_PREFIX=$(TEST_WORKDIR_PREFIX) RUST_BACKTRACE=1 cargo test --workspace $(FUSEDEV_COMMON) -- --skip integration --nocapture --test-threads=8
+	TEST_WORKDIR_PREFIX=$(TEST_WORKDIR_PREFIX) RUST_BACKTRACE=1 ${CARGO} test --workspace $(FUSEDEV_COMMON) -- --skip integration --nocapture --test-threads=8
 # If virtiofs test must be performed, only run binary part since other package is not affected by feature - virtiofs
 # Use same traget to avoid re-compile for differnt targets like gnu and musl
-	RUST_BACKTRACE=1 cargo test $(VIRIOFS_COMMON) --bin nydusd -- --nocapture --test-threads=8
+	RUST_BACKTRACE=1 ${CARGO} test $(VIRIOFS_COMMON) --bin nydusd -- --nocapture --test-threads=8
 
 macos-ut:
-	cargo clippy --target-dir target-fusedev --features=fusedev --bin nydusd --release --workspace -- -Dwarnings
+	${CARGO} clippy --target-dir ${current_dir}/target-fusedev --features=fusedev --bin nydusd --release --workspace -- -Dwarnings
 	echo "Testing packages: ${PACKAGES}"
-	$(foreach var,$(PACKAGES),cargo test $(FUSEDEV_COMMON) -p $(var);)
-	TEST_WORKDIR_PREFIX=$(TEST_WORKDIR_PREFIX) RUST_BACKTRACE=1 cargo test $(FUSEDEV_COMMON) --bin nydusd -- --nocapture --test-threads=8
-
-CARGO_BUILD_GEARS = -v ~/.ssh/id_rsa:/root/.ssh/id_rsa -v ~/.cargo/git:/root/.cargo/git -v ~/.cargo/registry:/root/.cargo/registry
-
-CARGO = $(shell which cargo)
-SUDO = $(shell which sudo)
+	$(foreach var,$(PACKAGES),${CARGO} test $(FUSEDEV_COMMON) -p $(var);)
+	TEST_WORKDIR_PREFIX=$(TEST_WORKDIR_PREFIX) RUST_BACKTRACE=1 ${CARGO} test $(FUSEDEV_COMMON) --bin nydusd -- --nocapture --test-threads=8
 
 docker-static:
 	docker build -t nydus-rs-static --build-arg ARCH=${ARCH} misc/musl-static
-	docker run --rm ${CARGO_BUILD_GEARS} --workdir /nydus-rs -v ${current_dir}:/nydus-rs nydus-rs-static
+	docker run --rm ${CARGO_BUILD_GEARS} -e ARCH=${ARCH} --workdir /nydus-rs -v ${current_dir}:/nydus-rs nydus-rs-static
 
 # Run smoke test including general integration tests and unit tests in container.
 # Nydus binaries should already be prepared.

--- a/contrib/ctr-remote/Makefile
+++ b/contrib/ctr-remote/Makefile
@@ -1,10 +1,11 @@
 PACKAGES ?= $(shell go list ./... | grep -v /vendor/)
+GOARCH ?= amd64
 
 all:clear build
 
 .PHONY: build
 build:
-	GOOS=linux go build -v -o bin/ctr-remote ./cmd/main.go
+	GOOS=linux GOARCH=${GOARCH} go build -v -o bin/ctr-remote ./cmd/main.go
 
 .PHONY: clear
 clear:
@@ -12,7 +13,7 @@ clear:
 
 .PHONY: static-release
 static-release:
-	GOOS=linux go build -ldflags '-s -w -extldflags "-static"' -v -o bin/ctr-remote ./cmd/main.go
+	GOOS=linux GOARCH=${GOARCH} go build -ldflags '-s -w -extldflags "-static"' -v -o bin/ctr-remote ./cmd/main.go
 
 .PHONY: test
 test: build

--- a/contrib/docker-nydus-graphdriver/Makefile
+++ b/contrib/docker-nydus-graphdriver/Makefile
@@ -1,10 +1,11 @@
 PACKAGES ?= $(shell go list ./... | grep -v /vendor/)
+GOARCH ?= amd64
 
 all:clear build
 
 .PHONY: build
 build:
-	GOOS=linux go build -v -o bin/nydus_graphdriver .
+	GOOS=linux GOARCH=${GOARCH} go build -v -o bin/nydus_graphdriver .
 
 .PHONY: clear
 clear:
@@ -12,7 +13,7 @@ clear:
 
 .PHONY: static-release
 static-release:
-	GOOS=linux go build -ldflags '-s -w -extldflags "-static"' -v -o bin/nydus_graphdriver .
+	GOOS=linux GOARCH=${GOARCH} go build -ldflags '-s -w -extldflags "-static"' -v -o bin/nydus_graphdriver .
 
 .PHONY: test
 test: build

--- a/contrib/nydus-overlayfs/Makefile
+++ b/contrib/nydus-overlayfs/Makefile
@@ -3,10 +3,11 @@ all:clear build
 GIT_COMMIT := $(shell git rev-parse --verify HEAD --short=7)
 BUILD_TIME := $(shell date -u +%Y%m%d.%H%M)
 PACKAGES ?= $(shell go list ./... | grep -v /vendor/)
+GOARCH ?= amd64
 
 .PHONY: build
 build:
-	GOOS=linux go build  -ldflags="-s -w -X 'main.Version=${GIT_COMMIT}' -X 'main.BuildTime=${BUILD_TIME}'" -v -o bin/nydus-overlayfs ./cmd/main.go
+	GOOS=linux GOARCH=${GOARCH} go build  -ldflags="-s -w -X 'main.Version=${GIT_COMMIT}' -X 'main.BuildTime=${BUILD_TIME}'" -v -o bin/nydus-overlayfs ./cmd/main.go
 
 .PHONY: clear
 clear:
@@ -14,7 +15,7 @@ clear:
 
 .PHONY: static-release
 static-release:
-	GOOS=linux go build -ldflags '-s -w -extldflags "-static"' -v -o bin/nydus-overlayfs ./cmd/main.go
+	GOOS=linux GOARCH=${GOARCH} go build -ldflags '-s -w -extldflags "-static"' -v -o bin/nydus-overlayfs ./cmd/main.go
 
 .PHONY: test
 test: build

--- a/contrib/nydusify/Makefile
+++ b/contrib/nydusify/Makefile
@@ -2,6 +2,7 @@ GIT_COMMIT := $(shell git rev-list -1 HEAD)
 BUILD_TIME := $(shell date -u +%Y%m%d.%H%M)
 CURRENT_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 PACKAGES ?= $(shell go list ./... | grep -v /vendor/)
+GOARCH ?= amd64
 #GOPROXY ?= https://goproxy.io
 
 ifdef GOPROXY
@@ -10,11 +11,11 @@ endif
 
 .PHONY: build
 build:
-	@CGO_ENABLED=0 ${PROXY} GOOS=linux go build -ldflags '-X main.versionGitCommit=${GIT_COMMIT} -X main.versionBuildTime=${BUILD_TIME}' -gcflags=all="-N -l" -o ./cmd ./cmd/nydusify.go
+	@CGO_ENABLED=0 ${PROXY} GOOS=linux GOARCH=${GOARCH} go build -ldflags '-X main.versionGitCommit=${GIT_COMMIT} -X main.versionBuildTime=${BUILD_TIME}' -gcflags=all="-N -l" -o ./cmd ./cmd/nydusify.go
 
 .PHONY: static-release
 static-release:
-	@CGO_ENABLED=0 ${PROXY} GOOS=linux go build -ldflags '-X main.versionGitCommit=${GIT_COMMIT} -X main.versionBuildTime=${BUILD_TIME}' -o ./cmd ./cmd/nydusify.go
+	@CGO_ENABLED=0 ${PROXY} GOOS=linux GOARCH=${GOARCH} go build -ldflags '-X main.versionGitCommit=${GIT_COMMIT} -X main.versionBuildTime=${BUILD_TIME}' -o ./cmd ./cmd/nydusify.go
 
 .PHONY: test
 test: build build-smoke
@@ -23,4 +24,4 @@ test: build build-smoke
 	@go test -count=1 -v -timeout 20m -race ./pkg/...
 
 build-smoke:
-	${PROXY} GOOS=linux go test -race -v -c -o ./nydusify-smoke ./tests
+	${PROXY} go test -race -v -c -o ./nydusify-smoke ./tests

--- a/misc/musl-static/Dockerfile
+++ b/misc/musl-static/Dockerfile
@@ -1,8 +1,10 @@
 FROM clux/muslrust:1.52.1
 
+ARG ARCH=x86_64
+
 WORKDIR /nydus-rs
 
 CMD rustup component add clippy && \
   rustup component add rustfmt && \
-  rustup target add x86_64-unknown-linux-musl && \
+  rustup target add $ARCH-unknown-linux-musl && \
   make static-release


### PR DESCRIPTION
Add $ARCH to all cargo/go build commands for supporting multiple
arch compilation.

Use rust cross tool instead of clux/muslrust docker image to
resolve cross compiling issue for arm64 arch.

All the amd64 and arm64 binaries have been tested on separate
machines and basically work well.

A successful action can be found here: https://github.com/imeoer/image-service/actions/runs/2230520032

The macOS binary release support and removing clux/muslrust docker
image will as TODO next.

Close #401

Signed-off-by: Yan Song <imeoer@linux.alibaba.com>