### PR TITLE
docs: fix some typo

### DIFF
--- a/contrib/nydusify/pkg/converter/layer.go
+++ b/contrib/nydusify/pkg/converter/layer.go
@@ -135,14 +135,14 @@ func (layer *buildLayer) pushBootstrap(ctx context.Context) (*ocispec.Descriptor
 		layer.bootstrapPath, utils.BootstrapFileNameInLayer, true,
 	)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "Calculate compressed boostrap digest")
+		return nil, nil, errors.Wrap(err, "Calculate compressed bootstrap digest")
 	}
 
 	uncompressedDigest, _, err := utils.PackTargzInfo(
 		layer.bootstrapPath, utils.BootstrapFileNameInLayer, false,
 	)
 	if err != nil {
-		return nil, nil, errors.Wrap(err, "Calculate uncompressed boostrap digest")
+		return nil, nil, errors.Wrap(err, "Calculate uncompressed bootstrap digest")
 	}
 
 	bootstrapMediaType := ocispec.MediaTypeImageLayerGzip
@@ -171,7 +171,7 @@ func (layer *buildLayer) pushBootstrap(ctx context.Context) (*ocispec.Descriptor
 			layer.bootstrapPath, utils.BootstrapFileNameInLayer, true,
 		)
 		if err != nil {
-			return errors.Wrap(err, "Compress boostrap layer")
+			return errors.Wrap(err, "Compress bootstrap layer")
 		}
 		defer compressedReader.Close()
 

--- a/docs/nydus-design.md
+++ b/docs/nydus-design.md
@@ -98,13 +98,14 @@ Nydus can be configured to set up a cache for blob, called `blobcache`.  With `b
 ##    6. Compression
 Nydus can be configured to save either compressed chunk or noncompressed chunk, with compressed chunk is the default configuration.
 
-The compression algorithm is lz4 and gzip, `None` stands for noncompression.
+The compression algorithm is lz4, gzip and zstd, `None` stands for noncompression.
 
 ```rust
 pub enum Algorithm {
     None,
     LZ4Block,
     GZip,
+    Zstd,
 }
 ```
 
@@ -359,9 +360,9 @@ A typical image manifest of nydus consists of `config.json`, one nydus metadata 
 * nydus metadata layer
 
 This layer refers to the metadata part of files and directories in the image, including rafs filesystem metadata and digest for validation purpose.
-The special part is that an annotation `"containerd.io/snapshot/nydus-bootstrap": "true"` is set and lets containerd's snapshotter know it's nydus metadata layer and do its job accordingly.
 
 * nydus data layer
+
 This layer refers to the data part, please note that the data layers of an image can be owned solely by this image or shared by others, similarly, each data layer is annotated with `"containerd.io/snapshot/nydus-blob": "true"`, which can be used to tell containerd's snapshotter to skip downloading them.
 
 The manifest is designed to be compatible with the dependency architect and garbage collection algorithm widely used by containerd and registry.

--- a/docs/nydus-image.md
+++ b/docs/nydus-image.md
@@ -35,7 +35,7 @@ Generally, this is regular file which blob content will be dumped into. It can a
 ```shell
 # Build from lower layer
 nydus-image create \
-  --bootstrap /path/to/parent-bootstrap \
+  --bootstrap /path/to/bootstrap \
   --blob /path/to/blob \
   /path/to/lower/dir
 # Build from upper layer based on lower layer
