### PR TITLE
storage: convert chunk info per as blob meta regardless of

### DIFF
--- a/storage/src/cache/filecache/mod.rs
+++ b/storage/src/cache/filecache/mod.rs
@@ -255,7 +255,10 @@ impl FileCacheEntry {
         // The builder now records the number of chunks in the blob table, so we can
         // use IndexedChunkMap as a chunk map, but for the old Nydus bootstrap, we
         // need downgrade to use DigestedChunkMap as a compatible solution.
-        let chunk_map: Arc<dyn ChunkMap> = if mgr.disable_indexed_map
+
+        let is_v5 = !blob_info.meta_ci_is_valid();
+
+        let chunk_map: Arc<dyn ChunkMap> = if (is_v5 && mgr.disable_indexed_map)
             || blob_info.has_feature(BlobFeatures::V5_NO_EXT_BLOB_TABLE)
         {
             direct_chunkmap = false;


### PR DESCRIPTION
indexed_chunk_map

Rafs v6 chunks' info from filesystem only has blob_id and chunk_index.
So storage layer has to convert it. But current code only load blob
meta with disable_indexed_map=false, which only affets v5 image

It cause nydusd panic when do prefetch or fs io

---
[2022-08-02 14:52:45.103790 +08:00] INFO [api/src/http.rs:778] <--- Get Uri { string: "/api/v1/metrics/blobcache" }
   1: nydus_storage::cache::BlobIoMergeState<F>::merge_and_issue
   2: <nydus_storage::cache::cachedfile::FileCacheEntry as nydus_storage::cache::BlobCache[2022-08-02 14:52:45.103943 +08:00] INFO [api/src/http.rs:783] ---> Get Status Code: OK, Elapse: Ok(157.427µs), Body Size: 365
>::prefetch
   3: nydus_storage::device::BlobDevice::prefetch
   4: nydus_rafs::fs::Rafs::do_prefetch::{{closure}}
   5: nydus_rafs::metadata::RafsSuper::prefetch_inode
   6: nydus_rafs::metadata::RafsSuper::prefetch_data
   7: nydus_rafs::metadata::RafsSuper::prefetch_files
   8: nydus_rafs::fs::Rafs::do_prefetch
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.

Signed-off-by: Changwei Ge <gechangwei@bytedance.com>