### PR TITLE
rafs: delete RafsSuperBlobs trait

### DIFF
--- a/rafs/src/fs.rs
+++ b/rafs/src/fs.rs
@@ -488,7 +488,7 @@ impl Rafs {
         // Without too much layout concern, just prefetch a certain range from backend.
         let prefetches = sb
             .superblock
-            .get_blobs()
+            .get_blob_infos()
             .iter()
             .map(|b| BlobPrefetchRequest {
                 blob_id: b.blob_id().to_owned(),

--- a/rafs/src/metadata/cached_v5.rs
+++ b/rafs/src/metadata/cached_v5.rs
@@ -32,8 +32,8 @@ use crate::metadata::layout::v5::{
 use crate::metadata::layout::{bytes_to_os_str, parse_xattr, RAFS_ROOT_INODE};
 use crate::metadata::{
     BlobIoVec, ChildInodeHandler, Inode, PostWalkAction, RafsError, RafsInode, RafsResult,
-    RafsSuperBlobs, RafsSuperBlock, RafsSuperInodes, RafsSuperMeta, XattrName, XattrValue, DOT,
-    DOTDOT, RAFS_ATTR_BLOCK_SIZE, RAFS_MAX_NAME,
+    RafsSuperBlock, RafsSuperInodes, RafsSuperMeta, XattrName, XattrValue, DOT, DOTDOT,
+    RAFS_ATTR_BLOCK_SIZE, RAFS_MAX_NAME,
 };
 use crate::RafsIoReader;
 
@@ -156,12 +156,6 @@ impl RafsSuperInodes for CachedSuperBlockV5 {
         digester: Algorithm,
     ) -> Result<bool> {
         rafsv5_validate_digest(inode, recursive, digester)
-    }
-}
-
-impl RafsSuperBlobs for CachedSuperBlockV5 {
-    fn get_blobs(&self) -> Vec<Arc<BlobInfo>> {
-        self.s_blob.get_all()
     }
 }
 

--- a/rafs/src/metadata/direct_v5.rs
+++ b/rafs/src/metadata/direct_v5.rs
@@ -45,9 +45,9 @@ use crate::metadata::layout::{
     RAFS_ROOT_INODE,
 };
 use crate::metadata::{
-    Attr, ChildInodeHandler, Entry, Inode, PostWalkAction, RafsInode, RafsSuperBlobs,
-    RafsSuperBlock, RafsSuperInodes, RafsSuperMeta, DOT, DOTDOT, RAFS_ATTR_BLOCK_SIZE,
-    RAFS_MAX_METADATA_SIZE, RAFS_MAX_NAME,
+    Attr, ChildInodeHandler, Entry, Inode, PostWalkAction, RafsInode, RafsSuperBlock,
+    RafsSuperInodes, RafsSuperMeta, DOT, DOTDOT, RAFS_ATTR_BLOCK_SIZE, RAFS_MAX_METADATA_SIZE,
+    RAFS_MAX_NAME,
 };
 use crate::{RafsError, RafsIoReader, RafsResult};
 
@@ -379,12 +379,6 @@ impl RafsSuperInodes for DirectSuperBlockV5 {
         digester: Algorithm,
     ) -> Result<bool> {
         rafsv5_validate_digest(inode, recursive, digester)
-    }
-}
-
-impl RafsSuperBlobs for DirectSuperBlockV5 {
-    fn get_blobs(&self) -> Vec<Arc<BlobInfo>> {
-        self.state.load().blob_table.get_all()
     }
 }
 

--- a/rafs/src/metadata/direct_v6.rs
+++ b/rafs/src/metadata/direct_v6.rs
@@ -46,8 +46,8 @@ use crate::metadata::{
         XattrName, XattrValue,
     },
     {
-        Attr, ChildInodeHandler, Entry, Inode, PostWalkAction, RafsInode, RafsSuperBlobs,
-        RafsSuperBlock, RafsSuperInodes, RafsSuperMeta, RAFS_ATTR_BLOCK_SIZE,
+        Attr, ChildInodeHandler, Entry, Inode, PostWalkAction, RafsInode, RafsSuperBlock,
+        RafsSuperInodes, RafsSuperMeta, RAFS_ATTR_BLOCK_SIZE,
     },
 };
 use crate::{MetaType, RafsError, RafsIoReader, RafsResult};
@@ -284,12 +284,6 @@ impl RafsSuperInodes for DirectSuperBlockV6 {
         _digester: Algorithm,
     ) -> Result<bool> {
         todo!()
-    }
-}
-
-impl RafsSuperBlobs for DirectSuperBlockV6 {
-    fn get_blobs(&self) -> Vec<Arc<BlobInfo>> {
-        self.state.load().blob_table.get_all()
     }
 }
 