@@ -54,7 +54,7 @@ nydus-image create \
 ```shell
 # Build with bootstrap type chunk-dict
 nydus-image create \
-  --bootstrap /path/to/parent-bootstrap \
+  --bootstrap /path/to/bootstrap \
   --chunk-dict bootstrap=/path/to/dict.boot \
   --blob /path/to/blob \
   /path/to/lower/dir

--- a/docs/nydusify.md
+++ b/docs/nydusify.md
@@ -1,7 +1,7 @@
 # Nydusify
 
 The Nydusify CLI tool supports:
-1. Convert an OCI container image from source registry into a Nydus image using `nydus-image` CLI layer by layer, then pushes Nydus image to target registry.
+1. Convert an OCI container image from source registry into a Nydus image using `nydus-image` CLI layer by layer, then push Nydus image to target registry.
 2. Convert local file system dictionary into Nydus image using `nydus-image`, then push Nydus-image to target remote storage(e.g. oss) optionally.
 
 ### Get binaries from release page

--- a/docs/prefetch.md
+++ b/docs/prefetch.md
@@ -1,6 +1,6 @@
 # Cache and Prefetch
 
-Nydus stores blobs in OCI compatible registry, OSS (Aliyun Object Storage Service) and local file system. Regarding to local filesystem storage backend, it doesn't mean blob can only be stored on local disk. It can surely be stored in the NAS device, which can be accessed by Posix file system interfaces.
+Nydus stores blobs in OCI compatible registry, OSS (Aliyun Object Storage Service) and local file system. Regarding to local filesystem storage backend, it doesn't mean blob can only be stored on local disk. It can surely be stored in the NAS device, which can be accessed by POSIX file system interfaces.
 
 Nydus divides a single regular file into segments by 1MB size which will be compressed by a configurable compressor like lz4, etc. The compressed segments are called chunk. Chunks are contiguously arranged within a blob file.
 
@@ -35,7 +35,7 @@ Prefetch is configurable by Rafs configuration file.
 - bandwidth_rate
 
   In unit of bytes.
-  In order to mitigate possible backend bandwidth contention, we can give a bandwidth ratelimit to prefetch. Note that the `bandwidth_rate` sets the limit to the aggregated backend bandwidth consumed by all the threads configured by `threads_count`. So with a lower `bandwidth_rate` limit, more prefetch threads might be meaningless.
+  In order to mitigate possible backend bandwidth contention, we can give a bandwidth rate limit to prefetch. Note that the `bandwidth_rate` sets the limit to the aggregated backend bandwidth consumed by all the threads configured by `threads_count`. So with a lower `bandwidth_rate` limit, more prefetch threads might be meaningless.
 
 A rafs configuration file (only `$.fs_prefetch` shows, other properties are omitted) follows:
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -46,7 +46,7 @@ The registry is now ready to use. Please refer to [docker document](https://docs
 
 ### Convert OCI Image to Nydus Image
 
-You can pull an image from Docker Hub and push it to your local registry. The following example pulls the `ubuntu:16.04` image from Docker Hub, convert to Nydus image, then pushes it to the local registry and re-tags it as `ubuntu:16.04-nydus`.
+You can pull an image from Docker Hub and push it to your local registry. The following example pulls the `ubuntu:16.04` image from Docker Hub, converts to Nydus image, then pushes it to the local registry and re-tags it as `ubuntu:16.04-nydus`.
 
 ```bash
 # workdir: image-service/contrib/nydusify

--- a/src/bin/nydus-image/core/blob_compact.rs
+++ b/src/bin/nydus-image/core/blob_compact.rs
@@ -553,14 +553,14 @@ impl BlobCompactor {
     }
 
     pub fn do_compact(
-        s_boostrap: PathBuf,
+        s_bootstrap: PathBuf,
         d_bootstrap: PathBuf,
         chunk_dict: Option<Arc<dyn ChunkDict>>,
         backend: Arc<dyn BlobBackend + Send + Sync>,
         cfg: &Config,
     ) -> Result<Option<BuildOutput>> {
-        let rs = RafsSuper::load_from_metadata(&s_boostrap, RafsMode::Direct, true)?;
-        info!("load bootstrap {:?} successfully", s_boostrap);
+        let rs = RafsSuper::load_from_metadata(&s_bootstrap, RafsMode::Direct, true)?;
+        info!("load bootstrap {:?} successfully", s_bootstrap);
         let mut build_ctx = BuildContext::new(
             "".to_string(),
             false,
@@ -599,7 +599,7 @@ impl BlobCompactor {
         compactor.compact(cfg)?;
         compactor.dump_new_blobs(&cfg.blobs_dir, build_ctx.aligned_chunk)?;
         if compactor.new_blob_mgr.len() == 0 {
-            info!("blobs of {:?} have already been optimized", s_boostrap);
+            info!("blobs of {:?} have already been optimized", s_bootstrap);
             return Ok(None);
         }
         info!("compact blob successfully");

--- a/src/bin/nydus-image/core/context.rs
+++ b/src/bin/nydus-image/core/context.rs
@@ -235,7 +235,7 @@ impl ArtifactWriter {
     // file. We need some header to index the location of the blob and bootstrap,
     // write_tar_header uses tar header that arranges the data as follows:
 
-    // blob_data | blob_tar_header | bootstrap_data | boostrap_tar_header
+    // blob_data | blob_tar_header | bootstrap_data | bootstrap_tar_header
 
     // This is a tar-like structure, except that we put the tar header after the
     // data. The advantage is that we do not need to determine the size of the data

--- a/src/bin/nydus-image/core/node.rs
+++ b/src/bin/nydus-image/core/node.rs
@@ -167,7 +167,7 @@ impl Display for NodeChunk {
 /// ChunkSource flags chunk original source in bootstrap.
 #[derive(Clone, Hash, PartialEq, Eq)]
 pub enum ChunkSource {
-    /// Chunk from parent boostrap.
+    /// Chunk from parent bootstrap.
     Parent,
     /// Chunk from this build workflow.
     Build,


### PR DESCRIPTION
Fix some typo in docs, and other files use `boostrap` instead of
`bootstrap`.

Signed-off-by: Qi Wang <wangqi@linux.alibaba.com>