### PR TITLE
nydusify: infer BackendType and BackendConfig

### DIFF
--- a/.github/workflows/convert.yml
+++ b/.github/workflows/convert.yml
@@ -58,11 +58,8 @@ jobs:
                  --fs-version 5
 
             sudo rm -rf ./tmp
-            echo "{\"host\": \"localhost:5000\", \"repo\": \"${I}\", \"scheme\": \"http\"}" > backend.json
-            cat backend.json
             sudo DOCKER_CONFIG=$HOME/.docker nydusify check --source $I:latest \
-                --target localhost:5000/$I:nydus-nightly-v5 \
-                --backend-config-file ./backend.json --backend-type registry
+                --target localhost:5000/$I:nydus-nightly-v5
           done
       - name: Convert and check RAFS v6 images
         run: |
@@ -81,11 +78,8 @@ jobs:
                  --fs-version 6
 
             sudo rm -rf ./tmp
-            echo "{\"host\": \"localhost:5000\", \"repo\": \"${I}\", \"scheme\": \"http\"}" > backend.json
-            cat backend.json
             sudo DOCKER_CONFIG=$HOME/.docker nydusify check --source $I:latest \
-                --target localhost:5000/$I:nydus-nightly-v6 \
-                --backend-config-file ./backend.json --backend-type registry
+                --target localhost:5000/$I:nydus-nightly-v6
 
             sudo fsck.erofs -d9 output/nydus_bootstrap 
             sudo rm -rf ./output

