### PR TITLE
storage: fix a bug related caused by merging code

### DIFF
--- a/storage/src/cache/cachedfile.rs
+++ b/storage/src/cache/cachedfile.rs
@@ -398,7 +398,7 @@ impl FileCacheEntry {
                         }
                         trace!("persist_chunk idx {}", idx);
                         Self::persist_chunk(&self.file, offset, buf).map_err(|e| {
-                            eio!(format!("do_fetch_chunk failed to persist {:?}", e))
+                            eio!(format!("do_fetch_chunk failed to persist data, {:?}", e))
                         })?;
                     }
 

--- a/storage/src/utils.rs
+++ b/storage/src/utils.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 //! Utility helpers to supprt the storage subsystem.
+use std::alloc::{alloc, Layout};
 use std::cmp::{self, min};
 use std::io::{ErrorKind, Result};
 use std::os::unix::io::RawFd;
@@ -222,13 +223,12 @@ pub fn readahead(fd: libc::c_int, mut offset: u64, end: u64) {
 
 /// A customized buf allocator that avoids zeroing
 pub fn alloc_buf(size: usize) -> Vec<u8> {
-    let mut buf = Vec::with_capacity(size);
-    // It's ok to provide uninitialized data buffer, the caller should take care of it.
-    #[allow(clippy::uninit_vec)]
-    unsafe {
-        buf.set_len(size)
-    };
-    buf
+    debug_assert!(size < isize::MAX as usize);
+    let layout = Layout::from_size_align(size, 0x1000)
+        .unwrap()
+        .pad_to_align();
+    let ptr = unsafe { alloc(layout) };
+    unsafe { Vec::from_raw_parts(ptr, size, layout.size()) }
 }
 
 /// Check hash of data matches provided one


### PR DESCRIPTION
The fscache requires that data is 4K-aligned and and size is multiple of
4K. There's a mistake when merging code into the master branch, which
breaks fscache constraints.

Signed-off-by: Jiang Liu <gerry@linux.alibaba.com>