### PR TITLE
nydus-image: move set_v5_dir_size() to Node

### DIFF
--- a/src/bin/nydus-image/core/node.rs
+++ b/src/bin/nydus-image/core/node.rs
@@ -50,6 +50,16 @@ use super::chunk_dict::{ChunkDict, DigestWithBlobIndex};
 use super::context::{BlobContext, BootstrapContext, BuildContext, RafsVersion};
 use super::tree::Tree;
 
+// Filesystem may have different algorithms to calculate `i_size` for directory entries,
+// which may break "repeatable build". To support repeatable build, instead of reuse the value
+// provided by the source filesystem, we use our own algorithm to calculate `i_size` for directory
+// entries for stable `i_size`.
+//
+// Rafs v6 already has its own algorithm to calculate `i_size` for directory entries, but we don't
+// have directory entries for Rafs v5. So let's generate a pseudo `i_size` for Rafs v5 directory
+// inode.
+const RAFS_V5_VIRTUAL_ENTRY_SIZE: u64 = 8;
+
 pub const ROOT_PATH_NAME: &[u8] = &[b'/'];
 
 /// Prefix for OCI whiteout file.
@@ -1007,6 +1017,35 @@ impl Node {
     }
 }
 
+// Rafs v5 dedicated methods
+impl Node {
+    // Filesystem may have different algorithms to calculate `i_size` for directory entries,
+    // which may break "repeatable build". To support repeatable build, instead of reuse the value
+    // provided by the source filesystem, we use our own algorithm to calculate `i_size` for
+    // directory entries for stable `i_size`.
+    //
+    // Rafs v6 already has its own algorithm to calculate `i_size` for directory entries, but we
+    // don't have directory entries for Rafs v5. So let's generate a pseudo `i_size` for Rafs v5
+    // directory inode.
+    pub fn v5_set_dir_size(&mut self, fs_version: RafsVersion, children: &[Tree]) {
+        if !self.is_dir() || !fs_version.is_v5() {
+            return;
+        }
+
+        let mut d_size = 0u64;
+        for child in children.iter() {
+            d_size += child.node.inode.name_size() as u64 + RAFS_V5_VIRTUAL_ENTRY_SIZE;
+        }
+        if d_size == 0 {
+            self.inode.set_size(4096);
+        } else {
+            self.inode.set_size(try_round_up_4k(d_size).unwrap());
+        }
+        self.set_inode_blocks();
+    }
+}
+
+// Rafs v6 dedicated methods
 impl Node {
     fn v6_new_inode(&mut self) -> Box<dyn RafsV6OndiskInode> {
         match self.v6_compact_inode {


### PR DESCRIPTION
Method set_v5_dir_size() should be generic and may be used by other
builder too, so move it to Node.

Signed-off-by: Jiang Liu <gerry@linux.alibaba.com>