### PR TITLE
nydusify: bug fix, `check` subcommand mode setting

### DIFF
--- a/contrib/nydusify/pkg/checker/checker.go
+++ b/contrib/nydusify/pkg/checker/checker.go
@@ -108,10 +108,9 @@ func (checker *Checker) Check(ctx context.Context) error {
 
 	mode := "cached"
 	digestValidate := true
-	if checker.FsVersion == "6" {
+	if checker.Opt.FsVersion == "6" {
 		mode = "direct"
 		digestValidate = false
-
 	}
 
 	rules := []rule.Rule{


### PR DESCRIPTION
We didn't correctly get fs-version here.

When using nydusify check with `--source` specified, it alerts ` "Rafs v6 does not support cached mode"`.

Signed-off-by: Qi Wang <wangqi@linux.alibaba.com>