### PR TITLE
github actions: bug fix, the build nydus-rs always gets cancelled

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       run: |
         declare -A rust_arch_map=( ["amd64"]="x86_64" ["arm64"]="aarch64")
         arch=${rust_arch_map[${{ matrix.arch }}]}
-        cargo install cross
+        cargo install --version 0.2.1 cross
         rustup component add rustfmt clippy
         make -e ARCH=$arch -e CARGO=cross static-release
         sudo mv target-fusedev/$arch-unknown-linux-musl/release/nydusd nydusd-fusedev


### PR DESCRIPTION
The cross release version 0.2.2, may contain bug,
leads to the ci gets cancelled, downgrade it to 0.2.1.

Signed-off-by: Qi Wang <wangqi@linux.alibaba.com>