### PR TITLE
api: rename BlobPrefetchConfig to PrefetchConfig

### DIFF
--- a/rafs/src/fs.rs
+++ b/rafs/src/fs.rs
@@ -534,7 +534,7 @@ impl Rafs {
             }
         }
 
-        let ignore_prefetch_all = prefetch_files
+        let mut ignore_prefetch_all = prefetch_files
             .as_ref()
             .map(|f| f.len() == 1 && f[0].as_os_str() == "/")
             .unwrap_or(false);
@@ -543,27 +543,32 @@ impl Rafs {
         // - prefetch listed passed in by user
         // - or file prefetch list in metadata
         let inodes = prefetch_files.map(|files| Self::convert_file_list(&files, &sb));
-        sb.prefetch_files(&mut reader, inodes, &|desc| {
-            device.prefetch(&[desc], &[]).unwrap_or_else(|e| {
-                warn!("Prefetch error, {:?}", e);
-            });
-        })
-        .unwrap_or_else(|e| {
-            info!("No file to be prefetched {:?}", e);
+        let res = sb.prefetch_files(&mut reader, root_ino, inodes, &|desc| {
+            if desc.bi_size > 0 {
+                device.prefetch(&[desc], &[]).unwrap_or_else(|e| {
+                    warn!("Prefetch error, {:?}", e);
+                });
+            }
         });
+        match res {
+            Ok(true) => ignore_prefetch_all = true,
+            Ok(false) => {}
+            Err(e) => info!("No file to be prefetched {:?}", e),
+        }
 
         // Last optionally prefetch all data
         if prefetch_all && !ignore_prefetch_all {
             let root = vec![root_ino];
-
-            sb.prefetch_files(&mut reader, Some(root), &|desc| {
-                device.prefetch(&[desc], &[]).unwrap_or_else(|e| {
-                    warn!("Prefetch error, {:?}", e);
-                });
-            })
-            .unwrap_or_else(|e| {
-                info!("No file to be prefetched {:?}", e);
+            let res = sb.prefetch_files(&mut reader, root_ino, Some(root), &|desc| {
+                if desc.bi_size > 0 {
+                    device.prefetch(&[desc], &[]).unwrap_or_else(|e| {
+                        warn!("Prefetch error, {:?}", e);
+                    });
+                }
             });
+            if let Err(e) = res {
+                info!("No file to be prefetched {:?}", e);
+            }
         }
     }
 

--- a/rafs/src/fs.rs
+++ b/rafs/src/fs.rs
@@ -37,6 +37,7 @@ use serde::Deserialize;
 use nydus_api::http::{BlobPrefetchConfig, FactoryConfig};
 use nydus_storage::device::{BlobDevice, BlobPrefetchRequest};
 use nydus_utils::metrics::{self, FopRecorder, StatsFop::*};
+use storage::RAFS_DEFAULT_CHUNK_SIZE;
 
 use crate::metadata::{
     Inode, PostWalkAction, RafsInode, RafsSuper, RafsSuperMeta, DOT, DOTDOT, RAFS_MAX_CHUNK_SIZE,
@@ -503,28 +504,45 @@ impl Rafs {
         sb: Arc<RafsSuper>,
         device: BlobDevice,
     ) {
-        // Without too much layout concern, just prefetch a certain range from backend.
-        let prefetches = sb
-            .superblock
-            .get_blob_infos()
-            .iter()
-            .map(|b| BlobPrefetchRequest {
-                blob_id: b.blob_id().to_owned(),
-                offset: b.readahead_offset(),
-                len: b.readahead_size(),
-            })
-            .collect::<Vec<BlobPrefetchRequest>>();
-        device.prefetch(&[], &prefetches).unwrap_or_else(|e| {
-            warn!("Prefetch error, {:?}", e);
-        });
+        // First do range based prefetch for rafs v6.
+        if sb.meta.is_v6() {
+            let mut prefetches = Vec::new();
+
+            for blob in sb.superblock.get_blob_infos() {
+                let sz = blob.readahead_size();
+                if sz > 0 {
+                    let mut offset = 0;
+                    while offset < sz {
+                        let len = if sz - offset < RAFS_DEFAULT_CHUNK_SIZE {
+                            sz - offset
+                        } else {
+                            RAFS_DEFAULT_CHUNK_SIZE
+                        };
+                        prefetches.push(BlobPrefetchRequest {
+                            blob_id: blob.blob_id().to_owned(),
+                            offset,
+                            len,
+                        });
+                        offset += len;
+                    }
+                }
+            }
+            if !prefetches.is_empty() {
+                device.prefetch(&[], &prefetches).unwrap_or_else(|e| {
+                    warn!("Prefetch error, {:?}", e);
+                });
+            }
+        }
 
         let ignore_prefetch_all = prefetch_files
             .as_ref()
             .map(|f| f.len() == 1 && f[0].as_os_str() == "/")
             .unwrap_or(false);
 
+        // Then do file based prefetch based on:
+        // - prefetch listed passed in by user
+        // - or file prefetch list in metadata
         let inodes = prefetch_files.map(|files| Self::convert_file_list(&files, &sb));
-        // Prefetch procedure does not affect rafs mounting
         sb.prefetch_files(&mut reader, inodes, &|desc| {
             device.prefetch(&[desc], &[]).unwrap_or_else(|e| {
                 warn!("Prefetch error, {:?}", e);
@@ -534,6 +552,7 @@ impl Rafs {
             info!("No file to be prefetched {:?}", e);
         });
 
+        // Last optionally prefetch all data
         if prefetch_all && !ignore_prefetch_all {
             let root = vec![root_ino];
 

--- a/rafs/src/metadata/cached_v5.rs
+++ b/rafs/src/metadata/cached_v5.rs
@@ -585,7 +585,6 @@ impl RafsInode for CachedInodeV5 {
 
         for child_inode in &self.i_child {
             if child_inode.is_dir() {
-                trace!("Got dir {:?}", child_inode.name());
                 child_dirs.push(child_inode.clone());
             } else if !child_inode.is_empty_size() {
                 descendants.push(child_inode.clone());

--- a/rafs/src/metadata/direct_v5.rs
+++ b/rafs/src/metadata/direct_v5.rs
@@ -821,7 +821,6 @@ impl RafsInode for OndiskInodeWrapper {
         for idx in child_index..(child_index + child_count) {
             let child_inode = self.mapping.get_inode(idx, false).unwrap();
             if child_inode.is_dir() {
-                trace!("Got dir {:?}", child_inode.name());
                 child_dirs.push(child_inode);
             } else if !child_inode.is_empty_size() {
                 descendants.push(child_inode);

--- a/rafs/src/metadata/direct_v6.rs
+++ b/rafs/src/metadata/direct_v6.rs
@@ -1185,7 +1185,6 @@ impl RafsInode for OndiskInodeWrapper {
                                            name: OsString,
                                            ino,
                                            offset| {
-            // Safe to unwrap since it must have child inode.
             if let Some(child_inode) = inode {
                 if child_inode.is_dir() {
                     child_dirs.push(child_inode);
@@ -1198,6 +1197,7 @@ impl RafsInode for OndiskInodeWrapper {
             }
         })
         .unwrap();
+
         for d in child_dirs {
             // EROFS packs dot and dotdot, so skip them two.
             if d.name() == "." || d.name() == ".." {

--- a/rafs/src/metadata/md_v5.rs
+++ b/rafs/src/metadata/md_v5.rs
@@ -97,12 +97,9 @@ impl RafsSuper {
             return Ok(false);
         }
 
-        let mut prefetch_table = RafsV5PrefetchTable::new();
-        let mut hardlinks: HashSet<u64> = HashSet::new();
-        let mut head_desc = BlobIoVec::new();
-
         // Try to prefetch according to the list of files specified by the
         // builder's `--prefetch-policy fs` option.
+        let mut prefetch_table = RafsV5PrefetchTable::new();
         prefetch_table
             .load_prefetch_table_from(r, self.meta.prefetch_table_offset, hint_entries)
             .map_err(|e| {
@@ -112,6 +109,8 @@ impl RafsSuper {
                 ))
             })?;
 
+        let mut hardlinks: HashSet<u64> = HashSet::new();
+        let mut state = BlobIoMerge::default();
         let mut found_root_inode = false;
         for ino in prefetch_table.inodes {
             // Inode number 0 is invalid, it was added because prefetch table has to be aligned.
@@ -122,11 +121,12 @@ impl RafsSuper {
                 found_root_inode = true;
             }
             debug!("hint prefetch inode {}", ino);
-            self.prefetch_data(ino as u64, &mut head_desc, &mut hardlinks, &fetcher)
+            self.prefetch_data(ino as u64, &mut state, &mut hardlinks, &fetcher)
                 .map_err(|e| RafsError::Prefetch(e.to_string()))?;
         }
-        // The left chunks whose size is smaller than 4MB will be fetched here.
-        fetcher(&mut head_desc);
+        for (_id, mut desc) in state.drain() {
+            fetcher(&mut desc);
+        }
 
         Ok(found_root_inode)
     }

--- a/rafs/src/metadata/mod.rs
+++ b/rafs/src/metadata/mod.rs
@@ -25,7 +25,7 @@ use nydus_utils::compress;
 use nydus_utils::digest::{self, RafsDigest};
 use serde::Serialize;
 use serde_with::{serde_as, DisplayFromStr};
-use storage::device::{BlobChunkInfo, BlobInfo, BlobIoVec};
+use storage::device::{BlobChunkInfo, BlobInfo, BlobIoMerge, BlobIoVec};
 
 use self::layout::{XattrName, XattrValue, RAFS_SUPER_VERSION_V5, RAFS_SUPER_VERSION_V6};
 use self::noop::NoopSuperBlock;
@@ -647,17 +647,15 @@ impl RafsSuper {
         if let Some(files) = files {
             // Avoid prefetching multiple times for hardlinks to the same file.
             let mut hardlinks: HashSet<u64> = HashSet::new();
-            let mut head_desc = BlobIoVec {
-                bi_size: 0,
-                bi_flags: 0,
-                bi_vec: Vec::new(),
-            };
+            let mut state = BlobIoMerge::default();
             for f_ino in files {
-                self.prefetch_data(f_ino, &mut head_desc, &mut hardlinks, fetcher)
+                self.prefetch_data(f_ino, &mut state, &mut hardlinks, fetcher)
                     .map_err(|e| RafsError::Prefetch(e.to_string()))?;
             }
+            for (_id, mut desc) in state.drain() {
+                fetcher(&mut desc);
+            }
             // Flush the pending prefetch requests.
-            fetcher(&mut head_desc);
             Ok(false)
         } else if self.meta.is_v5() {
             self.prefetch_data_v5(r, root_nid, fetcher)
@@ -673,12 +671,12 @@ impl RafsSuper {
     #[inline]
     fn prefetch_inode<F>(
         inode: &Arc<dyn RafsInode>,
-        head_desc: &mut BlobIoVec,
+        state: &mut BlobIoMerge,
         hardlinks: &mut HashSet<u64>,
         prefetcher: F,
     ) -> Result<()>
     where
-        F: Fn(&mut BlobIoVec, bool),
+        F: Fn(&mut BlobIoMerge),
     {
         // Check for duplicated hardlinks.
         if inode.is_hardlink() {
@@ -691,12 +689,8 @@ impl RafsSuper {
 
         let descs = inode.alloc_bio_vecs(0, inode.size() as usize, false)?;
         for desc in descs {
-            // Flush the pending prefetch if the next desc target a different blob.
-            if !head_desc.has_same_blob(&desc) {
-                prefetcher(head_desc, true);
-            }
-            head_desc.append(desc);
-            prefetcher(head_desc, false);
+            state.append(desc);
+            prefetcher(state);
         }
 
         Ok(())
@@ -705,21 +699,23 @@ impl RafsSuper {
     fn prefetch_data<F>(
         &self,
         ino: u64,
-        head_desc: &mut BlobIoVec,
+        state: &mut BlobIoMerge,
         hardlinks: &mut HashSet<u64>,
         fetcher: F,
     ) -> Result<()>
     where
         F: Fn(&mut BlobIoVec),
     {
-        let try_prefetch = |desc: &mut BlobIoVec, flush: bool| {
-            // Issue a prefetch request since target is large enough.
-            // As files belonging to the same directory are arranged in adjacent,
-            // it should fetch a range of blob in batch.
-            if flush || desc.bi_size >= (4 * RAFS_DEFAULT_CHUNK_SIZE) as u32 {
-                trace!("fetching head bio size {}", desc.bi_size);
-                fetcher(desc);
-                desc.reset();
+        let try_prefetch = |state: &mut BlobIoMerge| {
+            if let Some(desc) = state.get_current_element() {
+                // Issue a prefetch request since target is large enough.
+                // As files belonging to the same directory are arranged in adjacent,
+                // it should fetch a range of blob in batch.
+                if (desc.bi_size as u64) >= RAFS_DEFAULT_CHUNK_SIZE {
+                    trace!("fetching head bio size {}", desc.bi_size);
+                    fetcher(desc);
+                    desc.reset();
+                }
             }
         };
 
@@ -732,7 +728,7 @@ impl RafsSuper {
             let mut descendants = Vec::new();
             let _ = inode.collect_descendants_inodes(&mut descendants)?;
             for i in descendants.iter() {
-                Self::prefetch_inode(i, head_desc, hardlinks, try_prefetch)?;
+                Self::prefetch_inode(i, state, hardlinks, try_prefetch)?;
             }
         } else if !inode.is_empty_size() && inode.is_reg() {
             // An empty regular file will also be packed into nydus image,
@@ -740,7 +736,7 @@ impl RafsSuper {
             // Moreover, for rafs v5, symlink has size of zero but non-zero size
             // for symlink size. For rafs v6, symlink size is also represented by i_size.
             // So we have to restrain the condition here.
-            Self::prefetch_inode(&inode, head_desc, hardlinks, try_prefetch)?;
+            Self::prefetch_inode(&inode, state, hardlinks, try_prefetch)?;
         }
 
         Ok(())

--- a/src/bin/nydusd/fs_cache.rs
+++ b/src/bin/nydusd/fs_cache.rs
@@ -20,6 +20,7 @@ use std::{thread, time};
 
 use mio::unix::SourceFd;
 use mio::{Events, Interest, Poll, Token, Waker};
+use nydus_api::http::default_prefetch_merging_size;
 use storage::cache::BlobCache;
 use storage::device::BlobPrefetchRequest;
 use storage::factory::{ASYNC_RUNTIME, BLOB_FACTORY};
@@ -516,8 +517,8 @@ impl FsCacheHandler {
             .merging_size
             .checked_next_power_of_two()
         {
-            None => rafs::fs::default_merging_size() as u64,
-            Some(1) => rafs::fs::default_merging_size() as u64,
+            None => default_prefetch_merging_size() as u64,
+            Some(1) => default_prefetch_merging_size() as u64,
             Some(s) => s as u64,
         };
         let blob_size = blob_info.compressed_size();

--- a/storage/src/device.rs
+++ b/storage/src/device.rs
@@ -950,6 +950,7 @@ impl BlobDevice {
                 let _ = blob.prefetch(blob.clone(), &prefetches[idx..idx + 1], &[]);
             }
         }
+
         for io_vec in io_vecs.iter() {
             if let Some(blob) = self.get_blob_by_iovec(io_vec) {
                 let _ = blob


### PR DESCRIPTION
Rename BlobPrefetchConfig to PrefetchConfig, also replace FsPrefetchConfig and AsyncPrefetchConfig with it.
    
Signed-off-by: Jiang Liu <gerry@linux.alibaba.com>
