### PR TITLE
Nydusify: support "view" subcommand to view Nydus image

### DIFF
--- a/contrib/nydusify/pkg/checker/rule/filesystem.go
+++ b/contrib/nydusify/pkg/checker/rule/filesystem.go
@@ -235,7 +235,7 @@ func (rule *FilesystemRule) verify() error {
 	}
 
 	if !validate {
-		return fmt.Errorf("Failed to verify source image and Nydus image")
+		return errors.Errorf("Failed to verify source image and Nydus image")
 	}
 
 	return nil
@@ -257,7 +257,7 @@ func (rule *FilesystemRule) Validate() error {
 	if err != nil {
 		return err
 	}
-	defer nydusd.Umount()
+	defer nydusd.Umount(false)
 
 	if err := rule.verify(); err != nil {
 		return err

--- a/contrib/nydusify/pkg/checker/tool/nydusd.go
+++ b/contrib/nydusify/pkg/checker/tool/nydusd.go
@@ -157,7 +157,9 @@ func NewNydusd(conf NydusdConfig) (*Nydusd, error) {
 }
 
 func (nydusd *Nydusd) Mount() error {
-	nydusd.Umount()
+	// Umount is called to clean up mountpoint in nydusd's mount path
+	// Flag is used as a hint to prevent redundant error message
+	nydusd.Umount(true)
 
 	args := []string{
 		"--config",
@@ -203,11 +205,14 @@ func (nydusd *Nydusd) Mount() error {
 	return nil
 }
 
-func (nydusd *Nydusd) Umount() error {
+func (nydusd *Nydusd) Umount(silent bool) error {
 	if _, err := os.Stat(nydusd.MountPath); err == nil {
 		cmd := exec.Command("umount", nydusd.MountPath)
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
+
+		if !silent {
+			cmd.Stdout = os.Stdout
+			cmd.Stderr = os.Stderr
+		}
 		if err := cmd.Run(); err != nil {
 			return err
 		}

--- a/contrib/nydusify/pkg/viewer/viewer.go
+++ b/contrib/nydusify/pkg/viewer/viewer.go
@@ -1,0 +1,194 @@
+package viewer
+
+import (
+	"context"
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+
+	"github.com/dragonflyoss/image-service/contrib/nydusify/pkg/checker/tool"
+	"github.com/dragonflyoss/image-service/contrib/nydusify/pkg/converter/provider"
+	"github.com/dragonflyoss/image-service/contrib/nydusify/pkg/parser"
+	"github.com/dragonflyoss/image-service/contrib/nydusify/pkg/utils"
+)
+
+func prettyDump(obj interface{}, name string) error {
+	bytes, err := json.MarshalIndent(obj, "", "  ")
+	if err != nil {
+		return err
+	}
+	return ioutil.WriteFile(name, bytes, 0644)
+}
+
+// Opt defines fsViewer options, Target is the Nydus image reference
+type Opt struct {
+	WorkDir        string
+	Target         string
+	TargetInsecure bool
+
+	MountPath     string
+	NydusdPath    string
+	BackendType   string
+	BackendConfig string
+	ExpectedArch  string
+	FsVersion     string
+}
+
+// fsViewer provides complete view of file system in nydus image
+type FsViewer struct {
+	Opt
+	Parser       *parser.Parser
+	NydusdConfig tool.NydusdConfig
+}
+
+// New creates fsViewer instance, Target is the Nydus image reference
+func New(opt Opt) (*FsViewer, error) {
+	var targetParser *parser.Parser
+	if opt.Target != "" {
+		targetRemote, err := provider.DefaultRemote(opt.Target, opt.TargetInsecure)
+		if err != nil {
+			return nil, errors.Wrap(err, "init image error")
+		}
+		targetParser, err = parser.New(targetRemote, opt.ExpectedArch)
+		if targetParser == nil {
+			return nil, errors.Wrap(err, "failed to create parser")
+		}
+	}
+
+	mode := "cached"
+	digestValidate := true
+	if opt.FsVersion == "6" {
+		mode = "direct"
+		digestValidate = false
+	}
+
+	nydusdConfig := tool.NydusdConfig{
+		NydusdPath:     opt.NydusdPath,
+		BackendType:    opt.BackendType,
+		BackendConfig:  opt.BackendConfig,
+		BootstrapPath:  filepath.Join(opt.WorkDir, "nydus_bootstrap"),
+		ConfigPath:     filepath.Join(opt.WorkDir, "fs/nydusd_config.json"),
+		BlobCacheDir:   filepath.Join(opt.WorkDir, "fs/nydus_blobs"),
+		MountPath:      opt.MountPath,
+		APISockPath:    filepath.Join(opt.WorkDir, "fs/nydus_api.sock"),
+		Mode:           mode,
+		DigestValidate: digestValidate,
+	}
+
+	fsViewer := &FsViewer{
+		Opt:          opt,
+		Parser:       targetParser,
+		NydusdConfig: nydusdConfig,
+	}
+
+	return fsViewer, nil
+}
+
+// Pull Bootstrap, includes nydus_manifest.json and nydus_config.json
+func (fsViewer *FsViewer) PullBootstrap(ctx context.Context, targetParsed *parser.Parsed) error {
+	if err := os.RemoveAll(fsViewer.WorkDir); err != nil {
+		return errors.Wrap(err, "clean up work directory error")
+	}
+
+	if err := os.MkdirAll(filepath.Join(fsViewer.WorkDir, "fs"), 0750); err != nil {
+		return errors.Wrap(err, "create work directory error")
+	}
+
+	if targetParsed.NydusImage != nil {
+		if err := prettyDump(
+			targetParsed.NydusImage.Manifest,
+			filepath.Join(fsViewer.WorkDir, "nydus_manifest.json"),
+		); err != nil {
+			return errors.Wrap(err, "output Nydus manifest file")
+		}
+		if err := prettyDump(
+			targetParsed.NydusImage.Config,
+			filepath.Join(fsViewer.WorkDir, "nydus_config.json"),
+		); err != nil {
+			return errors.Wrap(err, "output Nydus config file")
+		}
+
+		target := filepath.Join(fsViewer.WorkDir, "nydus_bootstrap")
+		logrus.Infof("Pulling Nydus bootstrap to %s", target)
+		bootstrapReader, err := fsViewer.Parser.PullNydusBootstrap(ctx, targetParsed.NydusImage)
+		if err != nil {
+			return errors.Wrap(err, "pull Nydus bootstrap layer error")
+		}
+		defer bootstrapReader.Close()
+
+		if err := utils.UnpackFile(bootstrapReader, utils.BootstrapFileNameInLayer, target); err != nil {
+			return errors.Wrap(err, "unpack Nydus bootstrap layer")
+		}
+	}
+
+	return nil
+}
+
+// Mount nydus image.
+func (fsViewer *FsViewer) MountImage() error {
+	logrus.Infof("Mounting Nydus image to %s", fsViewer.NydusdConfig.MountPath)
+
+	if err := os.MkdirAll(fsViewer.NydusdConfig.BlobCacheDir, 0750); err != nil {
+		return errors.Wrap(err, "create blob cache directory for Nydusd error")
+	}
+
+	if err := os.MkdirAll(fsViewer.NydusdConfig.MountPath, 0750); err != nil {
+		return errors.Wrap(err, "create mountpoint directory of Nydus image error")
+	}
+
+	nydusd, err := tool.NewNydusd(fsViewer.NydusdConfig)
+	if err != nil {
+		return errors.Wrap(err, "create Nydusd daemon error")
+	}
+
+	if err := nydusd.Mount(); err != nil {
+		return errors.Wrap(err, "mount Nydus image error")
+	}
+
+	return nil
+}
+
+// View provides the structure of the file system in target nydus image
+// It includes two steps, pull the boostrap of the image, and mount the
+// image under specified path.
+func (fsViewer *FsViewer) View(ctx context.Context) error {
+	// Pull bootstrap
+	targetParsed, err := fsViewer.Parser.Parse(ctx)
+	if err != nil {
+		return errors.Wrap(err, "parse Nydus image error")
+	}
+	err = fsViewer.PullBootstrap(ctx, targetParsed)
+	if err != nil {
+		return errors.Wrap(err, "fsViewer pull bootstrap error")
+	}
+
+	err = fsViewer.MountImage()
+	if err != nil {
+		return err
+	}
+
+	// Block current goroutine in order to umount the file system and clean up workdir
+	sigs := make(chan os.Signal, 1)
+	done := make(chan bool, 1)
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+
+	go func() {
+		sig := <-sigs
+		logrus.Infof("Received Signal: %s", sig)
+		done <- true
+	}()
+
+	logrus.Infof("Please send signal SIGINT/SIGTERM to umount the file system")
+	<-done
+	if err := os.RemoveAll(fsViewer.WorkDir); err != nil {
+		return errors.Wrap(err, "clean up work directory error")
+	}
+
+	return nil
+}


### PR DESCRIPTION
Nydusify provides a fsViewer to view the file system in the Nydus image.
The fsViewer will pull image's bootstrap according to its url, and it
will mount the file system to pointed path.

Users can view the file system then. For example, they can ran
`$ trivy fs mount-path`
to scan the whole image.

Signed-off-by: YushuoEdge <y-shuo@sjtu.edu.cn>