### PR TITLE
rafs/v6: fix wrongly calculated prefetch table size

### DIFF
--- a/rafs/src/metadata/md_v6.rs
+++ b/rafs/src/metadata/md_v6.rs
@@ -47,7 +47,7 @@ impl RafsSuper {
         self.meta.meta_blkaddr = sb.s_meta_blkaddr;
         self.meta.root_nid = sb.s_root_nid;
 
-        self.meta.prefetch_table_entries = ext_sb.prefetch_table_size() / size_of::<u64>() as u32;
+        self.meta.prefetch_table_entries = ext_sb.prefetch_table_size() / size_of::<u32>() as u32;
         self.meta.prefetch_table_offset = ext_sb.prefetch_table_offset();
 
         trace!(


### PR DESCRIPTION
When specifying v6 prefetching files by --prefetch-polich=fs,
"/" indicates that all files should be prefetched in this nydus image.

The prefetch table size is defined as u32, but the count of prefetching
entries is wrongly calculated since the divisor is the size of u64 resulting
in no files being prefetch.

Moreover,  we should consider picking this patch into stable branches.

Signed-off-by: Changwei Ge <chge@linux.alibaba.com>