### PR TITLE
rafs: v6 must have local blobcache configured

### DIFF
--- a/rafs/src/fs.rs
+++ b/rafs/src/fs.rs
@@ -254,6 +254,13 @@ impl Rafs {
                 .as_secs(),
         };
 
+        // Rafs v6 does must store chunk info into local file cache. So blob cache is required
+        if rafs.metadata().is_v6() && conf.device.cache.cache_type != "blobcache" {
+            return Err(RafsError::Configure(
+                "Rafs v6 must have local blobcache configured".to_string(),
+            ));
+        }
+
         rafs.ios.toggle_files_recording(conf.iostats_files);
         rafs.ios.toggle_access_pattern(conf.access_pattern);
         rafs.ios


### PR DESCRIPTION
Rafs v6 must store its chunks' info into local
blobcache. So we must configure blobcache in the
rafs conf file.

Check it strictly.

Otherwise, rafs can be mounted, but IO causes panic

```
thread 'fuse_server' panicked at 'explicit panic', storage/src/device.rs:418:18
stack backtrace:
   0: std::panicking::begin_panic
             at /rustc/fe5b13d681f25ee6474be29d748c65adcd91f69e/library/std/src/panicking.rs:616:12
   1: nydus_storage::device::BlobIoChunk::as_base
             at /data00/home/gechangwei/git_repo/nydus-rs/storage/src/device.rs:418:18
   2: <nydus_storage::device::BlobIoChunk as nydus_storage::device::BlobChunkInfo>::uncompress_size
             at /data00/home/gechangwei/git_repo/nydus-rs/storage/src/device.rs:471:9
   3: <nydus_storage::cache::dummycache::DummyCache as nydus_storage::cache::BlobCache>::read
             at /data00/home/gechangwei/git_repo/nydus-rs/storage/src/cache/dummycache.rs:127:22
   4: <nydus_storage::device::BlobDeviceIoVec as fuse_backend_rs::transport::file_traits::FileReadWriteVolatile>::read_vectored_at_volatile
             at /data00/home/gechangwei/git_repo/nydus-rs/storage/src/device.rs:1088:24
```