### PR TITLE
cat heredoc will not work with sudo

### DIFF
--- a/docs/containerd-env-setup.md
+++ b/docs/containerd-env-setup.md
@@ -23,7 +23,7 @@ sudo cp nydusify containerd-nydus-grpc /usr/local/bin
 Nydus provides a containerd remote snapshotter `containerd-nydus-grpc` to prepare container rootfs with nydus formatted images. To start it, first save a `nydusd` configuration to `/etc/nydusd-config.json`:
 
 ```bash
-$ sudo cat > /etc/nydusd-config.json << EOF
+$ sudo tee /etc/nydusd-config.json > /dev/null << EOF
 {
   "device": {
     "backend": {


### PR DESCRIPTION
`sudo cat > SOMEPATH <<EOF` won't work when user has no permission to write to SOMEPATH.
Using `sudo tee SOMEPATH` instead.