### PR TITLE
builder: fix panic on building big file

### DIFF
--- a/src/bin/nydus-image/core/node.rs
+++ b/src/bin/nydus-image/core/node.rs
@@ -368,7 +368,7 @@ impl Node {
             let file_offset = i as u64 * chunk_size as u64;
             let uncompressed_size = if i == self.inode.child_count() - 1 {
                 (self.inode.size() as u64)
-                    .checked_sub((chunk_size * i) as u64)
+                    .checked_sub(chunk_size as u64 * i as u64)
                     .ok_or_else(|| {
                         anyhow!("the rest chunk size of inode is bigger than chunk_size")
                     })? as u32


### PR DESCRIPTION
Panic when the size of a regular file exceeds 4GB:

```
thread 'main' panicked at 'attempt to multiply with overflow': src/bin/nydus-image/core/node.rs:371
```

Fix it by changing `(chunk_size * i) as u64` to `chunk_size as u64 * i as u64`.

Fix https://github.com/dragonflyoss/image-service/issues/662

Signed-off-by: Yan Song <imeoer@linux.alibaba.com>