### PR TITLE
makefile: add target `install`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,10 @@ clean:
 	${CARGO} clean --target-dir ${current_dir}/target-virtiofs
 	${CARGO} clean --target-dir ${current_dir}/target-fusedev
 
+install: fusedev-release
+	@sudo install -D -m 755 target-fusedev/release/nydusd /usr/local/bin/nydusd
+	@sudo install -D -m 755 target-fusedev/release/nydus-image /usr/local/bin/nydus-image
+
 # If virtiofs test must be performed, only run binary part
 # Use same traget to avoid re-compile for differnt targets like gnu and musl
 ut:


### PR DESCRIPTION
We don't provide software package yet. In order to
let users easily install nydus tool chain onto machine.
We'd better provide `make install` to automatically
copy necessary binaris to run nydus-snapshotter, thus to
pull and run nydus image.

Moreover, nydus-snapshotter had already provide `make install`
helper.

Signed-off-by: Changewei Ge <gechangwei@bytedance.com>