### PR TITLE
Clean up code for v2.1

### DIFF
--- a/src/bin/nydus-image/builder/mod.rs
+++ b/src/bin/nydus-image/builder/mod.rs
@@ -6,14 +6,15 @@ use anyhow::Result;
 
 use crate::core::context::{BlobManager, BootstrapManager, BuildContext, BuildOutput};
 
-pub(crate) use diff::DiffBuilder;
-pub(crate) use directory::DirectoryBuilder;
-pub(crate) use stargz::StargzBuilder;
+pub(crate) use self::diff::DiffBuilder;
+pub(crate) use self::directory::DirectoryBuilder;
+pub(crate) use self::stargz::StargzBuilder;
 
 mod diff;
 mod directory;
 mod stargz;
 
+/// Trait to generate a Nydus image from the source.
 pub(crate) trait Builder {
     fn build(
         &mut self,

--- a/src/bin/nydus-image/core/blob.rs
+++ b/src/bin/nydus-image/core/blob.rs
@@ -112,7 +112,7 @@ impl Blob {
 
     pub(crate) fn dump_meta_data(ctx: &BuildContext, blob_ctx: &mut BlobContext) -> Result<()> {
         // Dump is only required if there is chunk in the blob or blob meta info enabled
-        if !blob_ctx.blob_meta_info_enabled || blob_ctx.decompressed_blob_size == 0 {
+        if !blob_ctx.blob_meta_info_enabled || blob_ctx.uncompressed_blob_size == 0 {
             return Ok(());
         }
 

--- a/src/bin/nydus-image/core/blob_compact.rs
+++ b/src/bin/nydus-image/core/blob_compact.rs
@@ -156,15 +156,15 @@ impl ChunkSet {
             // file offset field is useless
             new_chunk.set_index(new_blob_ctx.chunk_count);
             new_chunk.set_blob_index(new_blob_idx);
-            new_chunk.set_compressed_offset(new_blob_ctx.compress_offset);
-            new_chunk.set_uncompressed_offset(new_blob_ctx.decompress_offset);
+            new_chunk.set_compressed_offset(new_blob_ctx.compressed_offset);
+            new_chunk.set_uncompressed_offset(new_blob_ctx.uncompressed_offset);
             new_blob_ctx.add_chunk_meta_info(&new_chunk)?;
             // insert change ops
             chunks_change.push((chunk.clone(), new_chunk));
 
             new_blob_ctx.blob_hash.update(&buf);
             new_blob_ctx.chunk_count += 1;
-            new_blob_ctx.compress_offset += chunk.compressed_size() as u64;
+            new_blob_ctx.compressed_offset += chunk.compressed_size() as u64;
             new_blob_ctx.compressed_blob_size += chunk.compressed_size() as u64;
 
             let aligned_size = if aligned_chunk {
@@ -172,8 +172,8 @@ impl ChunkSet {
             } else {
                 chunk.uncompressed_size() as u64
             };
-            new_blob_ctx.decompress_offset += aligned_size;
-            new_blob_ctx.decompressed_blob_size += aligned_size;
+            new_blob_ctx.uncompressed_offset += aligned_size;
+            new_blob_ctx.uncompressed_blob_size += aligned_size;
         }
         new_blob_ctx.blob_id = format!("{:x}", new_blob_ctx.blob_hash.clone().finalize());
         // dump blob meta for v6

--- a/src/bin/nydus-image/core/prefetch.rs
+++ b/src/bin/nydus-image/core/prefetch.rs
@@ -195,15 +195,15 @@ impl Prefetch {
                 trace!(
                     "v6 prefetch table: map node index {} to offset {} nid {} path {:?} name {:?}",
                     i,
-                    nodes[array_index].offset,
-                    calculate_nid(nodes[array_index].offset, meta_addr),
+                    nodes[array_index].v6_offset,
+                    calculate_nid(nodes[array_index].v6_offset, meta_addr),
                     nodes[array_index].path(),
                     nodes[array_index].name()
                 );
                 // 32bit nid can represent 128GB bootstrap, it is large enough, no need
                 // to worry about casting here
                 prefetch_table
-                    .add_entry(calculate_nid(nodes[array_index].offset, meta_addr) as u32);
+                    .add_entry(calculate_nid(nodes[array_index].v6_offset, meta_addr) as u32);
             }
             Some(prefetch_table)
         } else {

--- a/src/bin/nydus-image/core/tree.rs
+++ b/src/bin/nydus-image/core/tree.rs
@@ -30,7 +30,7 @@ use super::node::{
 
 /// An in-memory tree structure to maintain information and topology of filesystem nodes.
 #[derive(Clone)]
-pub(crate) struct Tree {
+pub struct Tree {
     /// Filesystem node.
     pub node: Node,
     /// Children tree nodes.
@@ -352,12 +352,12 @@ impl<'a> MetadataTreeBuilder<'a> {
             xattrs,
             layer_idx: 0,
             ctime: 0,
-            offset: 0,
-            dirents: Vec::<(u64, OsString, u32)>::new(),
+            v6_offset: 0,
+            v6_dirents: Vec::<(u64, OsString, u32)>::new(),
             v6_datalayout: 0,
             v6_compact_inode: false,
             v6_force_extended_inode: false,
-            dirents_offset: 0,
+            v6_dirents_offset: 0,
         })
     }
 }


### PR DESCRIPTION
    Code style and comment related changes, should be no functional changes:
    1) refine comments
    2) rename Node::set_v5_inode_blocks() to set_inode_block()
    3) make DirectoryBuilder::set_v5_dir_size() take values
    4) rename decompress_xxx to uncompress_xxx.
    5) replace compress/uncompress with compressed/uncompressed
    6) add common prefix for v6 related methods of Node.
    7) add "v6" prefex for v6 dedicated fields in Tree
