### PR TITLE
action: release macos bianries as well

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build-nydus-rs:
+  nydus-linux:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -33,9 +33,10 @@ jobs:
         declare -A rust_arch_map=( ["amd64"]="x86_64" ["arm64"]="aarch64")
         arch=${rust_arch_map[${{ matrix.arch }}]}
         cargo install cross
-        rustup component add rustfmt && rustup component add clippy
+        rustup component add rustfmt clippy
         make -e ARCH=$arch -e CARGO=cross static-release
         sudo mv target-fusedev/$arch-unknown-linux-musl/release/nydusd nydusd-fusedev
+        sudo mv target-fusedev/$arch-unknown-linux-musl/release/nydus-cached .
         sudo mv target-fusedev/$arch-unknown-linux-musl/release/nydus-image .
         sudo mv target-fusedev/$arch-unknown-linux-musl/release/nydusctl .
         sudo mv target-virtiofs/$arch-unknown-linux-musl/release/nydusd nydusd-virtiofs
@@ -44,14 +45,53 @@ jobs:
     - name: store-artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: nydus-artifacts-${{ matrix.arch }}
+        name: nydus-artifacts-linux-${{ matrix.arch }}
         path: |
           nydusd-fusedev
           nydusd-virtiofs
+          nydus-cached
           nydus-image
           nydusctl
           configs
-  build-contrib:
+
+  nydus-macos:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        arch: [amd64, arm64]
+    steps:
+    - uses: actions/checkout@v2
+    - name: Cache cargo
+      uses: Swatinem/rust-cache@v1
+      with:
+        target-dir: |
+          ./target-fusedev
+        cache-on-failure: true
+        key: ${{ runner.os }}-cargo-${{ matrix.arch }}
+    - name: build
+      # nydusd link failure on arm64 Darwin
+      if: matrix.arch != 'arm64'
+      run: |
+        # MacOS bash is too old to support declare -A
+        arch=$(test ${{ matrix.arch }} == "amd64" && echo "x86_64" || echo "aarch64")
+        rustup component add rustfmt clippy
+        rustup target install $arch-apple-darwin
+        make -e ARCH=$arch macos-fusedev
+        sudo mv target-fusedev/$arch-apple-darwin/release/nydusd nydusd-fusedev
+        sudo mv target-fusedev/$arch-apple-darwin/release/nydusctl .
+        sudo cp -r misc/configs .
+        sudo chown -R $(id -un):$(id -gn) . ~/.cargo/
+    - name: store-artifacts
+      if: matrix.arch != 'arm64'
+      uses: actions/upload-artifact@v2
+      with:
+        name: nydus-artifacts-darwin-${{ matrix.arch }}
+        path: |
+          nydusd-fusedev
+          nydusctl
+          configs
+
+  contrib-linux:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -80,46 +120,90 @@ jobs:
     - name: store-artifacts
       uses: actions/upload-artifact@v2
       with:
-        name: nydus-artifacts-${{ matrix.arch }}
+        name: nydus-artifacts-linux-${{ matrix.arch }}
         path: |
           ctr-remote
           nydus_graphdriver
           nydusify
           nydus-overlayfs
           containerd-nydus-grpc
-  upload-artifacts:
+
+  prepare-tarball-linux:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         arch: [amd64, arm64]
-    needs: [build-nydus-rs, build-contrib]
+        os: [linux]
+    needs: [nydus-linux, contrib-linux]
     steps:
-    - uses: actions/checkout@v2
-    - name: install hub
-      run: |
-        HUB_VER=$(curl -s "https://api.github.com/repos/github/hub/releases/latest" | jq -r .tag_name | sed 's/^v//')
-        wget -q -O- https://github.com/github/hub/releases/download/v$HUB_VER/hub-linux-amd64-$HUB_VER.tgz | \
-        tar xz --strip-components=2 --wildcards '*/bin/hub'
-        sudo mv hub /usr/local/bin/hub
     - name: download artifacts
       uses: actions/download-artifact@v2
       with:
-        name: nydus-artifacts-${{ matrix.arch }}
+        name: nydus-artifacts-${{ matrix.os }}-${{ matrix.arch }}
         path: nydus-static
