### PR TITLE
backend-proxy: don't panic if address already binded

### DIFF
--- a/contrib/nydus-backend-proxy/src/main.rs
+++ b/contrib/nydus-backend-proxy/src/main.rs
@@ -297,6 +297,7 @@ async fn main() {
         .launch()
         .await
     {
-        panic!("Rocket didn't launch! Err:{:#?}", e);
+        error!("Rocket didn't launch! Err:{:#?}", e);
+        std::process::exit(-1);
     }
 }


### PR DESCRIPTION
Don't panic. Just exit with error and print error message.
