### PR TITLE
nydus-image: fix the prefetch table was out of bounds due to use the wrong index

### DIFF
--- a/src/bin/nydus-image/core/prefetch.rs
+++ b/src/bin/nydus-image/core/prefetch.rs
@@ -188,17 +188,22 @@ impl Prefetch {
         if self.policy == PrefetchPolicy::Fs {
             let mut prefetch_table = RafsV6PrefetchTable::new();
             for i in self.readahead_patterns.values().filter_map(|v| *v) {
+                debug_assert!(i > 0);
+                // i holds the Node.index, which starts at 1, so it needs to be converted to the
+                // index of the Node array to index the corresponding Node
+                let array_index = i as usize - 1;
                 trace!(
                     "v6 prefetch table: map node index {} to offset {} nid {} path {:?} name {:?}",
                     i,
-                    nodes[i as usize].offset,
-                    calculate_nid(nodes[i as usize].offset, meta_addr),
-                    nodes[i as usize].path(),
-                    nodes[i as usize].name()
+                    nodes[array_index].offset,
+                    calculate_nid(nodes[array_index].offset, meta_addr),
+                    nodes[array_index].path(),
+                    nodes[array_index].name()
                 );
                 // 32bit nid can represent 128GB bootstrap, it is large enough, no need
                 // to worry about casting here
-                prefetch_table.add_entry(calculate_nid(nodes[i as usize].offset, meta_addr) as u32);
+                prefetch_table
+                    .add_entry(calculate_nid(nodes[array_index].offset, meta_addr) as u32);
             }
             Some(prefetch_table)
         } else {

--- a/tests/builder.rs
+++ b/tests/builder.rs
@@ -358,6 +358,27 @@ impl<'a> Builder<'a> {
         ).unwrap();
     }
 
+    pub fn build_empty_dir_with_prefetch(&mut self, compressor: &str, rafs_version: &str) {
+        let empty_dir = self.work_dir.join("empty-dir");
+        self.create_dir(&empty_dir);
+        self.create_dir(&self.work_dir.join("blobs"));
+        exec(
+            format!(
+                "{:?} create --bootstrap {:?} --prefetch-policy fs --blob-dir {:?}  --log-level info --compressor {} --whiteout-spec {} --fs-version {} {:?}",
+                self.builder,
+                self.work_dir.join("bootstrap-empty-dir"),
+                self.work_dir.join("blobs"),
+                compressor,
+                self.whiteout_spec,
+                rafs_version,
+                empty_dir,
+            )
+            .as_str(),
+            false,
+            b"/",
+        ).unwrap();
+    }
+
     pub fn build_empty_file_with_prefetch(&mut self, compressor: &str, rafs_version: &str) {
         let empty_file_dir = self.work_dir.join("empty");
         self.create_dir(&empty_file_dir);
@@ -365,8 +386,9 @@ impl<'a> Builder<'a> {
         self.create_file(&empty_file_dir.join("empty-file"), b"");
         exec(
             format!(
-                "{:?} create --bootstrap {:?} --prefetch-policy fs --blob-dir {:?}  --log-level info --compressor {} --whiteout-spec {} --fs-version {} {:?}",
+                "{:?} create --parent-bootstrap {:?} --bootstrap {:?} --prefetch-policy fs --blob-dir {:?}  --log-level info --compressor {} --whiteout-spec {} --fs-version {} {:?}",
                 self.builder,
+                self.work_dir.join("bootstrap-empty-dir"),
                 self.work_dir.join("bootstrap-empty"),
                 self.work_dir.join("blobs"),
                 compressor,

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -73,12 +73,13 @@ fn test(
     let lower_texture = "directory/lower.result".to_string();
     let overlay_texture = "directory/overlay.result".to_string();
     let empty_texture = "directory/empty.result".to_string();
+    let emptydir_texture = "directory/emptydir.result".to_string();
 
     let mut builder = builder::new(&work_dir, whiteout_spec);
     let rafsv6 = rafs_version == "6";
     {
-        // Create & build empty rootfs
-        builder.build_empty_file_with_prefetch(compressor, rafs_version);
+        // Create & build empty dir rootfs
+        builder.build_empty_dir_with_prefetch(compressor, rafs_version);
         // Mount empty rootfs and check
         let nydusd = nydusd::new(
             &work_dir,
@@ -87,6 +88,23 @@ fn test(
             rafs_mode.parse().unwrap(),
             "api.sock".into(),
             // FIXME: Currently no digest validation is implemented for rafs v6.
+            !rafsv6,
+        );
+        nydusd.start(Some("bootstrap-empty-dir"), "mnt");
+        nydusd.check(&emptydir_texture, "mnt");
+        nydusd.umount("mnt");
+    }
+
+    {
+        // Create & build empty file rootfs
+        builder.build_empty_file_with_prefetch(compressor, rafs_version);
+        // Mount empty rootfs and check
+        let nydusd = nydusd::new(
+            &work_dir,
+            enable_cache,
+            cache_compressed,
+            rafs_mode.parse().unwrap(),
+            "api.sock".into(),
             !rafsv6,
         );
         nydusd.start(Some("bootstrap-empty"), "mnt");

--- a/tests/texture/directory/emptydir.result
+++ b/tests/texture/directory/emptydir.result
@@ -1,0 +1,5 @@
+[
+  {"type":"directory","name":"","contents":[
+  ]},
+  {"type":"report","directories":0,"files":0}
+]


### PR DESCRIPTION


At present, the prefetch table of v6 is stored in Node.index, which starts from 1,
and when we get the prefetch table, we mistakenly treat it as an array index

Signed-off-by: zyfjeff <zyfjeff@linux.alibaba.com>