### PR TITLE
action: avoid print tons of logs

### DIFF
--- a/.github/workflows/convert.yml
+++ b/.github/workflows/convert.yml
@@ -87,6 +87,6 @@ jobs:
                 --target localhost:5000/$I:nydus-nightly-v6 \
                 --backend-config-file ./backend.json --backend-type registry
 
-            sudo fsck.erofs -d9 output/nydus_bootstrap 
+            sudo fsck.erofs -d1 output/nydus_bootstrap
             sudo rm -rf ./output
           done


### PR DESCRIPTION
We can hardly get useful information from github action

Signed-off-by: Changwei Ge <gechangwei@bytedance.com>