### PR TITLE
nydus-image: supports multiple versions of merge

### DIFF
--- a/src/bin/nydus-image/core/context.rs
+++ b/src/bin/nydus-image/core/context.rs
@@ -24,6 +24,7 @@ use nydus_utils::{compress, digest, div_round_up, round_down_4k};
 use rafs::metadata::layout::v5::RafsV5BlobTable;
 use rafs::metadata::layout::v6::{RafsV6BlobTable, EROFS_BLOCK_SIZE, EROFS_INODE_SLOT_SIZE};
 use rafs::metadata::layout::RafsBlobTable;
+use rafs::metadata::layout::{RAFS_SUPER_VERSION_V5, RAFS_SUPER_VERSION_V6};
 use rafs::metadata::RafsSuperFlags;
 use rafs::metadata::{Inode, RAFS_DEFAULT_CHUNK_SIZE, RAFS_MAX_CHUNK_SIZE};
 use rafs::{RafsIoReader, RafsIoWrite};
@@ -47,6 +48,17 @@ pub enum RafsVersion {
 
 impl Default for RafsVersion {
     fn default() -> Self {
+        RafsVersion::V5
+    }
+}
+
+impl From<u32> for RafsVersion {
+    fn from(version: u32) -> Self {
+        if version == RAFS_SUPER_VERSION_V5 {
+            return RafsVersion::V5;
+        } else if version == RAFS_SUPER_VERSION_V6 {
+            return RafsVersion::V6;
+        }
         RafsVersion::V5
     }
 }

--- a/src/bin/nydus-image/core/context.rs
+++ b/src/bin/nydus-image/core/context.rs
@@ -23,8 +23,7 @@ use vmm_sys_util::tempfile::TempFile;
 use nydus_utils::{compress, digest, div_round_up, round_down_4k};
 use rafs::metadata::layout::v5::RafsV5BlobTable;
 use rafs::metadata::layout::v6::{RafsV6BlobTable, EROFS_BLOCK_SIZE, EROFS_INODE_SLOT_SIZE};
-use rafs::metadata::layout::RafsBlobTable;
-use rafs::metadata::layout::{RAFS_SUPER_VERSION_V5, RAFS_SUPER_VERSION_V6};
+use rafs::metadata::layout::{RafsBlobTable, RAFS_SUPER_VERSION_V5, RAFS_SUPER_VERSION_V6};
 use rafs::metadata::RafsSuperFlags;
 use rafs::metadata::{Inode, RAFS_DEFAULT_CHUNK_SIZE, RAFS_MAX_CHUNK_SIZE};
 use rafs::{RafsIoReader, RafsIoWrite};
@@ -52,14 +51,15 @@ impl Default for RafsVersion {
     }
 }
 
-impl From<u32> for RafsVersion {
-    fn from(version: u32) -> Self {
+impl TryFrom<u32> for RafsVersion {
+    type Error = Error;
+    fn try_from(version: u32) -> Result<Self, Self::Error> {
         if version == RAFS_SUPER_VERSION_V5 {
-            return RafsVersion::V5;
+            return Ok(RafsVersion::V5);
         } else if version == RAFS_SUPER_VERSION_V6 {
-            return RafsVersion::V6;
+            return Ok(RafsVersion::V6);
         }
-        RafsVersion::V5
+        Err(anyhow!("invalid version {}", version))
     }
 }
 

--- a/src/bin/nydus-image/merge.rs
+++ b/src/bin/nydus-image/merge.rs
@@ -14,7 +14,7 @@ use rafs::metadata::{RafsInode, RafsMode, RafsSuper, RafsSuperMeta};
 
 use crate::core::bootstrap::Bootstrap;
 use crate::core::chunk_dict::HashChunkDict;
-use crate::core::context::ArtifactStorage;
+use crate::core::context::{ArtifactStorage, RafsVersion};
 use crate::core::context::{BlobContext, BlobManager, BootstrapContext, BuildContext};
 use crate::core::node::{ChunkSource, Overlay, WhiteoutSpec};
 use crate::core::tree::{MetadataTreeBuilder, Tree};
@@ -183,7 +183,7 @@ impl Merger {
         }
 
         // Safe to unwrap because a valid version must exist
-        ctx.fs_version = fs_version.unwrap().into();
+        ctx.fs_version = RafsVersion::try_from(fs_version.unwrap())?;
         // Safe to unwrap because there is at least one source bootstrap.
         let mut tree = tree.unwrap();
         let mut bootstrap = Bootstrap::new()?;


### PR DESCRIPTION
Let the merge subcommand support multiple versions of image merging

Signed-off-by: zyfjeff <zyfjeff@linux.alibaba.com>