### PR TITLE
test(nydus-image): remove unneeded `tree` dependency in unit test

### DIFF
--- a/src/bin/nydus-image/builder/diff.rs
+++ b/src/bin/nydus-image/builder/diff.rs
@@ -979,11 +979,11 @@ pub mod tests {
 
         println!(
             "lower dir:\n {}",
-            exec(&format!("tree -a {:?}", lower_dir), true).unwrap()
+            exec(&format!("ls -R {:?}", lower_dir), true).unwrap()
         );
         println!(
             "merge dir:\n{}",
-            exec(&format!("tree -a {:?}", merge_dir), true).unwrap()
+            exec(&format!("ls -R {:?}", merge_dir), true).unwrap()
         );
 
         // Diff build lower layer


### PR DESCRIPTION
Use `ls -R` instead, to avoid using `tree`.

fix #432

Signed-off-by: Qi Wang <wangqi@linux.alibaba.com>