### PR TITLE
fscache: print error message when nydusd can't start

### DIFF
--- a/src/bin/nydusd/main.rs
+++ b/src/bin/nydusd/main.rs
@@ -699,7 +699,10 @@ fn process_daemon_arguments(
     bti: BuildTimeInfo,
 ) -> Result<()> {
     info!("Start Nydus in daemon mode!");
-    let daemon = create_daemon(subargs, bti)?;
+    let daemon = create_daemon(subargs, bti).map_err(|e| {
+        error!("Failed to start daemon: {}", e);
+        e
+    })?;
     DAEMON_CONTROLLER.set_daemon(daemon);
     Ok(())
 }


### PR DESCRIPTION
At present, nydusd says nothing before exit. It's
better to give users and developers a message about
what's going on.

Signed-off-by: Changwei Ge <gechangwei@bytedance.com>