### PR TITLE
nydusd: fixed getting the wrong chunk due to using the wrong blob index

### DIFF
--- a/rafs/src/metadata/direct_v6.rs
+++ b/rafs/src/metadata/direct_v6.rs
@@ -1239,7 +1239,7 @@ impl RafsInode for OndiskInodeWrapper {
                 content_len = std::cmp::min(chunk_size, left);
                 let desc = self.make_chunk_io(c, 0, content_len, user_io);
 
-                if c.blob_index() as u32 != descs.bi_vec[0].blob.blob_index() {
+                if desc.blob.blob_index() as u32 != descs.bi_vec[0].blob.blob_index() {
                     vec.push(descs);
                     descs = BlobIoVec::new();
                 }

--- a/rafs/src/metadata/layout/v6.rs
+++ b/rafs/src/metadata/layout/v6.rs
@@ -992,6 +992,9 @@ impl RafsV6InodeChunkAddr {
         }
     }
 
+    /// Note: for erofs, bump id by 1 since device id 0 is bootstrap.
+    /// The index in BlobInfo grows from 0, so when using this method to index the corresponding blob,
+    /// the index always needs to be minus 1
     /// Get the blob index of the chunk.
     pub fn blob_index(&self) -> u8 {
         (u16::from_le(self.c_blob_addr_hi) & 0x00ff) as u8


### PR DESCRIPTION
The blob index on the disk where erofs exists starts at 1, but the blob index in BlobInfo starts at 0,
and the blob index on the disk is mistakenly used here instead of blobInfo's index
this will eventually result in the wrong file contents being obtained.

Signed-off-by: zyfjeff <zyfjeff@linux.alibaba.com>