### PR TITLE
builder: fix broken symlink in unpack

### DIFF
--- a/src/bin/nydus-image/unpack/pax.rs
+++ b/src/bin/nydus-image/unpack/pax.rs
@@ -553,8 +553,6 @@ impl PAXUtil {
     }
 
     fn set_link(header: &mut Header, path: &Path) -> Result<Option<PAXRecord>> {
-        let path = Util::normalize_path(path).with_context(|| "fail to normalize path")?;
-
         let max_len = header.as_old().linkname.len();
         if path.as_os_str().len() <= max_len {
             return header
@@ -568,7 +566,7 @@ impl PAXUtil {
             v: path.to_owned().into_os_string().into_vec(),
         };
 
-        let path = Util::truncate_path(&path, max_len)
+        let path = Util::truncate_path(path, max_len)
             .with_context(|| "fail to truncate link for pax header")?;
 
         header


### PR DESCRIPTION
When a symlink file in nydus with an absolute path like `/usr/bin/touch -> /bin/touch`,
unpack will output the tar with symlink file like `/usr/bin/touch -> bin/touch`,
this behavior causes that the symlink is broken.

Signed-off-by: Yan Song <imeoer@linux.alibaba.com>