### PR TITLE
ctr-remote: note user this ctr is only enhanced for nydus

### DIFF
--- a/contrib/ctr-remote/cmd/main.go
+++ b/contrib/ctr-remote/cmd/main.go
@@ -33,6 +33,7 @@ func init() {
 func main() {
 	customCommands := []cli.Command{commands.RpullCommand}
 	app := app.New()
+	app.Description = "NOTE: Enhanced for nydus-snapshotter\n" + app.Description
 	for i := range app.Commands {
 		if app.Commands[i].Name == "images" {
 			sc := map[string]cli.Command{}

--- a/contrib/ctr-remote/commands/rpull.go
+++ b/contrib/ctr-remote/commands/rpull.go
@@ -36,9 +36,9 @@ const (
 
 var RpullCommand = cli.Command{
 	Name:      "rpull",
-	Usage:     "pull an image from a registry levaraging nydus snapshotter",
+	Usage:     "pull an image from a registry leveraging nydus-snapshotter",
 	ArgsUsage: "[flags] <ref>",
-	Description: `Fetch and prepare an image for use in containerd levaraging nydus snapshotter.
+	Description: `Fetch and prepare an image for use in containerd leveraging nydus-snapshotter.
 After pulling an image, it should be ready to use the same reference in a run command.`,
 	Flags: append(commands.RegistryFlags, commands.LabelFlag),
 	Action: func(context *cli.Context) error {


### PR DESCRIPTION
Other containerd snapshotter could also be named as "ctr-remote",
e.g. stargz. So we'd better give users a conspicuous note that
this is nydus ctr-remote tool.

In addition, correct spelling mistakes.