### PR TITLE
cargo: virtiofs does not depend on blobfs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,7 +74,7 @@ rand = "0.8.5"
 
 [features]
 fusedev = ["nydus-utils/fusedev", "fuse-backend-rs/fusedev"]
-virtiofs = ["fuse-backend-rs/vhost-user-fs", "vm-memory", "vhost", "vhost-user-backend", "virtio-queue", "virtio-bindings", "blobfs/virtiofs"]
+virtiofs = ["fuse-backend-rs/vhost-user-fs", "vm-memory", "vhost", "vhost-user-backend", "virtio-queue", "virtio-bindings"]
 
 [workspace]
 members = ["api", "app", "error", "rafs", "storage", "utils", "blobfs"]


### PR DESCRIPTION
Other projects should enable the blobfs/virtiofs feature directly instead of
rely on the virtiofs feature.
