### PR TITLE
Fix test

### DIFF
--- a/contrib/nydus-test/framework/utils.py
+++ b/contrib/nydus-test/framework/utils.py
@@ -6,6 +6,8 @@ import os
 import signal
 from typing import Tuple
 import io
+import string
+import random
 
 try:
     import psutil
@@ -321,7 +323,7 @@ def mess_file(path):
 
 
 # based on https://stackoverflow.com/a/42865957/2002471
-units = {"B": 1, "KB": 1024, "MB": 1024 ** 2, "GB": 1024 ** 3}
+units = {"B": 1, "KB": 1024, "MB": 1024**2, "GB": 1024**3}
 
 
 def parse_size(size):
@@ -623,3 +625,8 @@ def parse_stargz(stargz):
 
 def docker_image_repo(reference):
     return posixpath.basename(reference).split(":")[0]
+
+
+def random_string(l=64):
+    res = "".join(random.choices(string.ascii_uppercase + string.digits, k=l))
+    return res

--- a/contrib/nydus-test/functional-test/test_nydus.py
+++ b/contrib/nydus-test/functional-test/test_nydus.py
@@ -799,7 +799,7 @@ def test_build_image_param_blobid(
     """
     # More strict id check?
     nydus_image.set_backend(Backend.BACKEND_PROXY).set_param(
-        "blob-id", uuid.uuid4()
+        "blob-id", utils.random_string()
     ).create_image()
     rafs_conf.set_rafs_backend(Backend.BACKEND_PROXY)
     rafs = RafsMount(nydus_anchor, nydus_image, rafs_conf)


### PR DESCRIPTION
Fix failed nightly CI case 

nydus-image now claims its blob id must be 64 chars length

```

(34 durations < 0.005s hidden.  Use -vv to show these durations.)
=========================== short test summary info ============================
FAILED functional-test/test_nydus.py::test_build_image_param_blobid - Asserti...
======= 1 failed, 48 passed, 2 skipped, 2 warnings in 488.91s (0:08:08) ========
Error: Process completed with exit code 1.

```