### PR TITLE
nydus-test: delay for some time before verifying prefetch metrics

### DIFF
--- a/contrib/nydus-test/functional-test/test_api.py
+++ b/contrib/nydus-test/functional-test/test_api.py
@@ -254,9 +254,9 @@ def test_api_mount_with_prefetch(
     )
 
     # Only one rafs mountpoint exists, so whether set rafs id or not is not important.
+    time.sleep(0.5)
     m = nc.get_blobcache_metrics()
-    # TODO this won't pass
-    # assert m["prefetch_data_amount"] != 0
+    assert m["prefetch_data_amount"] != 0
 
     wg = WorkloadGen(
         os.path.join(nydus_anchor.mount_point, "pseudo_fs_1"), nydus_image.rootfs()

--- a/contrib/nydus-test/functional-test/test_image_compatibility.py
+++ b/contrib/nydus-test/functional-test/test_image_compatibility.py
@@ -10,6 +10,7 @@ import random
 from nydusd_client import NydusAPIClient
 import time
 
+
 @pytest.mark.skip(reason="Constantly failed for no reason.")
 @pytest.mark.parametrize("thread_cnt", [4])
 @pytest.mark.parametrize("compressor", [Compressor.LZ4_BLOCK, Compressor.NONE])
@@ -72,8 +73,8 @@ def test_prefetch_with_cache(
 
     nc = NydusAPIClient(rafs.get_apisock())
     workload_gen = WorkloadGen(nydus_anchor.mount_point, nydus_scratch_image.rootfs())
+    time.sleep(0.5)
     m = nc.get_blobcache_metrics()
-    time.sleep(0.3)
     assert m["prefetch_data_amount"] != 0
 
     workload_gen.verify_entire_fs()

--- a/contrib/nydus-test/functional-test/test_layered_image.py
+++ b/contrib/nydus-test/functional-test/test_layered_image.py
@@ -154,9 +154,9 @@ def test_blobcache(
     rafs.thread_num(4).mount()
 
     nc = NydusAPIClient(rafs.get_apisock())
+    time.sleep(0.5)
     m = nc.get_blobcache_metrics()
     # TODO: Open this check when prefetch is fixed.
-    time.sleep(1)
     assert m["prefetch_data_amount"] != 0
 
     wg = WorkloadGen(nydus_anchor.mount_point, nydus_anchor.overlayfs)

--- a/contrib/nydus-test/functional-test/test_nydus.py
+++ b/contrib/nydus-test/functional-test/test_nydus.py
@@ -196,7 +196,7 @@ def test_prefetch_with_cache(
 
     nc = NydusAPIClient(rafs.get_apisock())
     workload_gen = WorkloadGen(nydus_anchor.mount_point, nydus_scratch_image.rootfs())
-    time.sleep(0.3)
+    time.sleep(0.5)
     m = nc.get_blobcache_metrics()
     assert m["prefetch_data_amount"] != 0
 


### PR DESCRIPTION
Somehow, prefetch is not started very fast ending up with zero
prefetch metrics retained.

**This is fixing broken nightly CI**

Signed-off-by: Changwei Ge <gechangwei@bytedance.com>