### PR TITLE
ci: remove nydus-cached binary build

### DIFF
--- a/.github/workflows/it.yml
+++ b/.github/workflows/it.yml
@@ -55,7 +55,6 @@ jobs:
           make -e ARCH=$arch -e CARGO=cross static-release
           make release  -C contrib/nydus-backend-proxy/
           #sudo mv target-fusedev/$arch-unknown-linux-musl/release/nydusd nydusd-fusedev
-          #sudo mv target-fusedev/$arch-unknown-linux-musl/release/nydus-cached .
           #sudo mv target-fusedev/$arch-unknown-linux-musl/release/nydus-image .
           #sudo mv target-fusedev/$arch-unknown-linux-musl/release/nydusctl .
           #sudo mv target-virtiofs/$arch-unknown-linux-musl/release/nydusd nydusd-virtiofs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,7 +36,6 @@ jobs:
         rustup component add rustfmt clippy
         make -e ARCH=$arch -e CARGO=cross static-release
         sudo mv target-fusedev/$arch-unknown-linux-musl/release/nydusd nydusd-fusedev
-        sudo mv target-fusedev/$arch-unknown-linux-musl/release/nydus-cached .
         sudo mv target-fusedev/$arch-unknown-linux-musl/release/nydus-image .
         sudo mv target-fusedev/$arch-unknown-linux-musl/release/nydusctl .
         sudo mv target-virtiofs/$arch-unknown-linux-musl/release/nydusd nydusd-virtiofs
@@ -49,7 +48,6 @@ jobs:
         path: |
           nydusd-fusedev
           nydusd-virtiofs
-          nydus-cached
           nydus-image
           nydusctl
           configs
@@ -76,7 +74,6 @@ jobs:
         rustup target install $arch-apple-darwin
         make -e ARCH=$arch macos-fusedev
         sudo mv target-fusedev/$arch-apple-darwin/release/nydusd nydusd-fusedev
-        sudo mv target-fusedev/$arch-apple-darwin/release/nydus-cached .
         sudo mv target-fusedev/$arch-apple-darwin/release/nydus-image .
         sudo mv target-fusedev/$arch-apple-darwin/release/nydusctl .
         sudo cp -r misc/configs .

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ ut:
 	RUST_BACKTRACE=1 ${CARGO} test $(VIRIOFS_COMMON) --bin nydusd -- --nocapture --test-threads=8
 
 macos-fusedev:
-	${CARGO} build --target ${ARCH}-apple-darwin --target-dir ${current_dir}/target-fusedev --features=fusedev --release --bin nydusctl --bin nydusd --bin nydus-image --bin nydus-cached
+	${CARGO} build --target ${ARCH}-apple-darwin --target-dir ${current_dir}/target-fusedev --features=fusedev --release --bin nydusctl --bin nydusd --bin nydus-image
 
 macos-ut:
 	${CARGO} clippy --target-dir ${current_dir}/target-fusedev --features=fusedev --bin nydusd --release --workspace -- -Dwarnings


### PR DESCRIPTION
The nydus-cached functionality was moved to nydusd daemon mode,
so we don't need to compile this binary in CI anymore.

Signed-off-by: Yan Song <imeoer@linux.alibaba.com>