### PR TITLE
FIX: miss blob header in inline-nydus-file

### DIFF
--- a/src/bin/nydus-image/builder/directory.rs
+++ b/src/bin/nydus-image/builder/directory.rs
@@ -173,9 +173,7 @@ impl Builder for DirectoryBuilder {
         let blob_id = blob_ctx.blob_id();
         if blob_exists {
             if ctx.inline_bootstrap {
-                if let Some(blob_writer) = &mut blob_ctx.writer {
-                    blob_writer.write_tar_header(TAR_BLOB_NAME, blob_writer.pos()?)?;
-                }
+                blob_writer.write_tar_header(TAR_BLOB_NAME, blob_writer.pos()?)?;
             } else {
                 blob_writer.finalize(blob_id.clone())?;
             }

--- a/tests/builder.rs
+++ b/tests/builder.rs
@@ -4,9 +4,10 @@
 
 use nix::sys::stat::{dev_t, makedev, mknod, Mode, SFlag};
 use std::fs::{self, File};
-use std::io::Write;
+use std::io::{Read, Seek, SeekFrom, Write};
 use std::os::unix::fs as unix_fs;
 use std::path::{Path, PathBuf};
+use tar::Header;
 
 use nydus_utils::exec;
 
@@ -186,6 +187,23 @@ impl<'a> Builder<'a> {
             &dir.join("sub/more/more-sub/more-sub-2"),
             b"upper:more-sub-2",
         );
+    }
+
+    pub fn build_inline_lower(&mut self, rafs_version: &str) {
+        let lower_dir = self.work_dir.join("lower");
+
+        exec(
+            format!(
+                "{:?} create --source-type directory --blob {:?} --log-level info  --fs-version {} --inline-bootstrap {:?}",
+                self.builder,
+                self.work_dir.join("inline.nydus"),
+                rafs_version,
+                lower_dir,
+            )
+            .as_str(),
+            false,
+            b""
+        ).unwrap();
     }
 
     pub fn build_lower(&mut self, compressor: &str, rafs_version: &str) {
@@ -378,5 +396,35 @@ impl<'a> Builder<'a> {
             false,
             b"/",
         ).unwrap();
+    }
+
+    pub fn check_inline_layout(&self) {
+        let header_size = 512;
+
+        let mut f = File::open(self.work_dir.join("inline.nydus")).unwrap();
+
+        assert!(f.metadata().unwrap().len() > header_size);
+        let mut cur = f.seek(SeekFrom::End(0 - header_size as i64)).unwrap();
+
+        let mut header = Header::new_old();
+        let bs = header.as_mut_bytes();
+
+        f.read_exact(bs).unwrap();
+        assert_eq!(&header.path_bytes().as_ref(), b"image.boot");
+
+        assert!(cur > header.size().unwrap());
+        cur = f
+            .seek(SeekFrom::Start(cur - header.size().unwrap()))
+            .unwrap();
+
+        assert!(cur > header_size);
+        cur = f.seek(SeekFrom::Start(cur - header_size)).unwrap();
+
+        let mut header = Header::new_old();
+        let bs = header.as_mut_bytes();
+
+        f.read_exact(bs).unwrap();
+        assert_eq!(&header.path_bytes().as_ref(), b"image.blob");
+        assert_eq!(cur, header.size().unwrap());
     }
 }

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -301,3 +301,21 @@ fn integration_test_stargz() {
     test_stargz("5");
     test_stargz("6");
 }
+
+#[test]
+fn integration_test_inline_directory() {
+    test_inline("5");
+    test_inline("6");
+}
+
+fn test_inline(rafs_version: &str) {
+    info!("\n\n==================== testing run: stargz test");
+
+    let tmp_dir = TempDir::new().unwrap();
+    let work_dir = tmp_dir.as_path().to_path_buf();
+
+    let mut builder = builder::new(&work_dir, "oci");
+    builder.make_lower();
+    builder.build_inline_lower(rafs_version);
+    builder.check_inline_layout();
+}


### PR DESCRIPTION
### DESCRIPTION
Inline-nydus-file consists of blob data, blob header, bootstrap data, bootstrap header. However the part of blob header is missed now.

### REPRODUCTION
``` shell
# Source Directory
export source=${SOURCE_DIR}
# Output File
export output=${OUTPUT}

sudo nydus-image create --log-level info  --blob ${output}--source-type directory --whiteout-spec none --fs-version 5 --inline-bootstrap ${source}

# There is no blob header
sudo hexdump -C ${output}
```

### EXPECT
Inline File consist of blob data, blob header, bootstrap data, bootstrap header in order.

### FIX
1. Fix a condition.
2. Add smoke for inline file in V5 & V6