### PR TITLE
nydusify: skip tls verification

### DIFF
--- a/contrib/nydusify/examples/converter/main.go
+++ b/contrib/nydusify/examples/converter/main.go
@@ -9,7 +9,7 @@ import (
 
 func main() {
 	// Configurable parameters for converter
-	wordDir := "./tmp"
+	workDir := "./tmp"
 	nydusImagePath := "/path/to/nydus-image"
 	source := "localhost:5000/ubuntu:latest"
 	target := "localhost:5000/ubuntu:latest-nydus"
@@ -39,18 +39,13 @@ func main() {
 		panic(err)
 	}
 
-	// Source provider gets source image manifest, config, and layer
-	sourceProviders, err := provider.DefaultSource(context.Background(), sourceRemote, wordDir, "linux/amd64")
-	if err != nil {
-		panic(err)
-	}
-
 	opt := converter.Opt{
-		Logger:          logger,
-		SourceProviders: sourceProviders,
-		TargetRemote:    targetRemote,
+		Logger:         logger,
+		TargetPlatform: "linux/amd64",
+		SourceRemote:   sourceRemote,
+		TargetRemote:   targetRemote,
 
-		WorkDir:          wordDir,
+		WorkDir:          workDir,
 		PrefetchPatterns: "/",
 		NydusImagePath:   nydusImagePath,
 		MultiPlatform:    false,

--- a/contrib/nydusify/tests/nydusify.go
+++ b/contrib/nydusify/tests/nydusify.go
@@ -99,14 +99,7 @@ func (nydusify *Nydusify) Convert(t *testing.T) {
 	logger, err := provider.DefaultLogger()
 	assert.Nil(t, err)
 
-	sourceDir := filepath.Join(nydusify.workDir, "source")
-	err = os.MkdirAll(sourceDir, 0755)
-	assert.Nil(t, err)
-
 	sourceRemote, err := provider.DefaultRemote(host+"/"+nydusify.Source, true)
-	assert.Nil(t, err)
-
-	sourceProviders, err := provider.DefaultSource(context.Background(), sourceRemote, sourceDir, "linux/amd64")
 	assert.Nil(t, err)
 
 	targetRemote, err := provider.DefaultRemote(host+"/"+nydusify.Target, true)
@@ -120,10 +113,11 @@ func (nydusify *Nydusify) Convert(t *testing.T) {
 	}
 
 	opt := converter.Opt{
-		Logger:          logger,
-		SourceProviders: sourceProviders,
+		Logger: logger,
 
-		TargetRemote: targetRemote,
+		TargetPlatform: "linux/amd64",
+		SourceRemote:   sourceRemote,
+		TargetRemote:   targetRemote,
 
 		CacheRemote:     cacheRemote,
 		CacheMaxRecords: 10,


### PR DESCRIPTION
An error is thrown when converting image to https registry with
self-signed TLS cert:

```
failed to do request: x509: certificte signed by unknown authority
```

1. Fixed it by retrying with `InsecureSkipVerify` option, if users specify
`--source-insecure` or `--target-insecure` option, then skips verifying
HTTPS certs.

2. Allows falling back to plain HTTP for registry if https request failed.

Tested to enable `--source-insecure` and `--target-insecure`:

- Tested with http registry with domain name like `registry.com`;
- Tested with https registry with self-signed TLS cert;

Tested to disable `--source-insecure` and `--target-insecure`:

- Tested with https registry with CA-signed TLS cert;
- Tested with http registry with localhost/127.0.0.1 address;

Signed-off-by: Yan Song <imeoer@linux.alibaba.com>