-    - name: upload artifacts
-      if: ${{ github.event_name == 'push' }}
+    - name: prepare release tarball
       run: |
         tag=$(echo $GITHUB_REF | cut -d/ -f3-)
-        tarball="nydus-static-$tag-linux-${{ matrix.arch }}.tgz"
+        tarball="nydus-static-$tag-${{ matrix.os }}-${{ matrix.arch }}.tgz"
         chmod +x nydus-static/*
         tar cf - nydus-static | gzip > ${tarball}
-        echo "tag=$tag" >> $GITHUB_ENV
-        echo "tarball=$tarball" >> $GITHUB_ENV
-    - name: Release
-      if: ${{ github.event_name == 'push' }}
+        echo "tarball=${tarball}" >> $GITHUB_ENV
+    - name: store-artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: nydus-release-tarball
+        path: ${{ env.tarball }}
+
+  # use a seperate job for darwin because github action if: condition cannot handle && properly.
+  prepare-tarball-darwin:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: [amd64]
+        os: [darwin]
+    needs: [nydus-macos]
+    steps:
+    - name: download artifacts
+      uses: actions/download-artifact@v2
+      with:
+        name: nydus-artifacts-${{ matrix.os }}-${{ matrix.arch }}
+        path: nydus-static
+    - name: prepare release tarball
+      run: |
+        tag=$(echo $GITHUB_REF | cut -d/ -f3-)
+        tarball="nydus-static-$tag-${{ matrix.os }}-${{ matrix.arch }}.tgz"
+        chmod +x nydus-static/*
+        tar cf - nydus-static | gzip > ${tarball}
+        echo "tarball=${tarball}" >> $GITHUB_ENV
+    - name: store-artifacts
+      uses: actions/upload-artifact@v2
+      with:
+        name: nydus-release-tarball
+        path: ${{ env.tarball }}
+
+  create-release:
+    runs-on: ubuntu-latest
+    needs: [prepare-tarball-linux, prepare-tarball-darwin]
+    steps:
+    - name: download artifacts
+      uses: actions/download-artifact@v2
+      with:
+        name: nydus-release-tarball
+        path: nydus-tarball
+    - name: prepare release env
+      run: |
+        cnt=0
+        for I in $(ls nydus-tarball);do cnt=$((cnt+1)); echo "tarball${cnt}=nydus-tarball/${I}" >> $GITHUB_ENV; done
+        tag=$(echo $GITHUB_REF | cut -d/ -f3-)
+        echo "tag=${tag}" >> $GITHUB_ENV
+        cat $GITHUB_ENV
+    - name: push release
+      if: github.event_name == 'push'
       uses: softprops/action-gh-release@v1
       with:
         name: "Nydus Image Service ${{ env.tag }}"
         generate_release_notes: true
-        files:
-          ${{ env.tarball }}
+        files: |
+          ${{ env.tarball1 }}
+          ${{ env.tarball2 }}
+          ${{ env.tarball3 }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -192,8 +192,10 @@ jobs:
         path: nydus-tarball
     - name: prepare release env
       run: |
+        echo "tarballs<<EOF" >> $GITHUB_ENV
         cnt=0
-        for I in $(ls nydus-tarball);do cnt=$((cnt+1)); echo "tarball${cnt}=nydus-tarball/${I}" >> $GITHUB_ENV; done
+        for I in $(ls nydus-tarball);do cnt=$((cnt+1)); echo "nydus-tarball/${I}" >> $GITHUB_ENV; done
+        echo "EOF" >> $GITHUB_ENV
         tag=$(echo $GITHUB_REF | cut -d/ -f3-)
         echo "tag=${tag}" >> $GITHUB_ENV
         cat $GITHUB_ENV
@@ -204,6 +206,4 @@ jobs:
         name: "Nydus Image Service ${{ env.tag }}"
         generate_release_notes: true
         files: |
-          ${{ env.tarball1 }}
-          ${{ env.tarball2 }}
-          ${{ env.tarball3 }}
+          ${{ env.tarballs }}


### PR DESCRIPTION
Right now, only nydusctl and nydusd compile on macos. So just include
them in the release tarball. Other binaries can be included later.

Example run can be found here: https://github.com/bergwolf/image-service/runs/6420841588