### PR TITLE
Fixed several correctness issues with Nydus v6 at runtime.

### DIFF
--- a/contrib/nydusify/cmd/nydusify.go
+++ b/contrib/nydusify/cmd/nydusify.go
@@ -356,6 +356,7 @@ func main() {
 				&cli.StringFlag{Name: "backend-type", Value: "", Usage: "Specify Nydus blob storage backend type, will check file data in Nydus image if specified", EnvVars: []string{"BACKEND_TYPE"}},
 				&cli.StringFlag{Name: "backend-config", Value: "", Usage: "Specify Nydus blob storage backend in JSON config string", EnvVars: []string{"BACKEND_CONFIG"}},
 				&cli.StringFlag{Name: "backend-config-file", Value: "", TakesFile: true, Usage: "Specify Nydus blob storage backend config from path", EnvVars: []string{"BACKEND_CONFIG_FILE"}},
+				&cli.StringFlag{Name: "fs-version", Required: false, Usage: "Version number of nydus image format, possible values: 5, 6", EnvVars: []string{"FS_VERSION"}, Value: "5", DefaultText: "V5 format"},
 			},
 			Action: func(c *cli.Context) error {
 				setupLogLevel(c)
@@ -389,6 +390,7 @@ func main() {
 					BackendType:    backendType,
 					BackendConfig:  backendConfig,
 					ExpectedArch:   arch,
+					FsVersion:      c.String("fs-version"),
 				})
 				if err != nil {
 					return err

--- a/contrib/nydusify/cmd/nydusify.go
+++ b/contrib/nydusify/cmd/nydusify.go
@@ -356,7 +356,6 @@ func main() {
 				&cli.StringFlag{Name: "backend-type", Value: "", Usage: "Specify Nydus blob storage backend type, will check file data in Nydus image if specified", EnvVars: []string{"BACKEND_TYPE"}},
 				&cli.StringFlag{Name: "backend-config", Value: "", Usage: "Specify Nydus blob storage backend in JSON config string", EnvVars: []string{"BACKEND_CONFIG"}},
 				&cli.StringFlag{Name: "backend-config-file", Value: "", TakesFile: true, Usage: "Specify Nydus blob storage backend config from path", EnvVars: []string{"BACKEND_CONFIG_FILE"}},
-				&cli.StringFlag{Name: "fs-version", Required: false, Usage: "Version number of nydus image format, possible values: 5, 6", EnvVars: []string{"FS_VERSION"}, Value: "5", DefaultText: "V5 format"},
 			},
 			Action: func(c *cli.Context) error {
 				setupLogLevel(c)
@@ -390,7 +389,6 @@ func main() {
 					BackendType:    backendType,
 					BackendConfig:  backendConfig,
 					ExpectedArch:   arch,
-					FsVersion:      c.String("fs-version"),
 				})
 				if err != nil {
 					return err

--- a/contrib/nydusify/pkg/checker/checker.go
+++ b/contrib/nydusify/pkg/checker/checker.go
@@ -16,6 +16,7 @@ import (
 	"github.com/dragonflyoss/image-service/contrib/nydusify/pkg/checker/tool"
 	"github.com/dragonflyoss/image-service/contrib/nydusify/pkg/converter/provider"
 	"github.com/dragonflyoss/image-service/contrib/nydusify/pkg/parser"
+	"github.com/dragonflyoss/image-service/contrib/nydusify/pkg/utils"
 )
 
 // Opt defines Checker options.
@@ -32,7 +33,6 @@ type Opt struct {
 	BackendType    string
 	BackendConfig  string
 	ExpectedArch   string
-	FsVersion      string
 }
 
 // Checker validates Nydus image manifest, bootstrap and mounts filesystem
@@ -108,6 +108,13 @@ func (checker *Checker) Check(ctx context.Context) error {
 
 	mode := "direct"
 	digestValidate := false
+
+	if sourceParsed.OCIImage.Manifest.Annotations[utils.LayerAnnotationNydusFsVersion] == "5" {
+		// Digest validate is not currently supported for v6,
+		// but v5 supports it. In order to make the check more sufficient,
+		// this validate needs to be turned on for v5.
+		digestValidate = true
+	}
 
 	rules := []rule.Rule{
 		&rule.ManifestRule{

--- a/contrib/nydusify/pkg/checker/checker.go
+++ b/contrib/nydusify/pkg/checker/checker.go
@@ -32,6 +32,7 @@ type Opt struct {
 	BackendType    string
 	BackendConfig  string
 	ExpectedArch   string
+	FsVersion      string
 }
 
 // Checker validates Nydus image manifest, bootstrap and mounts filesystem

--- a/contrib/nydusify/pkg/checker/checker.go
+++ b/contrib/nydusify/pkg/checker/checker.go
@@ -108,12 +108,14 @@ func (checker *Checker) Check(ctx context.Context) error {
 
 	mode := "direct"
 	digestValidate := false
-
-	if sourceParsed.OCIImage.Manifest.Annotations[utils.LayerAnnotationNydusFsVersion] == "5" {
-		// Digest validate is not currently supported for v6,
-		// but v5 supports it. In order to make the check more sufficient,
-		// this validate needs to be turned on for v5.
-		digestValidate = true
+	if targetParsed.NydusImage != nil {
+		v := utils.GetNydusFsVersionOrDefault(targetParsed.NydusImage.Manifest.Annotations, utils.V6)
+		if v == utils.V5 {
+			// Digest validate is not currently supported for v6,
+			// but v5 supports it. In order to make the check more sufficient,
+			// this validate needs to be turned on for v5.
+			digestValidate = true
+		}
 	}
 
 	rules := []rule.Rule{
@@ -158,4 +160,8 @@ func (checker *Checker) Check(ctx context.Context) error {
 	logrus.Infof("Verified Nydus image %s", checker.targetParser.Remote.Ref)
 
 	return nil
+}
+
+func GetNydusFsVersionOrDefault() {
+	panic("unimplemented")
 }

--- a/contrib/nydusify/pkg/checker/checker.go
+++ b/contrib/nydusify/pkg/checker/checker.go
@@ -109,7 +109,7 @@ func (checker *Checker) Check(ctx context.Context) error {
 	mode := "direct"
 	digestValidate := false
 	if targetParsed.NydusImage != nil {
-		v := utils.GetNydusFsVersionOrDefault(targetParsed.NydusImage.Manifest.Annotations, utils.V6)
+		v := utils.GetNydusFsVersionOrDefault(targetParsed.NydusImage.Manifest.Annotations, utils.V5)
 		if v == utils.V5 {
 			// Digest validate is not currently supported for v6,
 			// but v5 supports it. In order to make the check more sufficient,

--- a/contrib/nydusify/pkg/checker/checker.go
+++ b/contrib/nydusify/pkg/checker/checker.go
@@ -161,7 +161,3 @@ func (checker *Checker) Check(ctx context.Context) error {
 
 	return nil
 }
-
-func GetNydusFsVersionOrDefault() {
-	panic("unimplemented")
-}

--- a/contrib/nydusify/pkg/checker/checker.go
+++ b/contrib/nydusify/pkg/checker/checker.go
@@ -109,12 +109,15 @@ func (checker *Checker) Check(ctx context.Context) error {
 	mode := "direct"
 	digestValidate := false
 	if targetParsed.NydusImage != nil {
-		v := utils.GetNydusFsVersionOrDefault(targetParsed.NydusImage.Manifest.Annotations, utils.V5)
-		if v == utils.V5 {
-			// Digest validate is not currently supported for v6,
-			// but v5 supports it. In order to make the check more sufficient,
-			// this validate needs to be turned on for v5.
-			digestValidate = true
+		nydusManifest := parser.FindNydusBootstrapDesc(&targetParsed.NydusImage.Manifest)
+		if nydusManifest != nil {
+			v := utils.GetNydusFsVersionOrDefault(nydusManifest.Annotations, utils.V5)
+			if v == utils.V5 {
+				// Digest validate is not currently supported for v6,
+				// but v5 supports it. In order to make the check more sufficient,
+				// this validate needs to be turned on for v5.
+				digestValidate = true
+			}
 		}
 	}
 

--- a/contrib/nydusify/pkg/checker/tool/nydusd.go
+++ b/contrib/nydusify/pkg/checker/tool/nydusd.go
@@ -196,7 +196,7 @@ func (nydusd *Nydusd) Mount() error {
 		}
 	case <-ready:
 		return nil
-	case <-time.After(10 * time.Second):
+	case <-time.After(30 * time.Second):
 		return errors.New("timeout to wait Nydusd ready")
 	}
 

--- a/contrib/nydusify/pkg/parser/parser.go
+++ b/contrib/nydusify/pkg/parser/parser.go
@@ -61,7 +61,7 @@ func New(remote *remote.Remote, interestedArch string) (*Parser, error) {
 
 // Try to find the topmost layer in Nydus manifest, it should
 // be a Nydus bootstrap layer, see examples/manifest/manifest.json
-func findNydusBootstrapDesc(manifest *ocispec.Manifest) *ocispec.Descriptor {
+func FindNydusBootstrapDesc(manifest *ocispec.Manifest) *ocispec.Descriptor {
 	layers := manifest.Layers
 	if len(layers) != 0 {
 		desc := &layers[len(layers)-1]
@@ -163,7 +163,7 @@ func (parser *Parser) parseImage(
 
 // PullNydusBootstrap pulls Nydus bootstrap layer from Nydus image.
 func (parser *Parser) PullNydusBootstrap(ctx context.Context, image *Image) (io.ReadCloser, error) {
-	bootstrapDesc := findNydusBootstrapDesc(&image.Manifest)
+	bootstrapDesc := FindNydusBootstrapDesc(&image.Manifest)
 	if bootstrapDesc == nil {
 		return nil, fmt.Errorf("not found Nydus bootstrap layer in manifest")
 	}
@@ -207,7 +207,7 @@ func (parser *Parser) Parse(ctx context.Context) (*Parsed, error) {
 			return nil, err
 		}
 
-		bootstrapDesc := findNydusBootstrapDesc(onlyManifest)
+		bootstrapDesc := FindNydusBootstrapDesc(onlyManifest)
 		if bootstrapDesc != nil {
 			nydusDesc = imageDesc
 		} else {

--- a/contrib/nydusify/pkg/utils/utils.go
+++ b/contrib/nydusify/pkg/utils/utils.go
@@ -31,6 +31,29 @@ const (
 	PlatformArchARM64 string = "arm64"
 )
 
+type FsVersion int
+
+const (
+	V5 FsVersion = iota
+	V6
+)
+
+func GetNydusFsVersionOrDefault(annotations map[string]string, defaultVersion FsVersion) FsVersion {
+	if annotations == nil {
+		return defaultVersion
+	}
+	if v, ok := annotations[LayerAnnotationNydusFsVersion]; ok {
+		if v == "5" {
+			return V5
+		}
+		if v == "6" {
+			return V6
+		}
+	}
+
+	return defaultVersion
+}
+
 func WithRetry(op func() error) error {
 	var err error
 	attempts := defaultRetryAttempts

--- a/rafs/src/metadata/direct_v6.rs
+++ b/rafs/src/metadata/direct_v6.rs
@@ -922,9 +922,11 @@ impl RafsInode for OndiskInodeWrapper {
                 trace!("found file {:?}, nid {}", name, nid);
                 cur_offset += 1;
                 match handler(Some(inode), name.to_os_string(), nid, cur_offset) {
-                    Ok(PostWalkAction::Break) => break,
+                    // The PostWalkAction::Break indicates that the entire process needs to end,
+                    // so return is required here, because this is a nested loop, so you cannot use break to jump out of the loop.
+                    Ok(PostWalkAction::Break) => return Ok(()),
                     Ok(PostWalkAction::Continue) => continue,
-                    Err(_) => break,
+                    Err(e) => return Err(e),
                 };
             }
         }

--- a/rafs/src/metadata/direct_v6.rs
+++ b/rafs/src/metadata/direct_v6.rs
@@ -922,8 +922,8 @@ impl RafsInode for OndiskInodeWrapper {
                 trace!("found file {:?}, nid {}", name, nid);
                 cur_offset += 1;
                 match handler(Some(inode), name.to_os_string(), nid, cur_offset) {
-                    // The PostWalkAction::Break indicates that the entire process needs to end,
-                    // so return is required here, because this is a nested loop,
+                    // Break returned by handler indicates that there is not enough buffer of readdir for entries inreaddir,
+                    // such that it has to return. because this is a nested loop,
                     // using break can only jump out of the internal loop, there is no way to jump out of the whole loop.
                     Ok(PostWalkAction::Break) => return Ok(()),
                     Ok(PostWalkAction::Continue) => continue,

--- a/rafs/src/metadata/direct_v6.rs
+++ b/rafs/src/metadata/direct_v6.rs
@@ -923,7 +923,8 @@ impl RafsInode for OndiskInodeWrapper {
                 cur_offset += 1;
                 match handler(Some(inode), name.to_os_string(), nid, cur_offset) {
                     // The PostWalkAction::Break indicates that the entire process needs to end,
-                    // so return is required here, because this is a nested loop, so you cannot use break to jump out of the loop.
+                    // so return is required here, because this is a nested loop,
+                    // using break can only jump out of the internal loop, there is no way to jump out of the whole loop.
                     Ok(PostWalkAction::Break) => return Ok(()),
                     Ok(PostWalkAction::Continue) => continue,
                     Err(e) => return Err(e),

--- a/rafs/src/metadata/mod.rs
+++ b/rafs/src/metadata/mod.rs
@@ -98,7 +98,9 @@ pub trait RafsSuperBlock: RafsSuperInodes + Send + Sync {
 }
 
 pub enum PostWalkAction {
+    // Indicates the need to continue iterating
     Continue,
+    // Indicates that it is necessary to stop continuing to iterate
     Break,
 }
 

--- a/src/bin/nydus-image/core/chunk_dict.rs
+++ b/src/bin/nydus-image/core/chunk_dict.rs
@@ -16,6 +16,8 @@ use storage::device::BlobInfo;
 
 use crate::core::node::ChunkWrapper;
 use crate::core::tree::Tree;
+#[derive(Debug, PartialEq, Eq, Hash)]
+pub struct DigestWithBlobIndex(pub RafsDigest, pub u32);
 
 pub trait ChunkDict: Sync + Send + 'static {
     fn add_chunk(&mut self, chunk: ChunkWrapper);


### PR DESCRIPTION
1. nydus-image: fixed the incomplete chunk info caused by HashChunkDict
2. nydus-image: Fixed that the loop did not jump out because of the nested loop, causing the loop to continue running.
3. Nydusify: support check subcommand for nydus v6