### PR TITLE
github workflows: Convert top images and check bootstrap format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,10 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  REGISTRY: ghcr.io
+  ORGANIZATION: ${{ github.repository }}
+  IMAGE_LIST_PATH: misc/top_images/error_prone_images.txt
+  FSCK_PATCH_PATH: misc/top_images/fsck.patch
 
 jobs:
   contrib-ut:
@@ -78,3 +82,60 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: EmbarkStudios/cargo-deny-action@v1
+
+  convert-images:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+      - name: cache go mod
+        uses: actions/cache@v2
+        with:
+          path: /go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/contrib/nydusify/go.sum', '**/contrib/ctr-remote/go.sum', '**/contrib/docker-nydus-graphdriver/go.sum', '**/contrib/nydus-overlayfs/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go
+      - name: Build nydus
+        run: |
+          rustup component add rustfmt && rustup component add clippy
+          make fusedev && make nydusify
+          sudo cp target-fusedev/debug/nydus-image contrib/nydusify/cmd/nydusify /usr/local/bin/
+      - name: Build fsck.erofs
+        run: |
+          sudo apt-get update && sudo apt-get install -y build-essential git autotools-dev automake libtool pkg-config uuid-dev liblz4-dev
+          git clone https://git.kernel.org/pub/scm/linux/kernel/git/xiang/erofs-utils.git
+          cd erofs-utils && git apply ../${{ env.FSCK_PATCH_PATH }} && ./autogen.sh && ./configure && make && cd ..
+          sudo cp erofs-utils/fsck/fsck.erofs /usr/local/bin/
+      - name: Log in to the container registry
+        uses: docker/login-action@f054a8b539a109f9f41c372932f1ae047eff08c9
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Convert RAFS v5 images
+        run: |
+          for I in $(cat ${{ env.IMAGE_LIST_PATH }}); do
+            echo "converting $I:nydus-latest-v5"
+            sudo DOCKER_CONFIG=$HOME/.docker nydusify convert \
+                 --source $I:latest \
+                 --target ${{ env.REGISTRY }}/${{ env.ORGANIZATION }}/$I:nydus-latest-v5 \
+                 --build-cache ${{ env.REGISTRY }}/${{ env.ORGANIZATION }}/nydus-build-cache:$I \
+                 --fs-version 5
+            sudo rm -rf ./tmp
+          done
+      - name: Convert and check RAFS v6 images
+        run: |
+          for I in $(cat ${{ env.IMAGE_LIST_PATH }}); do
+            echo "converting $I:nydus-latest-v6"
+            sudo DOCKER_CONFIG=$HOME/.docker nydusify convert \
+                 --source $I:latest \
+                 --target ${{ env.REGISTRY }}/${{ env.ORGANIZATION }}/$I:nydus-latest-v6 \
+                 --build-cache ${{ env.REGISTRY }}/${{ env.ORGANIZATION }}/nydus-build-cache:$I \
+                 --fs-version 6
+            sudo rm -rf ./tmp
+            nydusify check \
+                --target ${{ env.REGISTRY }}/${{ env.ORGANIZATION }}/$I:nydus-latest-v6 2&>1 > /dev/null
+            fsck.erofs --extract -d9 output/nydus_bootstrap 
+            rm -rf ./output
+          done

--- a/.github/workflows/convert.yml
+++ b/.github/workflows/convert.yml
@@ -11,6 +11,7 @@ env:
   REGISTRY: ghcr.io
   ORGANIZATION: ${{ github.repository }}
   IMAGE_LIST_PATH: misc/top_images/image_list.txt
+  FSCK_PATCH_PATH: misc/top_images/fsck.patch
 
 jobs:
   convert-images:
@@ -30,13 +31,35 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Convert images
+      - name: Build fsck.erofs
+        run: |
+          sudo apt-get update && sudo apt-get install -y build-essential git autotools-dev automake libtool pkg-config uuid-dev liblz4-dev
+          git clone https://git.kernel.org/pub/scm/linux/kernel/git/xiang/erofs-utils.git
+          cd erofs-utils && git apply ../${{ env.FSCK_PATCH_PATH }} && ./autogen.sh && ./configure && make && cd ..
+          sudo cp erofs-utils/fsck/fsck.erofs /usr/local/bin/
+      - name: Convert RAFS v5 images
         run: |
           for I in $(cat ${{ env.IMAGE_LIST_PATH }}); do
-            echo "converting $I:latest"
+            echo "converting $I:latest to $I:nydus-nightly-v5"
             sudo DOCKER_CONFIG=$HOME/.docker nydusify convert \
                  --source $I:latest \
-                 --target ${{ env.REGISTRY }}/${{ env.ORGANIZATION }}/$I:nydus-latest \
-                 --build-cache ${{ env.REGISTRY }}/${{ env.ORGANIZATION }}/nydus-build-cache:$I
+                 --target ${{ env.REGISTRY }}/${{ env.ORGANIZATION }}/$I:nydus-nightly-v5 \
+                 --build-cache ${{ env.REGISTRY }}/${{ env.ORGANIZATION }}/nydus-build-cache:$I \
+                 --fs-version 5
             sudo rm -rf ./tmp
+          done
+      - name: Convert and check RAFS v6 images
+        run: |
+          for I in $(cat ${{ env.IMAGE_LIST_PATH }}); do
+            echo "converting $I:latest to $I:nydus-nightly-v6"
+            sudo DOCKER_CONFIG=$HOME/.docker nydusify convert \
+                 --source $I:latest \
+                 --target ${{ env.REGISTRY }}/${{ env.ORGANIZATION }}/$I:nydus-nightly-v6 \
+                 --build-cache ${{ env.REGISTRY }}/${{ env.ORGANIZATION }}/nydus-build-cache:$I \
+                 --fs-version 6
+            sudo rm -rf ./tmp
+            nydusify check \
+                --target ${{ env.REGISTRY }}/${{ env.ORGANIZATION }}/$I:nydus-nightly-v6 2&>1 > /dev/null
+            fsck.erofs --extract -d9 output/nydus_bootstrap 
+            rm -rf ./output
           done

--- a/misc/top_images/error_prone_images.txt
+++ b/misc/top_images/error_prone_images.txt
@@ -1,0 +1,4 @@
+centos
+telegraf
+ghost
+java

--- a/misc/top_images/fsck.patch
+++ b/misc/top_images/fsck.patch
@@ -1,0 +1,21 @@
+diff --git a/lib/super.c b/lib/super.c
+index 3ccc551..1a47369 100644
+--- a/lib/super.c
++++ b/lib/super.c
+@@ -36,11 +36,11 @@ static int erofs_init_devices(struct erofs_sb_info *sbi,
+ 	else
+ 		ondisk_extradevs = le16_to_cpu(dsb->extra_devices);
+ 
+-	if (ondisk_extradevs != sbi->extra_devices) {
+-		erofs_err("extra devices don't match (ondisk %u, given %u)",
+-			  ondisk_extradevs, sbi->extra_devices);
+-		return -EINVAL;
+-	}
++	// if (ondisk_extradevs != sbi->extra_devices) {
++	//	erofs_err("extra devices don't match (ondisk %u, given %u)",
++	//		  ondisk_extradevs, sbi->extra_devices);
++	//	return -EINVAL;
++	// }
+ 	if (!ondisk_extradevs)
+ 		return 0;
+ 


### PR DESCRIPTION
Add v6 images conversion to CI, and check it with the `fsck.erofs`.

Signed-off-by: Qi Wang <wangqi@linux.alibaba.com>