### PR TITLE
Tiny typo fix and improve nydusd help message

### DIFF
--- a/src/bin/nydusd/main.rs
+++ b/src/bin/nydusd/main.rs
@@ -210,7 +210,7 @@ fn append_fs_options(app: App<'static, 'static>) -> App<'static, 'static> {
         Arg::with_name("shared-dir")
             .long("shared-dir")
             .short("s")
-            .help("Directory shared by host and guest for passthroughfs, which also enables pathroughfs mode")
+            .help("Directory shared by host and guest for passthroughfs or a passthroughfs source for FUSE(for test and demonstration purpose), which also enables passthroughfs mode")
             .takes_value(true)
             .conflicts_with("bootstrap"),
     )

--- a/src/bin/nydusd/main.rs
+++ b/src/bin/nydusd/main.rs
@@ -195,6 +195,14 @@ extern "C" fn sig_exit(_sig: std::os::raw::c_int) {
     DAEMON_CONTROLLER.shutdown();
 }
 
+#[cfg(feature = "virtiofs")]
+const SHARED_DIR_HELP_MESSAGE: &str = "Directory shared by host and guest for \
+passthroughfs, which also enables passthroughfs mode";
+
+#[cfg(feature = "fusedev")]
+const SHARED_DIR_HELP_MESSAGE: &str = "A passthroughfs source for FUSE (the \
+purpose of testing and demonstration), which also enables passthroughfs mode";
+
 #[cfg(any(feature = "fusedev", feature = "virtiofs"))]
 fn append_fs_options(app: App<'static, 'static>) -> App<'static, 'static> {
     app.arg(
@@ -210,7 +218,7 @@ fn append_fs_options(app: App<'static, 'static>) -> App<'static, 'static> {
         Arg::with_name("shared-dir")
             .long("shared-dir")
             .short("s")
-            .help("Directory shared by host and guest for passthroughfs or a passthroughfs source for FUSE(for test and demonstration purpose), which also enables passthroughfs mode")
+            .help(SHARED_DIR_HELP_MESSAGE)
             .takes_value(true)
             .conflicts_with("bootstrap"),
     )

--- a/src/bin/nydusd/service_controller.rs
+++ b/src/bin/nydusd/service_controller.rs
@@ -20,7 +20,7 @@ use crate::daemon::{
 };
 use crate::{FsService, NydusDaemon, SubCmdArgs, DAEMON_CONTROLLER};
 
-pub struct ServiceContoller {
+pub struct ServiceController {
     bti: BuildTimeInfo,
     id: Option<String>,
     request_sender: Arc<Mutex<Sender<DaemonStateMachineInput>>>,
@@ -35,7 +35,7 @@ pub struct ServiceContoller {
     fscache: Mutex<Option<Arc<crate::fs_cache::FsCacheHandler>>>,
 }
 
-impl ServiceContoller {
+impl ServiceController {
     /// Start all enabled services.
     fn start_services(&self) -> Result<()> {
         info!("Starting all Nydus services...");
@@ -92,7 +92,7 @@ impl ServiceContoller {
 }
 
 #[cfg(target_os = "linux")]
-impl ServiceContoller {
+impl ServiceController {
     fn initialize_fscache_service(&self, subargs: &SubCmdArgs, path: &str) -> Result<()> {
         // Validate --fscache option value is an existing directory.
         let p = match Path::new(&path).canonicalize() {
@@ -135,7 +135,7 @@ impl ServiceContoller {
     }
 }
 
-impl NydusDaemon for ServiceContoller {
+impl NydusDaemon for ServiceController {
     fn as_any(&self) -> &dyn Any {
         self
     }
@@ -187,7 +187,7 @@ impl NydusDaemon for ServiceContoller {
     }
 }
 
-impl DaemonStateMachineSubscriber for ServiceContoller {
+impl DaemonStateMachineSubscriber for ServiceController {
     fn on_event(&self, event: DaemonStateMachineInput) -> DaemonResult<()> {
         self.request_sender
             .lock()
@@ -217,7 +217,7 @@ pub fn create_daemon(subargs: &SubCmdArgs, bti: BuildTimeInfo) -> Result<Arc<dyn
 
     let (to_sm, from_client) = channel::<DaemonStateMachineInput>();
     let (to_client, from_sm) = channel::<DaemonResult<()>>();
-    let service_controller = ServiceContoller {
+    let service_controller = ServiceController {
         bti,
         id,
         request_sender: Arc::new(Mutex::new(to_sm)),


### PR DESCRIPTION
Frankly speaking, `--shared-dir` is useless when nydusd works on FUSE mode. But we can still use this option to demonstrate that nydusd can work as FUSE passthroughfs and test the corresponding logics belong to `fuse-backend-rs`.

Add a more detailed help message telling why it is reserved.
In addition, fix a type name.