### PR TITLE
Adapt further to rafs v6 format test

### DIFF
--- a/contrib/nydus-test/framework/nydus_anchor.py
+++ b/contrib/nydus-test/framework/nydus_anchor.py
@@ -66,9 +66,10 @@ class NydusAnchor:
 
         artifacts = kwargs.pop("artifacts")
         self.containerd_bin = artifacts["containerd"]
-        if artifacts["ossutil_bin"]:
+
+        try:
             self.ossutil_bin = artifacts["ossutil_bin"]
-        else:
+        except KeyError:
             self.ossutil_bin = (
                 "framework/bin/ossutil64.x86"
                 if self.machine != "aarch64"
@@ -81,11 +82,14 @@ class NydusAnchor:
 
         self.fs_version = kwargs.pop("fs_version", 6)
 
-        oss_conf = kwargs.pop("oss")
-        self.oss_ak_id = oss_conf["ak_id"]
-        self.oss_ak_secret = oss_conf["ak_secret"]
-        self.oss_bucket = oss_conf["bucket"]
-        self.oss_endpoint = oss_conf["endpoint"]
+        try:
+            oss_conf = kwargs.pop("oss")
+            self.oss_ak_id = oss_conf["ak_id"]
+            self.oss_ak_secret = oss_conf["ak_secret"]
+            self.oss_bucket = oss_conf["bucket"]
+            self.oss_endpoint = oss_conf["endpoint"]
+        except KeyError:
+            pass
 
         self.logging_file_path = kwargs.pop("logging_file")
         self.logging_file = self.decide_logging_file()

--- a/contrib/nydus-test/framework/rafs.py
+++ b/contrib/nydus-test/framework/rafs.py
@@ -213,6 +213,9 @@ class RafsConf:
         return self
 
     def enable_validation(self):
+        if int(self.anchor.fs_version) == 6:
+            return self
+
         self._configure_rafs("digest_validate", True)
         return self
 

--- a/contrib/nydus-test/functional-test/test_nydus.py
+++ b/contrib/nydus-test/functional-test/test_nydus.py
@@ -196,8 +196,8 @@ def test_prefetch_with_cache(
 
     nc = NydusAPIClient(rafs.get_apisock())
     workload_gen = WorkloadGen(nydus_anchor.mount_point, nydus_scratch_image.rootfs())
-    m = nc.get_blobcache_metrics()
     time.sleep(0.3)
+    m = nc.get_blobcache_metrics()
     assert m["prefetch_data_amount"] != 0
 
     workload_gen.setup_workload_generator()
@@ -549,7 +549,7 @@ def test_pseudo_fs(nydus_anchor, nydus_image, rafs_conf: RafsConf):
     nc.umount_rafs("/pseudo3")
 
 
-def test_shared_blobcache(nydus_anchor, nydus_image, rafs_conf: RafsConf):
+def test_shared_blobcache(nydus_anchor: NydusAnchor, nydus_image, rafs_conf: RafsConf):
     """
     description:
         Start more than one nydusd, let them share the same blobcache.
@@ -588,7 +588,10 @@ def test_shared_blobcache(nydus_anchor, nydus_image, rafs_conf: RafsConf):
     for case in cases:
         case[1].finish_torture_read()
         # Ensure that blob & bitmap files are included in blobcache dir.
-        assert len(os.listdir(nydus_anchor.blobcache_dir)) == 2
+        if int(nydus_anchor.fs_version) == 5:
+            assert len(os.listdir(nydus_anchor.blobcache_dir)) == 2
+        elif int(nydus_anchor.fs_version) == 6:
+            assert len(os.listdir(nydus_anchor.blobcache_dir)) == 3
 
     for case in cases:
         case[0].umount()


### PR DESCRIPTION
OSS related artifacts are not necessary and make suitable nydusd config for rafs v6