### PR TITLE
builder: implement tar like build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -456,6 +456,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0408e2626025178a6a7f7ffc05a25bc47103229f19c113755de7bf63816290c"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "redox_syscall 0.2.10",
+ "winapi",
+]
+
+[[package]]
 name = "flate2"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1229,6 +1241,7 @@ dependencies = [
  "serde_with",
  "sha2",
  "storage",
+ "tar",
  "tokio",
  "vhost",
  "vhost-user-backend",
@@ -1882,6 +1895,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b55807c0344e1e6c04d7c965f5289c39a8d94ae23ed5c0b57aabac549f871c6"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ tokio = { version = "1.16.1", features = ["macros"] }
 hyper = "0.14.11"
 # pin rand_core to bring in fix for RUSTSEC-2021-0023
 rand_core = "0.6.2"
+tar = "0.4.38"
 
 fuse-backend-rs = { version = "0.9.0", optional = true }
 vhost = { version = "0.3.0", features = ["vhost-user-slave"], optional = true }

--- a/rafs/src/lib.rs
+++ b/rafs/src/lib.rs
@@ -140,6 +140,16 @@ pub trait RafsIoWrite: Write + Seek + 'static {
             e
         })
     }
+
+    /// Seek the writer to current position plus the specified offset.
+    fn seek_current(&mut self, offset: i64) -> Result<u64> {
+        self.seek(SeekFrom::Current(offset))
+    }
+
+    /// Do some finalization works.
+    fn finalize(&mut self, _name: Option<&str>) -> anyhow::Result<()> {
+        Ok(())
+    }
 }
 
 impl RafsIoWrite for File {

--- a/rafs/src/lib.rs
+++ b/rafs/src/lib.rs
@@ -147,8 +147,13 @@ pub trait RafsIoWrite: Write + Seek + 'static {
     }
 
     /// Do some finalization works.
-    fn finalize(&mut self, _name: Option<&str>) -> anyhow::Result<()> {
+    fn finalize(&mut self, _name: Option<String>) -> anyhow::Result<()> {
         Ok(())
+    }
+
+    /// Get all data has been written.
+    fn data(&self) -> &[u8] {
+        unimplemented!();
     }
 }
 

--- a/src/bin/nydus-image/builder/diff.rs
+++ b/src/bin/nydus-image/builder/diff.rs
@@ -324,6 +324,7 @@ fn dump_blob(
         blob_nodes,
         &mut chunk_cache,
     )? {
+        blob_ctx.finalize()?;
         Some(blob_ctx)
     } else {
         None
@@ -739,7 +740,7 @@ impl DiffBuilder {
                         .insert_blob(ChunkSource::Build, idx as u32, blob_ctx);
                 }
             }
-            let mut bootstrap_ctx = bootstrap_mgr.create_ctx()?;
+            let mut bootstrap_ctx = bootstrap_mgr.create_ctx(ctx.inline_bootstrap)?;
             bootstrap_ctx.name = format!("bootstrap-{}", idx);
             self.build_bootstrap(ctx, &mut bootstrap_ctx, idx as u32, paths[idx].clone())?;
             bootstrap_mgr.add(bootstrap_ctx);
