### PR TITLE
upgrade clap to 3.2.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,15 +27,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ansi_term"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -214,17 +205,41 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "2.34.0"
+version = "3.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+checksum = "ab8b79fe3946ceb4a0b1c080b4018992b8d27e9ff363644c1c9b6387c854614d"
 dependencies = [
- "ansi_term",
  "atty",
  "bitflags",
- "strsim 0.8.0",
+ "clap_derive",
+ "clap_lex",
+ "indexmap",
+ "once_cell",
+ "strsim",
+ "termcolor",
  "textwrap",
- "unicode-width",
- "vec_map",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "759bf187376e1afa7b85b959e6a664a3e7a95203415dba952ad19139e798f902"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -316,7 +331,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim 0.10.0",
+ "strsim",
  "syn",
 ]
 
@@ -697,6 +712,12 @@ name = "hashbrown"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -1340,6 +1361,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_str_bytes"
+version = "6.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "648001efe5d5c0102d8cea768e348da85d90af8ba91f0bea908f157951493cd4"
+
+[[package]]
 name = "parking_lot"
 version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1413,6 +1440,30 @@ name = "ppv-lite86"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
 
 [[package]]
 name = "proc-macro2"
@@ -1780,12 +1831,6 @@ checksum = "02a8428da277a8e3a15271d79943e80ccc2ef254e78813a166a08d65e4c3ece5"
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
@@ -1843,12 +1888,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.11.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"
@@ -2018,12 +2060,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-width"
-version = "0.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
-
-[[package]]
 name = "url"
 version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2040,12 +2076,6 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ rlimit = "0.8.3"
 log = "0.4.8"
 libc = "0.2"
 vmm-sys-util = "0.9.0"
-clap = "2.33"
+clap = {version = "3.2.12", features = ["derive", "cargo"]}
 flexi_logger = { version = "0.17" }
 # pin regex to fix RUSTSEC-2022-0013
 regex = "1.5.5"

