### PR TITLE
storage: fix batched comprssed blob read

### DIFF
--- a/storage/src/meta/mod.rs
+++ b/storage/src/meta/mod.rs
@@ -503,7 +503,7 @@ impl BlobMetaInfo {
         } else {
             std::cmp::min(
                 start.checked_add(batch_size).unwrap_or(end),
-                self.state.uncompressed_size,
+                self.state.compressed_size,
             )
         };
 


### PR DESCRIPTION
It should use ``compressed size`` instead of ``uncompressed size``
in get_chunks_compressed() so that prefetch can work properly.

Signed-off-by: Gao Xiang \<hsiangkao@linux.alibaba.com\>