--- a/contrib/nydusify/pkg/checker/checker.go
+++ b/contrib/nydusify/pkg/checker/checker.go
@@ -139,6 +139,8 @@ func (checker *Checker) Check(ctx context.Context) error {
 		&rule.FilesystemRule{
 			Source:          checker.Source,
 			SourceMountPath: filepath.Join(checker.WorkDir, "fs/source_mounted"),
+			Target:          checker.Target,
+			TargetInsecure:  checker.TargetInsecure,
 			NydusdConfig: tool.NydusdConfig{
 				NydusdPath:     checker.NydusdPath,
 				BackendType:    checker.BackendType,

--- a/contrib/nydusify/tests/e2e_test.go
+++ b/contrib/nydusify/tests/e2e_test.go
@@ -22,6 +22,15 @@ func testBasicConvert(t *testing.T, fsVersion string) {
 	nydusify.Check(t)
 }
 
+func testBasicAuth(t *testing.T, fsVersion string) {
+	registry := NewAuthRegistry(t)
+	defer registry.Destroy(t)
+	registry.AuthBuild(t, "image-basic")
+	nydusify := NewNydusify(registry, "image-basic", "image-basic-nydus", "", "", fsVersion)
+	nydusify.Convert(t)
+	nydusify.Check(t)
+}
+
 func testReproducableBuild(t *testing.T, fsVersion string) {
 	registry := NewRegistry(t)
 	registry.Build(t, "image-basic")
@@ -104,6 +113,7 @@ func testConvertWithChunkDict(t *testing.T, fsVersion string) {
 func TestSmoke(t *testing.T) {
 	fsVersions := [2]string{"5", "6"}
 	for _, v := range fsVersions {
+		testBasicAuth(t, v)
 		testBasicConvert(t, v)
 		testReproducableBuild(t, v)
 		testConvertWithCache(t, v)

--- a/contrib/nydusify/tests/nydusify.go
+++ b/contrib/nydusify/tests/nydusify.go
@@ -90,7 +90,6 @@ func (nydusify *Nydusify) GetBootstarpFilePath() string {
 
 func (nydusify *Nydusify) Convert(t *testing.T) {
 	host := nydusify.Registry.Host()
-
 	buildCache := ""
 	if nydusify.Cache != "" {
 		buildCache = host + "/" + nydusify.Cache
@@ -155,7 +154,6 @@ func (nydusify *Nydusify) Convert(t *testing.T) {
 
 func (nydusify *Nydusify) Check(t *testing.T) {
 	host := nydusify.Registry.Host()
-
 	checker, err := checker.New(checker.Opt{
 		WorkDir:        filepath.Join(nydusify.workDir, nydusify.Target),
 		Source:         host + "/" + nydusify.Source,
@@ -164,8 +162,6 @@ func (nydusify *Nydusify) Check(t *testing.T) {
 		TargetInsecure: true,
 		NydusImagePath: nydusImagePath,
 		NydusdPath:     nydusdPath,
-		BackendType:    nydusify.backendType,
-		BackendConfig:  nydusify.backendConfig,
 		ExpectedArch:   "amd64",
 	})
 	assert.Nil(t, err)

--- a/contrib/nydusify/tests/registry.go
+++ b/contrib/nydusify/tests/registry.go
@@ -5,9 +5,13 @@
 package tests
 
 import (
+	"encoding/base64"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"os/exec"
+	"path"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -35,8 +39,41 @@ func runWithOutput(t *testing.T, cmd string) string {
 }
 
 type Registry struct {
-	id   string
-	host string
+	id         string
+	host       string
+	authFile   string
+	configFile string
+}
+
+func NewAuthRegistry(t *testing.T) *Registry {
+	err := os.Mkdir("auth", 0755)
+	assert.Nil(t, err)
+	authString := runWithOutput(t, "docker run --rm --entrypoint htpasswd httpd:2 -Bbn testuser testpassword")
+	authFile, _ := filepath.Abs(filepath.Join("auth", "htpasswd"))
+	err = ioutil.WriteFile(authFile, []byte(authString), 0644)
+	assert.Nil(t, err)
+
+	err = os.Mkdir(".docker", 0755)
+	assert.Nil(t, err)
+	configString := fmt.Sprintf(`{"auths": { "localhost:%d": { "auth": "%s" }}}`,
+		registryPort, base64.StdEncoding.EncodeToString([]byte("testuser:testpassword")))
+	configFile, _ := filepath.Abs(filepath.Join(".docker", "config.json"))
+	err = os.Setenv("DOCKER_CONFIG", path.Dir(configFile))
+	assert.Nil(t, err)
+	err = ioutil.WriteFile(configFile, []byte(configString), 0644)
+	assert.Nil(t, err)
+
+	containerID := runWithOutput(t, fmt.Sprintf("docker run -p %d:5000 --rm -d  -v %s:/auth "+
+		`-e "REGISTRY_AUTH=htpasswd" -e "REGISTRY_AUTH_HTPASSWD_REALM=Registry Realm" `+
+		"-e REGISTRY_AUTH_HTPASSWD_PATH=/auth/htpasswd registry:2", registryPort, path.Dir(authFile)))
+	time.Sleep(time.Second * 2)
+
+	return &Registry{
+		id:         containerID,
+		host:       fmt.Sprintf("localhost:%d", registryPort),
+		authFile:   authFile,
+		configFile: configFile,
+	}
 }
 
 func NewRegistry(t *testing.T) *Registry {
@@ -51,11 +88,24 @@ func NewRegistry(t *testing.T) *Registry {
 func (registry *Registry) Destroy(t *testing.T) {
 	run(t, fmt.Sprintf("docker stop  %s", registry.id), true)
 	run(t, fmt.Sprintf("docker rm -f  %s", registry.id), true)
+	if registry.authFile != "" {
+		os.RemoveAll(path.Dir(registry.authFile))
+	}
+	if registry.configFile != "" {
+		os.RemoveAll(path.Dir(registry.configFile))
+	}
 }
 
 func (registry *Registry) Build(t *testing.T, source string) {
 	run(t, fmt.Sprintf("docker rmi -f %s/%s", registry.Host(), source), true)
 	run(t, fmt.Sprintf("docker build -t %s/%s ./texture/%s", registry.Host(), source, source), false)
+	run(t, fmt.Sprintf("docker push %s/%s", registry.Host(), source), false)
+}
+
+func (registry *Registry) AuthBuild(t *testing.T, source string) {
+	run(t, fmt.Sprintf("docker rmi -f %s/%s", registry.Host(), source), true)
+	run(t, fmt.Sprintf("docker build -t %s/%s ./texture/%s", registry.Host(), source, source), false)
+	run(t, fmt.Sprintf("docker login -u testuser -p testpassword %s", registry.Host()), false)
 	run(t, fmt.Sprintf("docker push %s/%s", registry.Host(), source), false)
 }
 


### PR DESCRIPTION
For registry backend, we can infer the type and the config automatically
so that users don't need to specify these two options.

Signed-off-by: wraymo <raywangv@gmail.com>