### PR TITLE
nydusify & nydus-image: v6 image conversion support

### DIFF
--- a/contrib/nydusify/cmd/nydusify.go
+++ b/contrib/nydusify/cmd/nydusify.go
@@ -210,7 +210,7 @@ func main() {
 				// chosen to make it compatible with the 127 max in graph driver of
 				// docker so that we can pull cache image using docker.
 				&cli.UintFlag{Name: "build-cache-max-records", Value: maxCacheMaxRecords, Usage: "Maximum cache records in cache image", EnvVars: []string{"BUILD_CACHE_MAX_RECORDS"}},
-				&cli.StringFlag{Name: "image-version", Required: false, Usage: "Image format version", EnvVars: []string{"IMAGE_VERSION"}, Value: "5", DefaultText: "V5 format"},
+				&cli.StringFlag{Name: "fs-version", Required: false, Usage: "Image format version", EnvVars: []string{"FS_VERSION"}, Value: "5", DefaultText: "V5 format"},
 			},
 			Action: func(c *cli.Context) error {
 				setupLogLevel(c)
@@ -312,7 +312,7 @@ func main() {
 
 					NydusifyVersion: version,
 					Source:          c.String("source"),
-					ImageVersion:    c.String("image-version"),
+					FsVersion:       c.String("fs-version"),
 
 					ChunkDict: converter.ChunkDictOpt{
 						Args:     c.String("chunk-dict"),

--- a/contrib/nydusify/cmd/nydusify.go
+++ b/contrib/nydusify/cmd/nydusify.go
@@ -210,6 +210,7 @@ func main() {
 				// chosen to make it compatible with the 127 max in graph driver of
 				// docker so that we can pull cache image using docker.
 				&cli.UintFlag{Name: "build-cache-max-records", Value: maxCacheMaxRecords, Usage: "Maximum cache records in cache image", EnvVars: []string{"BUILD_CACHE_MAX_RECORDS"}},
+				&cli.StringFlag{Name: "image-version", Required: false, Usage: "Image format version", EnvVars: []string{"IMAGE_VERSION"}, Value: "5", DefaultText: "V5 format"},
 			},
 			Action: func(c *cli.Context) error {
 				setupLogLevel(c)
@@ -311,6 +312,7 @@ func main() {
 
 					NydusifyVersion: version,
 					Source:          c.String("source"),
+					ImageVersion:    c.String("image-version"),
 
 					ChunkDict: converter.ChunkDictOpt{
 						Args:     c.String("chunk-dict"),

--- a/contrib/nydusify/cmd/nydusify.go
+++ b/contrib/nydusify/cmd/nydusify.go
@@ -210,7 +210,7 @@ func main() {
 				// chosen to make it compatible with the 127 max in graph driver of
 				// docker so that we can pull cache image using docker.
 				&cli.UintFlag{Name: "build-cache-max-records", Value: maxCacheMaxRecords, Usage: "Maximum cache records in cache image", EnvVars: []string{"BUILD_CACHE_MAX_RECORDS"}},
-				&cli.StringFlag{Name: "fs-version", Required: false, Usage: "Image format version", EnvVars: []string{"FS_VERSION"}, Value: "5", DefaultText: "V5 format"},
+				&cli.StringFlag{Name: "fs-version", Required: false, Usage: "Version number of nydus image format, possible values: 5, 6", EnvVars: []string{"FS_VERSION"}, Value: "5", DefaultText: "V5 format"},
 			},
 			Action: func(c *cli.Context) error {
 				setupLogLevel(c)

--- a/contrib/nydusify/pkg/build/builder.go
+++ b/contrib/nydusify/pkg/build/builder.go
@@ -26,6 +26,7 @@ type BuilderOption struct {
 	// A regular file or fifo into which commands nydus-image to dump contents.
 	BlobPath     string
 	AlignedChunk bool
+	ImageVersion string
 }
 
 type CompactOption struct {
@@ -120,6 +121,8 @@ func (builder *Builder) Run(option BuilderOption) error {
 		option.OutputJSONPath,
 		"--blob",
 		option.BlobPath,
+		"--fs-version",
+		option.ImageVersion,
 	)
 
 	if len(option.PrefetchPatterns) > 0 {

--- a/contrib/nydusify/pkg/build/builder.go
+++ b/contrib/nydusify/pkg/build/builder.go
@@ -26,7 +26,7 @@ type BuilderOption struct {
 	// A regular file or fifo into which commands nydus-image to dump contents.
 	BlobPath     string
 	AlignedChunk bool
-	ImageVersion string
+	FsVersion    string
 }
 
 type CompactOption struct {
@@ -122,7 +122,7 @@ func (builder *Builder) Run(option BuilderOption) error {
 		"--blob",
 		option.BlobPath,
 		"--fs-version",
-		option.ImageVersion,
+		option.FsVersion,
 	)
 
 	if len(option.PrefetchPatterns) > 0 {

--- a/contrib/nydusify/pkg/build/workflow.go
+++ b/contrib/nydusify/pkg/build/workflow.go
@@ -21,7 +21,7 @@ type WorkflowOption struct {
 	TargetDir        string
 	NydusImagePath   string
 	PrefetchPatterns string
-	ImageVersion     string
+	FsVersion        string
 }
 
 type Workflow struct {
@@ -119,7 +119,7 @@ func (workflow *Workflow) Build(
 		BlobPath:            blobPath,
 		AlignedChunk:        alignedChunk,
 		ChunkDict:           workflow.ChunkDict,
-		ImageVersion:        workflow.ImageVersion,
+		FsVersion:           workflow.FsVersion,
 	}); err != nil {
 		return "", errors.Wrapf(err, "build layer %s", layerDir)
 	}

--- a/contrib/nydusify/pkg/build/workflow.go
+++ b/contrib/nydusify/pkg/build/workflow.go
@@ -21,6 +21,7 @@ type WorkflowOption struct {
 	TargetDir        string
 	NydusImagePath   string
 	PrefetchPatterns string
+	ImageVersion     string
 }
 
 type Workflow struct {
@@ -118,6 +119,7 @@ func (workflow *Workflow) Build(
 		BlobPath:            blobPath,
 		AlignedChunk:        alignedChunk,
 		ChunkDict:           workflow.ChunkDict,
+		ImageVersion:        workflow.ImageVersion,
 	}); err != nil {
 		return "", errors.Wrapf(err, "build layer %s", layerDir)
 	}

--- a/contrib/nydusify/pkg/checker/checker.go
+++ b/contrib/nydusify/pkg/checker/checker.go
@@ -32,7 +32,7 @@ type Opt struct {
 	BackendType    string
 	BackendConfig  string
 	ExpectedArch   string
-	ImageVersion   string
+	FsVersion      string
 }
 
 // Checker validates Nydus image manifest, bootstrap and mounts filesystem
@@ -108,7 +108,7 @@ func (checker *Checker) Check(ctx context.Context) error {
 
 	mode := "cache"
 	digestValidate := true
-	if checker.ImageVersion == "6" {
+	if checker.FsVersion == "6" {
 		mode = "direct"
 		digestValidate = false
 

--- a/contrib/nydusify/pkg/checker/checker.go
+++ b/contrib/nydusify/pkg/checker/checker.go
@@ -32,6 +32,7 @@ type Opt struct {
 	BackendType    string
 	BackendConfig  string
 	ExpectedArch   string
+	ImageVersion   string
 }
 
 // Checker validates Nydus image manifest, bootstrap and mounts filesystem
@@ -105,6 +106,14 @@ func (checker *Checker) Check(ctx context.Context) error {
 		return errors.Wrap(err, "output image information")
 	}
 
+	mode := "cache"
+	digestValidate := true
+	if checker.ImageVersion == "6" {
+		mode = "direct"
+		digestValidate = false
+
+	}
+
 	rules := []rule.Rule{
 		&rule.ManifestRule{
 			SourceParsed:  sourceParsed,
@@ -124,14 +133,16 @@ func (checker *Checker) Check(ctx context.Context) error {
 			Source:          checker.Source,
 			SourceMountPath: filepath.Join(checker.WorkDir, "fs/source_mounted"),
 			NydusdConfig: tool.NydusdConfig{
-				NydusdPath:    checker.NydusdPath,
-				BackendType:   checker.BackendType,
-				BackendConfig: checker.BackendConfig,
-				BootstrapPath: filepath.Join(checker.WorkDir, "nydus_bootstrap"),
-				ConfigPath:    filepath.Join(checker.WorkDir, "fs/nydusd_config.json"),
-				BlobCacheDir:  filepath.Join(checker.WorkDir, "fs/nydus_blobs"),
-				MountPath:     filepath.Join(checker.WorkDir, "fs/nydus_mounted"),
-				APISockPath:   filepath.Join(checker.WorkDir, "fs/nydus_api.sock"),
+				NydusdPath:     checker.NydusdPath,
+				BackendType:    checker.BackendType,
+				BackendConfig:  checker.BackendConfig,
+				BootstrapPath:  filepath.Join(checker.WorkDir, "nydus_bootstrap"),
+				ConfigPath:     filepath.Join(checker.WorkDir, "fs/nydusd_config.json"),
+				BlobCacheDir:   filepath.Join(checker.WorkDir, "fs/nydus_blobs"),
+				MountPath:      filepath.Join(checker.WorkDir, "fs/nydus_mounted"),
+				APISockPath:    filepath.Join(checker.WorkDir, "fs/nydus_api.sock"),
+				Mode:           mode,
+				DigestValidate: digestValidate,
 			},
 		},
 	}

--- a/contrib/nydusify/pkg/checker/checker.go
+++ b/contrib/nydusify/pkg/checker/checker.go
@@ -106,7 +106,7 @@ func (checker *Checker) Check(ctx context.Context) error {
 		return errors.Wrap(err, "output image information")
 	}
 
-	mode := "cache"
+	mode := "cached"
 	digestValidate := true
 	if checker.FsVersion == "6" {
 		mode = "direct"

--- a/contrib/nydusify/pkg/checker/tool/nydusd.go
+++ b/contrib/nydusify/pkg/checker/tool/nydusd.go
@@ -30,6 +30,8 @@ type NydusdConfig struct {
 	BlobCacheDir   string
 	APISockPath    string
 	MountPath      string
+	Mode           string
+	DigestValidate bool
 }
 
 // Nydusd runs nydusd binary.
@@ -55,14 +57,14 @@ var configTpl = `
 			}
 		}
 	},
-	"mode": "cached",
+	"mode": "{{.Mode}}",
 	"iostats_files": false,
 	"fs_prefetch": {
 		"enable": {{.EnablePrefetch}},
 		"threads_count": 10,
 		"merging_size": 131072
 	},
-	"digest_validate": true,
+	"digest_validate": {{.DigestValidate}},
 	"enable_xattr": true
 }
 `

--- a/contrib/nydusify/pkg/converter/converter.go
+++ b/contrib/nydusify/pkg/converter/converter.go
@@ -89,7 +89,8 @@ type Opt struct {
 	NydusifyVersion string
 	Source          string
 
-	ChunkDict ChunkDictOpt
+	ChunkDict    ChunkDictOpt
+	ImageVersion string
 }
 
 type Converter struct {
@@ -117,7 +118,8 @@ type Converter struct {
 
 	storageBackend backend.Backend
 
-	chunkDict ChunkDictOpt
+	chunkDict    ChunkDictOpt
+	ImageVersion string
 }
 
 func imageRepository(ref string) (string, error) {
@@ -156,7 +158,8 @@ func New(opt Opt) (*Converter, error) {
 
 		storageBackend: backend,
 
-		chunkDict: opt.ChunkDict,
+		chunkDict:    opt.ChunkDict,
+		ImageVersion: opt.ImageVersion,
 	}, nil
 }
 
@@ -211,6 +214,7 @@ func (cvt *Converter) convert(ctx context.Context) (retErr error) {
 		NydusImagePath:   cvt.NydusImagePath,
 		PrefetchPatterns: cvt.PrefetchPatterns,
 		TargetDir:        cvt.WorkDir,
+		ImageVersion:     cvt.ImageVersion,
 	})
 	if err != nil {
 		return errors.Wrap(err, "Create build flow")

--- a/contrib/nydusify/pkg/converter/converter.go
+++ b/contrib/nydusify/pkg/converter/converter.go
@@ -89,8 +89,8 @@ type Opt struct {
 	NydusifyVersion string
 	Source          string
 
-	ChunkDict    ChunkDictOpt
-	ImageVersion string
+	ChunkDict ChunkDictOpt
+	FsVersion string
 }
 
 type Converter struct {
@@ -118,8 +118,8 @@ type Converter struct {
 
 	storageBackend backend.Backend
 
-	chunkDict    ChunkDictOpt
-	ImageVersion string
+	chunkDict ChunkDictOpt
+	FsVersion string
 }
 
 func imageRepository(ref string) (string, error) {
@@ -158,8 +158,8 @@ func New(opt Opt) (*Converter, error) {
 
 		storageBackend: backend,
 
-		chunkDict:    opt.ChunkDict,
-		ImageVersion: opt.ImageVersion,
+		chunkDict: opt.ChunkDict,
+		FsVersion: opt.FsVersion,
 	}, nil
 }
 
@@ -214,7 +214,7 @@ func (cvt *Converter) convert(ctx context.Context) (retErr error) {
 		NydusImagePath:   cvt.NydusImagePath,
 		PrefetchPatterns: cvt.PrefetchPatterns,
 		TargetDir:        cvt.WorkDir,
-		ImageVersion:     cvt.ImageVersion,
+		FsVersion:        cvt.FsVersion,
 	})
 	if err != nil {
 		return errors.Wrap(err, "Create build flow")

--- a/contrib/nydusify/tests/e2e_test.go
+++ b/contrib/nydusify/tests/e2e_test.go
@@ -9,73 +9,73 @@ import (
 	"testing"
 )
 
-func testBasicConvert(t *testing.T, imageVersion string) {
+func testBasicConvert(t *testing.T, fsVersion string) {
 	registry := NewRegistry(t)
 	defer registry.Destroy(t)
 	registry.Build(t, "image-basic")
-	nydusify := NewNydusify(registry, "image-basic", "image-basic-nydus", "", "", imageVersion)
+	nydusify := NewNydusify(registry, "image-basic", "image-basic-nydus", "", "", fsVersion)
 	nydusify.Convert(t)
 	nydusify.Check(t)
 }
 
-func testConvertWithCache(t *testing.T, imageVersion string) {
+func testConvertWithCache(t *testing.T, fsVersion string) {
 	registry := NewRegistry(t)
 	defer registry.Destroy(t)
 
 	registry.Build(t, "image-basic")
-	nydusify1 := NewNydusify(registry, "image-basic", "image-basic-nydus-1", "cache:v1", "", imageVersion)
+	nydusify1 := NewNydusify(registry, "image-basic", "image-basic-nydus-1", "cache:v1", "", fsVersion)
 	nydusify1.Convert(t)
 	nydusify1.Check(t)
-	nydusify2 := NewNydusify(registry, "image-basic", "image-basic-nydus-2", "cache:v1", "", imageVersion)
+	nydusify2 := NewNydusify(registry, "image-basic", "image-basic-nydus-2", "cache:v1", "", fsVersion)
 	nydusify2.Convert(t)
 	nydusify2.Check(t)
 
 	registry.Build(t, "image-from-1")
-	nydusify3 := NewNydusify(registry, "image-from-1", "image-from-nydus-1", "cache:v1", "", imageVersion)
+	nydusify3 := NewNydusify(registry, "image-from-1", "image-from-nydus-1", "cache:v1", "", fsVersion)
 	nydusify3.Convert(t)
 	nydusify3.Check(t)
 
 	registry.Build(t, "image-from-2")
-	nydusify4 := NewNydusify(registry, "image-from-2", "image-from-nydus-2", "cache:v1", "", imageVersion)
+	nydusify4 := NewNydusify(registry, "image-from-2", "image-from-nydus-2", "cache:v1", "", fsVersion)
 	nydusify4.Convert(t)
 	nydusify4.Check(t)
 }
 
-func testConvertWithChunkDict(t *testing.T, imageVersion string) {
+func testConvertWithChunkDict(t *testing.T, fsVersion string) {
 	registry := NewRegistry(t)
 	defer registry.Destroy(t)
 
 	registry.Build(t, "chunk-dict-1")
 	// build chunk-dict-1 bootstrap
-	nydusify1 := NewNydusify(registry, "chunk-dict-1", "nydus:chunk-dict-1", "", "", imageVersion)
+	nydusify1 := NewNydusify(registry, "chunk-dict-1", "nydus:chunk-dict-1", "", "", fsVersion)
 	nydusify1.Convert(t)
 	nydusify1.Check(t)
 	chunkDictOpt := fmt.Sprintf("bootstrap:registry:%s/%s", registry.Host(), "nydus:chunk-dict-1")
 	// build without build-cache
 	registry.Build(t, "image-basic")
-	nydusify2 := NewNydusify(registry, "image-basic", "nydus:image-basic", "", chunkDictOpt, imageVersion)
+	nydusify2 := NewNydusify(registry, "image-basic", "nydus:image-basic", "", chunkDictOpt, fsVersion)
 	nydusify2.Convert(t)
 	nydusify2.Check(t)
 	// build with build-cache
 	registry.Build(t, "image-from-1")
-	nydusify3 := NewNydusify(registry, "image-from-1", "nydus:image-from-1", "nydus:cache_v1", chunkDictOpt, imageVersion)
+	nydusify3 := NewNydusify(registry, "image-from-1", "nydus:image-from-1", "nydus:cache_v1", chunkDictOpt, fsVersion)
 	nydusify3.Convert(t)
 	nydusify3.Check(t)
 	// change chunk dict
 	registry.Build(t, "chunk-dict-2")
-	nydusify4 := NewNydusify(registry, "chunk-dict-2", "nydus:chunk-dict-2", "", "", imageVersion)
+	nydusify4 := NewNydusify(registry, "chunk-dict-2", "nydus:chunk-dict-2", "", "", fsVersion)
 	nydusify4.Convert(t)
 	nydusify4.Check(t)
 	chunkDictOpt = fmt.Sprintf("bootstrap:registry:%s/%s", registry.Host(), "nydus:chunk-dict-2")
 	registry.Build(t, "image-from-2")
-	nydusify5 := NewNydusify(registry, "image-from-2", "nydus:image-from-2", "nydus:cache_v1", chunkDictOpt, imageVersion)
+	nydusify5 := NewNydusify(registry, "image-from-2", "nydus:image-from-2", "nydus:cache_v1", chunkDictOpt, fsVersion)
 	nydusify5.Convert(t)
 	nydusify5.Check(t)
 }
 
 func TestSmoke(t *testing.T) {
-	imageVersions := [2]string{"5", "6"}
-	for _, v := range imageVersions {
+	fsVersions := [2]string{"5", "6"}
+	for _, v := range fsVersions {
 		testBasicConvert(t, v)
 		testConvertWithCache(t, v)
 		testConvertWithChunkDict(t, v)

--- a/contrib/nydusify/tests/e2e_test.go
+++ b/contrib/nydusify/tests/e2e_test.go
@@ -9,74 +9,75 @@ import (
 	"testing"
 )
 
-func testBasicConvert(t *testing.T) {
+func testBasicConvert(t *testing.T, imageVersion string) {
 	registry := NewRegistry(t)
 	defer registry.Destroy(t)
-
 	registry.Build(t, "image-basic")
-	nydusify := NewNydusify(registry, "image-basic", "image-basic-nydus", "", "")
+	nydusify := NewNydusify(registry, "image-basic", "image-basic-nydus", "", "", imageVersion)
 	nydusify.Convert(t)
 	nydusify.Check(t)
 }
 
-func testConvertWithCache(t *testing.T) {
+func testConvertWithCache(t *testing.T, imageVersion string) {
 	registry := NewRegistry(t)
 	defer registry.Destroy(t)
 
 	registry.Build(t, "image-basic")
-	nydusify1 := NewNydusify(registry, "image-basic", "image-basic-nydus-1", "cache:v1", "")
+	nydusify1 := NewNydusify(registry, "image-basic", "image-basic-nydus-1", "cache:v1", "", imageVersion)
 	nydusify1.Convert(t)
 	nydusify1.Check(t)
-
-	nydusify2 := NewNydusify(registry, "image-basic", "image-basic-nydus-2", "cache:v1", "")
+	nydusify2 := NewNydusify(registry, "image-basic", "image-basic-nydus-2", "cache:v1", "", imageVersion)
 	nydusify2.Convert(t)
 	nydusify2.Check(t)
 
 	registry.Build(t, "image-from-1")
-	nydusify3 := NewNydusify(registry, "image-from-1", "image-from-nydus-1", "cache:v1", "")
+	nydusify3 := NewNydusify(registry, "image-from-1", "image-from-nydus-1", "cache:v1", "", imageVersion)
 	nydusify3.Convert(t)
 	nydusify3.Check(t)
 
 	registry.Build(t, "image-from-2")
-	nydusify4 := NewNydusify(registry, "image-from-2", "image-from-nydus-2", "cache:v1", "")
+	nydusify4 := NewNydusify(registry, "image-from-2", "image-from-nydus-2", "cache:v1", "", imageVersion)
 	nydusify4.Convert(t)
 	nydusify4.Check(t)
 }
 
-func testConvertWithChunkDict(t *testing.T) {
+func testConvertWithChunkDict(t *testing.T, imageVersion string) {
 	registry := NewRegistry(t)
 	defer registry.Destroy(t)
 
 	registry.Build(t, "chunk-dict-1")
 	// build chunk-dict-1 bootstrap
-	nydusify1 := NewNydusify(registry, "chunk-dict-1", "nydus:chunk-dict-1", "", "")
+	nydusify1 := NewNydusify(registry, "chunk-dict-1", "nydus:chunk-dict-1", "", "", imageVersion)
 	nydusify1.Convert(t)
 	nydusify1.Check(t)
 	chunkDictOpt := fmt.Sprintf("bootstrap:registry:%s/%s", registry.Host(), "nydus:chunk-dict-1")
 	// build without build-cache
 	registry.Build(t, "image-basic")
-	nydusify2 := NewNydusify(registry, "image-basic", "nydus:image-basic", "", chunkDictOpt)
+	nydusify2 := NewNydusify(registry, "image-basic", "nydus:image-basic", "", chunkDictOpt, imageVersion)
 	nydusify2.Convert(t)
 	nydusify2.Check(t)
 	// build with build-cache
 	registry.Build(t, "image-from-1")
-	nydusify3 := NewNydusify(registry, "image-from-1", "nydus:image-from-1", "nydus:cache_v1", chunkDictOpt)
+	nydusify3 := NewNydusify(registry, "image-from-1", "nydus:image-from-1", "nydus:cache_v1", chunkDictOpt, imageVersion)
 	nydusify3.Convert(t)
 	nydusify3.Check(t)
 	// change chunk dict
 	registry.Build(t, "chunk-dict-2")
-	nydusify4 := NewNydusify(registry, "chunk-dict-2", "nydus:chunk-dict-2", "", "")
+	nydusify4 := NewNydusify(registry, "chunk-dict-2", "nydus:chunk-dict-2", "", "", imageVersion)
 	nydusify4.Convert(t)
 	nydusify4.Check(t)
 	chunkDictOpt = fmt.Sprintf("bootstrap:registry:%s/%s", registry.Host(), "nydus:chunk-dict-2")
 	registry.Build(t, "image-from-2")
-	nydusify5 := NewNydusify(registry, "image-from-2", "nydus:image-from-2", "nydus:cache_v1", chunkDictOpt)
+	nydusify5 := NewNydusify(registry, "image-from-2", "nydus:image-from-2", "nydus:cache_v1", chunkDictOpt, imageVersion)
 	nydusify5.Convert(t)
 	nydusify5.Check(t)
 }
 
 func TestSmoke(t *testing.T) {
-	testBasicConvert(t)
-	testConvertWithCache(t)
-	testConvertWithChunkDict(t)
+	imageVersions := [2]string{"5", "6"}
+	for _, v := range imageVersions {
+		testBasicConvert(t, v)
+		testConvertWithCache(t, v)
+		testConvertWithChunkDict(t, v)
+	}
 }

--- a/contrib/nydusify/tests/image_test.go
+++ b/contrib/nydusify/tests/image_test.go
@@ -34,11 +34,11 @@ func transfer(t *testing.T, ref string) {
 	run(t, fmt.Sprintf("docker push %s/%s", host, ref), true)
 }
 
-func convert(t *testing.T, ref string, imageVersion string) {
+func convert(t *testing.T, ref string, fsVersion string) {
 	registry := NewRegistry(t)
 	defer registry.Destroy(t)
 	transfer(t, ref)
-	nydusify := NewNydusify(registry, ref, fmt.Sprintf("%s-nydus", ref), "", "", imageVersion)
+	nydusify := NewNydusify(registry, ref, fmt.Sprintf("%s-nydus", ref), "", "", fsVersion)
 	nydusify.Convert(t)
 	nydusify.Check(t)
 }

--- a/contrib/nydusify/tests/image_test.go
+++ b/contrib/nydusify/tests/image_test.go
@@ -34,17 +34,18 @@ func transfer(t *testing.T, ref string) {
 	run(t, fmt.Sprintf("docker push %s/%s", host, ref), true)
 }
 
-func convert(t *testing.T, ref string) {
+func convert(t *testing.T, ref string, imageVersion string) {
 	registry := NewRegistry(t)
 	defer registry.Destroy(t)
 	transfer(t, ref)
-	nydusify := NewNydusify(registry, ref, fmt.Sprintf("%s-nydus", ref), "", "")
+	nydusify := NewNydusify(registry, ref, fmt.Sprintf("%s-nydus", ref), "", "", imageVersion)
 	nydusify.Convert(t)
 	nydusify.Check(t)
 }
 
 func TestDockerHubImage(t *testing.T) {
 	for _, ref := range list {
-		convert(t, ref)
+		convert(t, ref, "5")
+		convert(t, ref, "6")
 	}
 }

--- a/contrib/nydusify/tests/nydusify.go
+++ b/contrib/nydusify/tests/nydusify.go
@@ -42,9 +42,10 @@ type Nydusify struct {
 	backendType   string
 	backendConfig string
 	chunkDictArgs string
+	imageVersion  string
 }
 
-func NewNydusify(registry *Registry, source, target, cache string, chunkDictArgs string) *Nydusify {
+func NewNydusify(registry *Registry, source, target, cache string, chunkDictArgs string, imageVersion string) *Nydusify {
 	host := registry.Host()
 
 	backendType := "registry"
@@ -60,6 +61,9 @@ func NewNydusify(registry *Registry, source, target, cache string, chunkDictArgs
 	if os.Getenv("BACKEND_CONFIG") != "" {
 		backendConfig = os.Getenv("BACKEND_CONFIG")
 	}
+	if len(imageVersion) == 0 {
+		imageVersion = "5"
+	}
 
 	return &Nydusify{
 		Registry:      registry,
@@ -69,6 +73,7 @@ func NewNydusify(registry *Registry, source, target, cache string, chunkDictArgs
 		backendType:   backendType,
 		backendConfig: backendConfig,
 		chunkDictArgs: chunkDictArgs,
+		imageVersion:  imageVersion,
 	}
 }
 
@@ -128,6 +133,7 @@ func (nydusify *Nydusify) Convert(t *testing.T) {
 			Insecure: false,
 			Platform: "linux/amd64",
 		},
+		ImageVersion: nydusify.imageVersion,
 	}
 
 	cvt, err := converter.New(opt)

--- a/contrib/nydusify/tests/nydusify.go
+++ b/contrib/nydusify/tests/nydusify.go
@@ -42,10 +42,10 @@ type Nydusify struct {
 	backendType   string
 	backendConfig string
 	chunkDictArgs string
-	imageVersion  string
+	fsVersion     string
 }
 
-func NewNydusify(registry *Registry, source, target, cache string, chunkDictArgs string, imageVersion string) *Nydusify {
+func NewNydusify(registry *Registry, source, target, cache string, chunkDictArgs string, fsVersion string) *Nydusify {
 	host := registry.Host()
 
 	backendType := "registry"
@@ -61,8 +61,8 @@ func NewNydusify(registry *Registry, source, target, cache string, chunkDictArgs
 	if os.Getenv("BACKEND_CONFIG") != "" {
 		backendConfig = os.Getenv("BACKEND_CONFIG")
 	}
-	if len(imageVersion) == 0 {
-		imageVersion = "5"
+	if len(fsVersion) == 0 {
+		fsVersion = "5"
 	}
 
 	return &Nydusify{
@@ -73,7 +73,7 @@ func NewNydusify(registry *Registry, source, target, cache string, chunkDictArgs
 		backendType:   backendType,
 		backendConfig: backendConfig,
 		chunkDictArgs: chunkDictArgs,
-		imageVersion:  imageVersion,
+		fsVersion:     fsVersion,
 	}
 }
 
@@ -133,7 +133,7 @@ func (nydusify *Nydusify) Convert(t *testing.T) {
 			Insecure: false,
 			Platform: "linux/amd64",
 		},
-		ImageVersion: nydusify.imageVersion,
+		FsVersion: nydusify.fsVersion,
 	}
 
 	cvt, err := converter.New(opt)
@@ -157,7 +157,7 @@ func (nydusify *Nydusify) Check(t *testing.T) {
 		BackendType:    nydusify.backendType,
 		BackendConfig:  nydusify.backendConfig,
 		ExpectedArch:   "amd64",
-		ImageVersion:   nydusify.imageVersion,
+		FsVersion:      nydusify.fsVersion,
 	})
 	assert.Nil(t, err)
 

--- a/contrib/nydusify/tests/nydusify.go
+++ b/contrib/nydusify/tests/nydusify.go
@@ -157,6 +157,7 @@ func (nydusify *Nydusify) Check(t *testing.T) {
 		BackendType:    nydusify.backendType,
 		BackendConfig:  nydusify.backendConfig,
 		ExpectedArch:   "amd64",
+		ImageVersion:   nydusify.imageVersion,
 	})
 	assert.Nil(t, err)
 

--- a/contrib/nydusify/tests/registry.go
+++ b/contrib/nydusify/tests/registry.go
@@ -49,7 +49,8 @@ func NewRegistry(t *testing.T) *Registry {
 }
 
 func (registry *Registry) Destroy(t *testing.T) {
-	run(t, fmt.Sprintf("docker rm -f %s", registry.id), true)
+	run(t, fmt.Sprintf("docker stop  %s", registry.id), true)
+	run(t, fmt.Sprintf("docker rm -f  %s", registry.id), true)
 }
 
 func (registry *Registry) Build(t *testing.T, source string) {

--- a/rafs/src/metadata/direct_v6.rs
+++ b/rafs/src/metadata/direct_v6.rs
@@ -18,6 +18,7 @@
 /// rule is to call validate() after creating any data structure from the on-disk bootstrap.
 use std::any::Any;
 use std::cell::Cell;
+use std::collections::HashMap;
 use std::ffi::{OsStr, OsString};
 use std::fs::File;
 use std::io::{Result, SeekFrom};
@@ -31,6 +32,7 @@ use std::slice;
 use std::sync::Arc;
 
 use arc_swap::{ArcSwap, Guard};
+use std::cell::RefCell;
 
 use crate::metadata::layout::MetaRange;
 use crate::metadata::{
@@ -61,6 +63,12 @@ use storage::device::{
     BlobIoVec,
 };
 use storage::utils::readahead;
+
+// Use to store chunk info pre inode, Oour build is actually single-threaded,
+// so there's no lazy_static + mutex approach here, thread_local plus Refcell is enough.
+thread_local! {
+        static CHUNK_DICT_MAP: RefCell<Option<HashMap<RafsV6InodeChunkAddr, Arc<dyn BlobChunkInfo>>>> = RefCell::new(None);
+}
 
 fn err_invalidate_data(rafs_err: RafsError) -> std::io::Error {
     std::io::Error::new(std::io::ErrorKind::InvalidData, rafs_err)
@@ -153,6 +161,7 @@ pub struct DirectSuperBlockV6 {
 impl DirectSuperBlockV6 {
     /// Create a new instance of `DirectSuperBlockV6`.
     pub fn new(meta: &RafsSuperMeta, validate_digest: bool) -> Self {
+        CHUNK_DICT_MAP.with(|dict| *dict.borrow_mut() = None);
         let state = DirectMappingState::new(meta, validate_digest);
 
         Self {
@@ -282,6 +291,35 @@ impl DirectSuperBlockV6 {
         self.state.store(Arc::new(state));
 
         Ok(())
+    }
+
+    // For RafsV6, inode doesn't store detailed chunk info, only a simple RafsV6InodeChunkAddr
+    // so we need to use the chunk table at the end of the bootstrap to restore the chunk info of an inode
+    fn load_chunk_map(&self) -> Result<HashMap<RafsV6InodeChunkAddr, Arc<dyn BlobChunkInfo>>> {
+        let mut chunk_dict: HashMap<RafsV6InodeChunkAddr, Arc<dyn BlobChunkInfo>> =
+            HashMap::default();
+        let state = self.state.load();
+        let size = state.meta.chunk_table_size as usize;
+        if size == 0 {
+            return Ok(chunk_dict);
+        }
+
+        let unit_size = size_of::<RafsV5ChunkInfo>();
+        if size % unit_size != 0 {
+            return Err(std::io::Error::from_raw_os_error(libc::EINVAL));
+        }
+
+        for idx in 0..(size / unit_size) {
+            let chunk = self.get_chunk_info(idx)?;
+
+            let mut v6_chunk = RafsV6InodeChunkAddr::new();
+            v6_chunk.set_blob_index((chunk.blob_index() + 1) as u8);
+            v6_chunk.set_blob_comp_index(chunk.id());
+            v6_chunk.set_block_addr((chunk.uncompress_offset() / EROFS_BLOCK_SIZE) as u32);
+            chunk_dict.insert(v6_chunk, chunk);
+        }
+
+        Ok(chunk_dict)
     }
 }
 
@@ -905,7 +943,37 @@ impl RafsInode for OndiskInodeWrapper {
     /// It depends on Self::validate() to ensure valid memory layout.
     #[allow(clippy::cast_ptr_alignment)]
     fn get_chunk_info(&self, idx: u32) -> Result<Arc<dyn BlobChunkInfo>> {
-        self.mapping.get_chunk_info(idx as usize)
+        let state = self.mapping.state.load();
+        let inode = self.disk_inode();
+        if !self.is_reg() || idx >= self.get_chunk_count() {
+            return Err(enoent!("invalid chunk info"));
+        }
+        let offset = self.offset as usize
+            + round_up(
+                self.this_inode_size() as u64 + self.xattr_size() as u64,
+                size_of::<RafsV6InodeChunkAddr>() as u64,
+            ) as usize
+            + (idx as usize * size_of::<RafsV6InodeChunkAddr>());
+
+        let chunk_addr = state.cast_to_ref::<RafsV6InodeChunkAddr>(state.base, offset)?;
+
+        let mut find = None;
+        // Lazy initializes all chunk info
+        CHUNK_DICT_MAP.with(|dict| {
+            if dict.borrow().is_none() {
+                // # Safety
+                // There will always be chunk info in bootstrap, or zero chunk.
+                *dict.borrow_mut() = Some(self.mapping.load_chunk_map().unwrap());
+            }
+            find = dict
+                .borrow()
+                .as_ref()
+                .unwrap()
+                .get(chunk_addr)
+                .map(Arc::clone);
+        });
+
+        find.ok_or_else(|| enoent!("can't find chunk info"))
     }
 
     fn get_xattr(&self, name: &OsStr) -> Result<Option<XattrValue>> {

--- a/rafs/src/metadata/direct_v6.rs
+++ b/rafs/src/metadata/direct_v6.rs
@@ -803,8 +803,6 @@ impl RafsInode for OndiskInodeWrapper {
     /// `idx` is the number of child files in line. So we can keep the term `idx`
     /// in super crate and keep it consistent with layout v5.
     fn get_child_by_index(&self, idx: u32) -> Result<Arc<dyn RafsInode>> {
-        // Skip DOT and DOTDOT
-        let idx = idx + 2;
         let inode = self.disk_inode();
         let child_count = self.get_child_count();
 
@@ -821,25 +819,27 @@ impl RafsInode for OndiskInodeWrapper {
                 .unwrap();
             let name_offset = head_entry.e_nameoff;
             let entries_count = name_offset as u32 / size_of::<RafsV6Dirent>() as u32;
-            if cur_idx + entries_count <= idx {
-                cur_idx += entries_count;
-                continue;
+
+            for j in 0..entries_count {
+                let de = self
+                    .get_entry(i as usize, j as usize)
+                    .map_err(err_invalidate_data)?;
+                let name = self
+                    .entry_name(i as usize, j as usize, entries_count as usize)
+                    .map_err(err_invalidate_data)?;
+                if name == "." || name == ".." {
+                    continue;
+                }
+                if cur_idx == idx {
+                    let nid = de.e_nid;
+                    return Ok(self.mapping.inode_wrapper_with_info(
+                        nid,
+                        self.ino(),
+                        OsString::from(name),
+                    )? as Arc<dyn RafsInode>);
+                }
+                cur_idx += 1;
             }
-
-            let de = self
-                .get_entry(i as usize, (idx - cur_idx) as usize)
-                .map_err(err_invalidate_data)?;
-
-            let d_name = self
-                .entry_name(i as usize, (idx - cur_idx) as usize, entries_count as usize)
-                .map_err(err_invalidate_data)?;
-
-            let nid = de.e_nid;
-            return Ok(self.mapping.inode_wrapper_with_info(
-                nid,
-                self.ino(),
-                OsString::from(d_name),
-            )? as Arc<dyn RafsInode>);
         }
 
         Err(enoent!("invalid child index"))
@@ -1088,10 +1088,9 @@ impl RafsInode for OndiskInodeWrapper {
             let parent_inode = self.mapping.inode_wrapper(self.parent()).unwrap();
             let mut curr_name = OsString::from("");
 
-            // EROFS packs dot and dotdot, so skip them two.
             parent_inode
                 .walk_children_inodes(
-                    2,
+                    0,
                     &mut |inode: Option<Arc<dyn RafsInode>>, name: OsString, ino, offset| {
                         if cur_ino == ino {
                             curr_name = name;
@@ -1182,8 +1181,7 @@ impl RafsInode for OndiskInodeWrapper {
 
         let mut child_dirs: Vec<Arc<dyn RafsInode>> = Vec::new();
 
-        // EROFS packs dot and dotdot, so skip them two.
-        self.walk_children_inodes(2, &mut |inode: Option<Arc<dyn RafsInode>>,
+        self.walk_children_inodes(0, &mut |inode: Option<Arc<dyn RafsInode>>,
                                            name: OsString,
                                            ino,
                                            offset| {
@@ -1200,8 +1198,11 @@ impl RafsInode for OndiskInodeWrapper {
             }
         })
         .unwrap();
-
         for d in child_dirs {
+            // EROFS packs dot and dotdot, so skip them two.
+            if d.name() == "." || d.name() == ".." {
+                continue;
+            }
             d.collect_descendants_inodes(descendants)?;
         }
 

--- a/rafs/src/metadata/direct_v6.rs
+++ b/rafs/src/metadata/direct_v6.rs
@@ -1069,8 +1069,9 @@ impl RafsInode for OndiskInodeWrapper {
     /// # Safety
     /// It depends on Self::validate() to ensure valid memory layout.
     fn name(&self) -> OsString {
+        let mut curr_name = OsString::from("");
         match self.name.borrow().as_ref() {
-            Some(name) => name.clone(),
+            Some(name) => return name.clone(),
             None => {
                 debug_assert!(self.is_dir());
                 let cur_ino = self.ino();
@@ -1078,8 +1079,6 @@ impl RafsInode for OndiskInodeWrapper {
                     return OsString::from("");
                 }
                 let parent_inode = self.mapping.inode_wrapper(self.parent()).unwrap();
-                let mut curr_name = OsString::from("");
-
                 parent_inode
                     .walk_children_inodes(
                         0,
@@ -1092,10 +1091,10 @@ impl RafsInode for OndiskInodeWrapper {
                         },
                     )
                     .unwrap();
-                *self.name.borrow_mut() = Some(curr_name.clone());
-                curr_name
             }
         }
+        *self.name.borrow_mut() = Some(curr_name.clone());
+        curr_name
     }
     // RafsV5 flags, not used by v6, return 0
     fn flags(&self) -> u64 {

--- a/rafs/src/metadata/layout/v6.rs
+++ b/rafs/src/metadata/layout/v6.rs
@@ -949,7 +949,7 @@ impl_bootstrap_converter!(RafsV6InodeChunkHeader);
 
 /// Rafs v6 chunk address on-disk format, 8 bytes.
 #[repr(C)]
-#[derive(Default, Clone, Copy, Debug)]
+#[derive(Default, Clone, Copy, Debug, Hash, Eq, PartialEq)]
 pub struct RafsV6InodeChunkAddr {
     /// Lower part of encoded blob address.
     c_blob_addr_lo: u16,

--- a/rafs/src/metadata/layout/v6.rs
+++ b/rafs/src/metadata/layout/v6.rs
@@ -41,9 +41,9 @@ pub const EROFS_I_VERSION_BITS: u16 = 1;
 pub const EROFS_I_DATALAYOUT_BITS: u16 = 3;
 
 // Offset of EROFS super block.
-const EROFS_SUPER_OFFSET: u16 = 1024;
+pub const EROFS_SUPER_OFFSET: u16 = 1024;
 // Size of EROFS super block.
-const EROFS_SUPER_BLOCK_SIZE: u16 = 128;
+pub const EROFS_SUPER_BLOCK_SIZE: u16 = 128;
 // Size of extended super block, used for rafs v6 specific fields
 const EROFS_EXT_SUPER_BLOCK_SIZE: u16 = 256;
 // Magic number for EROFS super block.

--- a/src/bin/nydus-image/core/bootstrap.rs
+++ b/src/bin/nydus-image/core/bootstrap.rs
@@ -33,7 +33,7 @@ const WRITE_PADDING_DATA: [u8; 4096] = [0u8; 4096];
 pub(crate) struct Bootstrap {}
 
 impl Bootstrap {
-    /// Create a new instance of `BootStrap`.
+    /// Create a new instance of `Bootstrap`.
     pub fn new() -> Result<Self> {
         Ok(Self {})
     }
@@ -77,7 +77,7 @@ impl Bootstrap {
         nodes.push(tree.node.clone());
         self.build_rafs(ctx, bootstrap_ctx, tree, &mut nodes)?;
 
-        if ctx.fs_version.is_v6() {
+        if ctx.fs_version.is_v6() && !bootstrap_ctx.layered {
             self.update_dirents(&mut nodes, tree, root_offset);
         }
         bootstrap_ctx.nodes = nodes;
@@ -116,6 +116,11 @@ impl Bootstrap {
 
         // Clear all cached states for next upper layer build.
         bootstrap_ctx.inode_map.clear();
+        bootstrap_ctx.nodes.clear();
+        bootstrap_ctx
+            .available_blocks
+            .iter_mut()
+            .for_each(|v| v.clear());
         ctx.prefetch.clear();
 
         Ok(tree)

--- a/src/bin/nydus-image/core/node.rs
+++ b/src/bin/nydus-image/core/node.rs
@@ -25,8 +25,8 @@ use nydus_utils::{
     div_round_up, round_down_4k, round_up, try_round_up_4k, ByteSize,
 };
 use rafs::metadata::cached_v5::{CachedChunkInfoV5, CachedInodeV5};
-use rafs::metadata::direct_v5::{DirectChunkInfoV5, OndiskInodeWrapper};
-use rafs::metadata::direct_v6::DirectChunkInfoV6;
+use rafs::metadata::direct_v5::{DirectChunkInfoV5, OndiskInodeWrapper as OndiskInodeWrapperV5};
+use rafs::metadata::direct_v6::{DirectChunkInfoV6, OndiskInodeWrapper as OndiskInodeWrapperV6};
 use rafs::metadata::layout::v5::{
     RafsV5ChunkInfo, RafsV5Inode, RafsV5InodeFlags, RafsV5InodeWrapper,
 };
@@ -1253,8 +1253,10 @@ impl InodeWrapper {
     pub fn from_inode_info(inode: &dyn RafsInode) -> Self {
         if let Some(inode) = inode.as_any().downcast_ref::<CachedInodeV5>() {
             InodeWrapper::V5(to_rafsv5_inode(inode))
-        } else if let Some(inode) = inode.as_any().downcast_ref::<OndiskInodeWrapper>() {
+        } else if let Some(inode) = inode.as_any().downcast_ref::<OndiskInodeWrapperV5>() {
             InodeWrapper::V5(to_rafsv5_inode(inode))
+        } else if let Some(inode) = inode.as_any().downcast_ref::<OndiskInodeWrapperV6>() {
+            InodeWrapper::V6(to_rafsv5_inode(inode))
         } else {
             panic!("unknown inode information struct");
         }

--- a/src/bin/nydus-image/core/tree.rs
+++ b/src/bin/nydus-image/core/tree.rs
@@ -20,7 +20,7 @@ use std::ffi::OsString;
 use std::path::PathBuf;
 
 use anyhow::Result;
-use rafs::metadata::layout::{bytes_to_os_str, RafsXAttrs, RAFS_ROOT_INODE};
+use rafs::metadata::layout::{bytes_to_os_str, RafsXAttrs};
 use rafs::metadata::{Inode, RafsInode, RafsSuper};
 
 use super::chunk_dict::ChunkDict;
@@ -49,13 +49,13 @@ impl Tree {
     /// Load a `Tree` from a bootstrap file, and optionally caches chunk information.
     pub fn from_bootstrap<T: ChunkDict>(rs: &RafsSuper, chunk_dict: &mut T) -> Result<Self> {
         let tree_builder = MetadataTreeBuilder::new(rs);
-        let root_inode = rs.get_inode(RAFS_ROOT_INODE, true)?;
+        let root_inode = rs.get_inode(rs.superblock.root_ino(), true)?;
         let root_node =
             MetadataTreeBuilder::parse_node(rs, root_inode.as_ref(), PathBuf::from("/"))?;
         let mut tree = Tree::new(root_node);
 
         tree.children = timing_tracer!(
-            { tree_builder.load_children(RAFS_ROOT_INODE, None, chunk_dict, true) },
+            { tree_builder.load_children(rs.superblock.root_ino(), None, chunk_dict, true) },
             "load_tree_from_bootstrap"
         )?;
 

--- a/tests/builder.rs
+++ b/tests/builder.rs
@@ -191,24 +191,17 @@ impl<'a> Builder<'a> {
 
     pub fn build_lower(&mut self, compressor: &str, rafs_version: &str) {
         let lower_dir = self.work_dir.join("lower");
-        let disable_check = if rafs_version == "6" {
-            "--disable-check"
-        } else {
-            ""
-        };
-
         self.create_dir(&self.work_dir.join("blobs"));
 
         exec(
             format!(
-                "{:?} create --bootstrap {:?} --blob-dir {:?} --log-level info --compressor {} --whiteout-spec {} --fs-version {} {} {:?}",
+                "{:?} create --bootstrap {:?} --blob-dir {:?} --log-level info --compressor {} --whiteout-spec {} --fs-version {} {:?}",
                 self.builder,
                 self.work_dir.join("bootstrap-lower"),
                 self.work_dir.join("blobs"),
                 compressor,
                 self.whiteout_spec,
                 rafs_version,
-                disable_check,
                 lower_dir,
             )
             .as_str(),

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -109,7 +109,7 @@ fn test(
             cache_compressed,
             rafs_mode.parse().unwrap(),
             "api.sock".into(),
-            true,
+            !rafsv6,
         );
         nydusd.start(Some("bootstrap-overlay"), "mnt");
         nydusd.check(&overlay_texture, "mnt");
@@ -124,7 +124,7 @@ fn test(
             cache_compressed,
             rafs_mode.parse().unwrap(),
             "api.sock".into(),
-            true,
+            !rafsv6,
         );
         nydusd.start(Some("bootstrap-overlay"), "mnt");
         nydusd.check(&overlay_texture, "mnt");

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -96,12 +96,6 @@ fn test(
         nydusd.umount("mnt");
     }
 
-    // FIXME: Currently no load is implemented for rafs v6 parent bootstrap,
-    // so the layered build is temporarily unsupported and need to be fixed.
-    if rafsv6 {
-        return;
-    }
-
     // Mount upper rootfs and check
     {
         // Create & build upper rootfs based lower


### PR DESCRIPTION
We have adapted the nydusify and nydus-image to support using nydusify directly to build v6 image, to accomplish this purpose, we have introduce several features and fix several bugs.

Features:
1. Previously, the load_parent_bootstrap is unusable for v6 image, we have adapted it for both V5 and V6.
2. We have implemented all methods for v6's OndiskInodeWrapper.

Bug fixes:
1. The dirents_offset will only be used by dir and symlink files, for other files, calculating it may leads to overflow.
2. Correct chunk info implementation for v6.
3. Previous, we assume the . and .. are the first and second dirents, which is wrong.
4. Under some circumstances, the xattr size is wrong.

FYI, we have tested converting all top images in the image_list.txt and checked their bootstraps with fsck.erofs.
#425 