### PR TITLE
nydusify & nydus-image: nydusify v6 image build support

### DIFF
--- a/contrib/nydusify/cmd/nydusify.go
+++ b/contrib/nydusify/cmd/nydusify.go
@@ -210,6 +210,7 @@ func main() {
 				// chosen to make it compatible with the 127 max in graph driver of
 				// docker so that we can pull cache image using docker.
 				&cli.UintFlag{Name: "build-cache-max-records", Value: maxCacheMaxRecords, Usage: "Maximum cache records in cache image", EnvVars: []string{"BUILD_CACHE_MAX_RECORDS"}},
+				&cli.StringFlag{Name: "image-version", Required: false, Usage: "Image format version", EnvVars: []string{"IMAGE_VERSION"}, Value: "5", DefaultText: "V5 format"},
 			},
 			Action: func(c *cli.Context) error {
 				setupLogLevel(c)
@@ -311,6 +312,7 @@ func main() {
 
 					NydusifyVersion: version,
 					Source:          c.String("source"),
+					ImageVersion:    c.String("image-version"),
 
 					ChunkDict: converter.ChunkDictOpt{
 						Args:     c.String("chunk-dict"),

--- a/contrib/nydusify/pkg/build/builder.go
+++ b/contrib/nydusify/pkg/build/builder.go
@@ -26,6 +26,7 @@ type BuilderOption struct {
 	// A regular file or fifo into which commands nydus-image to dump contents.
 	BlobPath     string
 	AlignedChunk bool
+	ImageVersion string
 }
 
 type CompactOption struct {
@@ -120,6 +121,8 @@ func (builder *Builder) Run(option BuilderOption) error {
 		option.OutputJSONPath,
 		"--blob",
 		option.BlobPath,
+		"--fs-version",
+		option.ImageVersion,
 	)
 
 	if len(option.PrefetchPatterns) > 0 {

--- a/contrib/nydusify/pkg/build/workflow.go
+++ b/contrib/nydusify/pkg/build/workflow.go
@@ -21,6 +21,7 @@ type WorkflowOption struct {
 	TargetDir        string
 	NydusImagePath   string
 	PrefetchPatterns string
+	ImageVersion     string
 }
 
 type Workflow struct {
@@ -118,6 +119,7 @@ func (workflow *Workflow) Build(
 		BlobPath:            blobPath,
 		AlignedChunk:        alignedChunk,
 		ChunkDict:           workflow.ChunkDict,
+		ImageVersion:        workflow.ImageVersion,
 	}); err != nil {
 		return "", errors.Wrapf(err, "build layer %s", layerDir)
 	}

--- a/contrib/nydusify/pkg/converter/converter.go
+++ b/contrib/nydusify/pkg/converter/converter.go
@@ -89,7 +89,8 @@ type Opt struct {
 	NydusifyVersion string
 	Source          string
 
-	ChunkDict ChunkDictOpt
+	ChunkDict    ChunkDictOpt
+	ImageVersion string
 }
 
 type Converter struct {
@@ -117,7 +118,8 @@ type Converter struct {
 
 	storageBackend backend.Backend
 
-	chunkDict ChunkDictOpt
+	chunkDict    ChunkDictOpt
+	ImageVersion string
 }
 
 func imageRepository(ref string) (string, error) {
@@ -156,7 +158,8 @@ func New(opt Opt) (*Converter, error) {
 
 		storageBackend: backend,
 
-		chunkDict: opt.ChunkDict,
+		chunkDict:    opt.ChunkDict,
+		ImageVersion: opt.ImageVersion,
 	}, nil
 }
 
@@ -211,6 +214,7 @@ func (cvt *Converter) convert(ctx context.Context) (retErr error) {
 		NydusImagePath:   cvt.NydusImagePath,
 		PrefetchPatterns: cvt.PrefetchPatterns,
 		TargetDir:        cvt.WorkDir,
+		ImageVersion:     cvt.ImageVersion,
 	})
 	if err != nil {
 		return errors.Wrap(err, "Create build flow")

--- a/rafs/src/metadata/direct_v6.rs
+++ b/rafs/src/metadata/direct_v6.rs
@@ -17,6 +17,7 @@
 /// before making use of any bootstrap, especially we are using them in memory-mapped mode. The
 /// rule is to call validate() after creating any data structure from the on-disk bootstrap.
 use std::any::Any;
+use std::cell::Cell;
 use std::ffi::{OsStr, OsString};
 use std::fs::File;
 use std::io::{Result, SeekFrom};
@@ -47,7 +48,7 @@ use crate::metadata::{
     },
     {
         Attr, ChildInodeHandler, Entry, Inode, PostWalkAction, RafsInode, RafsSuperBlock,
-        RafsSuperInodes, RafsSuperMeta, RAFS_ATTR_BLOCK_SIZE,
+        RafsSuperInodes, RafsSuperMeta, RAFS_ATTR_BLOCK_SIZE, RAFS_MAX_NAME,
     },
 };
 use crate::{MetaType, RafsError, RafsIoReader, RafsResult};
@@ -116,17 +117,17 @@ impl DirectMappingState {
         Ok(unsafe { &*(start as *const T) })
     }
 
-    // #[inline]
-    // fn validate_range(&self, offset: usize, size: usize) -> Result<()> {
-    //     let start = self.base.wrapping_add(offset);
-    //     let end = start.wrapping_add(size);
+    #[inline]
+    fn validate_range(&self, offset: usize, size: usize) -> Result<()> {
+        let start = self.base.wrapping_add(offset);
+        let end = start.wrapping_add(size);
 
-    //     if start > end || start < self.base || end < self.base || end > self.end {
-    //         return Err(einval!("invalid range"));
-    //     }
+        if start > end || start < self.base || end < self.base || end > self.end {
+            return Err(einval!("invalid range"));
+        }
 
-    //     Ok(())
-    // }
+        Ok(())
+    }
 }
 impl Drop for DirectMappingState {
     fn drop(&mut self) {
@@ -170,7 +171,7 @@ impl DirectSuperBlockV6 {
         }
     }
 
-    pub fn inode_wrapper(&self, nid: u64) -> Result<Arc<OndiskInodeWrapper>> {
+    fn inode_wrapper(&self, nid: u64) -> Result<Arc<OndiskInodeWrapper>> {
         // TODO(chge): ensure safety
         let offset = self.calculate_inode_offset(nid) as usize;
         let inode = self.disk_inode(offset);
@@ -179,14 +180,15 @@ impl DirectSuperBlockV6 {
             mapping: self.clone(),
             offset,
             blocks_count,
+            // so the parent_inode and name field is None, the other Inodes are created through OndiskInodeWrapper,
+            // these field will be filled with inode_wrapper_with_info
+            parent_inode: Cell::new(None),
+            name: Cell::new(None),
         }))
     }
 
-    fn calculate_inode_offset(&self, nid: u64) -> u64 {
-        let meta_offset = self.state.load().meta.meta_blkaddr as u64 * EROFS_BLOCK_SIZE;
-        meta_offset + nid * EROFS_INODE_SLOT_SIZE as u64
-    }
-
+    // For RafsV6, we can't get the parent info of a non-dir file with its on-disk inode,
+    // so we need to pass corresponding parent info when constructing the child inode.
     #[allow(clippy::cast_ptr_alignment)]
     fn update_state(&self, r: &mut RafsIoReader) -> Result<()> {
         let old_state = self.state.load();
@@ -277,13 +279,14 @@ impl RafsSuperInodes for DirectSuperBlockV6 {
         Ok(wrapper as Arc<dyn RafsInode>)
     }
 
+    /// Always return Ok(true) for RAFS v6
     fn validate_digest(
         &self,
         _inode: Arc<dyn RafsInode>,
         _recursive: bool,
         _digester: Algorithm,
     ) -> Result<bool> {
-        todo!()
+        Ok(true)
     }
 }
 
@@ -334,6 +337,12 @@ pub struct OndiskInodeWrapper {
     pub mapping: DirectSuperBlockV6,
     pub offset: usize,
     pub blocks_count: u64,
+    // OndiskInodeWrapper always through Tree::from_bootstarp to create
+    // And from_bootstarp will only create Root Inode through RafsSuperInodes:::get_inode,
+    // this time parent_inode field is None, the other Inodes are created through OndiskInodeWrapper,
+    // this field will be filled with inode_wrapper_with_parent
+    parent_inode: Cell<Option<Inode>>,
+    name: Cell<Option<OsString>>,
 }
 
 impl OndiskInodeWrapper {
@@ -578,7 +587,47 @@ impl OndiskInodeWrapper {
 impl RafsInode for OndiskInodeWrapper {
     #[allow(clippy::collapsible_if)]
     fn validate(&self, _inode_count: u64, chunk_size: u64) -> Result<()> {
-        todo!()
+        let state = self.mapping.state.load();
+        let inode = self.disk_inode();
+        let max_inode = self.mapping.get_max_ino();
+
+        if self.ino() > max_inode
+            || inode.nlink() == 0
+            || self.get_name_size() as usize > (RAFS_MAX_NAME + 1)
+        {
+            return Err(ebadf!(format!(
+                "inode validation failure, inode {:?}",
+                inode
+            )));
+        }
+
+        let xattr_size = self.xattr_size() as usize;
+
+        if self.is_reg() {
+            if state.meta.is_chunk_dict() {
+                // chunk-dict doesn't support chunk_count check
+                return Err(std::io::Error::from_raw_os_error(libc::EOPNOTSUPP));
+            }
+            let size = round_up(
+                self.this_inode_size() as u64 + xattr_size as u64,
+                size_of::<RafsV6InodeChunkAddr>() as u64,
+            ) as usize
+                + div_round_up(self.size(), self.chunk_size() as u64) as usize
+                    * size_of::<RafsV6InodeChunkAddr>();
+
+            state.validate_range(self.offset, size)?;
+        } else if self.is_dir() {
+            if self.get_child_count() as u64 >= max_inode {
+                return Err(einval!("invalid directory"));
+            }
+            let size = self.this_inode_size() + xattr_size;
+            state.validate_range(self.offset, size)?;
+        } else if self.is_symlink() {
+            if self.size() == 0 {
+                return Err(einval!("invalid symlink target"));
+            }
+        }
+        Ok(())
     }
 
     fn get_entry(&self) -> Entry {
@@ -617,7 +666,7 @@ impl RafsInode for OndiskInodeWrapper {
 
     /// Check whether the inode has extended attributes.
     fn has_xattr(&self) -> bool {
-        todo!()
+        self.disk_inode().xattr_inline_count() > 0
     }
 
     /// Get symlink target of the inode.
@@ -681,7 +730,10 @@ impl RafsInode for OndiskInodeWrapper {
         };
 
         if let Some(nid) = target {
-            Ok(self.mapping.inode_wrapper(nid)? as Arc<dyn RafsInode>)
+            Ok(self
+                .mapping
+                .inode_wrapper_with_info(nid, self.ino(), OsString::from(name))?
+                as Arc<dyn RafsInode>)
         } else {
             Err(enoent!())
         }
@@ -694,16 +746,75 @@ impl RafsInode for OndiskInodeWrapper {
     /// `idx` is the number of child files in line. So we can keep the term `idx`
     /// in super crate and keep it consistent with layout v5.
     fn get_child_by_index(&self, idx: u32) -> Result<Arc<dyn RafsInode>> {
-        todo!()
+        // Skip DOT and DOTDOT
+        let idx = idx + 2;
+        let inode = self.disk_inode();
+        let child_count = self.get_child_count();
+
+        if !self.is_dir() {
+            return Err(einval!("inode is not a directory"));
+        }
+
+        let blocks_count = div_round_up(inode.size(), EROFS_BLOCK_SIZE);
+        let mut cur_idx = 0u32;
+        for i in 0..blocks_count {
+            let head_entry = self
+                .get_entry(i as usize, 0)
+                .map_err(err_invalidate_data)
+                .unwrap();
+            let name_offset = head_entry.e_nameoff;
+            let entries_count = name_offset as u32 / size_of::<RafsV6Dirent>() as u32;
+            if cur_idx + entries_count <= idx {
+                cur_idx += entries_count;
+                continue;
+            }
+
+            let de = self
+                .get_entry(i as usize, (idx - cur_idx) as usize)
+                .map_err(err_invalidate_data)?;
+
+            let d_name = self
+                .entry_name(i as usize, (idx - cur_idx) as usize, entries_count as usize)
+                .map_err(err_invalidate_data)?;
+
+            let nid = de.e_nid;
+            return Ok(self.mapping.inode_wrapper_with_info(
+                nid,
+                self.ino(),
+                OsString::from(d_name),
+            )? as Arc<dyn RafsInode>);
+        }
+
+        Err(enoent!("invalid child index"))
     }
 
     #[inline]
     fn get_child_count(&self) -> u32 {
-        todo!()
+        // For regular file, return chunk info count.
+        if !self.is_dir() {
+            return div_round_up(self.size(), self.chunk_size() as u64) as u32;
+        }
+
+        let mut child_cnt = 0;
+        let inode = self.disk_inode();
+        let blocks_count = div_round_up(self.size(), EROFS_BLOCK_SIZE);
+        for i in 0..blocks_count {
+            let head_entry = self
+                .get_entry(i as usize, 0)
+                .map_err(err_invalidate_data)
+                .unwrap();
+            let name_offset = head_entry.e_nameoff;
+            let entries_count = name_offset / size_of::<RafsV6Dirent>() as u16;
+
+            child_cnt += entries_count as u32;
+        }
+        // Skip DOT and DOTDOT
+        child_cnt - 2
     }
 
     fn get_child_index(&self) -> Result<u32> {
-        todo!()
+        // TODO: used when inspect, indicates the index in Nodes Vec.
+        Ok(0)
     }
 
     fn walk_children_inodes(&self, entry_offset: u64, handler: ChildInodeHandler) -> Result<()> {
@@ -747,7 +858,10 @@ impl RafsInode for OndiskInodeWrapper {
                 }
 
                 let nid = de.e_nid;
-                let inode = self.mapping.inode_wrapper(nid)? as Arc<dyn RafsInode>;
+                let inode =
+                    self.mapping
+                        .inode_wrapper_with_info(nid, self.ino(), OsString::from(name))?
+                        as Arc<dyn RafsInode>;
                 trace!("found file {:?}, nid {}", name, nid);
                 cur_offset += 1;
                 match handler(Some(inode), name.to_os_string(), nid, cur_offset) {
@@ -772,7 +886,7 @@ impl RafsInode for OndiskInodeWrapper {
     /// It depends on Self::validate() to ensure valid memory layout.
     #[allow(clippy::cast_ptr_alignment)]
     fn get_chunk_info(&self, idx: u32) -> Result<Arc<dyn BlobChunkInfo>> {
-        todo!()
+        self.mapping.get_chunk_info(idx as usize)
     }
 
     fn get_xattr(&self, name: &OsStr) -> Result<Option<XattrValue>> {
@@ -789,8 +903,9 @@ impl RafsInode for OndiskInodeWrapper {
 
         let mut size = size_of::<RafsV6XattrIbodyHeader>() as u32;
 
-        while size as usize
-            <= total as usize * size_of::<RafsV6XattrEntry>() - size_of::<RafsV6XattrIbodyHeader>()
+        while (size as usize)
+            < ((total as usize) * size_of::<RafsV6XattrEntry>()
+                + size_of::<RafsV6XattrIbodyHeader>())
         {
             let e = unsafe { &*(cur as *const RafsV6XattrEntry) };
 
@@ -840,8 +955,9 @@ impl RafsInode for OndiskInodeWrapper {
 
         let mut size = size_of::<RafsV6XattrIbodyHeader>() as u32;
 
-        while size as usize
-            <= total as usize * size_of::<RafsV6XattrEntry>() - size_of::<RafsV6XattrIbodyHeader>()
+        while (size as usize)
+            < ((total as usize) * size_of::<RafsV6XattrEntry>()
+                + size_of::<RafsV6XattrIbodyHeader>())
         {
             let e = unsafe { &*(cur as *const RafsV6XattrEntry) };
 
@@ -873,15 +989,42 @@ impl RafsInode for OndiskInodeWrapper {
     /// # Safety
     /// It depends on Self::validate() to ensure valid memory layout.
     fn name(&self) -> OsString {
-        todo!()
-    }
+        if let Some(name) = self.name.take() {
+            self.name.set(Some(name.clone()));
+            name
+        } else {
+            debug_assert!(self.is_dir());
+            let cur_ino = self.ino();
+            if cur_ino == self.mapping.root_ino() {
+                return OsString::from("");
+            }
+            let parent_inode = self.mapping.inode_wrapper(self.parent()).unwrap();
+            let mut curr_name = OsString::from("");
 
+            // EROFS packs dot and dotdot, so skip them two.
+            parent_inode
+                .walk_children_inodes(
+                    2,
+                    &mut |inode: Option<Arc<dyn RafsInode>>, name: OsString, ino, offset| {
+                        if cur_ino == ino {
+                            curr_name = name;
+                            return Ok(PostWalkAction::Break);
+                        }
+                        Ok(PostWalkAction::Continue)
+                    },
+                )
+                .unwrap();
+            self.name.set(Some(curr_name.clone()));
+            curr_name
+        }
+    }
+    // RafsV5 flags, not used by v6, return 0
     fn flags(&self) -> u64 {
-        todo!()
+        0
     }
 
     fn get_digest(&self) -> RafsDigest {
-        todo!()
+        RafsDigest { data: [0u8; 32] }
     }
 
     fn is_dir(&self) -> bool {
@@ -906,17 +1049,24 @@ impl RafsInode for OndiskInodeWrapper {
 
     /// Get inode number of the parent directory.
     fn parent(&self) -> u64 {
-        todo!()
+        if let Some(parent) = self.parent_inode.get() {
+            parent
+        } else {
+            debug_assert!(self.is_dir());
+            let ino = self.get_child_by_name(OsStr::new("..")).unwrap().ino();
+            self.parent_inode.set(Some(ino));
+            ino
+        }
     }
 
     /// Get real device number of the inode.
     fn rdev(&self) -> u32 {
-        todo!()
+        self.disk_inode().union()
     }
 
     /// Get project id associated with the inode.
     fn projid(&self) -> u32 {
-        todo!()
+        0
     }
 
     /// Get data size of the inode.
@@ -927,7 +1077,7 @@ impl RafsInode for OndiskInodeWrapper {
 
     /// Get file name size of the inode.
     fn get_name_size(&self) -> u16 {
-        todo!()
+        self.name().len() as u16
     }
 
     fn get_symlink_size(&self) -> u16 {

--- a/rafs/src/metadata/direct_v6.rs
+++ b/rafs/src/metadata/direct_v6.rs
@@ -954,38 +954,34 @@ impl RafsInode for OndiskInodeWrapper {
 
         find.ok_or_else(|| enoent!("can't find chunk info"))
     }
-
+    // TODO(tianqian.zyf): Use get_xattrs implement it
     fn get_xattr(&self, name: &OsStr) -> Result<Option<XattrValue>> {
         let inode = self.disk_inode();
         let total = inode.xattr_inline_count();
         if total == 0 {
             return Ok(None);
         }
+        // xattr body size
+        let mut remaining = (total - 1) as usize * size_of::<RafsV6XattrEntry>()
+            + size_of::<RafsV6XattrIbodyHeader>();
         let m = self.mapping.state.load();
         let mut cur = unsafe {
             m.base
                 .add(self.offset + self.this_inode_size() + size_of::<RafsV6XattrIbodyHeader>())
         };
 
-        let mut size = size_of::<RafsV6XattrIbodyHeader>() as u32;
+        remaining -= size_of::<RafsV6XattrIbodyHeader>();
 
-        while (size as usize)
-            < ((total as usize) * size_of::<RafsV6XattrEntry>()
-                + size_of::<RafsV6XattrIbodyHeader>())
-        {
+        while remaining > 0 {
             let e = unsafe { &*(cur as *const RafsV6XattrEntry) };
-
             let mut xa_name = recover_namespace(e.name_index())?;
-
             let suffix = OsStr::from_bytes(unsafe {
                 slice::from_raw_parts(
                     cur.add(size_of::<RafsV6XattrEntry>()),
                     e.name_len() as usize,
                 )
             });
-
             xa_name.push(suffix);
-
             if xa_name == name {
                 let value = unsafe {
                     slice::from_raw_parts(
@@ -996,13 +992,11 @@ impl RafsInode for OndiskInodeWrapper {
                 .to_vec();
                 return Ok(Some(value));
             }
-
             let mut s = e.name_len() + e.value_size() + size_of::<RafsV6XattrEntry>() as u32;
             s = round_up(s as u64, size_of::<RafsV6XattrEntry>() as u64) as u32;
-            size += s;
+            remaining -= s as usize;
             cur = unsafe { cur.add(s as usize) };
         }
-
         Ok(None)
     }
 
@@ -1013,18 +1007,17 @@ impl RafsInode for OndiskInodeWrapper {
         if total == 0 {
             return Ok(xattrs);
         }
+        // xattr body size
+        let mut remaining = (total - 1) as usize * size_of::<RafsV6XattrEntry>()
+            + size_of::<RafsV6XattrIbodyHeader>();
         let m = self.mapping.state.load();
         let mut cur = unsafe {
             m.base
                 .add(self.offset + self.this_inode_size() + size_of::<RafsV6XattrIbodyHeader>())
         };
+        remaining -= size_of::<RafsV6XattrIbodyHeader>();
 
-        let mut size = size_of::<RafsV6XattrIbodyHeader>() as u32;
-
-        while (size as usize)
-            < ((total as usize) * size_of::<RafsV6XattrEntry>()
-                + size_of::<RafsV6XattrIbodyHeader>())
-        {
+        while remaining > 0 {
             let e = unsafe { &*(cur as *const RafsV6XattrEntry) };
 
             let ns = recover_namespace(e.name_index())?;
@@ -1038,7 +1031,7 @@ impl RafsInode for OndiskInodeWrapper {
             xattrs.push(xa);
             let mut s = e.name_len() + e.value_size() + size_of::<RafsV6XattrEntry>() as u32;
             s = round_up(s as u64, size_of::<RafsV6XattrEntry>() as u64) as u32;
-            size += s;
+            remaining -= s as usize;
             cur = unsafe { cur.add(s as usize) };
         }
 

--- a/rafs/src/metadata/layout/v6.rs
+++ b/rafs/src/metadata/layout/v6.rs
@@ -949,7 +949,7 @@ impl_bootstrap_converter!(RafsV6InodeChunkHeader);
 
 /// Rafs v6 chunk address on-disk format, 8 bytes.
 #[repr(C)]
-#[derive(Default, Clone, Copy, Debug)]
+#[derive(Default, Clone, Copy, Debug, Hash, Eq, PartialEq)]
 pub struct RafsV6InodeChunkAddr {
     /// Lower part of encoded blob address.
     c_blob_addr_lo: u16,

--- a/src/bin/nydus-image/core/bootstrap.rs
+++ b/src/bin/nydus-image/core/bootstrap.rs
@@ -33,7 +33,7 @@ const WRITE_PADDING_DATA: [u8; 4096] = [0u8; 4096];
 pub(crate) struct Bootstrap {}
 
 impl Bootstrap {
-    /// Create a new instance of `BootStrap`.
+    /// Create a new instance of `Bootstrap`.
     pub fn new() -> Result<Self> {
         Ok(Self {})
     }
@@ -77,7 +77,7 @@ impl Bootstrap {
         nodes.push(tree.node.clone());
         self.build_rafs(ctx, bootstrap_ctx, tree, &mut nodes)?;
 
-        if ctx.fs_version.is_v6() {
+        if ctx.fs_version.is_v6() && !bootstrap_ctx.layered {
             self.update_dirents(&mut nodes, tree, root_offset);
         }
         bootstrap_ctx.nodes = nodes;
@@ -116,6 +116,11 @@ impl Bootstrap {
 
         // Clear all cached states for next upper layer build.
         bootstrap_ctx.inode_map.clear();
+        bootstrap_ctx.nodes.clear();
+        bootstrap_ctx
+            .available_blocks
+            .iter_mut()
+            .for_each(|v| v.clear());
         ctx.prefetch.clear();
 
         Ok(tree)

--- a/src/bin/nydus-image/core/node.rs
+++ b/src/bin/nydus-image/core/node.rs
@@ -25,8 +25,8 @@ use nydus_utils::{
     div_round_up, round_down_4k, round_up, try_round_up_4k, ByteSize,
 };
 use rafs::metadata::cached_v5::{CachedChunkInfoV5, CachedInodeV5};
-use rafs::metadata::direct_v5::{DirectChunkInfoV5, OndiskInodeWrapper};
-use rafs::metadata::direct_v6::DirectChunkInfoV6;
+use rafs::metadata::direct_v5::{DirectChunkInfoV5, OndiskInodeWrapper as OndiskInodeWrapperV5};
+use rafs::metadata::direct_v6::{DirectChunkInfoV6, OndiskInodeWrapper as OndiskInodeWrapperV6};
 use rafs::metadata::layout::v5::{
     RafsV5ChunkInfo, RafsV5Inode, RafsV5InodeFlags, RafsV5InodeWrapper,
 };
@@ -1253,8 +1253,10 @@ impl InodeWrapper {
     pub fn from_inode_info(inode: &dyn RafsInode) -> Self {
         if let Some(inode) = inode.as_any().downcast_ref::<CachedInodeV5>() {
             InodeWrapper::V5(to_rafsv5_inode(inode))
-        } else if let Some(inode) = inode.as_any().downcast_ref::<OndiskInodeWrapper>() {
+        } else if let Some(inode) = inode.as_any().downcast_ref::<OndiskInodeWrapperV5>() {
             InodeWrapper::V5(to_rafsv5_inode(inode))
+        } else if let Some(inode) = inode.as_any().downcast_ref::<OndiskInodeWrapperV6>() {
+            InodeWrapper::V6(to_rafsv5_inode(inode))
         } else {
             panic!("unknown inode information struct");
         }

--- a/src/bin/nydus-image/core/tree.rs
+++ b/src/bin/nydus-image/core/tree.rs
@@ -20,7 +20,7 @@ use std::ffi::OsString;
 use std::path::PathBuf;
 
 use anyhow::Result;
-use rafs::metadata::layout::{bytes_to_os_str, RafsXAttrs, RAFS_ROOT_INODE};
+use rafs::metadata::layout::{bytes_to_os_str, RafsXAttrs};
 use rafs::metadata::{Inode, RafsInode, RafsSuper};
 
 use super::chunk_dict::ChunkDict;
@@ -49,13 +49,13 @@ impl Tree {
     /// Load a `Tree` from a bootstrap file, and optionally caches chunk information.
     pub fn from_bootstrap<T: ChunkDict>(rs: &RafsSuper, chunk_dict: &mut T) -> Result<Self> {
         let tree_builder = MetadataTreeBuilder::new(rs);
-        let root_inode = rs.get_inode(RAFS_ROOT_INODE, true)?;
+        let root_inode = rs.get_inode(rs.superblock.root_ino(), true)?;
         let root_node =
             MetadataTreeBuilder::parse_node(rs, root_inode.as_ref(), PathBuf::from("/"))?;
         let mut tree = Tree::new(root_node);
 
         tree.children = timing_tracer!(
-            { tree_builder.load_children(RAFS_ROOT_INODE, None, chunk_dict, true) },
+            { tree_builder.load_children(rs.superblock.root_ino(), None, chunk_dict, true) },
             "load_tree_from_bootstrap"
         )?;
 


### PR DESCRIPTION
We have adapted the `nydusify` and `nydus-image` to support using nydusify directly to build v6 image, to accomplish this purpose, we have introduce several features and fix several bugs.

Features:
1. Previously, the `load_parent_bootstrap` is unusable for v6 image, we have adapted it for both V5 and V6.
2. We have implemented all methods for v6's `OndiskInodeWrapper`.

Bug fixes:
1. The `dirents_offset` will only be used by dir and symlink files, for other files, calculating it may leads to overflow.
2. Correct chunk info implementation for v6.
3. Previous, we assume the `.` and `..` are the first and second dirents, which is wrong.
4. Under some circumstances, the xattr size is wrong.

FYI, we have tested converting all top images in the `image_list.txt` and checked their bootstraps with `fsck.erofs`.
#425 