### PR TITLE
Rename nydusctl subcommand

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,6 +86,7 @@ clean:
 install: fusedev-release
 	@sudo install -D -m 755 target-fusedev/release/nydusd /usr/local/bin/nydusd
 	@sudo install -D -m 755 target-fusedev/release/nydus-image /usr/local/bin/nydus-image
+	@sudo install -D -m 755 target-fusedev/release/nydusctl /usr/local/bin/nydusctl
 
 # If virtiofs test must be performed, only run binary part
 # Use same traget to avoid re-compile for differnt targets like gnu and musl

--- a/src/bin/nydusctl/commands.rs
+++ b/src/bin/nydusctl/commands.rs
@@ -29,7 +29,7 @@ fn load_param_interval(params: &Option<CommandParams>) -> Result<Option<u32>> {
     }
 }
 
-pub(crate) struct CommandBlobcache {}
+pub(crate) struct CommandCache {}
 
 macro_rules! items_map(
     { $($key:expr => $value:expr),+ } => {
@@ -48,7 +48,7 @@ lazy_static! {
         items_map!("log-level" => "log_level");
 }
 
-impl CommandBlobcache {
+impl CommandCache {
     pub async fn execute(
         &self,
         raw: bool,

--- a/src/bin/nydusctl/main.rs
+++ b/src/bin/nydusctl/main.rs
@@ -22,7 +22,7 @@ mod client;
 mod commands;
 
 use commands::{
-    CommandBackend, CommandBlobcache, CommandDaemon, CommandFsStats, CommandMount, CommandUmount,
+    CommandBackend, CommandCache, CommandDaemon, CommandFsStats, CommandMount, CommandUmount,
 };
 
 #[tokio::main]
@@ -74,13 +74,13 @@ async fn main() -> Result<()> {
         .subcommand(
             SubCommand::with_name("metrics")
                 .about(
-                    "Query nydus metrics. Possible metrics category: fsstats; blobcache; backend",
+                    "Query nydus metrics. Possible metrics category: fsstats; cache; backend",
                 )
                 .arg(
                     Arg::with_name("category")
-                        .help("Show the category of metrics: blobcache, backend, fsstats")
+                        .help("Show the category of metrics: cache, backend, fsstats")
                         .required(true)
-                        .possible_values(&["blobcache", "backend", "fsstats"])
+                        .possible_values(&["cache", "backend", "fsstats"])
                         .takes_value(true)
                         .index(1),
                 )
@@ -169,8 +169,8 @@ async fn main() -> Result<()> {
             .map(|i| context.insert("interval".to_string(), i.to_string()));
 
         match category {
-            "blobcache" => {
-                let cmd = CommandBlobcache {};
+            "cache" => {
+                let cmd = CommandCache {};
                 cmd.execute(raw, &client, None).await?
             }
             "backend" => {


### PR DESCRIPTION
Now nydusd can work as a cachefilesd. So the cache is a moregeneric name.