### PR TITLE
nydusify: bug fix, `check` subcommand uses direct mode

### DIFF
--- a/contrib/nydusify/pkg/checker/checker.go
+++ b/contrib/nydusify/pkg/checker/checker.go
@@ -32,7 +32,6 @@ type Opt struct {
 	BackendType    string
 	BackendConfig  string
 	ExpectedArch   string
-	FsVersion      string
 }
 
 // Checker validates Nydus image manifest, bootstrap and mounts filesystem
@@ -106,13 +105,8 @@ func (checker *Checker) Check(ctx context.Context) error {
 		return errors.Wrap(err, "output image information")
 	}
 
-	mode := "cached"
-	digestValidate := true
-	if checker.FsVersion == "6" {
-		mode = "direct"
-		digestValidate = false
-
-	}
+	mode := "direct"
+	digestValidate := false
 
 	rules := []rule.Rule{
 		&rule.ManifestRule{

--- a/contrib/nydusify/tests/nydusify.go
+++ b/contrib/nydusify/tests/nydusify.go
@@ -157,7 +157,6 @@ func (nydusify *Nydusify) Check(t *testing.T) {
 		BackendType:    nydusify.backendType,
 		BackendConfig:  nydusify.backendConfig,
 		ExpectedArch:   "amd64",
-		FsVersion:      nydusify.fsVersion,
 	})
 	assert.Nil(t, err)
 


### PR DESCRIPTION
The cache mode is used to speed up. However, when checking, especially the RAFS v6 haven't support the cache mode,
we should directly use direct mode. 

What's more, the `--fs-version` hasn't been add to nydusify check's arg.

Signed-off-by: Qi Wang <wangqi@linux.alibaba.com>