### PR TITLE
nydus-image: Feature, add a block allocator for reducing bootstrap size by reusing used blocks

### DIFF
--- a/src/bin/nydus-image/builder/stargz.rs
+++ b/src/bin/nydus-image/builder/stargz.rs
@@ -556,6 +556,7 @@ impl StargzIndexTreeBuilder {
             v6_datalayout: 0,
             v6_compact_inode: false,
             v6_force_extended_inode: false,
+            dirents_offset: 0,
         })
     }
 }

--- a/src/bin/nydus-image/core/tree.rs
+++ b/src/bin/nydus-image/core/tree.rs
@@ -357,6 +357,7 @@ impl<'a> MetadataTreeBuilder<'a> {
             v6_datalayout: 0,
             v6_compact_inode: false,
             v6_force_extended_inode: false,
+            dirents_offset: 0,
         })
     }
 }


### PR DESCRIPTION

Firstly, we add a `dirents_offset` field in `struct Node`, which is used by directory files.
Previously, the dirents have to be placed the next block where its dir inode was placed, by
introducing this field, we allow the dirents to be seperated from its dir inode.
Secondly, we add an `available_blocks` field in `struct BootstrapCtx`,
to record blocks that are used but still contain unused space.

feature #348

Signed-off-by: Qi Wang <mpiglet@outlook.com>