### PR TITLE
Doc: make sure snapshotter's root dir exist

### DIFF
--- a/docs/nydus-fscache.md
+++ b/docs/nydus-fscache.md
@@ -85,6 +85,11 @@ make
 4. Start nydus snapshotter with the command below:
 
 ```
+# make sure the _--root_ directory exists,
+mkdir /var/lib/containerd/io.containerd.snapshotter.v1.nydus
+```
+
+```
 ./bin/containerd-nydus-grpc \
  --config-path /path/nydus-erofs-config.json \
  --daemon-mode shared \


### PR DESCRIPTION
For the very 1st run, snapshotter's root dir may not exist, leading to errors such as,

"
sudo ctr run --rm -t --snapshotter=nydus docker.io/hsiangkao/ubuntu:20.04-rafs-v6 ubuntu /bin/bash
ctr: failed to mount daemon wMZ3kd7hRWCtE1M_5bnfVA: failed to shared mount: failed to share mount: failed to create new nydus client: failed to build transport for nydus client: stat /var/lib/containerd/io.containerd.snapshotter.v1.nydus/socket/shared_daemon/api.sock: no such file or directory: unknown
"

Reported-by: Benjamin Huang <benjaminhuanghuang@gmail.com>
Signed-off-by: Liu Bo <bo.liu@linux.alibaba.com>