### PR TITLE
Display detailed error in FsCacheHandler constructor when cachefiles device not ready

### DIFF
--- a/src/bin/nydusd/fs_cache.rs
+++ b/src/bin/nydusd/fs_cache.rs
@@ -250,7 +250,12 @@ impl FsCacheHandler {
             .write(true)
             .read(true)
             .create(false)
-            .open(path)?;
+            .open(path)
+            .map_err(|e| {
+                error!("Failed to open cachefiles device {}. {}", path, e);
+                e
+            })?;
+
         let poller =
             Poll::new().map_err(|_e| eother!("fscache: failed to create poller for service"))?;
         let waker = Waker::new(poller.registry(), Token(TOKEN_EVENT_WAKER))


### PR DESCRIPTION
Display detailed error when construct FsCacheHandler with a nonexistent path

Files: fs_cache.rs

Signed-off-by: Benjamin Huang <benjaminhuanghuang@gmail.com>