### PR TITLE
fix compile from source

### DIFF
--- a/src/bin/nydusd/fs_cache.rs
+++ b/src/bin/nydusd/fs_cache.rs
@@ -423,7 +423,6 @@ impl FsCacheHandler {
         let domain_id = msg
             .volume_key
             .strip_prefix("erofs,")
-            //.unwrap_or(msg.volume_key.as_str());
             .unwrap_or_else(|| msg.volume_key.as_str());
 
         let key = generate_blob_key(domain_id, &msg.cookie_key);

--- a/src/bin/nydusd/fs_cache.rs
+++ b/src/bin/nydusd/fs_cache.rs
@@ -423,7 +423,8 @@ impl FsCacheHandler {
         let domain_id = msg
             .volume_key
             .strip_prefix("erofs,")
-            .unwrap_or(msg.volume_key.as_str());
+            //.unwrap_or(msg.volume_key.as_str());
+            .unwrap_or_else(|| msg.volume_key.as_str());
 
         let key = generate_blob_key(domain_id, &msg.cookie_key);
         let msg = match self.get_config(&key) {


### PR DESCRIPTION
error: use of `unwrap_or` followed by a function call
   --> src/bin/nydusd/fs_cache.rs:426:14
    |
426 |             .unwrap_or(msg.volume_key.as_str());
    |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try this: `unwrap_or_else(|| msg.volume_key.as_str())`
    |
note: the lint level is defined here
   --> src/bin/nydusd/main.rs:6:9
    |
6   | #![deny(warnings)]
    |         ^^^^^^^^
    = note: `#[deny(clippy::or_fun_call)]` implied by `#[deny(warnings)]`
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#or_fun_call

error: could not compile `nydus-rs` due to previous error
warning: build failed, waiting for other jobs to finish...
error: build failed
