### PR TITLE
Dump nydusd panic info and backtrace into logger and show nydusd git commit version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -932,6 +932,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "log-panics"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f9dd8546191c1850ecf67d22f5ff00a935b890d0e84713159a55495cc2ac5f"
+dependencies = [
+ "backtrace",
+ "log",
+]
+
+[[package]]
 name = "lz4-sys"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1096,6 +1106,7 @@ dependencies = [
  "flexi_logger",
  "libc",
  "log",
+ "log-panics",
  "nix",
  "nydus-error",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ hyper = "0.14.11"
 # pin rand_core to bring in fix for https://rustsec.org/advisories/RUSTSEC-2021-0023
 rand_core = "0.6.2"
 tar = "0.4.38"
-mio = { version = "0.8", features = ["os-poll", "os-ext"]}
+mio = { version = "0.8", features = ["os-poll", "os-ext"] }
 
 fuse-backend-rs = { version = "0.9.5" }
 vhost = { version = "0.4.0", features = ["vhost-user-slave"], optional = true }

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -20,5 +20,6 @@ libc = "0.2"
 log = "0.4"
 nix = "0.24"
 serde = { version = "1.0.110", features = ["serde_derive"] }
+log-panics = { version = "2.1.0", features = ["with-backtrace"] }
 
 nydus-error = { version = "0.2", path = "../error" }

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -180,6 +180,12 @@ pub fn setup_logging(log_file_path: Option<PathBuf>, level: LevelFilter) -> Resu
     }
 
     log::set_max_level(level);
+
+    // Dump panic info and backtrace to logger.
+    log_panics::Config::new()
+        .backtrace_mode(log_panics::BacktraceMode::Resolved)
+        .install_panic_hook();
+
     Ok(())
 }
 

--- a/src/bin/nydusctl/commands.rs
+++ b/src/bin/nydusctl/commands.rs
@@ -334,10 +334,12 @@ impl CommandDaemon {
 Version:                {version}
 Status:                 {state}
 Profile:                {profile}
+Commit:                 {git_commit}
 "#,
                     version = version_info["package_ver"],
                     state = i["state"],
                     profile = version_info["profile"],
+                    git_commit = version_info["git_commit"],
                 );
 
                 if !backend_list.is_empty() {

--- a/src/bin/nydusd/main.rs
+++ b/src/bin/nydusd/main.rs
@@ -717,6 +717,7 @@ fn main() -> Result<()> {
     let apisock = args.value_of("apisock");
 
     setup_logging(logging_file, level)?;
+
     dump_program_info(crate_version!());
     handle_rlimit_nofile_option(&args, "rlimit-nofile")?;
 


### PR DESCRIPTION
This RR helps debug and develop nydusd.
1. Nydusd is sometimes forked by nydus-snapshotter and has no stdout and stderr to print panic info. So dumping the panic info into logger is a good choice.
2. print nydusd git commit version by nydusctl CLI tool

This can address https://github.com/containerd/nydus-snapshotter/issues/104