### PR TITLE
storage: remove localfs based prefetch

### DIFF
--- a/src/bin/nydus-image/unpack/pax/test.rs
+++ b/src/bin/nydus-image/unpack/pax/test.rs
@@ -41,14 +41,6 @@ impl BlobReader for MockBlobReader {
     fn blob_size(&self) -> storage::backend::BackendResult<u64> {
         todo!();
     }
-
-    fn prefetch_blob_data_range(&self, _: u64, _: u64) -> storage::backend::BackendResult<()> {
-        todo!();
-    }
-
-    fn stop_data_prefetch(&self) -> storage::backend::BackendResult<()> {
-        todo!();
-    }
 }
 
 struct MockChunkInfo {

--- a/storage/src/backend/localfs.rs
+++ b/storage/src/backend/localfs.rs
@@ -4,38 +4,23 @@
 
 //! Storage backend driver to access blobs on local filesystems.
 
-#[cfg(target_os = "macos")]
-use libc::{fcntl, radvisory};
 use std::collections::HashMap;
-use std::fs::{remove_file, File, OpenOptions};
+use std::fs::{File, OpenOptions};
 use std::io::{Error, Result};
-use std::mem::{size_of, ManuallyDrop};
 use std::os::unix::io::AsRawFd;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::{Arc, Condvar, Mutex, RwLock};
-use std::thread;
-use std::time::Duration;
+use std::sync::{Arc, RwLock};
 
 use fuse_backend_rs::file_buf::FileVolatileSlice;
 use nix::sys::uio;
 
 use nydus_api::http::LocalFsConfig;
-use nydus_utils::{metrics::BackendMetrics, round_down_4k, try_round_up_4k};
+use nydus_utils::metrics::BackendMetrics;
 
 use crate::backend::{BackendError, BackendResult, BlobBackend, BlobReader};
-use crate::utils::{readahead, readv, MemSliceCursor};
-
-const BLOB_ACCESSED_SUFFIX: &str = ".access";
-
-// Each access record takes 16 bytes: u64 + u32 + u32
-// So we allow 2048 entries at most to avoid hurting backend upon flush
-const ACCESS_RECORD_ENTRY_SIZE: usize = size_of::<u64>() + size_of::<u32>() + size_of::<u32>();
-const MAX_ACCESS_RECORD_FILE_SIZE: usize = 32768;
-const MAX_ACCESS_RECORD: usize = MAX_ACCESS_RECORD_FILE_SIZE / ACCESS_RECORD_ENTRY_SIZE;
+use crate::utils::{readv, MemSliceCursor};
 
 type LocalFsResult<T> = std::result::Result<T, LocalFsError>;
-type AccessLogEntry = (u64, u32, u32);
 
 /// Error codes related to localfs storage backend.
 #[derive(Debug)]
@@ -56,13 +41,8 @@ impl From<LocalFsError> for BackendError {
 
 struct LocalFsEntry {
     id: String,
-    path: PathBuf,
     file: File,
     metrics: Arc<BackendMetrics>,
-    readahead: bool,
-    trace: Arc<LocalFsTracer>,
-    trace_sec: u32,
-    trace_condvar: Arc<(Mutex<bool>, Condvar)>,
 }
 
 impl BlobReader for LocalFsEntry {
@@ -82,11 +62,6 @@ impl BlobReader for LocalFsEntry {
         );
 
         uio::pread(self.file.as_raw_fd(), buf, offset as i64)
-            .map(|v| {
-                debug!("local blob file read {} bytes", v);
-                self.trace.record(offset, v as u32);
-                v
-            })
             .map_err(|e| LocalFsError::ReadBlob(e).into())
     }
 
@@ -100,88 +75,7 @@ impl BlobReader for LocalFsEntry {
         let mut iovec = c.consume(max_size);
 
         readv(self.file.as_raw_fd(), &mut iovec, offset)
-            .map(|v| {
-                debug!("local blob file read {} bytes", v);
-                self.trace.record(offset, v as u32);
-                v
-            })
             .map_err(|e| LocalFsError::ReadVecBlob(e).into())
-    }
-
-    fn prefetch_blob_data_range(&self, ra_offset: u64, ra_size: u64) -> BackendResult<()> {
-        if !self.readahead {
-            return Ok(());
-        }
-
-        let blob_size = self.blob_size()?;
-        let prefix = self
-            .path
-            .to_str()
-            .ok_or_else(|| LocalFsError::BlobFile(einval!("invalid blob path")))?;
-        let log_path = prefix.to_owned() + BLOB_ACCESSED_SUFFIX;
-
-        // Prefetch according to the trace file if it's ready.
-        if let Ok(log_file) = OpenOptions::new().read(true).open(Path::new(&log_path)) {
-            // Found access log, kick off readahead
-            if log_file.metadata().map_err(LocalFsError::AccessLog)?.len() > 0 {
-                // Don't expect poisoned lock here.
-                let prefetcher = Prefetcher::new(log_file, log_path, &self.file, blob_size)
-                    .map_err(LocalFsError::AccessLog)?;
-                let _ = thread::Builder::new()
-                    .name("nydus-localfs-readahead".to_string())
-                    .spawn(move || {
-                        let _ = prefetcher.do_readahead();
-                    });
-                return Ok(());
-            }
-        }
-
-        // Prefetch data according to the hint if it's valid.
-        let end = ra_offset + ra_size;
-        if ra_size != 0 && end <= blob_size {
-            info!(
-                "kick off hinted blob readahead offset {} len {}",
-                ra_offset, ra_size
-            );
-            readahead(self.file.as_raw_fd(), ra_offset, end);
-        }
-
-        // start file access logging
-        if let Ok(log_file) = OpenOptions::new()
-            .write(true)
-            .create_new(true)
-            .open(Path::new(&log_path))
-        {
-            let tracer = self.trace.clone();
-            let trace_sec = self.trace_sec;
-            let trace_to = Duration::from_secs(trace_sec as u64);
-            let trace_cond = self.trace_condvar.clone();
-
-            tracer.active.store(true, Ordering::Release);
-
-            // Spawn a working thread to flush access trace records.
-            let _ = thread::Builder::new()
-                .name("nydus-localfs-access-recorder".to_string())
-                .spawn(move || {
-                    let &(ref lock, ref cvar) = &*trace_cond;
-                    let guard = lock.lock().unwrap();
-                    if !*guard {
-                        let _guard = cvar.wait_timeout(guard, trace_to);
-                    }
-                    LocalFsTracer::flush(log_file, log_path, tracer);
-                });
-        }
-
-        Ok(())
-    }
-
-    fn stop_data_prefetch(&self) -> BackendResult<()> {
-        // Disable writing file trace log
-        let &(ref lock, ref cvar) = &*self.trace_condvar;
-        *lock.lock().unwrap() = true;
-        cvar.notify_all();
-
-        Ok(())
     }
 
     fn metrics(&self) -> &BackendMetrics {
@@ -199,10 +93,6 @@ pub struct LocalFs {
     dir: String,
     // Alternative directories to store blob files
     alt_dirs: Vec<String>,
-    // Whether to prefetch data from the blob file
-    readahead: bool,
-    // Number of seconds to collect blob access logs
-    readahead_sec: u32,
     // Metrics collector.
     metrics: Arc<BackendMetrics>,
     // Hashmap to map blob id to blob file.
@@ -222,8 +112,6 @@ impl LocalFs {
             blob_file: config.blob_file,
             dir: config.dir,
             alt_dirs: config.alt_dirs,
-            readahead: config.readahead,
-            readahead_sec: config.readahead_sec,
             metrics: BackendMetrics::new(id, "localfs"),
             entries: RwLock::new(HashMap::new()),
         })
@@ -282,13 +170,8 @@ impl LocalFs {
         } else {
             let entry = Arc::new(LocalFsEntry {
                 id: blob_id.to_owned(),
-                path: blob_file_path,
                 file,
                 metrics: self.metrics.clone(),
-                readahead: self.readahead,
-                trace: Arc::new(LocalFsTracer::new()),
-                trace_sec: self.readahead_sec,
-                trace_condvar: Arc::new((Mutex::new(false), Condvar::new())),
             });
             table_guard.insert(blob_id.to_string(), entry.clone());
             Ok(entry)
@@ -297,13 +180,7 @@ impl LocalFs {
 }
 
 impl BlobBackend for LocalFs {
-    fn shutdown(&self) {
-        for entry in self.entries.read().unwrap().values() {
-            let &(ref lock, ref cvar) = &*entry.trace_condvar;
-            *lock.lock().unwrap() = true;
-            cvar.notify_all();
-        }
-    }
+    fn shutdown(&self) {}
 
     fn metrics(&self) -> &BackendMetrics {
         &self.metrics
@@ -320,201 +197,10 @@ impl Drop for LocalFs {
     }
 }
 
-struct LocalFsTracer {
-    active: AtomicBool,
-    records: Mutex<Vec<AccessLogEntry>>,
-}
-
-impl LocalFsTracer {
-    fn new() -> Self {
-        LocalFsTracer {
-            active: AtomicBool::new(false),
-            records: Mutex::new(Vec::new()),
-        }
-    }
-
-    fn record(&self, offset: u64, len: u32) {
-        // TODO: avoid rounding
-        if self.active.load(Ordering::Acquire) {
-            if let Some(rounded_len) = try_round_up_4k(len) {
-                let mut r = self.records.lock().unwrap();
-                if r.len() < MAX_ACCESS_RECORD {
-                    if self.active.load(Ordering::Acquire) {
-                        r.push((round_down_4k(offset), rounded_len, 0));
-                    }
-                } else {
-                    self.active.store(false, Ordering::Release);
-                }
-            }
-        }
-    }
-
-    fn flush(file: File, path: String, tracer: Arc<LocalFsTracer>) {
-        info!("flushing access log to {}", &path);
-
-        // Disable tracer and the underlying vector won't change anymore once we acquired the lock.
-        tracer.active.store(false, Ordering::Release);
-        // Do not expected poisoned lock here.
-        let mut r = tracer.records.lock().unwrap();
-
-        if r.len() == 0 {
-            drop(r);
-            info!("No read access is recorded. Drop access file {}", &path);
-            let _ = remove_file(Path::new(&path)).map_err(|e| {
-                warn!("failed to remove access file {}: {}", &path, e);
-            });
-        } else {
-            r.sort_unstable();
-            r.dedup();
-            // Safe because `records` is valid and never changes anymore.
-            let buf = unsafe {
-                std::slice::from_raw_parts(
-                    r.as_ptr() as *const u8,
-                    r.len() * std::mem::size_of::<AccessLogEntry>(),
-                )
-            };
-            drop(r);
-
-            let _ = nix::unistd::write(file.as_raw_fd(), buf).map_err(|e| {
-                warn!("fail to write access log: {}", e);
-            });
-
-            // Do not expected poisoned lock here.
-            tracer.records.lock().unwrap().resize(0, Default::default());
-        }
-    }
-}
-
-/// Struct to prefetch blob data according to access trace.
-#[derive(Debug)]
-struct Prefetcher {
-    blob_file: File, // blob file for readahead
-    blob_size: u64,  // blob file size
-    #[allow(unused)]
-    log_path: String, // log file path
-    #[allow(unused)]
-    log_file: File, // file for access logging
-    log_base: *const u8, // mmapped access log base
-    log_size: u64,   // size of mmapped area
-    records: ManuallyDrop<Vec<AccessLogEntry>>,
-}
-
-unsafe impl Send for Prefetcher {}
-
-unsafe impl Sync for Prefetcher {}
-
-impl Prefetcher {
-    fn new(log_file: File, log_path: String, blob_file: &File, blob_size: u64) -> Result<Self> {
-        let blob_file = blob_file.try_clone()?;
-        let size = log_file.metadata()?.len();
-        if size == 0 || size % (ACCESS_RECORD_ENTRY_SIZE as u64) != 0 || size > usize::MAX as u64 {
-            warn!("ignoring unaligned log file");
-            return Err(einval!("access trace log file is invalid"));
-        }
-
-        let count = size / (ACCESS_RECORD_ENTRY_SIZE as u64);
-        let base = unsafe {
-            libc::mmap(
-                std::ptr::null_mut(),
-                size as usize,
-                libc::PROT_READ,
-                libc::MAP_NORESERVE | libc::MAP_SHARED,
-                log_file.as_raw_fd(),
-                0,
-            )
-        };
-        if base == libc::MAP_FAILED {
-            return Err(last_error!("failed to mmap access log file"));
-        } else if base.is_null() {
-            return Err(ebadf!("failed to mmap access log file"));
-        }
-
-        // safe because we have validated size
-        let records = unsafe {
-            ManuallyDrop::new(Vec::from_raw_parts(
-                base as *mut AccessLogEntry,
-                count as usize,
-                count as usize,
-            ))
-        };
-
-        Ok(Prefetcher {
-            blob_file,
-            blob_size,
-            log_path,
-            log_file,
-            log_base: base as *const u8,
-            log_size: size,
-            records,
-        })
-    }
-
-    #[cfg(target_os = "macos")]
-    fn do_readahead(&self) -> Result<()> {
-        info!("starting localfs blob readahead");
-
-        for &(offset, len, zero) in self.records.iter() {
-            let end: u64 = offset
-                .checked_add(len as u64)
-                .ok_or_else(|| einval!("invalid length"))?;
-            if offset > self.blob_size || end > self.blob_size || zero != 0 {
-                return Err(einval!(format!(
-                    "invalid readahead entry ({}, {}), blob size {}",
-                    offset, len, self.blob_size
-                )));
-            }
-
-            unsafe {
-                fcntl(
-                    self.blob_file.as_raw_fd(),
-                    libc::F_RDADVISE,
-                    radvisory {
-                        ra_offset: offset as i64,
-                        ra_count: len as i32,
-                    },
-                );
-            };
-        }
-
-        Ok(())
-    }
-
-    #[cfg(target_os = "linux")]
-    fn do_readahead(&self) -> Result<()> {
-        info!("starting localfs blob readahead");
-
-        for &(offset, len, zero) in self.records.iter() {
-            let end: u64 = offset
-                .checked_add(len as u64)
-                .ok_or_else(|| einval!("invalid length"))?;
-            if offset > self.blob_size || end > self.blob_size || zero != 0 {
-                return Err(einval!(format!(
-                    "invalid readahead entry ({}, {}), blob size {}",
-                    offset, len, self.blob_size
-                )));
-            }
-
-            unsafe { libc::readahead(self.blob_file.as_raw_fd(), offset as i64, len as usize) };
-        }
-
-        Ok(())
-    }
-}
-
-impl Drop for Prefetcher {
-    fn drop(&mut self) {
-        if !self.log_base.is_null() {
-            let ptr = self.log_base as *mut u8 as *mut libc::c_void;
-            unsafe { libc::munmap(ptr, self.log_size as usize) };
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::io::{Read, Write};
-    use std::os::unix::fs::FileExt;
+    use std::io::Write;
     use std::os::unix::io::{FromRawFd, IntoRawFd};
     use vmm_sys_util::tempfile::TempFile;
 
@@ -662,68 +348,5 @@ mod tests {
         assert_eq!(blob2.blob_size().unwrap(), 4);
         let blob4 = fs.get_blob(filename).unwrap();
         assert_eq!(blob4.blob_size().unwrap(), 4);
-    }
-
-    #[test]
-    fn test_localfs_trace_and_prefetch() {
-        let tempfile = TempFile::new().unwrap();
-        let path = tempfile.as_path();
-        let filename = path.file_name().unwrap().to_str().unwrap();
-
-        {
-            let mut file = unsafe { File::from_raw_fd(tempfile.as_file().as_raw_fd()) };
-            file.write_all(&[0x1u8, 0x2, 0x3, 0x4]).unwrap();
-            file.write_all_at(&[0x1u8, 0x2, 0x3, 0x4], 0x1000).unwrap();
-            let _ = file.into_raw_fd();
-        }
-
-        let config = LocalFsConfig {
-            readahead: true,
-            readahead_sec: 10,
-            blob_file: "".to_string(),
-            dir: path.parent().unwrap().to_str().unwrap().to_owned(),
-            alt_dirs: Vec::new(),
-        };
-        let json = serde_json::to_value(&config).unwrap();
-        let fs = LocalFs::new(json, Some(filename)).unwrap();
-
-        fs.get_reader(filename)
-            .unwrap()
-            .prefetch_blob_data_range(0x0, 0x1)
-            .unwrap();
-
-        let blob1 = fs.get_reader(filename).unwrap();
-        let blob2 = fs.get_reader(filename).unwrap();
-        assert_eq!(Arc::strong_count(&blob1), 3);
-
-        let mut buf1 = [0x0u8];
-        blob1.read(&mut buf1, 0x0).unwrap();
-        assert_eq!(buf1[0], 0x1);
-
-        let mut buf2 = [0x0u8];
-        let mut buf3 = [0x0u8];
-        let bufs = [
-            unsafe { FileVolatileSlice::from_raw_ptr(buf2.as_mut_ptr(), buf2.len()) },
-            unsafe { FileVolatileSlice::from_raw_ptr(buf3.as_mut_ptr(), buf3.len()) },
-        ];
-        assert_eq!(blob2.readv(&bufs, 0x1001, 3).unwrap(), 2);
-        assert_eq!(buf2[0], 0x2);
-        assert_eq!(buf3[0], 0x3);
-
-        fs.shutdown();
-        thread::sleep(Duration::from_secs(1));
-
-        let mut trace: Vec<AccessLogEntry> = vec![Default::default(); 4];
-        let log_path = path.to_str().unwrap().to_owned() + BLOB_ACCESSED_SUFFIX;
-        let mut log_file = File::open(&log_path).unwrap();
-        let buf = unsafe { std::slice::from_raw_parts_mut(trace.as_mut_ptr() as *mut u8, 64) };
-        assert_eq!(log_file.read(buf).unwrap(), 32);
-
-        assert_eq!(trace[0].0, 0x0);
-        assert_eq!(trace[0].1, 0x1000);
-        assert_eq!(trace[0].2, 0);
-        assert_eq!(trace[1].0, 0x1000);
-        assert_eq!(trace[1].1, 0x1000);
-        assert_eq!(trace[1].2, 0);
     }
 }

--- a/storage/src/backend/mod.rs
+++ b/storage/src/backend/mod.rs
@@ -132,21 +132,6 @@ pub trait BlobReader: Send + Sync {
         }
     }
 
-    /// Give hints to prefetch blob data range.
-    ///
-    /// This is a really complex interface, which does following for localfs backend:
-    /// - prefetch blob data if access trace log file is present
-    /// - prefetch blob data according to the given range hint if access trace log file is missing
-    /// - generate access log if access trace log file is missing
-    ///
-    /// This method only prefetch blob data from storage backends, it doesn't cache data in the
-    /// blob cache subsystem. So it's useful for disk and file system based storage backends, but
-    /// it may not help for Registry/OSS based storage backends.
-    fn prefetch_blob_data_range(&self, ra_offset: u64, ra_size: u64) -> BackendResult<()>;
-
-    /// Stop the background data prefetching tasks.
-    fn stop_data_prefetch(&self) -> BackendResult<()>;
-
     /// Get metrics object.
     fn metrics(&self) -> &BackendMetrics;
 

--- a/storage/src/backend/oss.rs
+++ b/storage/src/backend/oss.rs
@@ -186,18 +186,6 @@ impl BlobReader for OssReader {
             .map(|size| size as usize)?)
     }
 
-    fn prefetch_blob_data_range(&self, _ra_offset: u64, _ra_size: u64) -> BackendResult<()> {
-        Err(BackendError::Unsupported(
-            "Oss backend does not support prefetch as per on-disk blob entries".to_string(),
-        ))
-    }
-
-    fn stop_data_prefetch(&self) -> BackendResult<()> {
-        Err(BackendError::Unsupported(
-            "Oss backend does not support prefetch as per on-disk blob entries".to_string(),
-        ))
-    }
-
     fn metrics(&self) -> &BackendMetrics {
         &self.metrics
     }

--- a/storage/src/backend/registry.rs
+++ b/storage/src/backend/registry.rs
@@ -515,18 +515,6 @@ impl BlobReader for RegistryReader {
             .map_err(BackendError::Registry)
     }
 
-    fn prefetch_blob_data_range(&self, _ra_offset: u64, _ra_size: u64) -> BackendResult<()> {
-        Err(BackendError::Unsupported(
-            "Registry backend does not support prefetch as per on-disk blob entries".to_string(),
-        ))
-    }
-
-    fn stop_data_prefetch(&self) -> BackendResult<()> {
-        Err(BackendError::Unsupported(
-            "Registry backend does not support prefetch as per on-disk blob entries".to_string(),
-        ))
-    }
-
     fn metrics(&self) -> &BackendMetrics {
         &self.metrics
     }

--- a/storage/src/cache/cachedfile.rs
+++ b/storage/src/cache/cachedfile.rs
@@ -263,8 +263,6 @@ impl BlobCache for FileCacheEntry {
                 warn!("storage: inaccurate prefetch status");
             }
             if val == 0 || val == 1 {
-                // Stop the localfs legacy prefetch worker thread to read data into page cache.
-                let _ = self.reader.stop_data_prefetch();
                 self.workers
                     .flush_pending_prefetch_requests(self.blob_info.blob_id());
                 return Ok(());

--- a/storage/src/cache/worker.rs
+++ b/storage/src/cache/worker.rs
@@ -363,9 +363,7 @@ impl AsyncWorkerMgr {
                 });
             }
         } else {
-            // This is only supported by localfs backend to prefetch data into page cache,
-            // or to generate/apply file trace log.
-            let _ = cache.reader().prefetch_blob_data_range(offset, size);
+            warn!("prefetch blob range is not supported");
         }
 
         Ok(())

--- a/storage/src/factory.rs
+++ b/storage/src/factory.rs
@@ -142,7 +142,7 @@ impl BlobFactory {
                 Arc::new(mgr) as Arc<dyn BlobCacheMgr>
             }
             _ => {
-                let mgr = DummyCacheMgr::new(config.cache.clone(), backend, false, false)?;
+                let mgr = DummyCacheMgr::new(config.cache.clone(), backend, false)?;
                 mgr.init()?;
                 Arc::new(mgr) as Arc<dyn BlobCacheMgr>
             }

--- a/storage/src/meta/mod.rs
+++ b/storage/src/meta/mod.rs
@@ -1025,18 +1025,6 @@ mod tests {
             Ok(ret)
         }
 
-        fn prefetch_blob_data_range(
-            &self,
-            _blob_readahead_offset: u64,
-            _blob_readahead_size: u64,
-        ) -> BackendResult<()> {
-            Ok(())
-        }
-
-        fn stop_data_prefetch(&self) -> BackendResult<()> {
-            Ok(())
-        }
-
         fn metrics(&self) -> &BackendMetrics {
             &self.metrics
         }

--- a/storage/src/test.rs
+++ b/storage/src/test.rs
@@ -32,18 +32,6 @@ impl BlobReader for MockBackend {
         Ok(i)
     }
 
-    fn prefetch_blob_data_range(
-        &self,
-        _blob_readahead_offset: u64,
-        _blob_readahead_size: u64,
-    ) -> BackendResult<()> {
-        Ok(())
-    }
-
-    fn stop_data_prefetch(&self) -> BackendResult<()> {
-        Ok(())
-    }
-
     fn metrics(&self) -> &BackendMetrics {
         // Safe because nydusd must have backend attached with id, only image builder can no id
         // but use backend instance to upload blob.


### PR DESCRIPTION
The special prefetch in localfs is not actually used, but causes
much complexity, so remove it.

Signed-off-by: Jiang Liu <gerry@linux.alibaba.com>