### PR TITLE
Prefetch limit

### DIFF
--- a/rafs/src/fs.rs
+++ b/rafs/src/fs.rs
@@ -727,7 +727,7 @@ impl FileSystem for Rafs {
             let r = self.device.read_to(w, desc)?;
             result += r;
             recorder.mark_success(r);
-            if r != desc.bi_size {
+            if r as u32 != desc.bi_size {
                 break;
             }
         }

--- a/rafs/src/metadata/direct_v6.rs
+++ b/rafs/src/metadata/direct_v6.rs
@@ -581,13 +581,7 @@ impl OndiskInodeWrapper {
 
         let blob = blob_table[blob_index as usize].clone();
 
-        BlobIoDesc::new(
-            blob,
-            io_chunk,
-            content_offset,
-            content_len as usize,
-            user_io,
-        )
+        BlobIoDesc::new(blob, io_chunk, content_offset, content_len, user_io)
     }
 
     fn chunk_size(&self) -> u32 {
@@ -1239,7 +1233,7 @@ impl RafsInode for OndiskInodeWrapper {
 
         let mut descs = BlobIoVec::new();
         descs.bi_vec.push(desc);
-        descs.bi_size += content_len as usize;
+        descs.bi_size += content_len;
         left -= content_len;
 
         if left != 0 {
@@ -1260,9 +1254,8 @@ impl RafsInode for OndiskInodeWrapper {
                     descs = BlobIoVec::new();
                 }
 
-                // TODO: change type of bi_size to u32
                 descs.bi_vec.push(desc);
-                descs.bi_size += content_len as usize;
+                descs.bi_size += content_len;
                 left -= content_len;
                 if left == 0 {
                     break;

--- a/rafs/src/metadata/layout/v5.rs
+++ b/rafs/src/metadata/layout/v5.rs
@@ -1308,7 +1308,7 @@ fn add_chunk_to_bio_desc(
         blob,
         chunk.into(),
         chunk_start as u32,
-        (chunk_end - chunk_start) as usize,
+        (chunk_end - chunk_start) as u32,
         user_io,
     );
     desc.bi_size += bio.size;
@@ -1675,7 +1675,7 @@ pub mod tests {
                 assert_eq!(desc.bi_vec.len(), 1);
                 let bio = &desc.bi_vec[0];
                 assert_eq!(*expected_chunk_start, bio.offset);
-                assert_eq!(*expected_size as usize, bio.size);
+                assert_eq!(*expected_size as u32, bio.size);
             }
         }
     }

--- a/rafs/src/metadata/mod.rs
+++ b/rafs/src/metadata/mod.rs
@@ -716,7 +716,7 @@ impl RafsSuper {
             // Issue a prefetch request since target is large enough.
             // As files belonging to the same directory are arranged in adjacent,
             // it should fetch a range of blob in batch.
-            if flush || desc.bi_size >= (4 * RAFS_DEFAULT_CHUNK_SIZE) as usize {
+            if flush || desc.bi_size >= (4 * RAFS_DEFAULT_CHUNK_SIZE) as u32 {
                 trace!("fetching head bio size {}", desc.bi_size);
                 fetcher(desc);
                 desc.reset();

--- a/storage/src/cache/cachedfile.rs
+++ b/storage/src/cache/cachedfile.rs
@@ -292,7 +292,7 @@ impl BlobCache for FileCacheEntry {
     fn read(&self, iovec: &mut BlobIoVec, buffers: &[FileVolatileSlice]) -> Result<usize> {
         debug_assert!(iovec.validate());
         self.metrics.total.inc();
-        self.workers.consume_prefetch_budget(buffers);
+        self.workers.consume_prefetch_budget(iovec.bi_size);
 
         if let Some(ref chunks_meta) = self.meta {
             // TODO: the first blob backend io triggers chunks array download.

--- a/storage/src/cache/dummycache.rs
+++ b/storage/src/cache/dummycache.rs
@@ -145,13 +145,21 @@ impl BlobCache for DummyCache {
                 let mut d = alloc_buf(bio.chunkinfo.uncompress_size() as usize);
                 self.read_raw_chunk(&bio.chunkinfo, d.as_mut_slice(), false, None)?;
                 buffer_holder.push(d);
+                // Even a merged IO can hardly reach u32::MAX. So this is safe
                 user_size += bio.size;
             }
         }
 
-        copyv(&buffer_holder, bufs, offset as usize, user_size, 0, 0)
-            .map(|(n, _)| n)
-            .map_err(|e| eother!(e))
+        copyv(
+            &buffer_holder,
+            bufs,
+            offset as usize,
+            user_size as usize,
+            0,
+            0,
+        )
+        .map(|(n, _)| n)
+        .map_err(|e| eother!(e))
     }
 }
 

--- a/storage/src/cache/worker.rs
+++ b/storage/src/cache/worker.rs
@@ -11,7 +11,6 @@ use std::thread;
 use std::time::Duration;
 use tokio::time::interval;
 
-use fuse_backend_rs::file_buf::FileVolatileSlice;
 use governor::clock::QuantaClock;
 use governor::state::{InMemoryState, NotKeyed};
 use governor::{Quota, RateLimiter};
@@ -84,6 +83,7 @@ impl AsyncPrefetchMessage {
     }
 }
 
+/// An asynchronous task manager for data prefetching
 pub(crate) struct AsyncWorkerMgr {
     metrics: Arc<BlobcacheMetrics>,
     ping_requests: AtomicU32,
@@ -114,7 +114,7 @@ impl AsyncWorkerMgr {
         };
         let prefetch_limiter = NonZeroU32::new(tweaked_bw_limit).map(|v| {
             info!(
-                "stroage: prefetch bandwidth will be limited at {}Bytes/S",
+                "storage: prefetch bandwidth will be limited at {}Bytes/S",
                 v
             );
             Arc::new(RateLimiter::direct(Quota::per_second(v)))

--- a/storage/src/cache/worker.rs
+++ b/storage/src/cache/worker.rs
@@ -189,10 +189,9 @@ impl AsyncWorkerMgr {
     }
 
     /// Consume network bandwidth budget for prefetching.
-    pub fn consume_prefetch_budget(&self, buffers: &[FileVolatileSlice]) {
+    pub fn consume_prefetch_budget(&self, size: u32) {
         if self.prefetch_inflight.load(Ordering::Relaxed) > 0 {
-            let size = buffers.iter().fold(0, |v, i| v + i.len());
-            if let Some(v) = NonZeroU32::new(std::cmp::min(size, u32::MAX as usize) as u32) {
+            if let Some(v) = NonZeroU32::new(size) {
                 // Try to consume budget but ignore result.
                 if let Some(limiter) = self.prefetch_limiter.as_ref() {
                     let _ = limiter.check_n(v);

--- a/storage/src/device.rs
+++ b/storage/src/device.rs
@@ -516,7 +516,7 @@ pub struct BlobIoDesc {
     /// Offset from start of the chunk for the IO operation.
     pub offset: u32,
     /// Size of the IO operation
-    pub size: usize,
+    pub size: u32,
     /// Whether it's a user initiated IO, otherwise is a storage system internal IO.
     ///
     /// It might be initiated by user io amplification. With this flag, lower device
@@ -530,7 +530,7 @@ impl BlobIoDesc {
         blob: Arc<BlobInfo>,
         chunkinfo: BlobIoChunk,
         offset: u32,
-        size: usize,
+        size: u32,
         user_io: bool,
     ) -> Self {
         BlobIoDesc {
@@ -575,8 +575,9 @@ pub struct BlobIoVec {
     /// Blob IO flags.
     pub bi_flags: u32,
     /// Total size of blob IOs to be performed.
-    pub bi_size: usize,
+    pub bi_size: u32,
     /// Array of blob IOs, these IOs should executed sequentially.
+    // TODO: As bi_vec must stay within the same blob, move BlobInfo out here?
     pub bi_vec: Vec<BlobIoDesc>,
 }
 
@@ -933,7 +934,7 @@ impl BlobDevice {
             let mut f = BlobDeviceIoVec::new(self, desc);
             // The `off` parameter to w.write_from() is actually ignored by
             // BlobV5IoVec::read_vectored_at_volatile()
-            w.write_from(&mut f, size, 0)
+            w.write_from(&mut f, size as usize, 0)
         }
     }
 


### PR DESCRIPTION
The buffer size could be much larger than the real user io request.
For example, fuse-backend-rs will allocate 1MB buffer for each IO
regardless of its read request size ending up with eat up all
prefetch bandwidth when starting the container.