### PR TITLE
storage: fix range prefetch algorithm from panic and io hang

### DIFF
--- a/storage/src/cache/cachedfile.rs
+++ b/storage/src/cache/cachedfile.rs
@@ -316,19 +316,25 @@ impl BlobCache for FileCacheEntry {
         let mut total_size = 0;
         let mut start = 0;
         while start < pending.len() {
-            let mut end = start + 1;
-            while end < pending.len() && pending[end].id() == pending[end - 1].id() + 1 {
+            let mut end = start;
+
+            // `end` should be inclusive within `pending` slice.
+            while end < pending.len() - 1 && pending[end + 1].id() == pending[end].id() + 1 {
                 end += 1;
             }
 
             // Find a range with continuous chunk id
             let blob_offset = pending[start].compressed_offset();
+
+            // NOTE: Please be aware that being fetched chunks include index=`end` chunk in below `pending` slice.
+            // Do't forget to clear its pending state whenever backend IO fails.
             let blob_end = pending[end].compressed_offset() + pending[end].compressed_size() as u64;
             let blob_size = (blob_end - blob_offset) as usize;
-            match self.read_chunks(blob_offset, blob_size, &pending[start..end], true) {
+
+            match self.read_chunks(blob_offset, blob_size, &pending[start..=end], true) {
                 Ok(v) => {
                     total_size += blob_size;
-                    for idx in start..end {
+                    for idx in start..=end {
                         let offset = if self.is_compressed {
                             pending[idx].compressed_offset()
                         } else {
@@ -343,13 +349,14 @@ impl BlobCache for FileCacheEntry {
                     }
                 }
                 Err(_e) => {
-                    for chunk in pending.iter().take(end).skip(start) {
+                    // NOTE: We must clear pending flag for `end` chunk.
+                    for chunk in &mut pending[start..=end] {
                         self.chunk_map.clear_pending(chunk);
                     }
                 }
             }
 
-            start = end;
+            start = end + 1;
         }
 
         Ok(total_size)


### PR DESCRIPTION
The original algorithm uses end as the last data chunk index
caused panic since` end` can be equal to pending.len().

Moreover, `end` chunk's pending flag is not cleared after the chunk
is fetched from remote storage

Signed-off-by: Changwei Ge <gechangwei@bytedance.com>