### PR TITLE
builder: fix lost hardlink

### DIFF
--- a/src/bin/nydus-image/builder/diff.rs
+++ b/src/bin/nydus-image/builder/diff.rs
@@ -519,8 +519,8 @@ impl DiffBuilder {
                 .context("failed to load superblock from bootstrap")?;
             // Load blobs from the blob table of parent bootstrap.
             blob_mgr.from_blob_table(rs.superblock.get_blob_infos());
-            rs.walk_inodes(RAFS_ROOT_INODE, None, &mut |inode: &dyn RafsInode,
-                                                        path: &Path|
+            rs.walk_dir(RAFS_ROOT_INODE, None, &mut |inode: &dyn RafsInode,
+                                                     path: &Path|
              -> Result<()> {
                 let mut chunks = Vec::new();
                 if inode.is_reg() {

--- a/src/bin/nydus-image/merge.rs
+++ b/src/bin/nydus-image/merge.rs
@@ -127,8 +127,8 @@ impl Merger {
 
             if let Some(tree) = &mut tree {
                 let mut nodes = Vec::new();
-                rs.walk_inodes(RAFS_ROOT_INODE, None, &mut |inode: &dyn RafsInode,
-                                                            path: &Path|
+                rs.walk_dir(RAFS_ROOT_INODE, None, &mut |inode: &dyn RafsInode,
+                                                         path: &Path|
                  -> Result<()> {
                     let mut node = MetadataTreeBuilder::parse_node(&rs, inode, path.to_path_buf())
                         .context(format!("parse node from bootstrap {:?}", bootstrap_path))?;

--- a/tests/diff.rs
+++ b/tests/diff.rs
@@ -326,8 +326,8 @@ fn integration_test_diff_build_with_chunk_dict() {
     rs.load(&mut reader).unwrap();
     let mut actual = HashMap::new();
     let blobs = rs.superblock.get_blob_infos();
-    rs.walk_inodes(RAFS_ROOT_INODE, None, &mut |inode: &dyn RafsInode,
-                                                path: &Path|
+    rs.walk_dir(RAFS_ROOT_INODE, None, &mut |inode: &dyn RafsInode,
+                                             path: &Path|
      -> Result<()> {
         let mut chunks = Vec::new();
         if inode.is_reg() {
@@ -465,8 +465,8 @@ fn integration_test_diff_build_with_chunk_dict() {
     rs.load(&mut reader).unwrap();
     let mut actual = HashMap::new();
     let blobs = rs.superblock.get_blob_infos();
-    rs.walk_inodes(RAFS_ROOT_INODE, None, &mut |inode: &dyn RafsInode,
-                                                path: &Path|
+    rs.walk_dir(RAFS_ROOT_INODE, None, &mut |inode: &dyn RafsInode,
+                                             path: &Path|
      -> Result<()> {
         let mut chunks = Vec::new();
         if inode.is_reg() {
@@ -686,8 +686,8 @@ fn integration_test_diff_build_with_chunk_dict() {
     rs.load(&mut reader).unwrap();
     let mut actual = HashMap::new();
     let blobs = rs.superblock.get_blob_infos();
-    rs.walk_inodes(RAFS_ROOT_INODE, None, &mut |inode: &dyn RafsInode,
-                                                path: &Path|
+    rs.walk_dir(RAFS_ROOT_INODE, None, &mut |inode: &dyn RafsInode,
+                                             path: &Path|
      -> Result<()> {
         let mut chunks = Vec::new();
         if inode.is_reg() {


### PR DESCRIPTION
The merge operation in builder (nydus-image) use `RafsSuper::walk_inodes`
method to walkthrough the whole filesystem inodes by DFS order, but it
does not call the callback for the hardlink pair, which causes some hardlink
files to be lost in the final bootstrap after merge.

The root cause is that the `RafsSuper::get_inode` method always gets only
the RafsInode of a particular file name in the hardlink pair because the ino
number of the hardlink pair are the same.

Fix by passing `RafsInode` trait object in `RafsSuper::walk_inodes` directly.

Signed-off-by: Yan Song <imeoer@linux.alibaba.com>