### PR TITLE
storage: reflect prefetch state from each blob cache object

### DIFF
--- a/storage/src/cache/dummycache.rs
+++ b/storage/src/cache/dummycache.rs
@@ -19,7 +19,7 @@
 //!   The [is_chunk_cached()](../trait.BlobCache.html#tymethod.is_chunk_cached) method always
 //!   return true to enable data prefetching.
 use std::io::Result;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::Arc;
 
 use fuse_backend_rs::file_buf::FileVolatileSlice;
@@ -91,6 +91,10 @@ impl BlobCache for DummyCache {
 
     fn start_prefetch(&self) -> StorageResult<()> {
         Ok(())
+    }
+
+    fn get_prefetch_state(&self) -> StorageResult<&AtomicU32> {
+        Err(StorageError::Unsupported)
     }
 
     fn stop_prefetch(&self) -> StorageResult<()> {

--- a/storage/src/cache/mod.rs
+++ b/storage/src/cache/mod.rs
@@ -20,7 +20,10 @@ use std::cmp;
 use std::fs::File;
 use std::io::Result;
 use std::slice;
-use std::sync::Arc;
+use std::sync::{
+    atomic::{AtomicU32, Ordering},
+    Arc,
+};
 use std::time::Instant;
 
 use fuse_backend_rs::file_buf::FileVolatileSlice;
@@ -171,6 +174,13 @@ pub trait BlobCache: Send + Sync {
     ///
     /// It should be paired with start_prefetch().
     fn stop_prefetch(&self) -> StorageResult<()>;
+
+    fn get_prefetch_state(&self) -> StorageResult<&AtomicU32>;
+
+    fn is_prefetch_active(&self) -> bool {
+        // Safe to unwrap since only dummy cache returns error
+        self.get_prefetch_state().unwrap().load(Ordering::Acquire) > 0
+    }
 
     /// Execute filesystem data prefetch.
     fn prefetch_range(&self, _range: &BlobIoRange) -> Result<usize> {


### PR DESCRIPTION
The blob cache manager is associated with prefetch state, so we don't
have to clone it and pass it everywhere.
Thus simplifying code.
