### PR TITLE
fix: fscache and virtio fail to start

### DIFF
--- a/src/bin/nydusd/service_controller.rs
+++ b/src/bin/nydusd/service_controller.rs
@@ -242,6 +242,9 @@ pub fn create_daemon(subargs: &SubCmdArgs, bti: BuildTimeInfo) -> Result<Arc<dyn
     let machine = DaemonStateMachineContext::new(daemon.clone(), from_client, to_client);
     machine.kick_state_machine()?;
     daemon
+        .on_event(DaemonStateMachineInput::Mount)
+        .map_err(|e| eother!(e))?;
+    daemon
         .on_event(DaemonStateMachineInput::Start)
         .map_err(|e| eother!(e))?;
 

--- a/src/bin/nydusd/virtiofs.rs
+++ b/src/bin/nydusd/virtiofs.rs
@@ -400,6 +400,9 @@ pub fn create_virtiofs_daemon(
         daemon.service.mount(cmd)?;
     }
     daemon
+        .on_event(DaemonStateMachineInput::Mount)
+        .map_err(|e| eother!(e))?;
+    daemon
         .on_event(DaemonStateMachineInput::Start)
         .map_err(|e| eother!(e))?;
 


### PR DESCRIPTION
State machine is turned on arriving 'RUNNING' via 'READY', instead from 'INIT' to 'RUNNING' directly. The virtio and fscache miss the trigger from 'INIT' to 'READY', still trying to transfer from 'INIT' to 'RUNNING' which is old fashion. So this patch add additional transformation.