### PR TITLE
fscache: fix large stargz chunks processing

### DIFF
--- a/rafs/src/metadata/direct_v6.rs
+++ b/rafs/src/metadata/direct_v6.rs
@@ -976,7 +976,7 @@ impl RafsInode for OndiskInodeWrapper {
                 .map(Arc::clone);
         });
 
-        find.ok_or_else(|| enoent!("can't find chunk info"))
+        find.ok_or_else(|| enoent!(format!("can't find chunk info {}", chunk_addr.block_addr())))
     }
     // TODO(tianqian.zyf): Use get_xattrs implement it
     fn get_xattr(&self, name: &OsStr) -> Result<Option<XattrValue>> {

--- a/src/bin/nydusd/fs_cache.rs
+++ b/src/bin/nydusd/fs_cache.rs
@@ -502,7 +502,7 @@ impl FsCacheHandler {
 
         match BLOB_FACTORY.new_blob_cache(config.factory_config(), &blob_ref) {
             Err(_e) => Err(-libc::ENOENT),
-            Ok(blob) => match blob.blob_size() {
+            Ok(blob) => match blob.blob_uncompressed_size() {
                 Err(_e) => Err(-libc::EIO),
                 Ok(v) => Ok((blob, v)),
             },

--- a/storage/src/cache/cachedfile.rs
+++ b/storage/src/cache/cachedfile.rs
@@ -47,7 +47,8 @@ pub(crate) struct FileCacheEntry {
     pub(crate) runtime: Arc<Runtime>,
     pub(crate) workers: Arc<AsyncWorkerMgr>,
 
-    pub(crate) blob_size: u64,
+    pub(crate) blob_compressed_size: u64,
+    pub(crate) blob_uncompressed_size: u64,
     pub(crate) compressor: compress::Algorithm,
     pub(crate) digester: digest::Algorithm,
     // Whether `get_blob_object()` is supported.
@@ -89,8 +90,12 @@ impl BlobCache for FileCacheEntry {
         self.blob_info.blob_id()
     }
 
-    fn blob_size(&self) -> Result<u64> {
-        Ok(self.blob_size)
+    fn blob_compressed_size(&self) -> Result<u64> {
+        Ok(self.blob_compressed_size)
+    }
+
+    fn blob_uncompressed_size(&self) -> Result<u64> {
+        Ok(self.blob_uncompressed_size)
     }
 
     fn compressor(&self) -> compress::Algorithm {

--- a/storage/src/cache/dummycache.rs
+++ b/storage/src/cache/dummycache.rs
@@ -49,8 +49,12 @@ impl BlobCache for DummyCache {
         &self.blob_id
     }
 
-    fn blob_size(&self) -> Result<u64> {
+    fn blob_compressed_size(&self) -> Result<u64> {
         self.reader.blob_size().map_err(|e| eother!(e))
+    }
+
+    fn blob_uncompressed_size(&self) -> Result<u64> {
+        unimplemented!();
     }
 
     fn compressor(&self) -> compress::Algorithm {

--- a/storage/src/cache/filecache/mod.rs
+++ b/storage/src/cache/filecache/mod.rs
@@ -182,7 +182,8 @@ impl FileCacheEntry {
             .get_reader(blob_info.blob_id())
             .map_err(|_e| eio!("failed to get blob reader"))?;
 
-        let blob_size = Self::get_blob_size(&reader, &blob_info)?;
+        let blob_compressed_size = Self::get_blob_size(&reader, &blob_info)?;
+        let blob_uncompressed_size = blob_info.uncompressed_size();
         let compressor = blob_info.compressor();
         let digester = blob_info.digester();
         let is_stargz = blob_info.is_stargz();
@@ -225,7 +226,8 @@ impl FileCacheEntry {
             runtime,
             workers,
 
-            blob_size,
+            blob_compressed_size,
+            blob_uncompressed_size,
             compressor,
             digester,
             is_get_blob_object_supported,

--- a/storage/src/cache/fscache/mod.rs
+++ b/storage/src/cache/fscache/mod.rs
@@ -179,7 +179,7 @@ impl FileCacheEntry {
             .backend
             .get_reader(blob_info.blob_id())
             .map_err(|_e| eio!("failed to get blob reader"))?;
-        let blob_size = blob_info.uncompressed_size();
+        let blob_compressed_size = Self::get_blob_size(&reader, &blob_info)?;
         let meta = if blob_info.meta_ci_is_valid() {
             Some(Arc::new(BlobMetaInfo::new(
                 &blob_file_path,
@@ -201,7 +201,8 @@ impl FileCacheEntry {
             runtime,
             workers,
 
-            blob_size,
+            blob_compressed_size,
+            blob_uncompressed_size: blob_info.uncompressed_size(),
             compressor: blob_info.compressor(),
             digester: blob_info.digester(),
             is_get_blob_object_supported: true,

--- a/storage/src/cache/mod.rs
+++ b/storage/src/cache/mod.rs
@@ -124,8 +124,11 @@ pub trait BlobCache: Send + Sync {
     /// Get id of the blob object.
     fn blob_id(&self) -> &str;
 
-    /// Get size of the blob object.
-    fn blob_size(&self) -> Result<u64>;
+    /// Get size of the decompressed blob object.
+    fn blob_uncompressed_size(&self) -> Result<u64>;
+
+    /// Get size of the compressed blob object.
+    fn blob_compressed_size(&self) -> Result<u64>;
 
     /// Get data compression algorithm to handle chunks in the blob.
     fn compressor(&self) -> compress::Algorithm;
@@ -252,7 +255,7 @@ pub trait BlobCache: Send + Sync {
         let raw_chunk = if chunk.is_compressed() {
             // Need a scratch buffer to decompress compressed data.
             let c_size = if self.is_stargz() {
-                let blob_size = self.blob_size()?;
+                let blob_size = self.blob_compressed_size()?;
                 let max_size = blob_size.checked_sub(offset).ok_or_else(|| {
                     einval!("chunk compressed offset is bigger than blob file size")
                 })?;


### PR DESCRIPTION
builder: sort stargz chunks by uncompressed_offset

```
Ensure that the stargz chunks in the blob meta are sorted by
uncompressed_offset and ordered by chunk index so that they
can be found quickly at runtime with a binary search.
```

fscache: some fixups for large stargz chunk

```
1. use blob_compressed_size to compute stargz's compressed gzip_size;
2. use binary search to find stargz chunk (sorted by uncompressed_offset in blob meta);
```

Signed-off-by: Yan Song <yansong.ys@antfin.com>