@@ -792,7 +793,7 @@ impl DiffBuilder {
         for (snapshot_idx, worker) in workers.into_iter().enumerate() {
             // FIXME: the behavior of build with diff is not working.
             let (_, _) = worker.join().expect("panic on diff build")?;
-            let mut bootstrap_ctx = bootstrap_mgr.create_ctx()?;
+            let mut bootstrap_ctx = bootstrap_mgr.create_ctx(ctx.inline_bootstrap)?;
             let snapshot_path = paths[snapshot_idx + 1].clone().unwrap();
             self.build_bootstrap(ctx, &mut bootstrap_ctx, snapshot_idx as u32, snapshot_path)?;
             todo!();

--- a/src/bin/nydus-image/builder/stargz.rs
+++ b/src/bin/nydus-image/builder/stargz.rs
@@ -633,7 +633,7 @@ impl Builder for StargzBuilder {
         bootstrap_mgr: &mut BootstrapManager,
         blob_mgr: &mut BlobManager,
     ) -> Result<BuildOutput> {
-        let mut bootstrap_ctx = bootstrap_mgr.create_ctx()?;
+        let mut bootstrap_ctx = bootstrap_mgr.create_ctx(ctx.inline_bootstrap)?;
         // Build tree from source
         let layer_idx = if bootstrap_ctx.layered { 1u16 } else { 0u16 };
         let mut tree = self.build_tree_from_index(ctx, layer_idx)?;

--- a/src/bin/nydus-image/builder/stargz.rs
+++ b/src/bin/nydus-image/builder/stargz.rs
@@ -577,7 +577,12 @@ impl StargzBuilder {
         let mut decompressed_blob_size = 0u64;
         let mut compressed_blob_size = 0u64;
         let blob_index = blob_mgr.alloc_index()?;
-        let mut blob_ctx = BlobContext::new(ctx.blob_id.clone(), ctx.blob_storage.clone(), 0)?;
+        let mut blob_ctx = BlobContext::new(
+            ctx.blob_id.clone(),
+            ctx.blob_storage.clone(),
+            0,
+            ctx.inline_bootstrap,
+        )?;
         blob_ctx.set_chunk_dict(blob_mgr.get_chunk_dict());
         blob_ctx.set_chunk_size(ctx.chunk_size);
 

--- a/src/bin/nydus-image/core/blob.rs
+++ b/src/bin/nydus-image/core/blob.rs
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+use std::io::Write;
 use std::os::unix::ffi::OsStrExt;
 
 use anyhow::{Context, Result};

--- a/src/bin/nydus-image/core/blob.rs
+++ b/src/bin/nydus-image/core/blob.rs
@@ -74,7 +74,7 @@ impl Blob {
         }
 
         blob_ctx.set_blob_readahead_size(ctx);
-        blob_ctx.flush()?;
+        blob_ctx.finalize()?;
 
         let blob_exists = blob_ctx.compressed_blob_size > 0;
 
@@ -87,7 +87,7 @@ impl Blob {
         }
 
         if let Some(writer) = &mut blob_ctx.writer {
-            let pos = writer.get_pos()?;
+            let pos = writer.pos()?;
             let data = unsafe {
                 std::slice::from_raw_parts(
                     blob_ctx.blob_meta_info.as_ptr() as *const u8,

--- a/src/bin/nydus-image/core/blob.rs
+++ b/src/bin/nydus-image/core/blob.rs
@@ -74,7 +74,6 @@ impl Blob {
         }
 
         blob_ctx.set_blob_readahead_size(ctx);
-        blob_ctx.finalize()?;
 
         let blob_exists = blob_ctx.compressed_blob_size > 0;
 

--- a/src/bin/nydus-image/core/blob_compact.rs
+++ b/src/bin/nydus-image/core/blob_compact.rs
@@ -569,10 +569,11 @@ impl BlobCompactor {
             PathBuf::from(""),
             Default::default(),
             None,
+            false,
         );
         let mut bootstrap_mgr =
             BootstrapManager::new(ArtifactStorage::SingleFile(d_bootstrap), None);
-        let mut bootstrap_ctx = bootstrap_mgr.create_ctx()?;
+        let mut bootstrap_ctx = bootstrap_mgr.create_ctx(false)?;
         let mut ori_blob_mgr = BlobManager::new();
         ori_blob_mgr.from_blob_table(rs.superblock.get_blob_infos());
         if let Some(dict) = chunk_dict {

--- a/src/bin/nydus-image/core/blob_compact.rs
+++ b/src/bin/nydus-image/core/blob_compact.rs
@@ -2,6 +2,20 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use sha2::Digest;
+
+use nydus_utils::digest::RafsDigest;
+use nydus_utils::try_round_up_4k;
+use rafs::metadata::{RafsMode, RafsSuper};
+use storage::backend::BlobBackend;
+use storage::utils::alloc_buf;
+
 use crate::core::blob::Blob;
 use crate::core::bootstrap::Bootstrap;
 use crate::core::chunk_dict::{ChunkDict, HashChunkDict};
@@ -11,17 +25,6 @@ use crate::core::context::{
 };
 use crate::core::node::{ChunkWrapper, Node, WhiteoutSpec};
 use crate::core::tree::Tree;
-use anyhow::Result;
-use nydus_utils::digest::RafsDigest;
-use nydus_utils::try_round_up_4k;
-use rafs::metadata::{RafsMode, RafsSuper};
-use serde::{Deserialize, Serialize};
-use sha2::Digest;
-use std::collections::HashMap;
-use std::path::PathBuf;
-use std::sync::Arc;
-use storage::backend::BlobBackend;
-use storage::utils::alloc_buf;
 
 const DEFAULT_COMPACT_BLOB_SIZE: usize = 10 * 1024 * 1024;
 const DEFAULT_MAX_COMPACT_SIZE: usize = 100 * 1024 * 1024;
@@ -172,7 +175,7 @@ impl ChunkSet {
         new_blob_ctx.blob_id = format!("{:x}", new_blob_ctx.blob_hash.clone().finalize());
         // dump blob meta for v6
         Blob::new().dump_meta_data(new_blob_ctx)?;
-        new_blob_ctx.flush()?;
+        new_blob_ctx.finalize()?;
         Ok(chunks_change)
     }
 }

--- a/src/bin/nydus-image/core/bootstrap.rs
+++ b/src/bin/nydus-image/core/bootstrap.rs
@@ -5,7 +5,8 @@
 use std::convert::TryFrom;
 use std::convert::TryInto;
 use std::ffi::OsString;
-use std::io::{Seek, SeekFrom, Write};
+use std::io::Seek;
+use std::io::{SeekFrom, Write};
 use std::mem::size_of;
 
 use anyhow::{Context, Error, Result};
@@ -18,7 +19,6 @@ use rafs::metadata::layout::v6::{
     RafsV6SuperBlockExt, EROFS_BLOCK_SIZE, EROFS_DEVTABLE_OFFSET, EROFS_INODE_SLOT_SIZE,
 };
 use rafs::metadata::layout::RafsBlobTable;
-use rafs::RafsIoWrite;
 
 use rafs::metadata::layout::RAFS_ROOT_INODE;
 use rafs::metadata::{RafsMode, RafsStore, RafsSuper};
@@ -458,36 +458,36 @@ impl Bootstrap {
 
         // Dump super block
         super_block
-            .store(&mut bootstrap_writer)
+            .store(bootstrap_writer.as_mut())
             .context("failed to store superblock")?;
 
         // Dump inode table
         inode_table
-            .store(&mut bootstrap_writer)
+            .store(bootstrap_writer.as_mut())
             .context("failed to store inode table")?;
 
         // Dump prefetch table
         if let Some(mut prefetch_table) = ctx.prefetch.get_rafsv5_prefetch_table() {
             prefetch_table
-                .store(&mut bootstrap_writer)
+                .store(bootstrap_writer.as_mut())
                 .context("failed to store prefetch table")?;
         }
 
         // Dump blob table
         blob_table
-            .store(&mut bootstrap_writer)
+            .store(bootstrap_writer.as_mut())
             .context("failed to store blob table")?;
 
         // Dump extended blob table
         blob_table
-            .store_extended(&mut bootstrap_writer)
+            .store_extended(bootstrap_writer.as_mut())
             .context("failed to store extended blob table")?;
 
         // Dump inodes and chunks
         timing_tracer!(
             {
                 for node in &bootstrap_ctx.nodes {
-                    node.dump_bootstrap_v5(&ctx, &mut bootstrap_writer)
+                    node.dump_bootstrap_v5(&ctx, bootstrap_writer.as_mut())
                         .context("failed to dump bootstrap")?;
                 }
 
@@ -497,7 +497,7 @@ impl Bootstrap {
             Result<()>
         )?;
 
-        bootstrap_writer.release(Some(bootstrap_ctx.name.as_str()))?;
+        bootstrap_writer.finalize(Some(bootstrap_ctx.name.as_str()))?;
 
         Ok(())
     }
@@ -591,10 +591,10 @@ impl Bootstrap {
 
         sb.set_extra_devices(blob_table_entries as u16);
 
-        sb.store(&mut bootstrap_writer)
+        sb.store(bootstrap_writer.as_mut())
             .context("failed to store SB")?;
 
-        let ext_sb_offset = bootstrap_writer.file.stream_position()?;
+        let ext_sb_offset = bootstrap_writer.seek_current(0)?;
 
         // Dump extended superblock
         let mut ext_sb = RafsV6SuperBlockExt::new();
@@ -610,7 +610,7 @@ impl Bootstrap {
             .seek_offset(EROFS_DEVTABLE_OFFSET as u64)
             .context("failed to seek devtslot")?;
         for slot in devtable.iter() {
-            slot.store(&mut bootstrap_writer)
+            slot.store(bootstrap_writer.as_mut())
                 .context("failed to store device slot")?;
         }
 
@@ -619,7 +619,7 @@ impl Bootstrap {
             .seek_offset(blob_table_offset as u64)
             .context("failed seek for extended blob table offset")?;
         blob_table
-            .store(&mut bootstrap_writer)
+            .store(bootstrap_writer.as_mut())
             .context("failed to store extended blob table")?;
 
         // collect all chunks in this bootstrap.
@@ -630,7 +630,7 @@ impl Bootstrap {
             {
                 for node in &mut bootstrap_ctx.nodes {
                     node.dump_bootstrap_v6(
-                        &mut bootstrap_writer,
+                        bootstrap_writer.as_mut(),
                         orig_meta_addr,
                         meta_addr,
                         ctx,
@@ -658,7 +658,7 @@ impl Bootstrap {
                 .seek_offset(prefetch_table_offset as u64)
                 .context("failed seek prefetch table offset")?;
 
-            pt.store(&mut bootstrap_writer).unwrap();
+            pt.store(bootstrap_writer.as_mut()).unwrap();
         }
 
         // EROFS does not have inode table, so we lose the chance to decide if this
@@ -683,7 +683,7 @@ impl Bootstrap {
         for (_, chunk) in chunk_cache.m.iter() {
             let chunk = &chunk.0;
             let chunk_size = chunk
-                .store(&mut bootstrap_writer)
+                .store(bootstrap_writer.as_mut())
                 .context("failed to dump chunk table")?;
             chunk_table_size += chunk_size as u64;
         }
@@ -695,9 +695,9 @@ impl Bootstrap {
 
         ext_sb.set_chunk_table(chunk_table_offset, chunk_table_size);
 
-        bootstrap_writer.file.seek(SeekFrom::Start(ext_sb_offset))?;
+        bootstrap_writer.seek(SeekFrom::Start(ext_sb_offset))?;
         ext_sb
-            .store(&mut bootstrap_writer)
+            .store(bootstrap_writer.as_mut())
             .context("failed to store extended SB")?;
 
         // Flush remaining data in BufWriter to file
@@ -716,7 +716,7 @@ impl Bootstrap {
             .write_all(&WRITE_PADDING_DATA[0..padding as usize])
             .context("failed to write 0 to padding of bootstrap's end")?;
 
-        bootstrap_writer.release(Some(bootstrap_ctx.name.as_str()))?;
+        bootstrap_writer.finalize(Some(bootstrap_ctx.name.as_str()))?;
 
         Ok(())
     }

--- a/src/bin/nydus-image/core/bootstrap.rs
+++ b/src/bin/nydus-image/core/bootstrap.rs
@@ -5,8 +5,7 @@
 use std::convert::TryFrom;
 use std::convert::TryInto;
 use std::ffi::OsString;
-use std::io::Seek;
-use std::io::{SeekFrom, Write};
+use std::io::SeekFrom;
 use std::mem::size_of;
 
 use anyhow::{Context, Error, Result};
@@ -454,40 +453,38 @@ impl Bootstrap {
             super_block.set_has_xattr();
         }
 
-        let mut bootstrap_writer = bootstrap_ctx.create_writer()?;
-
         // Dump super block
         super_block
-            .store(bootstrap_writer.as_mut())
+            .store(bootstrap_ctx.writer.as_mut())
             .context("failed to store superblock")?;
 
         // Dump inode table
         inode_table
-            .store(bootstrap_writer.as_mut())
+            .store(bootstrap_ctx.writer.as_mut())
             .context("failed to store inode table")?;
 
         // Dump prefetch table
         if let Some(mut prefetch_table) = ctx.prefetch.get_rafsv5_prefetch_table() {
             prefetch_table
-                .store(bootstrap_writer.as_mut())
+                .store(bootstrap_ctx.writer.as_mut())
                 .context("failed to store prefetch table")?;
         }
 
         // Dump blob table
         blob_table
-            .store(bootstrap_writer.as_mut())
+            .store(bootstrap_ctx.writer.as_mut())
             .context("failed to store blob table")?;
 
         // Dump extended blob table
         blob_table
-            .store_extended(bootstrap_writer.as_mut())
+            .store_extended(bootstrap_ctx.writer.as_mut())
             .context("failed to store extended blob table")?;
 
         // Dump inodes and chunks
         timing_tracer!(
             {
                 for node in &bootstrap_ctx.nodes {
-                    node.dump_bootstrap_v5(&ctx, bootstrap_writer.as_mut())
+                    node.dump_bootstrap_v5(&ctx, bootstrap_ctx.writer.as_mut())
                         .context("failed to dump bootstrap")?;
                 }
 
@@ -497,7 +494,9 @@ impl Bootstrap {
             Result<()>
         )?;
 
-        bootstrap_writer.finalize(Some(bootstrap_ctx.name.as_str()))?;
+        bootstrap_ctx
+            .writer
+            .finalize(Some(bootstrap_ctx.name.as_str()))?;
 
         Ok(())
     }
@@ -521,7 +520,6 @@ impl Bootstrap {
         // +---+---------+------------+-------------+-------------------------------------------------------------------+
 
         let blob_table_size = blob_table.size() as u64;
-        let mut bootstrap_writer = bootstrap_ctx.create_writer()?;
 
         // get devt_slotoff
         let mut devtable: Vec<RafsV6Device> = Vec::new();
@@ -591,10 +589,10 @@ impl Bootstrap {
 
         sb.set_extra_devices(blob_table_entries as u16);
 
-        sb.store(bootstrap_writer.as_mut())
+        sb.store(bootstrap_ctx.writer.as_mut())
             .context("failed to store SB")?;
 
-        let ext_sb_offset = bootstrap_writer.seek_current(0)?;
+        let ext_sb_offset = bootstrap_ctx.writer.seek_current(0)?;
 
         // Dump extended superblock
         let mut ext_sb = RafsV6SuperBlockExt::new();
@@ -606,20 +604,22 @@ impl Bootstrap {
         // we need to write extended_sb until chunk table is dumped.
 
         // dump devtslot
-        bootstrap_writer
+        bootstrap_ctx
+            .writer
             .seek_offset(EROFS_DEVTABLE_OFFSET as u64)
             .context("failed to seek devtslot")?;
         for slot in devtable.iter() {
-            slot.store(bootstrap_writer.as_mut())
+            slot.store(bootstrap_ctx.writer.as_mut())
                 .context("failed to store device slot")?;
         }
 
         // Dump blob table
-        bootstrap_writer
+        bootstrap_ctx
+            .writer
             .seek_offset(blob_table_offset as u64)
             .context("failed seek for extended blob table offset")?;
         blob_table
-            .store(bootstrap_writer.as_mut())
+            .store(bootstrap_ctx.writer.as_mut())
             .context("failed to store extended blob table")?;
 
         // collect all chunks in this bootstrap.
@@ -630,7 +630,7 @@ impl Bootstrap {
             {
                 for node in &mut bootstrap_ctx.nodes {
                     node.dump_bootstrap_v6(
-                        bootstrap_writer.as_mut(),
+                        bootstrap_ctx.writer.as_mut(),
                         orig_meta_addr,
                         meta_addr,
                         ctx,
@@ -654,11 +654,12 @@ impl Bootstrap {
             // Device slots are very close to extended super block.
             ext_sb.set_prefetch_table_offset(prefetch_table_offset);
             ext_sb.set_prefetch_table_size(prefetch_table_size);
-            bootstrap_writer
+            bootstrap_ctx
+                .writer
                 .seek_offset(prefetch_table_offset as u64)
                 .context("failed seek prefetch table offset")?;
 
-            pt.store(bootstrap_writer.as_mut()).unwrap();
+            pt.store(bootstrap_ctx.writer.as_mut()).unwrap();
         }
 
         // EROFS does not have inode table, so we lose the chance to decide if this
@@ -669,11 +670,13 @@ impl Bootstrap {
 
         // append chunk info table.
         // align chunk table to EROFS_BLOCK_SIZE firstly.
-        let pos = bootstrap_writer
+        let pos = bootstrap_ctx
+            .writer
             .seek_to_end()
             .context("failed to seek to bootstrap's end for chunk table")?;
         let padding = align_offset(pos, EROFS_BLOCK_SIZE as u64) - pos;
-        bootstrap_writer
+        bootstrap_ctx
+            .writer
             .write_all(&WRITE_PADDING_DATA[0..padding as usize])
             .context("failed to write 0 to padding of bootstrap's end for chunk table")?;
 
@@ -683,7 +686,7 @@ impl Bootstrap {
         for (_, chunk) in chunk_cache.m.iter() {
             let chunk = &chunk.0;
             let chunk_size = chunk
-                .store(bootstrap_writer.as_mut())
+                .store(bootstrap_ctx.writer.as_mut())
                 .context("failed to dump chunk table")?;
             chunk_table_size += chunk_size as u64;
         }
@@ -695,16 +698,18 @@ impl Bootstrap {
 
         ext_sb.set_chunk_table(chunk_table_offset, chunk_table_size);
 
-        bootstrap_writer.seek(SeekFrom::Start(ext_sb_offset))?;
+        bootstrap_ctx.writer.seek(SeekFrom::Start(ext_sb_offset))?;
         ext_sb
-            .store(bootstrap_writer.as_mut())
+            .store(bootstrap_ctx.writer.as_mut())
             .context("failed to store extended SB")?;
 
         // Flush remaining data in BufWriter to file
-        bootstrap_writer
+        bootstrap_ctx
+            .writer
             .flush()
             .context("failed to flush bootstrap")?;
-        let pos = bootstrap_writer
+        let pos = bootstrap_ctx
+            .writer
             .seek_to_end()
             .context("failed to seek to bootstrap's end")?;
         debug!(
@@ -712,11 +717,14 @@ impl Bootstrap {
             align_offset(pos, EROFS_BLOCK_SIZE as u64)
         );
         let padding = align_offset(pos, EROFS_BLOCK_SIZE as u64) - pos;
-        bootstrap_writer
+        bootstrap_ctx
+            .writer
             .write_all(&WRITE_PADDING_DATA[0..padding as usize])
             .context("failed to write 0 to padding of bootstrap's end")?;
 
-        bootstrap_writer.finalize(Some(bootstrap_ctx.name.as_str()))?;
+        bootstrap_ctx
+            .writer
+            .finalize(Some(bootstrap_ctx.name.as_str()))?;
 
         Ok(())
     }

--- a/src/bin/nydus-image/core/bootstrap.rs
+++ b/src/bin/nydus-image/core/bootstrap.rs
@@ -496,7 +496,7 @@ impl Bootstrap {
 
         bootstrap_ctx
             .writer
-            .finalize(Some(bootstrap_ctx.name.as_str()))?;
+            .finalize(Some(bootstrap_ctx.name.to_string()))?;
 
         Ok(())
     }
@@ -724,7 +724,7 @@ impl Bootstrap {
 
         bootstrap_ctx
             .writer
-            .finalize(Some(bootstrap_ctx.name.as_str()))?;
+            .finalize(Some(bootstrap_ctx.name.to_string()))?;
 
         Ok(())
     }

--- a/src/bin/nydus-image/core/node.rs
+++ b/src/bin/nydus-image/core/node.rs
@@ -1860,7 +1860,7 @@ mod tests {
 
         let bootstrap_path = TempFile::new().unwrap();
         let storage = ArtifactStorage::SingleFile(bootstrap_path.as_path().to_path_buf());
-        let mut bootstrap_ctx = BootstrapContext::new(storage, false).unwrap();
+        let mut bootstrap_ctx = BootstrapContext::new(storage, false, false).unwrap();
         bootstrap_ctx.offset = 0;
 
         // reg file.

--- a/src/bin/nydus-image/core/node.rs
+++ b/src/bin/nydus-image/core/node.rs
@@ -8,7 +8,7 @@
 use std::ffi::{OsStr, OsString};
 use std::fmt::{self, Display, Formatter, Result as FmtResult};
 use std::fs::{self, File};
-use std::io::{Read, SeekFrom};
+use std::io::{Read, SeekFrom, Write};
 use std::mem::size_of;
 use std::os::linux::fs::MetadataExt;
 use std::os::unix::ffi::OsStrExt;
@@ -1860,7 +1860,7 @@ mod tests {
 
         let bootstrap_path = TempFile::new().unwrap();
         let storage = ArtifactStorage::SingleFile(bootstrap_path.as_path().to_path_buf());
-        let mut bootstrap_ctx = BootstrapContext::new(storage, false, false).unwrap();
+        let mut bootstrap_ctx = BootstrapContext::new(Some(storage), false, false).unwrap();
         bootstrap_ctx.offset = 0;
 
         // reg file.

--- a/src/bin/nydus-image/core/node.rs
+++ b/src/bin/nydus-image/core/node.rs
@@ -8,8 +8,7 @@
 use std::ffi::{OsStr, OsString};
 use std::fmt::{self, Display, Formatter, Result as FmtResult};
 use std::fs::{self, File};
-use std::io::Read;
-use std::io::SeekFrom;
+use std::io::{Read, SeekFrom};
 use std::mem::size_of;
 use std::os::linux::fs::MetadataExt;
 use std::os::unix::ffi::OsStrExt;

--- a/src/bin/nydus-image/main.rs
+++ b/src/bin/nydus-image/main.rs
@@ -209,6 +209,12 @@ fn prepare_cmd_args(bti_string: String) -> ArgMatches<'static> {
                         .required_unless("blob-dir")
                         .takes_value(true)
                 ).arg(
+                    Arg::with_name("inline-bootstrap")
+                        .long("inline-bootstrap")
+                        .help("append bootstrap data to blob")
+                        .takes_value(false)
+                        .required(false),
+                ).arg(
                     Arg::with_name("blob-id")
                         .long("blob-id")
                         .help("blob id (as object id in backend/oss)")
@@ -609,6 +615,7 @@ impl Command {
         }
 
         let prefetch = Self::get_prefetch(matches)?;
+        let inline_bootstrap = matches.is_present("inline-bootstrap");
 
         let mut build_ctx = BuildContext::new(
             blob_id,
@@ -622,6 +629,7 @@ impl Command {
             source_path,
             prefetch,
             blob_stor,
+            inline_bootstrap,
         );
         build_ctx.set_fs_version(version);
         build_ctx.set_chunk_size(chunk_size);

--- a/src/bin/nydus-image/main.rs
+++ b/src/bin/nydus-image/main.rs
@@ -198,6 +198,8 @@ fn prepare_cmd_args(bti_string: String) -> ArgMatches<'static> {
                         .help("path to store the nydus image's metadata blob")
                         .required_unless("diff-bootstrap-dir")
                         .conflicts_with("diff-bootstrap-dir")
+                        .required_unless("inline-bootstrap")
+                        .conflicts_with("inline-bootstrap")
                         .takes_value(true),
                 ).arg(
                     Arg::with_name("blob")
@@ -642,7 +644,9 @@ impl Command {
             )?);
         }
 
-        let mut bootstrap_mgr = if source_type == SourceType::Diff {
+        let mut bootstrap_mgr = if inline_bootstrap {
+            BootstrapManager::new(None, parent_bootstrap)
+        } else if source_type == SourceType::Diff {
             let bootstrap_dir = matches.value_of("diff-bootstrap-dir");
             let storage = if let Some(bootstrap_dir) = bootstrap_dir {
                 Self::ensure_directory(&bootstrap_dir)?;
@@ -651,11 +655,11 @@ impl Command {
                 let bootstrap_path = Self::get_bootstrap(&matches)?;
                 ArtifactStorage::SingleFile(PathBuf::from(bootstrap_path))
             };
-            BootstrapManager::new(storage, parent_bootstrap)
+            BootstrapManager::new(Some(storage), parent_bootstrap)
         } else {
             let bootstrap_path = Self::get_bootstrap(&matches)?;
             BootstrapManager::new(
-                ArtifactStorage::SingleFile(PathBuf::from(bootstrap_path)),
+                Some(ArtifactStorage::SingleFile(PathBuf::from(bootstrap_path))),
                 parent_bootstrap,
             )
         };
@@ -685,9 +689,12 @@ impl Command {
         event_tracer!("egid", "{}", getegid());
 
         // Validate output bootstrap file
-        let bootstrap_path = bootstrap_mgr.get_bootstrap_path(&build_output.last_bootstrap_name);
-        Self::validate_image(&matches, &bootstrap_path)?;
-        info!("build successfully: {:?}", build_output,);
+        if let Some(bootstrap_path) =
+            bootstrap_mgr.get_bootstrap_path(&build_output.last_bootstrap_name)
+        {
+            Self::validate_image(&matches, &bootstrap_path)?;
+            info!("build successfully: {:?}", build_output,);
+        }
 
         OutputSerializer::dump(matches, build_output, &build_info)?;
 

--- a/src/bin/nydus-image/merge.rs
+++ b/src/bin/nydus-image/merge.rs
@@ -170,7 +170,7 @@ impl Merger {
         let mut tree = tree.unwrap();
         let mut bootstrap = Bootstrap::new()?;
         let storage = ArtifactStorage::SingleFile(target.clone());
-        let mut bootstrap_ctx = BootstrapContext::new(storage, false)?;
+        let mut bootstrap_ctx = BootstrapContext::new(storage, false, false)?;
         bootstrap.build(ctx, &mut bootstrap_ctx, &mut tree)?;
         let blob_table = blob_mgr.to_blob_table(&ctx)?;
         bootstrap

--- a/src/bin/nydus-image/merge.rs
+++ b/src/bin/nydus-image/merge.rs
@@ -170,7 +170,7 @@ impl Merger {
         let mut tree = tree.unwrap();
         let mut bootstrap = Bootstrap::new()?;
         let storage = ArtifactStorage::SingleFile(target.clone());
-        let mut bootstrap_ctx = BootstrapContext::new(storage, false, false)?;
+        let mut bootstrap_ctx = BootstrapContext::new(Some(storage), false, false)?;
         bootstrap.build(ctx, &mut bootstrap_ctx, &mut tree)?;
         let blob_table = blob_mgr.to_blob_table(&ctx)?;
         bootstrap


### PR DESCRIPTION
Enable `inline-bootstrap` option to merge the blob and bootstrap into one
file. We need some header to index the location of the blob and bootstrap,
this patch uses a tar header structure that arranges the data as follows:

`blob_data | blob_tar_header | bootstrap_data | boostrap_tar_header`

This is a tar-like structure, except that we put the tar header after the
data. The advantage is that we do not need to determine the size of the data
first, so that we can write the blob data by stream without seek to improve
the performance of the blob dump by using fifo, if we need to read the bootstrap
data quickly, first need to read the 512 bytes tar header from the end of blob
file first, and then seek offset to read bootstrap data.

Related PR: https://github.com/containerd/nydus-snapshotter/pull/44