### PR TITLE
Optimize performance by fix a bug in prefetch 

### DIFF
--- a/storage/src/cache/state/blob_state_map.rs
+++ b/storage/src/cache/state/blob_state_map.rs
@@ -97,6 +97,11 @@ where
         self.c.is_ready(chunk)
     }
 
+    fn is_pending(&self, chunk: &dyn BlobChunkInfo) -> Result<bool> {
+        let index = C::get_index(chunk);
+        Ok(self.inflight_tracer.lock().unwrap().get(&index).is_some())
+    }
+
     fn check_ready_and_mark_pending(&self, chunk: &dyn BlobChunkInfo) -> StorageResult<bool> {
         let mut ready = self.c.is_ready(chunk).map_err(StorageError::CacheIndex)?;
 

--- a/storage/src/cache/state/mod.rs
+++ b/storage/src/cache/state/mod.rs
@@ -56,6 +56,20 @@ pub trait ChunkMap: Any + Send + Sync {
     /// Check whether the chunk is ready for use.
     fn is_ready(&self, chunk: &dyn BlobChunkInfo) -> Result<bool>;
 
+    /// Check whether the chunk is pending for downloading.
+    fn is_pending(&self, _chunk: &dyn BlobChunkInfo) -> Result<bool> {
+        Ok(false)
+    }
+
+    /// Check whether a chunk is ready for use or pending for downloading.
+    fn is_ready_or_pending(&self, chunk: &dyn BlobChunkInfo) -> Result<bool> {
+        if matches!(self.is_pending(chunk), Ok(true)) {
+            Ok(true)
+        } else {
+            self.is_ready(chunk)
+        }
+    }
+
     /// Check whether the chunk is ready for use, and mark it as pending if not ready yet.
     ///
     /// The function returns:

--- a/storage/src/cache/worker.rs
+++ b/storage/src/cache/worker.rs
@@ -395,7 +395,7 @@ impl AsyncWorkerMgr {
         mgr.metrics.prefetch_data_amount.add(blob_size);
 
         if let Some(obj) = cache.get_blob_object() {
-            obj.fetch_chunks(&req)?;
+            obj.prefetch_chunks(&req)?;
         } else {
             cache.prefetch_range(&req)?;
         }

--- a/storage/src/cache/worker.rs
+++ b/storage/src/cache/worker.rs
@@ -90,7 +90,7 @@ pub(crate) struct AsyncWorkerMgr {
     workers: AtomicU32,
     active: AtomicBool,
 
-    prefetch_sema: Semaphore,
+    prefetch_sema: Arc<Semaphore>,
     prefetch_channel: Arc<Channel<AsyncPrefetchMessage>>,
     prefetch_config: Arc<AsyncPrefetchConfig>,
     prefetch_delayed: AtomicU64,
@@ -126,7 +126,7 @@ impl AsyncWorkerMgr {
             workers: AtomicU32::new(0),
             active: AtomicBool::new(false),
 
-            prefetch_sema: Semaphore::new(0),
+            prefetch_sema: Arc::new(Semaphore::new(0)),
             prefetch_channel: Arc::new(Channel::new()),
             prefetch_config,
             prefetch_delayed: AtomicU64::new(0),
@@ -237,8 +237,8 @@ impl AsyncWorkerMgr {
     }
 
     async fn handle_prefetch_requests(mgr: Arc<AsyncWorkerMgr>, rt: &Runtime) {
-        // Max 2 active requests per thread.
-        mgr.prefetch_sema.add_permits(2);
+        // Max 1 active requests per thread.
+        mgr.prefetch_sema.add_permits(1);
 
         while let Ok(msg) = mgr.prefetch_channel.recv().await {
             mgr.handle_prefetch_rate_limit(&msg).await;
@@ -246,7 +246,9 @@ impl AsyncWorkerMgr {
 
             match msg {
                 AsyncPrefetchMessage::BlobPrefetch(state, blob_cache, offset, size) => {
-                    let _ = mgr2.prefetch_sema.acquire().await;
+                    let token = Semaphore::acquire_owned(mgr2.prefetch_sema.clone())
+                        .await
+                        .unwrap();
                     if state.load(Ordering::Acquire) > 0 {
                         rt.spawn(async move {
                             let _ = Self::handle_blob_prefetch_request(
@@ -257,17 +259,19 @@ impl AsyncWorkerMgr {
                                 state.clone(),
                             )
                             .await;
-                            mgr2.prefetch_sema.add_permits(1);
+                            drop(token);
                         });
                     }
                 }
                 AsyncPrefetchMessage::FsPrefetch(state, blob_cache, req) => {
-                    let _ = mgr2.prefetch_sema.acquire().await;
+                    let token = Semaphore::acquire_owned(mgr2.prefetch_sema.clone())
+                        .await
+                        .unwrap();
                     if state.load(Ordering::Acquire) > 0 {
                         rt.spawn(async move {
                             let _ = Self::handle_fs_prefetch_request(mgr2.clone(), blob_cache, req)
                                 .await;
-                            mgr2.prefetch_sema.add_permits(1);
+                            drop(token)
                         });
                     }
                 }

--- a/storage/src/device.rs
+++ b/storage/src/device.rs
@@ -834,8 +834,8 @@ pub trait BlobObject: AsRawFd {
     /// for use.
     fn fetch_range_uncompressed(&self, offset: u64, size: u64) -> io::Result<usize>;
 
-    /// Fetch data for specified chunks from storage backend.
-    fn fetch_chunks(&self, range: &BlobIoRange) -> io::Result<usize>;
+    /// Prefetch data for specified chunks from storage backend.
+    fn prefetch_chunks(&self, range: &BlobIoRange) -> io::Result<usize>;
 }
 
 /// A wrapping object over an underlying [BlobCache] object.

--- a/storage/src/remote/client.rs
+++ b/storage/src/remote/client.rs
@@ -221,7 +221,7 @@ impl BlobObject for RemoteBlob {
         }
     }
 
-    fn fetch_chunks(&self, _range: &BlobIoRange) -> Result<usize> {
+    fn prefetch_chunks(&self, _range: &BlobIoRange) -> Result<usize> {
         Err(enosys!())
     }
 }


### PR DESCRIPTION
Optimize performance by fix a bug in prefetch. With these patches applied, it performs as better as v5, but reduce half of network IO requests to backend storage system.
![截屏2022-08-02 上午12 33 43](https://user-images.githubusercontent.com/1931516/182198902-83485e9e-4694-4822-a1b2-506481b7cc2e.png)