--- a/src/bin/nydus-cached/main.rs
+++ b/src/bin/nydus-cached/main.rs
@@ -35,7 +35,7 @@ fn main() -> Result<()> {
         .arg(
             Arg::with_name("sock")
                 .long("sock")
-                .short("S")
+                .short('S')
                 .help("Service API socket")
                 .takes_value(true)
                 .required(true),
@@ -43,7 +43,7 @@ fn main() -> Result<()> {
         .arg(
             Arg::with_name("config")
                 .long("config")
-                .short("C")
+                .short('C')
                 .help("Configuration file")
                 .takes_value(true)
                 .required(false)
@@ -51,7 +51,7 @@ fn main() -> Result<()> {
         .arg(
             Arg::with_name("log-level")
                 .long("log-level")
-                .short("l")
+                .short('l')
                 .help("Log level:")
                 .default_value("info")
                 .possible_values(&["trace", "debug", "info", "warn", "error"])
@@ -62,7 +62,7 @@ fn main() -> Result<()> {
         .arg(
             Arg::with_name("log-file")
                 .long("log-file")
-                .short("L")
+                .short('L')
                 .help("Log messages to the file. If file extension is not specified, the default extenstion \".log\" will be appended.")
                 .takes_value(true)
                 .required(false)
@@ -71,7 +71,7 @@ fn main() -> Result<()> {
         .arg(
             Arg::with_name("test")
                 .long("test")
-                .short("T")
+                .short('T')
                 .help("run as client for tests")
                 .takes_value(false)
                 .required(false),
@@ -79,7 +79,7 @@ fn main() -> Result<()> {
         .arg(
             Arg::with_name("workdir")
                 .long("workdir")
-                .short("W")
+                .short('W')
                 .help("working directory")
                 .takes_value(true)
                 .required(true),

--- a/src/bin/nydus-image/main.rs
+++ b/src/bin/nydus-image/main.rs
@@ -139,15 +139,15 @@ impl OutputSerializer {
     }
 }
 
-fn prepare_cmd_args(bti_string: String) -> ArgMatches<'static> {
+fn prepare_cmd_args(bti_string: &str) -> App {
     let arg_chunk_dict = Arg::with_name("chunk-dict")
         .long("chunk-dict")
-        .short("M")
+        .short('M')
         .help("Specify a chunk dictionary for chunk deduplication")
         .takes_value(true);
     let arg_prefetch_policy = Arg::with_name("prefetch-policy")
         .long("prefetch-policy")
-        .short("P")
+        .short('P')
         .help("blob data prefetch policy")
         .takes_value(true)
         .required(false)
@@ -156,7 +156,7 @@ fn prepare_cmd_args(bti_string: String) -> ArgMatches<'static> {
 
     // TODO: Try to use yaml to define below options
     App::new("")
-        .version(bti_string.as_str())
+        .version(bti_string)
         .author(crate_authors!())
         .about("Build or inspect RAFS filesystems for nydus accelerated container images.")
         .subcommand(
@@ -171,7 +171,7 @@ fn prepare_cmd_args(bti_string: String) -> ArgMatches<'static> {
                 .arg(
                     Arg::with_name("source-type")
                         .long("source-type")
-                        .short("t")
+                        .short('t')
                         .help("type of the source:")
                         .takes_value(true)
                         .default_value("directory")
@@ -199,7 +199,7 @@ fn prepare_cmd_args(bti_string: String) -> ArgMatches<'static> {
                 .arg(
                     Arg::with_name("bootstrap")
                         .long("bootstrap")
-                        .short("B")
+                        .short('B')
                         .help("path to store the nydus image's metadata blob")
                         .required_unless("diff-bootstrap-dir")
                         .conflicts_with("diff-bootstrap-dir")
@@ -209,7 +209,7 @@ fn prepare_cmd_args(bti_string: String) -> ArgMatches<'static> {
                 ).arg(
                     Arg::with_name("blob")
                         .long("blob")
-                        .short("b")
+                        .short('b')
                         .help("path to store nydus image's data blob")
                         .required_unless("backend-type")
                         .required_unless("source-type")
@@ -235,7 +235,7 @@ fn prepare_cmd_args(bti_string: String) -> ArgMatches<'static> {
                 .arg(
                     Arg::with_name("chunk-size")
                         .long("chunk-size")
-                        .short("S")
+                        .short('S')
                         .help("size of nydus image data chunk, must be power of two and between 0x1000-0x100000:")
                         .default_value("0x100000")
                         .required(false)
@@ -244,7 +244,7 @@ fn prepare_cmd_args(bti_string: String) -> ArgMatches<'static> {
                 .arg(
                     Arg::with_name("compressor")
                         .long("compressor")
-                        .short("c")
+                        .short('c')
                         .help("algorithm to compress image data blob:")
                         .takes_value(true)
                         .required(false)
@@ -254,7 +254,7 @@ fn prepare_cmd_args(bti_string: String) -> ArgMatches<'static> {
                 .arg(
                     Arg::with_name("digester")
                         .long("digester")
-                        .short("d")
+                        .short('d')
                         .help("algorithm to digest inodes and data chunks:")
                         .takes_value(true)
                         .required(false)
@@ -264,7 +264,7 @@ fn prepare_cmd_args(bti_string: String) -> ArgMatches<'static> {
                 .arg(
                     Arg::with_name("fs-version")
                         .long("fs-version")
-                        .short("v")
+                        .short('v')
                         .help("version number of nydus image format:")
                         .required(true)
                         .default_value("5")
@@ -273,7 +273,7 @@ fn prepare_cmd_args(bti_string: String) -> ArgMatches<'static> {
                 .arg(
                     Arg::with_name("parent-bootstrap")
                         .long("parent-bootstrap")
-                        .short("p")
+                        .short('p')
                         .help("path to parent/referenced image's metadata blob (optional)")
                         .takes_value(true)
                         .required(false),
@@ -284,7 +284,7 @@ fn prepare_cmd_args(bti_string: String) -> ArgMatches<'static> {
                 .arg(
                     Arg::with_name("repeatable")
                         .long("repeatable")
-                        .short("R")
+                        .short('R')
                         .help("generate reproducible nydus image")
                         .takes_value(false)
                         .required(false),
@@ -299,7 +299,7 @@ fn prepare_cmd_args(bti_string: String) -> ArgMatches<'static> {
                 .arg(
                     Arg::with_name("whiteout-spec")
                         .long("whiteout-spec")
-                        .short("W")
+                        .short('W')
                         .help("type of whiteout specification:")
                         .takes_value(true)
                         .required(true)
@@ -309,14 +309,14 @@ fn prepare_cmd_args(bti_string: String) -> ArgMatches<'static> {
                 .arg(
                     Arg::with_name("output-json")
                         .long("output-json")
-                        .short("J")
+                        .short('J')
                         .help("JSON output path for build result")
                         .takes_value(true)
                 )
                 .arg(
                     Arg::with_name("aligned-chunk")
                         .long("aligned-chunk")
-                        .short("A")
+                        .short('A')
                         .help("Align data chunks to 4K")
                         .takes_value(false)
                 )
@@ -330,7 +330,7 @@ fn prepare_cmd_args(bti_string: String) -> ArgMatches<'static> {
                 .arg(
                     Arg::with_name("blob-dir")
                         .long("blob-dir")
-                        .short("D")
+                        .short('D')
                         .help("directory to store nydus image's metadata and data blob")
                         .takes_value(true)
                 )
@@ -358,7 +358,7 @@ fn prepare_cmd_args(bti_string: String) -> ArgMatches<'static> {
                 .arg(
                     Arg::with_name("bootstrap")
                         .long("bootstrap")
-                        .short("B")
+                        .short('B')
                         .help("output path of nydus overlaid bootstrap")
                         .required(true)
                         .takes_value(true),
@@ -382,7 +382,7 @@ fn prepare_cmd_args(bti_string: String) -> ArgMatches<'static> {
                 .arg(
                     Arg::with_name("bootstrap")
                         .long("bootstrap")
-                        .short("B")
+                        .short('B')
                         .help("path to nydus image's metadata blob (required)")
                         .required(true)
                         .takes_value(true),
@@ -390,14 +390,14 @@ fn prepare_cmd_args(bti_string: String) -> ArgMatches<'static> {
                 .arg(
                     Arg::with_name("verbose")
                         .long("verbose")
-                        .short("V")
+                        .short('V')
                         .help("verbose output")
                         .required(false),
                 )
                 .arg(
                     Arg::with_name("output-json")
                         .long("output-json")
-                        .short("J")
+                        .short('J')
                         .help("path to JSON output file")
                         .takes_value(true)
                 )
@@ -408,7 +408,7 @@ fn prepare_cmd_args(bti_string: String) -> ArgMatches<'static> {
                 .arg(
                     Arg::with_name("bootstrap")
                         .long("bootstrap")
-                        .short("B")
+                        .short('B')
                         .help("path to nydus image's metadata blob (required)")
                         .required(true)
                         .takes_value(true),
@@ -416,7 +416,7 @@ fn prepare_cmd_args(bti_string: String) -> ArgMatches<'static> {
                 .arg(
                     Arg::with_name("request")
                         .long("request")
-                        .short("R")
+                        .short('R')
                         .help("inspect nydus image's filesystem metadata in request mode")
                         .required(false)
                         .takes_value(true),
@@ -428,7 +428,7 @@ fn prepare_cmd_args(bti_string: String) -> ArgMatches<'static> {
                 .arg(
                     Arg::with_name("bootstrap")
                         .long("bootstrap")
-                        .short("B")
+                        .short('B')
                         .help("generate stats information for base image from the specified metadata blob")
                         .required(false)
                         .takes_value(true),
@@ -436,7 +436,7 @@ fn prepare_cmd_args(bti_string: String) -> ArgMatches<'static> {
                 .arg(
                     Arg::with_name("blob-dir")
                         .long("blob-dir")
-                        .short("D")
+                        .short('D')
                         .help("Generate stats information for base image from the all metadata blobs in the directory")
                         .required(false)
                         .takes_value(true)
@@ -444,7 +444,7 @@ fn prepare_cmd_args(bti_string: String) -> ArgMatches<'static> {
                 .arg(
                     Arg::with_name("target")
                         .long("target")
-                        .short("T")
+                        .short('T')
                         .help("generate stats information for target image from the specified metadata blob, deduplicating all chunks existing in the base image")
                         .required(false)
                         .takes_value(true),
@@ -452,7 +452,7 @@ fn prepare_cmd_args(bti_string: String) -> ArgMatches<'static> {
                 .arg(
                     Arg::with_name("output-json")
                         .long("output-json")
-                        .short("J")
+                        .short('J')
                         .help("path to JSON output file")
                         .takes_value(true)
                 )
@@ -463,7 +463,7 @@ fn prepare_cmd_args(bti_string: String) -> ArgMatches<'static> {
                 .arg(
                     Arg::with_name("bootstrap")
                         .long("bootstrap")
-                        .short("B")
+                        .short('B')
                         .help("bootstrap to compact")
                         .required(true)
                         .takes_value(true),
@@ -471,7 +471,7 @@ fn prepare_cmd_args(bti_string: String) -> ArgMatches<'static> {
                 .arg(
                     Arg::with_name("config")
                         .long("config")
-                        .short("C")
+                        .short('C')
                         .help("config to compactor")
                         .required(true)
                         .takes_value(true),
@@ -493,21 +493,21 @@ fn prepare_cmd_args(bti_string: String) -> ArgMatches<'static> {
                 .arg(
                     Arg::with_name("chunk-dict")
                         .long("chunk-dict")
-                        .short("M")
+                        .short('M')
                         .help("Specify a chunk dictionary for chunk deduplication")
                         .takes_value(true),
                 )
                 .arg(
                     Arg::with_name("output-bootstrap")
                         .long("output-bootstrap")
-                        .short("O")
+                        .short('O')
                         .help("bootstrap to output, default is source bootstrap add suffix .compact")
                         .takes_value(true),
                 )
                 .arg(
                     Arg::with_name("output-json")
                         .long("output-json")
-                        .short("J")
+                        .short('J')
                         .help("path to JSON output file")
                         .takes_value(true))
         )
@@ -517,14 +517,14 @@ fn prepare_cmd_args(bti_string: String) -> ArgMatches<'static> {
             .arg(
                 Arg::with_name("bootstrap")
                 .long("bootstrap")
-                .short("B")
+                .short('B')
                 .help("path to bootstrap file")
                 .required(true)
                 .takes_value(true))
             .arg(
                 Arg::with_name("blob")
                 .long("blob")
-                .short("b")
+                .short('b')
                 .help("path to blob file")
                 .required(false)
                 .takes_value(true)
@@ -540,7 +540,7 @@ fn prepare_cmd_args(bti_string: String) -> ArgMatches<'static> {
         .arg(
             Arg::with_name("log-file")
                 .long("log-file")
-                .short("o")
+                .short('o')
                 .help("Specify log file name")
                 .takes_value(true)
                 .required(false)
@@ -549,7 +549,7 @@ fn prepare_cmd_args(bti_string: String) -> ArgMatches<'static> {
         .arg(
             Arg::with_name("log-level")
                 .long("log-level")
-                .short("l")
+                .short('l')
                 .help("Specify log level:")
                 .default_value("info")
                 .possible_values(&["trace", "debug", "info", "warn", "error"])
@@ -557,7 +557,6 @@ fn prepare_cmd_args(bti_string: String) -> ArgMatches<'static> {
                 .required(false)
                 .global(true),
         )
-        .get_matches()
 }
 
 fn init_log(matches: &ArgMatches) -> Result<()> {
@@ -576,7 +575,9 @@ fn init_log(matches: &ArgMatches) -> Result<()> {
 fn main() -> Result<()> {
     let (bti_string, build_info) = BuildTimeInfo::dump(crate_version!());
 
-    let cmd = prepare_cmd_args(bti_string);
+    let mut app = prepare_cmd_args(bti_string.as_ref());
+    let usage = app.render_usage();
+    let cmd = app.get_matches();
 
     init_log(&cmd)?;
 
@@ -598,7 +599,7 @@ fn main() -> Result<()> {
     } else if let Some(matches) = cmd.subcommand_matches("unpack") {
         Command::unpack(matches)
     } else {
-        println!("{}", cmd.usage());
+        println!("{}", usage);
         Ok(())
     }
 }
@@ -887,7 +888,7 @@ impl Command {
         Ok(())
     }
 
-    fn get_bootstrap<'a>(matches: &'a clap::ArgMatches) -> Result<&'a Path> {
+    fn get_bootstrap(matches: &clap::ArgMatches) -> Result<&Path> {
         match matches.value_of("bootstrap") {
             None => bail!("missing parameter `bootstrap`"),
             Some(s) => Ok(Path::new(s)),

--- a/src/bin/nydusctl/main.rs
+++ b/src/bin/nydusctl/main.rs
@@ -87,7 +87,7 @@ async fn main() -> Result<()> {
                 .arg(
                     Arg::with_name("interval")
                         .long("interval")
-                        .short("I")
+                        .short('I')
                         .required(false)
                         .takes_value(true),
                 ),


### PR DESCRIPTION
In order to use derive API to refactor, we upgrade clap firstly.

issue: https://github.com/dragonflyoss/image-service/issues/296