### PR TITLE
nydusify & nydus-image: v6 image conversion support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1251,7 +1251,6 @@ version = "0.2.1"
 dependencies = [
  "blake3",
  "flate2",
- "fuse-backend-rs",
  "lazy_static",
  "libc",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ env_logger = "0.8.2"
 rand = "0.8.5"
 
 [features]
-fusedev = ["nydus-utils/fusedev", "fuse-backend-rs/fusedev"]
+fusedev = ["fuse-backend-rs/fusedev"]
 virtiofs = ["fuse-backend-rs/vhost-user-fs", "vm-memory", "vhost", "vhost-user-backend", "virtio-queue", "virtio-bindings"]
 
 [workspace]

--- a/contrib/nydusify/cmd/nydusify.go
+++ b/contrib/nydusify/cmd/nydusify.go
@@ -210,6 +210,7 @@ func main() {
 				// chosen to make it compatible with the 127 max in graph driver of
 				// docker so that we can pull cache image using docker.
 				&cli.UintFlag{Name: "build-cache-max-records", Value: maxCacheMaxRecords, Usage: "Maximum cache records in cache image", EnvVars: []string{"BUILD_CACHE_MAX_RECORDS"}},
+				&cli.StringFlag{Name: "image-version", Required: false, Usage: "Image format version", EnvVars: []string{"IMAGE_VERSION"}, Value: "5", DefaultText: "V5 format"},
 			},
 			Action: func(c *cli.Context) error {
 				setupLogLevel(c)
@@ -311,6 +312,7 @@ func main() {
 
 					NydusifyVersion: version,
 					Source:          c.String("source"),
+					ImageVersion:    c.String("image-version"),
 
 					ChunkDict: converter.ChunkDictOpt{
 						Args:     c.String("chunk-dict"),

--- a/contrib/nydusify/pkg/build/builder.go
+++ b/contrib/nydusify/pkg/build/builder.go
@@ -26,6 +26,7 @@ type BuilderOption struct {
 	// A regular file or fifo into which commands nydus-image to dump contents.
 	BlobPath     string
 	AlignedChunk bool
+	ImageVersion string
 }
 
 type CompactOption struct {
@@ -120,6 +121,8 @@ func (builder *Builder) Run(option BuilderOption) error {
 		option.OutputJSONPath,
 		"--blob",
 		option.BlobPath,
+		"--fs-version",
+		option.ImageVersion,
 	)
 
 	if len(option.PrefetchPatterns) > 0 {

--- a/contrib/nydusify/pkg/build/workflow.go
+++ b/contrib/nydusify/pkg/build/workflow.go
@@ -21,6 +21,7 @@ type WorkflowOption struct {
 	TargetDir        string
 	NydusImagePath   string
 	PrefetchPatterns string
+	ImageVersion     string
 }
 
 type Workflow struct {
@@ -118,6 +119,7 @@ func (workflow *Workflow) Build(
 		BlobPath:            blobPath,
 		AlignedChunk:        alignedChunk,
 		ChunkDict:           workflow.ChunkDict,
+		ImageVersion:        workflow.ImageVersion,
 	}); err != nil {
 		return "", errors.Wrapf(err, "build layer %s", layerDir)
 	}

--- a/contrib/nydusify/pkg/converter/converter.go
+++ b/contrib/nydusify/pkg/converter/converter.go
@@ -89,7 +89,8 @@ type Opt struct {
 	NydusifyVersion string
 	Source          string
 
-	ChunkDict ChunkDictOpt
+	ChunkDict    ChunkDictOpt
+	ImageVersion string
 }
 
 type Converter struct {
@@ -117,7 +118,8 @@ type Converter struct {
 
 	storageBackend backend.Backend
 
-	chunkDict ChunkDictOpt
+	chunkDict    ChunkDictOpt
+	ImageVersion string
 }
 
 func imageRepository(ref string) (string, error) {
@@ -156,7 +158,8 @@ func New(opt Opt) (*Converter, error) {
 
 		storageBackend: backend,
 
-		chunkDict: opt.ChunkDict,
+		chunkDict:    opt.ChunkDict,
+		ImageVersion: opt.ImageVersion,
 	}, nil
 }
 
@@ -211,6 +214,7 @@ func (cvt *Converter) convert(ctx context.Context) (retErr error) {
 		NydusImagePath:   cvt.NydusImagePath,
 		PrefetchPatterns: cvt.PrefetchPatterns,
 		TargetDir:        cvt.WorkDir,
+		ImageVersion:     cvt.ImageVersion,
 	})
 	if err != nil {
 		return errors.Wrap(err, "Create build flow")

--- a/rafs/src/fs.rs
+++ b/rafs/src/fs.rs
@@ -208,7 +208,7 @@ impl fmt::Display for RafsConfig {
 pub struct Rafs {
     id: String,
     device: BlobDevice,
-    ios: Arc<metrics::GlobalIoStats>,
+    ios: Arc<metrics::FsIoStats>,
     sb: Arc<RafsSuper>,
 
     initialized: bool,
@@ -238,7 +238,7 @@ impl Rafs {
         let rafs = Rafs {
             id: id.to_string(),
             device,
-            ios: metrics::new(id),
+            ios: metrics::FsIoStats::new(id),
             sb: Arc::new(sb),
 
             initialized: false,

--- a/rafs/src/metadata/direct_v6.rs
+++ b/rafs/src/metadata/direct_v6.rs
@@ -18,6 +18,7 @@
 /// rule is to call validate() after creating any data structure from the on-disk bootstrap.
 use std::any::Any;
 use std::cell::Cell;
+use std::collections::HashMap;
 use std::ffi::{OsStr, OsString};
 use std::fs::File;
 use std::io::{Result, SeekFrom};
@@ -31,6 +32,7 @@ use std::slice;
 use std::sync::Arc;
 
 use arc_swap::{ArcSwap, Guard};
+use std::cell::RefCell;
 
 use crate::metadata::layout::MetaRange;
 use crate::metadata::{
@@ -61,6 +63,12 @@ use storage::device::{
     BlobIoVec,
 };
 use storage::utils::readahead;
+
+// Use to store chunk info pre inode, Oour build is actually single-threaded,
+// so there's no lazy_static + mutex approach here, thread_local plus Refcell is enough.
+thread_local! {
+        static CHUNK_DICT_MAP: RefCell<Option<HashMap<RafsV6InodeChunkAddr, Arc<dyn BlobChunkInfo>>>> = RefCell::new(None);
+}
 
 fn err_invalidate_data(rafs_err: RafsError) -> std::io::Error {
     std::io::Error::new(std::io::ErrorKind::InvalidData, rafs_err)
@@ -153,6 +161,7 @@ pub struct DirectSuperBlockV6 {
 impl DirectSuperBlockV6 {
     /// Create a new instance of `DirectSuperBlockV6`.
     pub fn new(meta: &RafsSuperMeta, validate_digest: bool) -> Self {
+        CHUNK_DICT_MAP.with(|dict| *dict.borrow_mut() = None);
         let state = DirectMappingState::new(meta, validate_digest);
 
         Self {
@@ -282,6 +291,35 @@ impl DirectSuperBlockV6 {
         self.state.store(Arc::new(state));
 
         Ok(())
+    }
+
+    // For RafsV6, inode doesn't store detailed chunk info, only a simple RafsV6InodeChunkAddr
+    // so we need to use the chunk table at the end of the bootstrap to restore the chunk info of an inode
+    fn load_chunk_map(&self) -> Result<HashMap<RafsV6InodeChunkAddr, Arc<dyn BlobChunkInfo>>> {
+        let mut chunk_dict: HashMap<RafsV6InodeChunkAddr, Arc<dyn BlobChunkInfo>> =
+            HashMap::default();
+        let state = self.state.load();
+        let size = state.meta.chunk_table_size as usize;
+        if size == 0 {
+            return Ok(chunk_dict);
+        }
+
+        let unit_size = size_of::<RafsV5ChunkInfo>();
+        if size % unit_size != 0 {
+            return Err(std::io::Error::from_raw_os_error(libc::EINVAL));
+        }
+
+        for idx in 0..(size / unit_size) {
+            let chunk = self.get_chunk_info(idx)?;
+
+            let mut v6_chunk = RafsV6InodeChunkAddr::new();
+            v6_chunk.set_blob_index((chunk.blob_index() + 1) as u8);
+            v6_chunk.set_blob_comp_index(chunk.id());
+            v6_chunk.set_block_addr((chunk.uncompress_offset() / EROFS_BLOCK_SIZE) as u32);
+            chunk_dict.insert(v6_chunk, chunk);
+        }
+
+        Ok(chunk_dict)
     }
 }
 
@@ -905,7 +943,37 @@ impl RafsInode for OndiskInodeWrapper {
     /// It depends on Self::validate() to ensure valid memory layout.
     #[allow(clippy::cast_ptr_alignment)]
     fn get_chunk_info(&self, idx: u32) -> Result<Arc<dyn BlobChunkInfo>> {
-        self.mapping.get_chunk_info(idx as usize)
+        let state = self.mapping.state.load();
+        let inode = self.disk_inode();
+        if !self.is_reg() || idx >= self.get_chunk_count() {
+            return Err(enoent!("invalid chunk info"));
+        }
+        let offset = self.offset as usize
+            + round_up(
+                self.this_inode_size() as u64 + self.xattr_size() as u64,
+                size_of::<RafsV6InodeChunkAddr>() as u64,
+            ) as usize
+            + (idx as usize * size_of::<RafsV6InodeChunkAddr>());
+
+        let chunk_addr = state.cast_to_ref::<RafsV6InodeChunkAddr>(state.base, offset)?;
+
+        let mut find = None;
+        // Lazy initializes all chunk info
+        CHUNK_DICT_MAP.with(|dict| {
+            if dict.borrow().is_none() {
+                // # Safety
+                // There will always be chunk info in bootstrap, or zero chunk.
+                *dict.borrow_mut() = Some(self.mapping.load_chunk_map().unwrap());
+            }
+            find = dict
+                .borrow()
+                .as_ref()
+                .unwrap()
+                .get(chunk_addr)
+                .map(Arc::clone);
+        });
+
+        find.ok_or_else(|| enoent!("can't find chunk info"))
     }
 
     fn get_xattr(&self, name: &OsStr) -> Result<Option<XattrValue>> {

--- a/rafs/src/metadata/direct_v6.rs
+++ b/rafs/src/metadata/direct_v6.rs
@@ -803,8 +803,6 @@ impl RafsInode for OndiskInodeWrapper {
     /// `idx` is the number of child files in line. So we can keep the term `idx`
     /// in super crate and keep it consistent with layout v5.
     fn get_child_by_index(&self, idx: u32) -> Result<Arc<dyn RafsInode>> {
-        // Skip DOT and DOTDOT
-        let idx = idx + 2;
         let inode = self.disk_inode();
         let child_count = self.get_child_count();
 
@@ -821,25 +819,27 @@ impl RafsInode for OndiskInodeWrapper {
                 .unwrap();
             let name_offset = head_entry.e_nameoff;
             let entries_count = name_offset as u32 / size_of::<RafsV6Dirent>() as u32;
-            if cur_idx + entries_count <= idx {
-                cur_idx += entries_count;
-                continue;
+
+            for j in 0..entries_count {
+                let de = self
+                    .get_entry(i as usize, j as usize)
+                    .map_err(err_invalidate_data)?;
+                let name = self
+                    .entry_name(i as usize, j as usize, entries_count as usize)
+                    .map_err(err_invalidate_data)?;
+                if name == "." || name == ".." {
+                    continue;
+                }
+                if cur_idx == idx {
+                    let nid = de.e_nid;
+                    return Ok(self.mapping.inode_wrapper_with_info(
+                        nid,
+                        self.ino(),
+                        OsString::from(name),
+                    )? as Arc<dyn RafsInode>);
+                }
+                cur_idx += 1;
             }
-
-            let de = self
-                .get_entry(i as usize, (idx - cur_idx) as usize)
-                .map_err(err_invalidate_data)?;
-
-            let d_name = self
-                .entry_name(i as usize, (idx - cur_idx) as usize, entries_count as usize)
-                .map_err(err_invalidate_data)?;
-
-            let nid = de.e_nid;
-            return Ok(self.mapping.inode_wrapper_with_info(
-                nid,
-                self.ino(),
-                OsString::from(d_name),
-            )? as Arc<dyn RafsInode>);
         }
 
         Err(enoent!("invalid child index"))
@@ -1088,10 +1088,9 @@ impl RafsInode for OndiskInodeWrapper {
             let parent_inode = self.mapping.inode_wrapper(self.parent()).unwrap();
             let mut curr_name = OsString::from("");
 
-            // EROFS packs dot and dotdot, so skip them two.
             parent_inode
                 .walk_children_inodes(
-                    2,
+                    0,
                     &mut |inode: Option<Arc<dyn RafsInode>>, name: OsString, ino, offset| {
                         if cur_ino == ino {
                             curr_name = name;
@@ -1182,8 +1181,7 @@ impl RafsInode for OndiskInodeWrapper {
 
         let mut child_dirs: Vec<Arc<dyn RafsInode>> = Vec::new();
 
-        // EROFS packs dot and dotdot, so skip them two.
-        self.walk_children_inodes(2, &mut |inode: Option<Arc<dyn RafsInode>>,
+        self.walk_children_inodes(0, &mut |inode: Option<Arc<dyn RafsInode>>,
                                            name: OsString,
                                            ino,
                                            offset| {
@@ -1200,8 +1198,11 @@ impl RafsInode for OndiskInodeWrapper {
             }
         })
         .unwrap();
-
         for d in child_dirs {
+            // EROFS packs dot and dotdot, so skip them two.
+            if d.name() == "." || d.name() == ".." {
+                continue;
+            }
             d.collect_descendants_inodes(descendants)?;
         }
 

--- a/rafs/src/metadata/direct_v6.rs
+++ b/rafs/src/metadata/direct_v6.rs
@@ -17,6 +17,7 @@
 /// before making use of any bootstrap, especially we are using them in memory-mapped mode. The
 /// rule is to call validate() after creating any data structure from the on-disk bootstrap.
 use std::any::Any;
+use std::cell::Cell;
 use std::ffi::{OsStr, OsString};
 use std::fs::File;
 use std::io::{Result, SeekFrom};
@@ -47,7 +48,7 @@ use crate::metadata::{
     },
     {
         Attr, ChildInodeHandler, Entry, Inode, PostWalkAction, RafsInode, RafsSuperBlock,
-        RafsSuperInodes, RafsSuperMeta, RAFS_ATTR_BLOCK_SIZE,
+        RafsSuperInodes, RafsSuperMeta, RAFS_ATTR_BLOCK_SIZE, RAFS_MAX_NAME,
     },
 };
 use crate::{MetaType, RafsError, RafsIoReader, RafsResult};
@@ -116,17 +117,17 @@ impl DirectMappingState {
         Ok(unsafe { &*(start as *const T) })
     }
 
-    // #[inline]
-    // fn validate_range(&self, offset: usize, size: usize) -> Result<()> {
-    //     let start = self.base.wrapping_add(offset);
-    //     let end = start.wrapping_add(size);
+    #[inline]
+    fn validate_range(&self, offset: usize, size: usize) -> Result<()> {
+        let start = self.base.wrapping_add(offset);
+        let end = start.wrapping_add(size);
 
-    //     if start > end || start < self.base || end < self.base || end > self.end {
-    //         return Err(einval!("invalid range"));
-    //     }
+        if start > end || start < self.base || end < self.base || end > self.end {
+            return Err(einval!("invalid range"));
+        }
 
-    //     Ok(())
-    // }
+        Ok(())
+    }
 }
 impl Drop for DirectMappingState {
     fn drop(&mut self) {
@@ -170,7 +171,7 @@ impl DirectSuperBlockV6 {
         }
     }
 
-    pub fn inode_wrapper(&self, nid: u64) -> Result<Arc<OndiskInodeWrapper>> {
+    fn inode_wrapper(&self, nid: u64) -> Result<Arc<OndiskInodeWrapper>> {
         // TODO(chge): ensure safety
         let offset = self.calculate_inode_offset(nid) as usize;
         let inode = self.disk_inode(offset);
@@ -179,7 +180,27 @@ impl DirectSuperBlockV6 {
             mapping: self.clone(),
             offset,
             blocks_count,
+            parent_inode: Cell::new(None),
+            name: Cell::new(None),
         }))
+    }
+
+    // For RafsV6, we can't get the parent info of a non-dir file with its on-disk inode,
+    // so we need to pass corresponding parent info when constructing the child inode.
+    fn inode_wrapper_with_info(
+        &self,
+        nid: u64,
+        parent_inode: Inode,
+        name: OsString,
+    ) -> Result<Arc<OndiskInodeWrapper>> {
+        self.inode_wrapper(nid).map(|inode| {
+            let mut inode = inode;
+            // # Safety
+            // inode always valid
+            Arc::get_mut(&mut inode).unwrap().parent_inode = Cell::new(Some(parent_inode));
+            Arc::get_mut(&mut inode).unwrap().name = Cell::new(Some(name));
+            inode
+        })
     }
 
     fn calculate_inode_offset(&self, nid: u64) -> u64 {
@@ -277,13 +298,14 @@ impl RafsSuperInodes for DirectSuperBlockV6 {
         Ok(wrapper as Arc<dyn RafsInode>)
     }
 
+    /// Always return Ok(true) for RAFS v6
     fn validate_digest(
         &self,
         _inode: Arc<dyn RafsInode>,
         _recursive: bool,
         _digester: Algorithm,
     ) -> Result<bool> {
-        todo!()
+        Ok(true)
     }
 }
 
@@ -334,6 +356,12 @@ pub struct OndiskInodeWrapper {
     pub mapping: DirectSuperBlockV6,
     pub offset: usize,
     pub blocks_count: u64,
+    // OndiskInodeWrapper always through Tree::from_bootstarp to create
+    // And from_bootstarp will only create Root Inode through RafsSuperInodes:::get_inode,
+    // this time parent_inode field is None, the other Inodes are created through OndiskInodeWrapper,
+    // this field will be filled with inode_wrapper_with_parent
+    parent_inode: Cell<Option<Inode>>,
+    name: Cell<Option<OsString>>,
 }
 
 impl OndiskInodeWrapper {
@@ -578,7 +606,47 @@ impl OndiskInodeWrapper {
 impl RafsInode for OndiskInodeWrapper {
     #[allow(clippy::collapsible_if)]
     fn validate(&self, _inode_count: u64, chunk_size: u64) -> Result<()> {
-        todo!()
+        let state = self.mapping.state.load();
+        let inode = self.disk_inode();
+        let max_inode = self.mapping.get_max_ino();
+
+        if self.ino() > max_inode
+            || inode.nlink() == 0
+            || self.get_name_size() as usize > (RAFS_MAX_NAME + 1)
+        {
+            return Err(ebadf!(format!(
+                "inode validation failure, inode {:?}",
+                inode
+            )));
+        }
+
+        let xattr_size = self.xattr_size() as usize;
+
+        if self.is_reg() {
+            if state.meta.is_chunk_dict() {
+                // chunk-dict doesn't support chunk_count check
+                return Err(std::io::Error::from_raw_os_error(libc::EOPNOTSUPP));
+            }
+            let size = round_up(
+                self.this_inode_size() as u64 + xattr_size as u64,
+                size_of::<RafsV6InodeChunkAddr>() as u64,
+            ) as usize
+                + div_round_up(self.size(), self.chunk_size() as u64) as usize
+                    * size_of::<RafsV6InodeChunkAddr>();
+
+            state.validate_range(self.offset, size)?;
+        } else if self.is_dir() {
+            if self.get_child_count() as u64 >= max_inode {
+                return Err(einval!("invalid directory"));
+            }
+            let size = self.this_inode_size() + xattr_size;
+            state.validate_range(self.offset, size)?;
+        } else if self.is_symlink() {
+            if self.size() == 0 {
+                return Err(einval!("invalid symlink target"));
+            }
+        }
+        Ok(())
     }
 
     fn get_entry(&self) -> Entry {
@@ -617,7 +685,7 @@ impl RafsInode for OndiskInodeWrapper {
 
     /// Check whether the inode has extended attributes.
     fn has_xattr(&self) -> bool {
-        todo!()
+        self.disk_inode().xattr_inline_count() > 0
     }
 
     /// Get symlink target of the inode.
@@ -681,7 +749,10 @@ impl RafsInode for OndiskInodeWrapper {
         };
 
         if let Some(nid) = target {
-            Ok(self.mapping.inode_wrapper(nid)? as Arc<dyn RafsInode>)
+            Ok(self
+                .mapping
+                .inode_wrapper_with_info(nid, self.ino(), OsString::from(name))?
+                as Arc<dyn RafsInode>)
         } else {
             Err(enoent!())
         }
@@ -694,16 +765,75 @@ impl RafsInode for OndiskInodeWrapper {
     /// `idx` is the number of child files in line. So we can keep the term `idx`
     /// in super crate and keep it consistent with layout v5.
     fn get_child_by_index(&self, idx: u32) -> Result<Arc<dyn RafsInode>> {
-        todo!()
+        // Skip DOT and DOTDOT
+        let idx = idx + 2;
+        let inode = self.disk_inode();
+        let child_count = self.get_child_count();
+
+        if !self.is_dir() {
+            return Err(einval!("inode is not a directory"));
+        }
+
+        let blocks_count = div_round_up(inode.size(), EROFS_BLOCK_SIZE);
+        let mut cur_idx = 0u32;
+        for i in 0..blocks_count {
+            let head_entry = self
+                .get_entry(i as usize, 0)
+                .map_err(err_invalidate_data)
+                .unwrap();
+            let name_offset = head_entry.e_nameoff;
+            let entries_count = name_offset as u32 / size_of::<RafsV6Dirent>() as u32;
+            if cur_idx + entries_count <= idx {
+                cur_idx += entries_count;
+                continue;
+            }
+
+            let de = self
+                .get_entry(i as usize, (idx - cur_idx) as usize)
+                .map_err(err_invalidate_data)?;
+
+            let d_name = self
+                .entry_name(i as usize, (idx - cur_idx) as usize, entries_count as usize)
+                .map_err(err_invalidate_data)?;
+
+            let nid = de.e_nid;
+            return Ok(self.mapping.inode_wrapper_with_info(
+                nid,
+                self.ino(),
+                OsString::from(d_name),
+            )? as Arc<dyn RafsInode>);
+        }
+
+        Err(enoent!("invalid child index"))
     }
 
     #[inline]
     fn get_child_count(&self) -> u32 {
-        todo!()
+        // For regular file, return chunk info count.
+        if !self.is_dir() {
+            return div_round_up(self.size(), self.chunk_size() as u64) as u32;
+        }
+
+        let mut child_cnt = 0;
+        let inode = self.disk_inode();
+        let blocks_count = div_round_up(self.size(), EROFS_BLOCK_SIZE);
+        for i in 0..blocks_count {
+            let head_entry = self
+                .get_entry(i as usize, 0)
+                .map_err(err_invalidate_data)
+                .unwrap();
+            let name_offset = head_entry.e_nameoff;
+            let entries_count = name_offset / size_of::<RafsV6Dirent>() as u16;
+
+            child_cnt += entries_count as u32;
+        }
+        // Skip DOT and DOTDOT
+        child_cnt - 2
     }
 
     fn get_child_index(&self) -> Result<u32> {
-        todo!()
+        // TODO: used when inspect, indicates the index in Nodes Vec.
+        Ok(0)
     }
 
     fn walk_children_inodes(&self, entry_offset: u64, handler: ChildInodeHandler) -> Result<()> {
@@ -747,7 +877,10 @@ impl RafsInode for OndiskInodeWrapper {
                 }
 
                 let nid = de.e_nid;
-                let inode = self.mapping.inode_wrapper(nid)? as Arc<dyn RafsInode>;
+                let inode =
+                    self.mapping
+                        .inode_wrapper_with_info(nid, self.ino(), OsString::from(name))?
+                        as Arc<dyn RafsInode>;
                 trace!("found file {:?}, nid {}", name, nid);
                 cur_offset += 1;
                 match handler(Some(inode), name.to_os_string(), nid, cur_offset) {
@@ -772,7 +905,7 @@ impl RafsInode for OndiskInodeWrapper {
     /// It depends on Self::validate() to ensure valid memory layout.
     #[allow(clippy::cast_ptr_alignment)]
     fn get_chunk_info(&self, idx: u32) -> Result<Arc<dyn BlobChunkInfo>> {
-        todo!()
+        self.mapping.get_chunk_info(idx as usize)
     }
 
     fn get_xattr(&self, name: &OsStr) -> Result<Option<XattrValue>> {
@@ -789,8 +922,9 @@ impl RafsInode for OndiskInodeWrapper {
 
         let mut size = size_of::<RafsV6XattrIbodyHeader>() as u32;
 
-        while size as usize
-            <= total as usize * size_of::<RafsV6XattrEntry>() - size_of::<RafsV6XattrIbodyHeader>()
+        while (size as usize)
+            < ((total as usize) * size_of::<RafsV6XattrEntry>()
+                + size_of::<RafsV6XattrIbodyHeader>())
         {
             let e = unsafe { &*(cur as *const RafsV6XattrEntry) };
 
@@ -840,8 +974,9 @@ impl RafsInode for OndiskInodeWrapper {
 
         let mut size = size_of::<RafsV6XattrIbodyHeader>() as u32;
 
-        while size as usize
-            <= total as usize * size_of::<RafsV6XattrEntry>() - size_of::<RafsV6XattrIbodyHeader>()
+        while (size as usize)
+            < ((total as usize) * size_of::<RafsV6XattrEntry>()
+                + size_of::<RafsV6XattrIbodyHeader>())
         {
             let e = unsafe { &*(cur as *const RafsV6XattrEntry) };
 
@@ -873,15 +1008,42 @@ impl RafsInode for OndiskInodeWrapper {
     /// # Safety
     /// It depends on Self::validate() to ensure valid memory layout.
     fn name(&self) -> OsString {
-        todo!()
-    }
+        if let Some(name) = self.name.take() {
+            self.name.set(Some(name.clone()));
+            name
+        } else {
+            debug_assert!(self.is_dir());
+            let cur_ino = self.ino();
+            if cur_ino == self.mapping.root_ino() {
+                return OsString::from("");
+            }
+            let parent_inode = self.mapping.inode_wrapper(self.parent()).unwrap();
+            let mut curr_name = OsString::from("");
 
+            // EROFS packs dot and dotdot, so skip them two.
+            parent_inode
+                .walk_children_inodes(
+                    2,
+                    &mut |inode: Option<Arc<dyn RafsInode>>, name: OsString, ino, offset| {
+                        if cur_ino == ino {
+                            curr_name = name;
+                            return Ok(PostWalkAction::Break);
+                        }
+                        Ok(PostWalkAction::Continue)
+                    },
+                )
+                .unwrap();
+            self.name.set(Some(curr_name.clone()));
+            curr_name
+        }
+    }
+    // RafsV5 flags, not used by v6, return 0
     fn flags(&self) -> u64 {
-        todo!()
+        0
     }
 
     fn get_digest(&self) -> RafsDigest {
-        todo!()
+        RafsDigest { data: [0u8; 32] }
     }
 
     fn is_dir(&self) -> bool {
@@ -906,17 +1068,24 @@ impl RafsInode for OndiskInodeWrapper {
 
     /// Get inode number of the parent directory.
     fn parent(&self) -> u64 {
-        todo!()
+        if let Some(parent) = self.parent_inode.get() {
+            parent
+        } else {
+            debug_assert!(self.is_dir());
+            let ino = self.get_child_by_name(OsStr::new("..")).unwrap().ino();
+            self.parent_inode.set(Some(ino));
+            ino
+        }
     }
 
     /// Get real device number of the inode.
     fn rdev(&self) -> u32 {
-        todo!()
+        self.disk_inode().union()
     }
 
     /// Get project id associated with the inode.
     fn projid(&self) -> u32 {
-        todo!()
+        0
     }
 
     /// Get data size of the inode.
@@ -927,7 +1096,7 @@ impl RafsInode for OndiskInodeWrapper {
 
     /// Get file name size of the inode.
     fn get_name_size(&self) -> u16 {
-        todo!()
+        self.name().len() as u16
     }
 
     fn get_symlink_size(&self) -> u16 {

--- a/rafs/src/metadata/layout/v6.rs
+++ b/rafs/src/metadata/layout/v6.rs
@@ -949,7 +949,7 @@ impl_bootstrap_converter!(RafsV6InodeChunkHeader);
 
 /// Rafs v6 chunk address on-disk format, 8 bytes.
 #[repr(C)]
-#[derive(Default, Clone, Copy, Debug)]
+#[derive(Default, Clone, Copy, Debug, Hash, Eq, PartialEq)]
 pub struct RafsV6InodeChunkAddr {
     /// Lower part of encoded blob address.
     c_blob_addr_lo: u16,

--- a/src/bin/nydus-image/core/bootstrap.rs
+++ b/src/bin/nydus-image/core/bootstrap.rs
@@ -33,7 +33,7 @@ const WRITE_PADDING_DATA: [u8; 4096] = [0u8; 4096];
 pub(crate) struct Bootstrap {}
 
 impl Bootstrap {
-    /// Create a new instance of `BootStrap`.
+    /// Create a new instance of `Bootstrap`.
     pub fn new() -> Result<Self> {
         Ok(Self {})
     }
@@ -77,7 +77,7 @@ impl Bootstrap {
         nodes.push(tree.node.clone());
         self.build_rafs(ctx, bootstrap_ctx, tree, &mut nodes)?;
 
-        if ctx.fs_version.is_v6() {
+        if ctx.fs_version.is_v6() && !bootstrap_ctx.layered {
             self.update_dirents(&mut nodes, tree, root_offset);
         }
         bootstrap_ctx.nodes = nodes;
@@ -116,6 +116,11 @@ impl Bootstrap {
 
         // Clear all cached states for next upper layer build.
         bootstrap_ctx.inode_map.clear();
+        bootstrap_ctx.nodes.clear();
+        bootstrap_ctx
+            .available_blocks
+            .iter_mut()
+            .for_each(|v| v.clear());
         ctx.prefetch.clear();
 
         Ok(tree)

--- a/src/bin/nydus-image/core/node.rs
+++ b/src/bin/nydus-image/core/node.rs
@@ -25,8 +25,8 @@ use nydus_utils::{
     div_round_up, round_down_4k, round_up, try_round_up_4k, ByteSize,
 };
 use rafs::metadata::cached_v5::{CachedChunkInfoV5, CachedInodeV5};
-use rafs::metadata::direct_v5::{DirectChunkInfoV5, OndiskInodeWrapper};
-use rafs::metadata::direct_v6::DirectChunkInfoV6;
+use rafs::metadata::direct_v5::{DirectChunkInfoV5, OndiskInodeWrapper as OndiskInodeWrapperV5};
+use rafs::metadata::direct_v6::{DirectChunkInfoV6, OndiskInodeWrapper as OndiskInodeWrapperV6};
 use rafs::metadata::layout::v5::{
     RafsV5ChunkInfo, RafsV5Inode, RafsV5InodeFlags, RafsV5InodeWrapper,
 };
@@ -1253,8 +1253,10 @@ impl InodeWrapper {
     pub fn from_inode_info(inode: &dyn RafsInode) -> Self {
         if let Some(inode) = inode.as_any().downcast_ref::<CachedInodeV5>() {
             InodeWrapper::V5(to_rafsv5_inode(inode))
-        } else if let Some(inode) = inode.as_any().downcast_ref::<OndiskInodeWrapper>() {
+        } else if let Some(inode) = inode.as_any().downcast_ref::<OndiskInodeWrapperV5>() {
             InodeWrapper::V5(to_rafsv5_inode(inode))
+        } else if let Some(inode) = inode.as_any().downcast_ref::<OndiskInodeWrapperV6>() {
+            InodeWrapper::V6(to_rafsv5_inode(inode))
         } else {
             panic!("unknown inode information struct");
         }

--- a/src/bin/nydus-image/core/tree.rs
+++ b/src/bin/nydus-image/core/tree.rs
@@ -20,7 +20,7 @@ use std::ffi::OsString;
 use std::path::PathBuf;
 
 use anyhow::Result;
-use rafs::metadata::layout::{bytes_to_os_str, RafsXAttrs, RAFS_ROOT_INODE};
+use rafs::metadata::layout::{bytes_to_os_str, RafsXAttrs};
 use rafs::metadata::{Inode, RafsInode, RafsSuper};
 
 use super::chunk_dict::ChunkDict;
@@ -49,13 +49,13 @@ impl Tree {
     /// Load a `Tree` from a bootstrap file, and optionally caches chunk information.
     pub fn from_bootstrap<T: ChunkDict>(rs: &RafsSuper, chunk_dict: &mut T) -> Result<Self> {
         let tree_builder = MetadataTreeBuilder::new(rs);
-        let root_inode = rs.get_inode(RAFS_ROOT_INODE, true)?;
+        let root_inode = rs.get_inode(rs.superblock.root_ino(), true)?;
         let root_node =
             MetadataTreeBuilder::parse_node(rs, root_inode.as_ref(), PathBuf::from("/"))?;
         let mut tree = Tree::new(root_node);
 
         tree.children = timing_tracer!(
-            { tree_builder.load_children(RAFS_ROOT_INODE, None, chunk_dict, true) },
+            { tree_builder.load_children(rs.superblock.root_ino(), None, chunk_dict, true) },
             "load_tree_from_bootstrap"
         )?;
 

--- a/tests/builder.rs
+++ b/tests/builder.rs
@@ -191,24 +191,17 @@ impl<'a> Builder<'a> {
 
     pub fn build_lower(&mut self, compressor: &str, rafs_version: &str) {
         let lower_dir = self.work_dir.join("lower");
-        let disable_check = if rafs_version == "6" {
-            "--disable-check"
-        } else {
-            ""
-        };
-
         self.create_dir(&self.work_dir.join("blobs"));
 
         exec(
             format!(
-                "{:?} create --bootstrap {:?} --blob-dir {:?} --log-level info --compressor {} --whiteout-spec {} --fs-version {} {} {:?}",
+                "{:?} create --bootstrap {:?} --blob-dir {:?} --log-level info --compressor {} --whiteout-spec {} --fs-version {} {:?}",
                 self.builder,
                 self.work_dir.join("bootstrap-lower"),
                 self.work_dir.join("blobs"),
                 compressor,
                 self.whiteout_spec,
                 rafs_version,
-                disable_check,
                 lower_dir,
             )
             .as_str(),

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -11,7 +11,6 @@ edition = "2018"
 [dependencies]
 blake3 = "1.3"
 flate2 = { version = "1.0", features = ["miniz-sys"], default-features = false }
-fuse-backend-rs = { version = "0.9.0" }
 lazy_static = "1.4"
 libc = "0.2"
 log = "0.4"
@@ -25,9 +24,6 @@ nydus-error = { version = "0.2", path = "../error" }
 
 [dev-dependencies]
 vmm-sys-util = ">=0.9.0"
-
-[features]
-fusedev = ["fuse-backend-rs/fusedev"]
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
We have adapted the nydusify and nydus-image to support using nydusify directly to build v6 image, to accomplish this purpose, we have introduce several features and fix several bugs.

Features:
1. Previously, the load_parent_bootstrap is unusable for v6 image, we have adapted it for both V5 and V6.
2. We have implemented all methods for v6's OndiskInodeWrapper.

Bug fixes:
1. The dirents_offset will only be used by dir and symlink files, for other files, calculating it may leads to overflow.
2. Correct chunk info implementation for v6.
3. Previous, we assume the . and .. are the first and second dirents, which is wrong.
4. Under some circumstances, the xattr size is wrong.

FYI, we have tested converting all top images in the image_list.txt and checked their bootstraps with fsck.erofs.
#425 