### PR TITLE
dependency: remove dependency on serde-with

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,7 +178,7 @@ dependencies = [
  "ansi_term",
  "atty",
  "bitflags",
- "strsim 0.8.0",
+ "strsim",
  "textwrap",
  "unicode-width",
  "vec_map",
@@ -242,41 +242,6 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
-]
-
-[[package]]
-name = "darling"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a01d95850c592940db9b8194bc39f4bc0e89dee5c4265e4b1807c34a9aba453c"
-dependencies = [
- "darling_core",
- "darling_macro",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "859d65a907b6852c9361e3185c862aae7fafd2887876799fa55f5f99dc40d610"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim 0.10.0",
- "syn",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.13.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c972679f83bdf9c42bd905396b6c3588a843a17f0f16dfcfa3e2c5d57441835"
-dependencies = [
- "darling_core",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -723,12 +688,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ident_case"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
 name = "idna"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1014,7 +973,6 @@ dependencies = [
  "nydus-storage",
  "serde",
  "serde_json",
- "serde_with",
  "vm-memory",
 ]
 
@@ -1054,7 +1012,6 @@ dependencies = [
  "nydus-utils",
  "serde",
  "serde_json",
- "serde_with",
  "sha-1",
  "sha2",
  "spmc",
@@ -1096,7 +1053,6 @@ dependencies = [
  "sendfd",
  "serde",
  "serde_json",
- "serde_with",
  "sha2",
  "tar",
  "time",
@@ -1134,7 +1090,6 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "serde_with",
  "sha-1",
  "sha2",
  "tokio",
@@ -1597,28 +1552,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_with"
-version = "1.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678b5a069e50bf00ecd22d0cd8ddf7c236f68581b03db652061ed5eb13a312ff"
-dependencies = [
- "serde",
- "serde_with_macros",
-]
-
-[[package]]
-name = "serde_with_macros"
-version = "1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e182d6ec6f05393cc0e5ed1bf81ad6db3a8feedf8ee515ecdd369809bcce8082"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "sha-1"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1676,12 +1609,6 @@ name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "subtle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ license = "Apache-2.0 OR BSD-3-Clause"
 homepage = "https://nydus.dev/"
 repository = "https://github.com/dragonflyoss/image-service"
 edition = "2018"
+resolver = "2"
 
 [profile.release]
 panic = "abort"
@@ -29,7 +30,6 @@ clap = "2.33"
 regex = "1.5.5"
 serde = { version = "1.0.110", features = ["serde_derive", "rc"] }
 serde_json = "1.0.51"
-serde_with = { version = "1.6.0", features = ["macros"] }
 sha2 = "0.10.2"
 time = { version = "0.3.14", features = ["serde-human-readable"] }
 lazy_static = "1.4.0"

--- a/api/src/http.rs
+++ b/api/src/http.rs
@@ -837,7 +837,7 @@ pub fn start_http_thread(
     from_api: Receiver<ApiResponse>,
 ) -> Result<(thread::JoinHandle<Result<()>>, Arc<Waker>)> {
     // Try to remove existed unix domain socket
-    std::fs::remove_file(path).unwrap_or_default();
+    let _ = fs::remove_file(path);
     let socket_path = PathBuf::from(path);
 
     let mut poll = Poll::new()?;

--- a/blobfs/Cargo.toml
+++ b/blobfs/Cargo.toml
@@ -14,7 +14,6 @@ libc = "0.2"
 log = "0.4.8"
 serde = { version = "1.0.110", features = ["serde_derive", "rc"] }
 serde_json = "1.0.53"
-serde_with = { version = "1.6.0", features = ["macros"] }
 vm-memory = { version = "0.9" }
 
 nydus-error = { version = "0.2", path = "../error" }

--- a/rafs/Cargo.toml
+++ b/rafs/Cargo.toml
@@ -23,7 +23,6 @@ lz4-sys = "1.9.4"
 nix = "0.24"
 serde = { version = "1.0.110", features = ["serde_derive", "rc"] }
 serde_json = "1.0.53"
-serde_with = { version = "1.6.0", features = ["macros"] }
 sha2 = { version = "0.10.2" }
 sha-1 = { version = "0.10.0", optional = true }
 spmc = "0.3.0"

--- a/rafs/src/metadata/mod.rs
+++ b/rafs/src/metadata/mod.rs
@@ -24,7 +24,6 @@ use fuse_backend_rs::api::filesystem::{Entry, ROOT_ID};
 use nydus_utils::compress;
 use nydus_utils::digest::{self, RafsDigest};
 use serde::Serialize;
-use serde_with::{serde_as, DisplayFromStr};
 use storage::device::{BlobChunkInfo, BlobInfo, BlobIoMerge, BlobIoVec};
 
 use self::layout::v5::RafsV5PrefetchTable;
@@ -273,7 +272,6 @@ impl Display for RafsSuperFlags {
 }
 
 /// Rafs filesystem meta-data cached from on disk RAFS super block.
-#[serde_as]
 #[derive(Clone, Copy, Debug, Serialize)]
 pub struct RafsSuperMeta {
     /// Filesystem magic number.
@@ -288,7 +286,6 @@ pub struct RafsSuperMeta {
     pub chunk_size: u32,
     /// Number of inodes in the filesystem.
     pub inodes_count: u64,
-    #[serde_as(as = "DisplayFromStr")]
     /// V5: superblock flags for Rafs v5.
     pub flags: RafsSuperFlags,
     /// Number of inode entries in inode offset table.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,7 +8,6 @@ use std::fmt::{self, Display};
 use std::str::FromStr;
 
 use serde::{Deserialize, Serialize};
-use serde_with::serde_as;
 
 /// Error code related to Nydus library.
 #[derive(Debug)]
@@ -52,7 +51,6 @@ impl Display for FsBackendType {
     }
 }
 
-#[serde_as]
 #[derive(Serialize, Clone, Deserialize)]
 pub struct FsBackendDesc {
     pub backend_type: FsBackendType,

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -26,7 +26,6 @@ nix = "0.24"
 reqwest = { version = "0.11.11", features = ["blocking", "json"], optional = true }
 serde = { version = "1.0.110", features = ["serde_derive", "rc"] }
 serde_json = "1.0.53"
-serde_with = { version = "1.6.0", features = ["macros"] }
 sha2 = { version = "0.10.2", optional = true }
 sha-1 = { version = "0.10.0", optional = true }
 tokio = { version = "1.19.0", features = ["rt", "rt-multi-thread", "sync", "time"] }


### PR DESCRIPTION
Remov dependency on serde-with by open-coding, which gets rid of:
    Removing darling v0.13.4
    Removing darling_core v0.13.4
    Removing darling_macro v0.13.4
    Removing ident_case v1.0.1
    Removing serde_with v1.14.0
    Removing serde_with_macros v1.5.2
    Removing strsim v0.10.0

Signed-off-by: Jiang Liu <gerry@linux.alibaba.com>