### PR TITLE
refact: nydusd's state machine

### DIFF
--- a/api/src/http.rs
+++ b/api/src/http.rs
@@ -25,7 +25,8 @@ use url::Url;
 use crate::http_endpoint_v1::{
     EventsHandler, ExitHandler, FsBackendInfo, InfoHandler, MetricsBackendHandler,
     MetricsBlobcacheHandler, MetricsFilesHandler, MetricsHandler, MetricsInflightHandler,
-    MetricsPatternHandler, MountHandler, SendFuseFdHandler, TakeoverHandler, HTTP_ROOT_V1,
+    MetricsPatternHandler, MountHandler, SendFuseFdHandler, StartHandler, TakeoverHandler,
+    HTTP_ROOT_V1,
 };
 use crate::http_endpoint_v2::{BlobObjectListHandlerV2, HTTP_ROOT_V2};
 
@@ -126,6 +127,7 @@ pub enum ApiRequest {
     ExportFilesMetrics(Option<String>, bool),
     Exit,
     Takeover,
+    Start,
 
     // Filesystem Related
     Mount(String, ApiMountCmd),
@@ -398,6 +400,8 @@ lazy_static! {
         r.routes.insert(endpoint_v2!("/daemon/events"), Box::new(EventsHandler{}));
         r.routes.insert(endpoint_v1!("/daemon/exit"), Box::new(ExitHandler{}));
         r.routes.insert(endpoint_v2!("/daemon/exit"), Box::new(ExitHandler{}));
+        r.routes.insert(endpoint_v1!("/daemon/start"), Box::new(StartHandler{}));
+        r.routes.insert(endpoint_v2!("/daemon/start"), Box::new(StartHandler{}));
         r.routes.insert(endpoint_v1!("/metrics/backend"), Box::new(MetricsBackendHandler{}));
         r.routes.insert(endpoint_v2!("/metrics/backend"), Box::new(MetricsBackendHandler{}));
         r.routes.insert(endpoint_v1!("/metrics/blobcache"), Box::new(MetricsBlobcacheHandler{}));

--- a/api/src/http_endpoint_v1.rs
+++ b/api/src/http_endpoint_v1.rs
@@ -245,6 +245,23 @@ impl EndpointHandler for MountHandler {
     }
 }
 
+pub struct StartHandler {}
+impl EndpointHandler for StartHandler {
+    fn handle_request(
+        &self,
+        req: &Request,
+        kicker: &dyn Fn(ApiRequest) -> ApiResponse,
+    ) -> HttpResult {
+        match (req.method(), req.body.as_ref()) {
+            (Method::Put, None) => {
+                let r = kicker(ApiRequest::Start);
+                Ok(convert_to_response(r, HttpError::Upgrade))
+            }
+            _ => Err(HttpError::BadRequest),
+        }
+    }
+}
+
 pub struct MetricsInflightHandler {}
 impl EndpointHandler for MetricsInflightHandler {
     fn handle_request(

--- a/src/bin/nydusd/api_server_glue.rs
+++ b/src/bin/nydusd/api_server_glue.rs
@@ -63,6 +63,7 @@ impl ApiServer {
             ApiRequest::ConfigureDaemon(conf) => self.configure_daemon(conf),
             ApiRequest::DaemonInfo => self.daemon_info(true),
             ApiRequest::Exit => self.do_exit(),
+            ApiRequest::Start => self.do_start(),
             ApiRequest::Takeover => self.do_takeover(),
             ApiRequest::Events => Self::events(),
             ApiRequest::ExportGlobalMetrics(id) => Self::export_global_metrics(id),
@@ -324,6 +325,13 @@ impl ApiServer {
                 }
             }
         }
+    }
+
+    fn do_start(&self) -> ApiResponse {
+        let d = self.get_daemon_object()?;
+        d.trigger_start()
+            .map(|_| ApiResponsePayload::Empty)
+            .map_err(|e| ApiError::DaemonAbnormal(e.into()))
     }
 }
 


### PR DESCRIPTION
### QUESTION
`UPGRADING` and `INTERRUPTED` are designed for hot-upgrading, which is a use case instead of daemon's state. As a result, they are weird in lack of upgrading function.

### DESIGN
Merge `UPGRADING` and `INTERRUPTED` to `READY`. `READY` means service is well-configured, but waiting for trigger. For fuse-based daemon, it means fuse device is mounted, while fuse mountpoint may be not attached. The daemon lives in `INIT` -> `READY` -> `RUNNING` -> `READY` -> `DIE`.

### CHANGE
1. Daemon context with new status.
2. Async `TerminateFuseService`, `Umount` actions.
3. `Start` endpoint, which is usually used after `takeover` endpoint.
4. Async exit after fuse device unmounted abnormally.