### PR TITLE
wip: storage: remove prefetch_range from BlobCache

### DIFF
--- a/storage/src/cache/filecache/mod.rs
+++ b/storage/src/cache/filecache/mod.rs
@@ -236,7 +236,6 @@ impl FileCacheEntry {
             blob_uncompressed_size,
             compressor,
             digester,
-            is_get_blob_object_supported,
             is_compressed,
             is_direct_chunkmap,
             is_stargz,

--- a/storage/src/cache/fscache/mod.rs
+++ b/storage/src/cache/fscache/mod.rs
@@ -231,7 +231,6 @@ impl FileCacheEntry {
             blob_uncompressed_size: blob_info.uncompressed_size(),
             compressor: blob_info.compressor(),
             digester: blob_info.digester(),
-            is_get_blob_object_supported: true,
             is_compressed: false,
             is_direct_chunkmap: true,
             is_stargz: blob_info.is_stargz(),

--- a/storage/src/cache/mod.rs
+++ b/storage/src/cache/mod.rs
@@ -172,11 +172,6 @@ pub trait BlobCache: Send + Sync {
     /// It should be paired with start_prefetch().
     fn stop_prefetch(&self) -> StorageResult<()>;
 
-    /// Execute filesystem data prefetch.
-    fn prefetch_range(&self, _range: &BlobIoRange) -> Result<usize> {
-        Err(enosys!("doesn't support prefetch_range()"))
-    }
-
     /// Read chunk data described by the blob Io descriptors from the blob cache into the buffer.
     fn read(&self, iovec: &mut BlobIoVec, buffers: &[FileVolatileSlice]) -> Result<usize>;
 

--- a/storage/src/cache/worker.rs
+++ b/storage/src/cache/worker.rs
@@ -394,11 +394,9 @@ impl AsyncWorkerMgr {
         mgr.metrics.prefetch_mr_count.inc();
         mgr.metrics.prefetch_data_amount.add(blob_size);
 
-        if let Some(obj) = cache.get_blob_object() {
-            obj.prefetch_chunks(&req)?;
-        } else {
-            cache.prefetch_range(&req)?;
-        }
+        // Safe to unwrap since FileCacheEntry implements both of the two traits.
+        let obj = cache.get_blob_object().unwrap();
+        obj.prefetch_chunks(&req)?;
 
         Ok(())
     }


### PR DESCRIPTION
BlobCache::prefetch_range and BlobObject::prefetch_chunks have very similar logic. So I am trying to remove the duplicated one prefetch_range. There are several advantages:

1. Make code neat
2. prefech_chunks has more sophisticated logic
3. Simplify choice of using what to do backend prefetch

Test already is run with:
v5 image with disable_indexed_map=true/false
v6 image with disable_indexed_map=true/false

All were running fine