### PR TITLE
action: add shasum file for released assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,11 +148,17 @@ jobs:
         chmod +x nydus-static/*
         tar cf - nydus-static | gzip > ${tarball}
         echo "tarball=${tarball}" >> $GITHUB_ENV
+
+        shasum="$tarball.sha256sum"
+        sha256sum $tarball > $shasum
+        echo "tarball_shasum=${shasum}" >> $GITHUB_ENV
     - name: store-artifacts
       uses: actions/upload-artifact@v2
       with:
         name: nydus-release-tarball
-        path: ${{ env.tarball }}
+        path: |
+          ${{ env.tarball }}
+          ${{ env.tarball_shasum }}
 
   # use a seperate job for darwin because github action if: condition cannot handle && properly.
   prepare-tarball-darwin:
@@ -175,11 +181,17 @@ jobs:
         chmod +x nydus-static/*
         tar cf - nydus-static | gzip > ${tarball}
         echo "tarball=${tarball}" >> $GITHUB_ENV
+
+        shasum="$tarball.sha256sum"
+        sha256sum $tarball > $shasum
+        echo "tarball_shasum=${shasum}" >> $GITHUB_ENV
     - name: store-artifacts
       uses: actions/upload-artifact@v2
       with:
         name: nydus-release-tarball
-        path: ${{ env.tarball }}
+        path: |
+          ${{ env.tarball }}
+          ${{ env.tarball_shasum }}
 
   create-release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
User can use this shasum file to verify the validity of
the downloaded nydus release tarball files.

A successful action can be found here:

https://github.com/imeoer/image-service/actions/runs/2318463434
https://github.com/imeoer/image-service/releases/tag/v2.0.5

Signed-off-by: Yan Song <yansong.ys@antfin.com>