### PR TITLE
storage: simplify BlobCache::is_prefetch_active()

### DIFF
--- a/storage/src/cache/cachedfile.rs
+++ b/storage/src/cache/cachedfile.rs
@@ -149,12 +149,12 @@ impl BlobCache for FileCacheEntry {
         self.blob_info.blob_id()
     }
 
-    fn blob_compressed_size(&self) -> Result<u64> {
-        Ok(self.blob_compressed_size)
-    }
-
     fn blob_uncompressed_size(&self) -> Result<u64> {
         Ok(self.blob_uncompressed_size)
+    }
+
+    fn blob_compressed_size(&self) -> Result<u64> {
+        Ok(self.blob_compressed_size)
     }
 
     fn compressor(&self) -> compress::Algorithm {
@@ -242,10 +242,6 @@ impl BlobCache for FileCacheEntry {
         Ok(())
     }
 
-    fn get_prefetch_state(&self) -> StorageResult<&AtomicU32> {
-        Ok(&self.prefetch_state)
-    }
-
     fn stop_prefetch(&self) -> StorageResult<()> {
         loop {
             let val = self.prefetch_state.load(Ordering::Acquire);
@@ -267,6 +263,10 @@ impl BlobCache for FileCacheEntry {
                 return Ok(());
             }
         }
+    }
+
+    fn is_prefetch_active(&self) -> bool {
+        self.prefetch_state.load(Ordering::Acquire) > 0
     }
 
     fn prefetch_range(&self, range: &BlobIoRange) -> Result<usize> {

--- a/storage/src/cache/dummycache.rs
+++ b/storage/src/cache/dummycache.rs
@@ -19,7 +19,7 @@
 //!   The [is_chunk_cached()](../trait.BlobCache.html#tymethod.is_chunk_cached) method always
 //!   return true to enable data prefetching.
 use std::io::Result;
-use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use fuse_backend_rs::file_buf::FileVolatileSlice;
@@ -48,12 +48,12 @@ impl BlobCache for DummyCache {
         &self.blob_id
     }
 
-    fn blob_compressed_size(&self) -> Result<u64> {
-        self.reader.blob_size().map_err(|e| eother!(e))
-    }
-
     fn blob_uncompressed_size(&self) -> Result<u64> {
         unimplemented!();
+    }
+
+    fn blob_compressed_size(&self) -> Result<u64> {
+        self.reader.blob_size().map_err(|e| eother!(e))
     }
 
     fn compressor(&self) -> compress::Algorithm {
@@ -93,12 +93,12 @@ impl BlobCache for DummyCache {
         Ok(())
     }
 
-    fn get_prefetch_state(&self) -> StorageResult<&AtomicU32> {
-        Err(StorageError::Unsupported)
-    }
-
     fn stop_prefetch(&self) -> StorageResult<()> {
         Ok(())
+    }
+
+    fn is_prefetch_active(&self) -> bool {
+        false
     }
 
     fn read(&self, iovec: &mut BlobIoVec, bufs: &[FileVolatileSlice]) -> Result<usize> {

--- a/storage/src/cache/mod.rs
+++ b/storage/src/cache/mod.rs
@@ -20,10 +20,7 @@ use std::cmp;
 use std::fs::File;
 use std::io::Result;
 use std::slice;
-use std::sync::{
-    atomic::{AtomicU32, Ordering},
-    Arc,
-};
+use std::sync::Arc;
 use std::time::Instant;
 
 use fuse_backend_rs::file_buf::FileVolatileSlice;
@@ -175,12 +172,8 @@ pub trait BlobCache: Send + Sync {
     /// It should be paired with start_prefetch().
     fn stop_prefetch(&self) -> StorageResult<()>;
 
-    fn get_prefetch_state(&self) -> StorageResult<&AtomicU32>;
-
-    fn is_prefetch_active(&self) -> bool {
-        // Safe to unwrap since only dummy cache returns error
-        self.get_prefetch_state().unwrap().load(Ordering::Acquire) > 0
-    }
+    // Check whether data prefetch is still active.
+    fn is_prefetch_active(&self) -> bool;
 
     /// Execute filesystem data prefetch.
     fn prefetch_range(&self, _range: &BlobIoRange) -> Result<usize> {

--- a/storage/src/cache/worker.rs
+++ b/storage/src/cache/worker.rs
@@ -170,12 +170,10 @@ impl AsyncWorkerMgr {
         self.prefetch_channel
             .flush_pending_prefetch_requests(|t| match t {
                 AsyncPrefetchMessage::BlobPrefetch(blob, _, _) => {
-                    blob_id == blob.blob_id()
-                        && blob.get_prefetch_state().unwrap().load(Ordering::Acquire) == 0
+                    blob_id == blob.blob_id() && !blob.is_prefetch_active()
                 }
                 AsyncPrefetchMessage::FsPrefetch(blob, _) => {
-                    blob_id == blob.blob_id()
-                        && blob.get_prefetch_state().unwrap().load(Ordering::Acquire) == 0
+                    blob_id == blob.blob_id() && !blob.is_prefetch_active()
                 }
                 _ => false,
             });


### PR DESCRIPTION
Simplify BlobCache::is_prefetch_active() related code and remove
BlobCache::get_prefetch_state().

Signed-off-by: Jiang Liu <gerry@linux.alibaba.com>