### PR TITLE
ci: don't run Convert Top Docker Hub Images job on forked repos

### DIFF
--- a/.github/workflows/convert.yml
+++ b/.github/workflows/convert.yml
@@ -16,6 +16,8 @@ env:
 jobs:
   convert-images:
     runs-on: ubuntu-latest
+    # don't run this action on forks
+    if: github.repository_owner == 'dragonflyoss'
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2


### PR DESCRIPTION
There is no need to run this job all repos, I recently received some emails about this job failure.

Signed-off-by: liubin <liubin0329@gmail.com>