### PR TITLE
nydusify: add fs-version annotation

### DIFF
--- a/contrib/nydusify/pkg/cache/cache_test.go
+++ b/contrib/nydusify/pkg/cache/cache_test.go
@@ -47,6 +47,7 @@ func makeBootstrapLayer(id int64, hasBlob bool) ocispec.Descriptor {
 		Size:      id,
 		Annotations: map[string]string{
 			utils.LayerAnnotationNydusBootstrap:     "true",
+			utils.LayerAnnotationNydusFsVersion:     "6",
 			utils.LayerAnnotationNydusSourceChainID: digest.FromString("chain-" + idStr).String(),
 			utils.LayerAnnotationUncompressed:       digest.FromString("bootstrap-uncompressed-" + idStr).String(),
 		},
@@ -76,6 +77,7 @@ func testWithBackend(t *testing.T, _backend backend.Backend) {
 		MaxRecords:     3,
 		DockerV2Format: false,
 		Backend:        _backend,
+		FsVersion:      "6",
 	})
 	assert.Nil(t, err)
 

--- a/contrib/nydusify/pkg/converter/cache.go
+++ b/contrib/nydusify/pkg/converter/cache.go
@@ -29,7 +29,7 @@ type cacheGlue struct {
 }
 
 func newCacheGlue(
-	ctx context.Context, maxRecords uint, version string, dockerV2Format bool, remote *remote.Remote, cacheRemote *remote.Remote, backend backend.Backend,
+	ctx context.Context, maxRecords uint, version string, fsVersion string, dockerV2Format bool, remote *remote.Remote, cacheRemote *remote.Remote, backend backend.Backend,
 ) (*cacheGlue, error) {
 	if cacheRemote == nil {
 		return &cacheGlue{}, nil
@@ -41,6 +41,7 @@ func newCacheGlue(
 	cache, err := cache.New(cacheRemote, cache.Opt{
 		MaxRecords:     maxRecords,
 		Version:        version,
+		FsVersion:      fsVersion,
 		DockerV2Format: dockerV2Format,
 		Backend:        backend,
 	})

--- a/contrib/nydusify/pkg/converter/converter.go
+++ b/contrib/nydusify/pkg/converter/converter.go
@@ -183,7 +183,7 @@ func (cvt *Converter) convert(ctx context.Context) (retErr error) {
 
 	// Try to pull Nydus cache image from remote registry
 	cg, err := newCacheGlue(
-		ctx, cvt.CacheMaxRecords, cvt.CacheVersion, cvt.DockerV2Format, cvt.TargetRemote, cvt.CacheRemote, cvt.storageBackend,
+		ctx, cvt.CacheMaxRecords, cvt.CacheVersion, cvt.FsVersion, cvt.DockerV2Format, cvt.TargetRemote, cvt.CacheRemote, cvt.storageBackend,
 	)
 	if err != nil {
 		return errors.Wrap(err, "Pull cache image")
@@ -254,6 +254,7 @@ func (cvt *Converter) convert(ctx context.Context) (retErr error) {
 			forcePush:      cvt.BackendForcePush,
 			alignedChunk:   cvt.BackendAlignedChunk,
 			referenceBlobs: blobLayers,
+			fsVersion:      cvt.FsVersion,
 		}
 		parentBuildLayer = buildLayer
 		buildLayers = append(buildLayers, buildLayer)

--- a/contrib/nydusify/pkg/converter/layer.go
+++ b/contrib/nydusify/pkg/converter/layer.go
@@ -56,8 +56,8 @@ type buildLayer struct {
 	backend         backend.Backend
 	forcePush       bool
 	alignedChunk    bool
-
-	referenceBlobs []ocispec.Descriptor
+	fsVersion       string
+	referenceBlobs  []ocispec.Descriptor
 }
 
 // parseSourceMount parses mounts object returned by the Mount method in
@@ -159,6 +159,7 @@ func (layer *buildLayer) pushBootstrap(ctx context.Context) (*ocispec.Descriptor
 			// DiffID of layer defined in OCI spec
 			utils.LayerAnnotationUncompressed:   uncompressedDigest.String(),
 			utils.LayerAnnotationNydusBootstrap: "true",
+			utils.LayerAnnotationNydusFsVersion: layer.fsVersion,
 		},
 	}
 	if len(layer.referenceBlobs) > 0 {

--- a/contrib/nydusify/pkg/converter/manifest.go
+++ b/contrib/nydusify/pkg/converter/manifest.go
@@ -253,6 +253,7 @@ func (mm *manifestManager) Push(ctx context.Context, buildLayers []*buildLayer) 
 		utils.LayerAnnotationNydusBlobIDs:          true,
 		utils.LayerAnnotationNydusReferenceBlobIDs: true,
 		utils.LayerAnnotationNydusBootstrap:        true,
+		utils.LayerAnnotationNydusFsVersion:        true,
 	}
 	for idx, desc := range layers {
 		layerDiffID := digest.Digest(desc.Annotations[utils.LayerAnnotationUncompressed])

--- a/contrib/nydusify/pkg/utils/constant.go
+++ b/contrib/nydusify/pkg/utils/constant.go
@@ -16,6 +16,7 @@ const (
 	LayerAnnotationNydusBlobSize      = "containerd.io/snapshot/nydus-blob-size"
 	LayerAnnotationNydusBlobIDs       = "containerd.io/snapshot/nydus-blob-ids"
 	LayerAnnotationNydusBootstrap     = "containerd.io/snapshot/nydus-bootstrap"
+	LayerAnnotationNydusFsVersion     = "containerd.io/snapshot/nydus-fs-version"
 	LayerAnnotationNydusSourceChainID = "containerd.io/snapshot/nydus-source-chainid"
 
 	LayerAnnotationNydusReferenceBlobIDs = "containerd.io/snapshot/nydus-reference-blob-ids"


### PR DESCRIPTION
Add an annotation to the image manifest for detecting the bootstrap fs
version without reading the magic number from bootstrap.

fix #496

Signed-off-by: Qi Wang <wangqi@linux.alibaba.com>