### PR TITLE
nydus-image: remove redundant -o short option

### DIFF
--- a/src/bin/nydus-image/main.rs
+++ b/src/bin/nydus-image/main.rs
@@ -532,7 +532,6 @@ fn prepare_cmd_args(bti_string: String) -> ArgMatches<'static> {
             .arg(
                 Arg::with_name("output")
                 .long("output")
-                .short("o")
                 .help("path to output tar file")
                 .required(true)
                 .takes_value(true)


### PR DESCRIPTION
Subcommand 'unpack' introduced short option "-o" which is
redundant with global option log-level ending up with a panic

Unfortunately, github CI action didn't catch such regression :-(

INFO [utils - 93:run] - /data00/home/gechangwei/git_repo/nydus-rs/target-fusedev/debug/nydus-image create --bootstrap bootstrap_scratched  --blob /data00/home/gechangwei/nydus-test-yard/blobihdgyw05 --log-level info --fs-version 6 --output-json /tmp/tmp46yv4v3_output.json /data00/home/gechangwei/nydus-test-yard/gen_rootfs_scratch
thread 'main' panicked at 'Argument short must be unique

	-o is already in use', /home/gechangwei/.cargo/registry/src/mirrors.sjtug.sjtu.edu.cn-4f7dbcce21e258a2/clap-2.34.0/src/app/parser.rs:190:13
stack backtrace:
   0: rust_begin_unwind
             at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/std/src/panicking.rs:584:5
   1: core::panicking::panic_fmt
             at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/core/src/panicking.rs:143:14
   2: clap::app::parser::Parser::debug_asserts

Signed-off-by: Changewei Ge <gechangwei@bytedance.com>