### PR TITLE
Zhaoshang/readahead

### DIFF
--- a/src/bin/nydus-image/core/blob.rs
+++ b/src/bin/nydus-image/core/blob.rs
@@ -42,6 +42,7 @@ impl Blob {
                         .dump_blob(ctx, blob_ctx, blob_index, chunk_dict)
                         .context("failed to dump blob chunks")?;
                     if idx < prefetch_entries {
+                        // Current node needs prefetch
                         blob_ctx.blob_readahead_size += size;
                     }
                 }

--- a/src/bin/nydus-image/core/prefetch.rs
+++ b/src/bin/nydus-image/core/prefetch.rs
@@ -149,11 +149,7 @@ impl Prefetch {
     }
 
     pub fn get_file_indexes(&self) -> Vec<u64> {
-        let mut indexes: Vec<u64> = self.readahead_files.values().copied().collect();
-
-        // Later, we might write chunks of data one by one according to inode number order.
-        indexes.sort_unstable();
-        indexes
+        self.readahead_files.values().copied().collect()
     }
 
     pub fn get_rafsv5_prefetch_table(&mut self) -> Option<RafsV5PrefetchTable> {


### PR DESCRIPTION
    1. Previously, due to the lack of deduplication when receiving
    readahead_patterns, the logical is redundancy when adding nodes to the
    readahead_files.
    2. remove duplicate sorting of readahead_files values