### PR TITLE
nydusify: change args order when calling nydus-image

### DIFF
--- a/contrib/nydusify/pkg/build/builder.go
+++ b/contrib/nydusify/pkg/build/builder.go
@@ -120,12 +120,13 @@ func (builder *Builder) Run(option BuilderOption) error {
 		option.OutputJSONPath,
 		"--blob",
 		option.BlobPath,
-		option.RootfsPath,
 	)
 
 	if len(option.PrefetchPatterns) > 0 {
 		args = append(args, "--prefetch-policy", "fs")
 	}
+
+	args = append(args, option.RootfsPath)
 
 	return builder.run(args, option.PrefetchPatterns)
 }

--- a/contrib/nydusify/pkg/converter/manifest.go
+++ b/contrib/nydusify/pkg/converter/manifest.go
@@ -348,7 +348,7 @@ func (mm *manifestManager) Push(ctx context.Context, buildLayers []*buildLayer) 
 		return errors.Wrap(err, "Get remote existing manifest index")
 	}
 
-	_index, err := mm.makeManifestIndex(ctx, existManifests, nydusManifestDesc, ociManifestDesc)
+	ociIndex, err := mm.makeManifestIndex(ctx, existManifests, nydusManifestDesc, ociManifestDesc)
 	if err != nil {
 		return errors.Wrap(err, "Make manifest index for target")
 	}
@@ -363,7 +363,7 @@ func (mm *manifestManager) Push(ctx context.Context, buildLayers []*buildLayer) 
 		ocispec.Index
 	}{
 		MediaType: indexMediaType,
-		Index:     *_index,
+		Index:     *ociIndex,
 	}
 
 	indexDesc, indexBytes, err := utils.MarshalToDesc(index, indexMediaType)


### PR DESCRIPTION
Move root path to the last, let all command line options
before root path.

before:

nydus-image create
--bootstrap tmp/bootstraps/...
--whiteout-spec oci
--output-json tmp/bootstraps/...-output.json
--blob tmp/blobs/a9151a84-9bb4-4f85-90c1-9a0630270143
tmp/source/...
--prefetch-policy fs

after:

nydus-image create
--bootstrap tmp/bootstraps/...
--whiteout-spec oci
--output-json tmp/bootstraps/...-output.json
--blob tmp/blobs/a9151a84-9bb4-4f85-90c1-9a0630270143
--prefetch-policy fs
tmp/source/...

Signed-off-by: bin liu <bin@hyper.sh>