--- a/rafs/src/metadata/mod.rs
+++ b/rafs/src/metadata/mod.rs
@@ -75,14 +75,8 @@ pub trait RafsSuperInodes {
     ) -> Result<bool>;
 }
 
-/// Trait to get information about a Rafs filesystem instance.
-pub trait RafsSuperBlobs {
-    /// Get blob information for all blobs referenced by the filesystem instance.
-    fn get_blobs(&self) -> Vec<Arc<BlobInfo>>;
-}
-
 /// Trait to access Rafs filesystem superblock and inodes.
-pub trait RafsSuperBlock: RafsSuperBlobs + RafsSuperInodes + Send + Sync {
+pub trait RafsSuperBlock: RafsSuperInodes + Send + Sync {
     /// Load the super block from a reader.
     fn load(&mut self, r: &mut RafsIoReader) -> Result<()>;
 

--- a/rafs/src/metadata/noop.rs
+++ b/rafs/src/metadata/noop.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use nydus_utils::digest;
 use storage::device::BlobInfo;
 
-use crate::metadata::{Inode, RafsInode, RafsSuperBlobs, RafsSuperBlock, RafsSuperInodes};
+use crate::metadata::{Inode, RafsInode, RafsSuperBlock, RafsSuperInodes};
 use crate::{RafsIoReader, RafsResult};
 
 pub struct NoopSuperBlock {}
@@ -42,12 +42,6 @@ impl RafsSuperInodes for NoopSuperBlock {
         _recursive: bool,
         _digester: digest::Algorithm,
     ) -> Result<bool> {
-        unimplemented!()
-    }
-}
-
-impl RafsSuperBlobs for NoopSuperBlock {
-    fn get_blobs(&self) -> Vec<Arc<BlobInfo>> {
         unimplemented!()
     }
 }

--- a/rafs/src/mock/mock_super.rs
+++ b/rafs/src/mock/mock_super.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use nydus_utils::digest;
 use storage::device::BlobInfo;
 
-use crate::metadata::{Inode, RafsInode, RafsSuperBlobs, RafsSuperBlock, RafsSuperInodes};
+use crate::metadata::{Inode, RafsInode, RafsSuperBlock, RafsSuperInodes};
 use crate::{RafsIoReader, RafsResult};
 
 pub struct MockSuperBlock {
@@ -50,12 +50,6 @@ impl RafsSuperInodes for MockSuperBlock {
         _recursive: bool,
         _digester: digest::Algorithm,
     ) -> Result<bool> {
-        unimplemented!()
-    }
-}
-
-impl RafsSuperBlobs for MockSuperBlock {
-    fn get_blobs(&self) -> Vec<Arc<BlobInfo>> {
         unimplemented!()
     }
 }


### PR DESCRIPTION
method get_blobs of RafsSuperBlobs has the same signature as
get_blob_infos of RafsSuperBlock,
and RafsSuperBlock is inheritance of RafsSuperBlobs.

But the only one use of the get_blobs is based on type of
RafsSuperBlock, so RafsSuperBlobs is no meanings, it can
be deleted and replaced by get_blob_infos method.

Signed-off-by: bin liu <bin@hyper.sh>