### PR TITLE
chore: change trivial logs from INFO to DEBUG

### DIFF
--- a/src/bin/nydus-image/unpack/mod.rs
+++ b/src/bin/nydus-image/unpack/mod.rs
@@ -158,7 +158,7 @@ impl OCIUnpacker {
 
 impl Unpacker for OCIUnpacker {
     fn unpack(&self) -> Result<()> {
-        info!(
+        debug!(
             "oci unpacker, bootstrap file: {:?}, blob file: {:?}, output file: {:?}",
             self.bootstrap, self.blob, self.output
         );


### PR DESCRIPTION
### DESCRIPTION
Working with multiple layers, snapshotter produces trivial logs.

### REFACT
This patch changes two logs from INFO to DEBUG.