### PR TITLE
nydus-test: ignore missing backend_proxy_url

### DIFF
--- a/contrib/nydus-test/framework/nydus_anchor.py
+++ b/contrib/nydus-test/framework/nydus_anchor.py
@@ -55,10 +55,13 @@ class NydusAnchor:
 
         registry_conf = kwargs.pop("registry")
         self.registry_url = registry_conf["registry_url"]
-        self.backend_proxy_url = registry_conf["backend_proxy_url"]
         self.registry_auth = registry_conf["registry_auth"]
         self.registry_namespace = registry_conf["registry_namespace"]
-        self.backend_proxy_blobs_dir = registry_conf["backend_proxy_blobs_dir"]
+        try:
+            self.backend_proxy_url = registry_conf["backend_proxy_url"]
+            self.backend_proxy_blobs_dir = registry_conf["backend_proxy_blobs_dir"]
+        except KeyError:
+            pass
 
         os.makedirs(self.backend_proxy_blobs_dir, exist_ok=True)
 


### PR DESCRIPTION
backend_proxy_url is not mandatory.

This fix nightly integration test action