### PR TITLE
action: enable nydus integration tests

### DIFF
--- a/.github/workflows/it.yml
+++ b/.github/workflows/it.yml
@@ -109,4 +109,6 @@ jobs:
           cd /home/runner/work/image-service/image-service/contrib/nydus-test
           sudo mkdir -p /blobdir
           sudo python3 nydus_test_config.py --dist fs_structure.yaml
-          sudo pytest -vs --durations=0  functional-test/test_api.py functional-test/test_layered_image.py
+          sudo pytest -vs --durations=0  functional-test/test_api.py \
+                                         functional-test/test_nydus.py \
+                                         functional-test/test_layered_image.py


### PR DESCRIPTION
So that we get to know the integration status.
