### PR TITLE
storage: avoid allocating memory when requesting registry

### DIFF
--- a/storage/src/backend/oss.rs
+++ b/storage/src/backend/oss.rs
@@ -143,7 +143,7 @@ impl BlobReader for OssReader {
 
         let resp = self
             .connection
-            .call::<&[u8]>(Method::HEAD, url.as_str(), None, None, headers, true)
+            .call::<&[u8]>(Method::HEAD, url.as_str(), None, None, &mut headers, true)
             .map_err(OssError::Request)?;
         let content_length = resp
             .headers()
@@ -178,7 +178,7 @@ impl BlobReader for OssReader {
         // Safe because the the call() is a synchronous operation.
         let mut resp = self
             .connection
-            .call::<&[u8]>(Method::GET, url.as_str(), None, None, headers, true)
+            .call::<&[u8]>(Method::GET, url.as_str(), None, None, &mut headers, true)
             .map_err(OssError::Request)?;
         Ok(resp
             .copy_to(&mut buf)


### PR DESCRIPTION
Try the best to reduce overhead in the IO path in the core registry connection code.

