### PR TITLE
nydus-test: Replace storage backend with BACKEND_PROXY and adapts github action

### DIFF
--- a/.github/workflows/it.yml
+++ b/.github/workflows/it.yml
@@ -53,6 +53,7 @@ jobs:
         cargo install --version 0.2.1 cross
         rustup component add rustfmt clippy
         make -e ARCH=$arch -e CARGO=cross static-release
+        make release  -C contrib/nydus-backend-proxy/
         #sudo mv target-fusedev/$arch-unknown-linux-musl/release/nydusd nydusd-fusedev
         #sudo mv target-fusedev/$arch-unknown-linux-musl/release/nydus-cached .
         #sudo mv target-fusedev/$arch-unknown-linux-musl/release/nydus-image .
@@ -68,6 +69,7 @@ jobs:
         OSS_AK_SEC: ${{ secrets.OSS_TEST_AK_SECRET }}
       run: |
         sudo mkdir -p /home/runner/nydus-test-workspace
+        sudo mkdir -p /home/runner/nydus-test-workspace/proxy_blobs
         sudo cat > /home/runner/work/image-service/image-service/contrib/nydus-test/anchor_conf.json << EOF
         {
             "workspace": "/home/runner/nydus-test-workspace",
@@ -79,7 +81,9 @@ jobs:
             "registry": {
                 "registry_url": "localhost:5000",
                 "registry_namespace": "",
-                "registry_auth": "Y2h1YW5sYW5nLmdjdzoxcWF6MndzeA=="
+                "registry_auth": "YOURAUTH==",
+                "backend_proxy_url": "127.0.0.1:8000",
+                "backend_proxy_blobs_dir": "/home/runner/nydus-test-workspace/proxy_blobs"
             },
             "oss": {
                 "endpoint": "oss-cn-beijing.aliyuncs.com",

--- a/contrib/nydus-test/conftest.py
+++ b/contrib/nydus-test/conftest.py
@@ -203,24 +203,26 @@ def local_registry():
         assert False, "fail in stopping container"
 
 
+try:
+    ANCHOR.backend_proxy_blobs_dir
 
-@pytest.fixture(scope="module", autouse=True)
-def nydus_backend_proxy():
-    backend_proxy = BackendProxy(
-        ANCHOR,
-        ANCHOR.backend_proxy_blobs_dir,
-        bin=os.path.join(
-            ANCHOR.nydus_project,
-            "contrib",
-            "nydus-backend-proxy",
-            "target",
-            "release",
-            "nydus-backend-proxy",
-        ),
-    )
+    @pytest.fixture(scope="module", autouse=True)
+    def nydus_backend_proxy():
+        backend_proxy = BackendProxy(
+            ANCHOR,
+            ANCHOR.backend_proxy_blobs_dir,
+            bin=os.path.join(
+                ANCHOR.nydus_project,
+                "contrib",
+                "nydus-backend-proxy",
+                "target",
+                "release",
+                "nydus-backend-proxy",
+            ),
+        )
+        backend_proxy.start()
+        yield
+        backend_proxy.stop()
 
-    backend_proxy.start()
-
-    yield
-
-    backend_proxy.stop()
+except AttributeError:
+    pass

--- a/contrib/nydus-test/framework/nydus_anchor.py
+++ b/contrib/nydus-test/framework/nydus_anchor.py
@@ -60,10 +60,9 @@ class NydusAnchor:
         try:
             self.backend_proxy_url = registry_conf["backend_proxy_url"]
             self.backend_proxy_blobs_dir = registry_conf["backend_proxy_blobs_dir"]
+            os.makedirs(self.backend_proxy_blobs_dir, exist_ok=True)
         except KeyError:
             pass
-
-        os.makedirs(self.backend_proxy_blobs_dir, exist_ok=True)
 
         artifacts = kwargs.pop("artifacts")
         self.containerd_bin = artifacts["containerd"]

--- a/contrib/nydus-test/functional-test/test_api.py
+++ b/contrib/nydus-test/functional-test/test_api.py
@@ -17,8 +17,8 @@ logging_setup()
 
 
 def test_daemon_info(nydus_anchor, nydus_image, rafs_conf: RafsConf):
-    nydus_image.set_backend(Backend.OSS).create_image()
-    rafs_conf.set_rafs_backend(Backend.OSS)
+    nydus_image.set_backend(Backend.BACKEND_PROXY).create_image()
+    rafs_conf.set_rafs_backend(Backend.BACKEND_PROXY)
     rafs = RafsMount(nydus_anchor, nydus_image, rafs_conf)
     rafs.mount()
     nc = NydusAPIClient(rafs.get_apisock())
@@ -30,9 +30,9 @@ def test_iostats(
 ):
     rafs_id = "/"
     rafs_conf.enable_files_iostats().enable_latest_read_files().set_rafs_backend(
-        Backend.OSS
+        Backend.BACKEND_PROXY
     )
-    nydus_image.set_backend(Backend.OSS).create_image()
+    nydus_image.set_backend(Backend.BACKEND_PROXY).create_image()
     rafs = RafsMount(nydus_anchor, nydus_image, rafs_conf)
 
     rafs.mount()
@@ -77,8 +77,8 @@ def test_iostats(
 def test_global_metrics(nydus_anchor, nydus_image: RafsImage, rafs_conf: RafsConf):
     rafs_id = "/"
 
-    rafs_conf.enable_files_iostats().set_rafs_backend(Backend.OSS)
-    nydus_image.set_backend(Backend.OSS).create_image()
+    rafs_conf.enable_files_iostats().set_rafs_backend(Backend.BACKEND_PROXY)
+    nydus_image.set_backend(Backend.BACKEND_PROXY).create_image()
 
     rafs = RafsMount(nydus_anchor, nydus_image, rafs_conf)
     rafs.mount()
@@ -132,10 +132,12 @@ def test_backend_swap(
     dist.generate_tree()
     dist.put_multiple_files(100, Size(2, Unit.MB))
 
-    nydus_scratch_image.set_backend(Backend.OSS).create_image(
+    nydus_scratch_image.set_backend(Backend.BACKEND_PROXY).create_image(
         readahead_policy="fs", readahead_files="/".encode()
     )
-    rafs_conf.set_rafs_backend(Backend.OSS).enable_rafs_blobcache().enable_fs_prefetch(
+    rafs_conf.set_rafs_backend(
+        Backend.BACKEND_PROXY
+    ).enable_rafs_blobcache().enable_fs_prefetch(
         threads_count=7, bandwidth_rate=Size(2, Unit.MB).B
     )
     rafs_conf.dump_rafs_conf()
@@ -192,12 +194,14 @@ def test_backend_swap(
     utils.clean_pagecache()
 
 
-def test_access_pattern(nydus_anchor, nydus_image, rafs_conf: RafsConf):
+def test_access_pattern(
+    nydus_anchor: NydusAnchor, nydus_image: RafsImage, rafs_conf: RafsConf
+):
     rafs_id = "/"
-    rafs_conf.enable_access_pattern().set_rafs_backend(Backend.OSS)
+    rafs_conf.enable_access_pattern().set_rafs_backend(Backend.BACKEND_PROXY)
     rafs_conf.dump_rafs_conf()
 
-    nydus_image.set_backend(Backend.OSS).create_image()
+    nydus_image.set_backend(Backend.BACKEND_PROXY).create_image()
 
     rafs = RafsMount(nydus_anchor, nydus_image, rafs_conf)
     rafs.mount()
@@ -226,14 +230,14 @@ def test_access_pattern(nydus_anchor, nydus_image, rafs_conf: RafsConf):
 def test_api_mount_with_prefetch(
     nydus_anchor, nydus_image: RafsImage, rafs_conf: RafsConf
 ):
-    nydus_image.set_backend(Backend.OSS).create_image()
+    nydus_image.set_backend(Backend.BACKEND_PROXY).create_image()
 
     hint_files = ["/"]
     rafs = RafsMount(nydus_anchor, None, None, with_defaults=False)
 
     # Prefetch must enable blobcache
     rafs_conf.enable_rafs_blobcache()
-    rafs_conf.set_rafs_backend(Backend.OSS)
+    rafs_conf.set_rafs_backend(Backend.BACKEND_PROXY)
     rafs_conf.enable_fs_prefetch(threads_count=4)
     rafs_conf.dump_rafs_conf()
     rafs.set_mountpoint(nydus_anchor.mount_point).apisock("api_sock").mount(
@@ -265,10 +269,10 @@ def test_api_mount_with_prefetch(
 
 def test_detect_io_hang(nydus_anchor, nydus_image: RafsImage, rafs_conf: RafsConf):
 
-    rafs_conf.enable_files_iostats().set_rafs_backend(Backend.OSS)
+    rafs_conf.enable_files_iostats().set_rafs_backend(Backend.BACKEND_PROXY)
     rafs_conf.dump_rafs_conf()
 
-    nydus_image.set_backend(Backend.OSS).create_image()
+    nydus_image.set_backend(Backend.BACKEND_PROXY).create_image()
 
     rafs = RafsMount(nydus_anchor, nydus_image, rafs_conf)
     rafs.thread_num(5).mount()


### PR DESCRIPTION
test_api is the only case suite being tested. Let's also replace its storage backend type.
In addition, fill backend proxy configurations into github action.