### PR TITLE
nydus-image: use BtreeMap replace HashMap to guarante order of chunkinfo

### DIFF
--- a/src/bin/nydus-image/core/bootstrap.rs
+++ b/src/bin/nydus-image/core/bootstrap.rs
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::convert::TryFrom;
 use std::convert::TryInto;
 use std::ffi::OsString;
@@ -647,7 +647,7 @@ impl Bootstrap {
         // but there is no deduplication during the actual construction.
         // Each layer uses the corresponding chunk in the blob of its own layer.
         // If HashChunkDict is used here, it will cause duplication. The chunks are removed, resulting in incomplete chunk info.
-        let mut chunk_cache = HashMap::new();
+        let mut chunk_cache = BTreeMap::new();
 
         // Dump bootstrap
         timing_tracer!(

--- a/src/bin/nydus-image/core/chunk_dict.rs
+++ b/src/bin/nydus-image/core/chunk_dict.rs
@@ -16,7 +16,7 @@ use storage::device::BlobInfo;
 
 use crate::core::node::ChunkWrapper;
 use crate::core::tree::Tree;
-#[derive(Debug, PartialEq, Eq, Hash)]
+#[derive(Debug, PartialEq, Eq, Hash, Ord, PartialOrd)]
 pub struct DigestWithBlobIndex(pub RafsDigest, pub u32);
 
 pub trait ChunkDict: Sync + Send + 'static {

--- a/src/bin/nydus-image/core/node.rs
+++ b/src/bin/nydus-image/core/node.rs
@@ -5,7 +5,7 @@
 
 //! An in-memory RAFS inode for image building and inspection.
 
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::ffi::{OsStr, OsString};
 use std::fmt::{self, Display, Formatter, Result as FmtResult};
 use std::fs::{self, File};
@@ -549,7 +549,7 @@ impl Node {
         orig_meta_addr: u64,
         meta_addr: u64,
         ctx: &mut BuildContext,
-        chunk_cache: &mut HashMap<DigestWithBlobIndex, ChunkWrapper>,
+        chunk_cache: &mut BTreeMap<DigestWithBlobIndex, ChunkWrapper>,
     ) -> Result<usize> {
         let mut inode = self.new_rafsv6_inode();
 

--- a/utils/src/digest.rs
+++ b/utils/src/digest.rs
@@ -132,7 +132,7 @@ impl DigestHasher for Sha256 {
     }
 }
 
-#[derive(Clone, Copy, Hash, PartialEq, Eq, Debug, Default)]
+#[derive(Clone, Copy, Hash, PartialEq, Eq, Debug, Default, Ord, PartialOrd)]
 pub struct RafsDigest {
     pub data: DigestData,
 }


### PR DESCRIPTION
Because chunkinfo uses HashMap for storage, the writing to bootstrap is out of order,
so repeated builds may cause the bootstrap content to change.

Signed-off-by: zyfjeff <zyfjeff@linux.alibaba.com>