### PR TITLE
builder: only reference the blob actually used in the chunk dict

### DIFF
--- a/src/bin/nydus-image/builder/directory.rs
+++ b/src/bin/nydus-image/builder/directory.rs
@@ -165,7 +165,7 @@ impl Builder for DirectoryBuilder {
                     &mut blob_ctx,
                     blob_index,
                     &mut bootstrap_ctx.nodes,
-                    &mut blob_mgr.chunk_dict_cache,
+                    &mut blob_mgr.layered_chunk_dict,
                 )
             },
             "dump_blob"

--- a/src/bin/nydus-image/builder/stargz.rs
+++ b/src/bin/nydus-image/builder/stargz.rs
@@ -605,7 +605,6 @@ impl StargzBuilder {
         let mut header = BlobMetaHeaderOndisk::default();
         header.set_4k_aligned(true);
 
-        blob_ctx.set_chunk_dict(blob_mgr.get_chunk_dict());
         blob_ctx.set_chunk_size(ctx.chunk_size);
         blob_ctx.set_meta_info_enabled(ctx.fs_version == RafsVersion::V6);
         blob_ctx.blob_meta_header = header;
@@ -714,16 +713,11 @@ impl Builder for StargzBuilder {
         )?;
 
         // Generate node chunks and digest
-        let mut blob_ctx = BlobContext::new(
-            ctx.blob_id.clone(),
-            ctx.blob_storage.clone(),
-            0,
-            ctx.inline_bootstrap,
-        )?;
+        let mut blob_ctx = BlobContext::new(ctx.blob_id.clone(), 0);
         self.generate_nodes(ctx, &mut bootstrap_ctx, &mut blob_ctx, blob_mgr)?;
 
         // Dump blob meta
-        Blob::dump_meta_data(ctx, &mut blob_ctx)?;
+        Blob::dump_meta_data(ctx, &mut blob_ctx, &mut None)?;
         if blob_ctx.uncompressed_blob_size > 0 {
             blob_mgr.add(blob_ctx);
         }

--- a/src/bin/nydus-image/core/blob.rs
+++ b/src/bin/nydus-image/core/blob.rs
@@ -3,17 +3,16 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::io::Write;
-use std::os::unix::ffi::OsStrExt;
 
 use anyhow::{Context, Result};
-use nydus_utils::digest::{self, DigestHasher, RafsDigest};
 use nydus_utils::{compress, try_round_up_4k};
 use sha2::Digest;
 use storage::meta::{BlobChunkInfoOndisk, BlobMetaHeaderOndisk};
 
-use super::chunk_dict::ChunkDict;
-use super::context::{ArtifactWriter, BlobContext, BuildContext, SourceType};
+use super::context::{ArtifactWriter, BlobContext, BlobManager, BuildContext, SourceType};
+use super::layout::BlobLayout;
 use super::node::Node;
+use rafs::metadata::RAFS_MAX_CHUNK_SIZE;
 
 pub struct Blob {}
 
@@ -23,62 +22,41 @@ impl Blob {
     }
 
     /// Dump blob file and generate chunks
-    pub fn dump<'a, T: ChunkDict>(
+    pub fn dump(
         &mut self,
         ctx: &BuildContext,
-        blob_ctx: &'a mut BlobContext,
-        blob_index: u32,
-        nodes: &mut Vec<Node>,
-        layered_chunk_dict: &mut T,
-    ) -> Result<bool> {
-        match ctx.source_type {
-            SourceType::Directory => {
-                let (inodes, prefetch_entries) = blob_ctx
-                    .blob_layout
-                    .layout_blob_simple(&ctx.prefetch, nodes)?;
-                for (idx, inode) in inodes.iter().enumerate() {
-                    let node = &mut nodes[*inode];
-                    let size = node
-                        .dump_blob(ctx, blob_ctx, blob_index, layered_chunk_dict)
-                        .context("failed to dump blob chunks")?;
-                    if idx < prefetch_entries {
+        nodes: &mut [Node],
+        blob_mgr: &mut BlobManager,
+        blob_writer: &mut Option<ArtifactWriter>,
+    ) -> Result<()> {
+        if ctx.source_type == SourceType::Directory {
+            let (inodes, prefetch_entries) = BlobLayout::layout_blob_simple(&ctx.prefetch, nodes)?;
+            let mut chunk_data_buf = vec![0u8; RAFS_MAX_CHUNK_SIZE as usize];
+            for (idx, inode) in inodes.iter().enumerate() {
+                let node = &mut nodes[*inode];
+                let size = node
+                    .dump_blob(ctx, blob_mgr, blob_writer, &mut chunk_data_buf)
+                    .context("failed to dump blob chunks")?;
+                if idx < prefetch_entries {
+                    if let Some((_, blob_ctx)) = blob_mgr.get_current_blob() {
                         blob_ctx.blob_readahead_size += size;
                     }
                 }
-                Self::dump_meta_data(ctx, blob_ctx)?;
             }
-            SourceType::StargzIndex => {
-                for node in nodes {
-                    if node.overlay.is_lower_layer() {
-                        continue;
-                    } else if node.is_symlink() {
-                        node.inode.set_digest(RafsDigest::from_buf(
-                            node.symlink.as_ref().unwrap().as_bytes(),
-                            digest::Algorithm::Sha256,
-                        ));
-                    } else {
-                        // Set blob index and inode digest for upper nodes
-                        let mut inode_hasher = RafsDigest::hasher(digest::Algorithm::Sha256);
-                        for chunk in node.chunks.iter_mut() {
-                            chunk.inner.set_blob_index(blob_index);
-                            inode_hasher.digest_update(chunk.inner.id().as_ref());
-                        }
-                        node.inode.set_digest(inode_hasher.digest_finalize());
-                    }
-                }
+            if let Some((_, blob_ctx)) = blob_mgr.get_current_blob() {
+                Self::dump_meta_data(ctx, blob_ctx, blob_writer)?;
             }
         }
 
         // Name blob id by blob hash if not specified.
-        if blob_ctx.blob_id.is_empty() {
-            blob_ctx.blob_id = format!("{:x}", blob_ctx.blob_hash.clone().finalize());
+        if let Some((_, blob_ctx)) = blob_mgr.get_current_blob() {
+            if blob_ctx.blob_id.is_empty() {
+                blob_ctx.blob_id = format!("{:x}", blob_ctx.blob_hash.clone().finalize());
+            }
+            blob_ctx.set_blob_readahead_size(ctx);
         }
 
-        blob_ctx.set_blob_readahead_size(ctx);
-
-        let blob_exists = blob_ctx.compressed_blob_size > 0;
-
-        Ok(blob_exists)
+        Ok(())
     }
 
     pub fn dump_meta_data_raw(
@@ -110,13 +88,17 @@ impl Blob {
         Ok((buf, header))
     }
 
-    pub(crate) fn dump_meta_data(ctx: &BuildContext, blob_ctx: &mut BlobContext) -> Result<()> {
+    pub(crate) fn dump_meta_data(
+        ctx: &BuildContext,
+        blob_ctx: &mut BlobContext,
+        blob_writer: &mut Option<ArtifactWriter>,
+    ) -> Result<()> {
         // Dump is only required if there is chunk in the blob or blob meta info enabled
         if !blob_ctx.blob_meta_info_enabled || blob_ctx.uncompressed_blob_size == 0 {
             return Ok(());
         }
 
-        if let Some(writer) = &mut blob_ctx.writer {
+        if let Some(writer) = blob_writer {
             let pos = writer.pos()?;
             let (data, header) = Self::dump_meta_data_raw(
                 pos,

--- a/src/bin/nydus-image/core/blob.rs
+++ b/src/bin/nydus-image/core/blob.rs
@@ -29,7 +29,7 @@ impl Blob {
         blob_ctx: &'a mut BlobContext,
         blob_index: u32,
         nodes: &mut Vec<Node>,
-        chunk_dict: &mut T,
+        layered_chunk_dict: &mut T,
     ) -> Result<bool> {
         match ctx.source_type {
             SourceType::Directory => {
@@ -39,7 +39,7 @@ impl Blob {
                 for (idx, inode) in inodes.iter().enumerate() {
                     let node = &mut nodes[*inode];
                     let size = node
-                        .dump_blob(ctx, blob_ctx, blob_index, chunk_dict)
+                        .dump_blob(ctx, blob_ctx, blob_index, layered_chunk_dict)
                         .context("failed to dump blob chunks")?;
                     if idx < prefetch_entries {
                         blob_ctx.blob_readahead_size += size;

--- a/src/bin/nydus-image/core/bootstrap.rs
+++ b/src/bin/nydus-image/core/bootstrap.rs
@@ -337,9 +337,9 @@ impl Bootstrap {
         // we need to append the blob entry of upper layer to the table
         blob_mgr.from_blob_table(ctx, rs.superblock.get_blob_infos());
 
-        // Build node tree of lower layer from a bootstrap file, drop by to add
-        // chunks of lower node to chunk_cache for chunk deduplication on next.
-        let tree = Tree::from_bootstrap(&rs, &mut blob_mgr.chunk_dict_cache)
+        // Build node tree of lower layer from a bootstrap file, and add chunks
+        // of lower node to layered_chunk_dict for chunk deduplication on next.
+        let tree = Tree::from_bootstrap(&rs, &mut blob_mgr.layered_chunk_dict)
             .context("failed to build tree from bootstrap")?;
 
         Ok(tree)

--- a/src/bin/nydus-image/core/context.rs
+++ b/src/bin/nydus-image/core/context.rs
@@ -24,13 +24,12 @@ use rafs::metadata::layout::v5::RafsV5BlobTable;
 use rafs::metadata::layout::v6::{RafsV6BlobTable, EROFS_BLOCK_SIZE, EROFS_INODE_SLOT_SIZE};
 use rafs::metadata::layout::{RafsBlobTable, RAFS_SUPER_VERSION_V5, RAFS_SUPER_VERSION_V6};
 use rafs::metadata::RafsSuperFlags;
-use rafs::metadata::{Inode, RAFS_DEFAULT_CHUNK_SIZE, RAFS_MAX_CHUNK_SIZE};
+use rafs::metadata::{Inode, RAFS_DEFAULT_CHUNK_SIZE};
 use rafs::{RafsIoReader, RafsIoWrite};
 use storage::device::{BlobFeatures, BlobInfo};
 use storage::meta::{BlobChunkInfoOndisk, BlobMetaHeaderOndisk};
 
 use super::chunk_dict::{ChunkDict, HashChunkDict};
-use super::layout::BlobLayout;
 use super::node::{ChunkSource, ChunkWrapper, Node, WhiteoutSpec};
 use super::prefetch::{Prefetch, PrefetchPolicy};
 
@@ -296,8 +295,6 @@ pub struct BlobContext {
     pub blob_id: String,
     pub blob_hash: Sha256,
     pub blob_readahead_size: u64,
-    /// Blob data layout manager
-    pub blob_layout: BlobLayout,
     /// Data chunks stored in the data blob, for v6.
     pub blob_meta_info: Vec<BlobChunkInfoOndisk>,
     /// Whether to generate blob metadata information.
@@ -318,15 +315,8 @@ pub struct BlobContext {
     pub chunk_count: u32,
     /// Chunk slice size.
     pub chunk_size: u32,
-    /// Scratch data buffer for reading from/writing to disk files.
-    pub chunk_data_buf: Vec<u8>,
-    /// ChunkDict which would be loaded when builder start
-    pub gloabl_chunk_dict: Arc<dyn ChunkDict>,
     /// Whether the blob is from chunk dict.
     pub chunk_source: ChunkSource,
-
-    // Blob writer for writing to disk file.
-    pub writer: Option<ArtifactWriter>,
 }
 
 impl Clone for BlobContext {
@@ -335,7 +325,6 @@ impl Clone for BlobContext {
             blob_id: self.blob_id.clone(),
             blob_hash: self.blob_hash.clone(),
             blob_readahead_size: self.blob_readahead_size,
-            blob_layout: self.blob_layout.clone(),
             blob_meta_info: self.blob_meta_info.clone(),
             blob_meta_info_enabled: self.blob_meta_info_enabled,
             blob_meta_header: self.blob_meta_header,
@@ -348,32 +337,35 @@ impl Clone for BlobContext {
 
             chunk_count: self.chunk_count,
             chunk_size: self.chunk_size,
-            chunk_data_buf: self.chunk_data_buf.clone(),
-            gloabl_chunk_dict: self.gloabl_chunk_dict.clone(),
             chunk_source: self.chunk_source.clone(),
-            writer: None,
         }
     }
 }
 
 impl BlobContext {
-    pub fn new(
-        blob_id: String,
-        blob_stor: Option<ArtifactStorage>,
-        blob_offset: u64,
-        fifo: bool,
-    ) -> Result<Self> {
-        let writer = if let Some(blob_stor) = blob_stor {
-            Some(ArtifactWriter::new(blob_stor, fifo)?)
-        } else {
-            None
-        };
+    pub fn new(blob_id: String, blob_offset: u64) -> Self {
+        Self {
+            blob_id,
+            blob_hash: Sha256::new(),
+            blob_readahead_size: 0,
+            blob_meta_info_enabled: false,
+            blob_meta_info: Vec::new(),
+            blob_meta_header: BlobMetaHeaderOndisk::default(),
 
-        Ok(Self::new_with_writer(blob_id, writer, blob_offset))
+            compressed_blob_size: 0,
+            uncompressed_blob_size: 0,
+
+            compressed_offset: blob_offset,
+            uncompressed_offset: 0,
+
+            chunk_count: 0,
+            chunk_size: RAFS_DEFAULT_CHUNK_SIZE as u32,
+            chunk_source: ChunkSource::Build,
+        }
     }
 
     pub fn from(ctx: &BuildContext, blob: &BlobInfo, chunk_source: ChunkSource) -> Self {
-        let mut blob_ctx = Self::new_with_writer(blob.blob_id().to_owned(), None, 0);
+        let mut blob_ctx = Self::new(blob.blob_id().to_owned(), 0);
 
         blob_ctx.blob_readahead_size = blob.readahead_size();
         blob_ctx.chunk_count = blob.chunk_count();
@@ -402,46 +394,6 @@ impl BlobContext {
         }
 
         blob_ctx
-    }
-
-    pub fn new_with_writer(
-        blob_id: String,
-        writer: Option<ArtifactWriter>,
-        blob_offset: u64,
-    ) -> Self {
-        let size = if writer.is_some() {
-            RAFS_MAX_CHUNK_SIZE as usize
-        } else {
-            0
-        };
-
-        Self {
-            blob_id,
-            blob_hash: Sha256::new(),
-            blob_readahead_size: 0,
-            blob_layout: BlobLayout::new(),
-            blob_meta_info_enabled: false,
-            blob_meta_info: Vec::new(),
-            blob_meta_header: BlobMetaHeaderOndisk::default(),
-
-            compressed_blob_size: 0,
-            uncompressed_blob_size: 0,
-
-            compressed_offset: blob_offset,
-            uncompressed_offset: 0,
-
-            chunk_count: 0,
-            chunk_size: RAFS_DEFAULT_CHUNK_SIZE as u32,
-            chunk_data_buf: vec![0u8; size],
-            gloabl_chunk_dict: Arc::new(()),
-            chunk_source: ChunkSource::Build,
-
-            writer,
-        }
-    }
-
-    pub fn set_chunk_dict(&mut self, dict: Arc<dyn ChunkDict>) {
-        self.gloabl_chunk_dict = dict;
     }
 
     pub fn set_chunk_size(&mut self, chunk_size: u32) {
@@ -514,6 +466,7 @@ pub struct BlobManager {
     /// We can get blob index for a layer by using:
     /// `self.blobs.iter().flatten().collect()[layer_index];`
     blobs: Vec<BlobContext>,
+    current_blob_index: Option<u32>,
     /// Chunk dictionary to hold chunks from an extra chunk dict file.
     /// Used for chunk data de-duplication within the whole image.
     pub global_chunk_dict: Arc<dyn ChunkDict>,
@@ -527,8 +480,35 @@ impl BlobManager {
     pub fn new() -> Self {
         Self {
             blobs: Vec::new(),
+            current_blob_index: None,
             global_chunk_dict: Arc::new(()),
             layered_chunk_dict: HashChunkDict::default(),
+        }
+    }
+
+    fn new_blob_ctx(ctx: &BuildContext) -> Result<BlobContext> {
+        let mut blob_ctx = BlobContext::new(ctx.blob_id.clone(), ctx.blob_offset);
+        blob_ctx.set_chunk_size(ctx.chunk_size);
+        blob_ctx.set_meta_info_enabled(ctx.fs_version == RafsVersion::V6);
+
+        Ok(blob_ctx)
+    }
+
+    pub fn set_current_blob(&mut self, ctx: &BuildContext) -> Result<(u32, &mut BlobContext)> {
+        if self.current_blob_index.is_none() {
+            let blob_ctx = Self::new_blob_ctx(ctx)?;
+            self.current_blob_index = Some(self.alloc_index()?);
+            self.add(blob_ctx);
+        }
+        // Safe to unwrap because the blob context has been added.
+        Ok(self.get_current_blob().unwrap())
+    }
+
+    pub fn get_current_blob(&mut self) -> Option<(u32, &mut BlobContext)> {
+        if let Some(idx) = self.current_blob_index {
+            Some((idx, &mut self.blobs[idx as usize]))
+        } else {
+            None
         }
     }
 

--- a/src/bin/nydus-image/core/layout.rs
+++ b/src/bin/nydus-image/core/layout.rs
@@ -11,15 +11,7 @@ use crate::core::prefetch::Prefetch;
 pub struct BlobLayout {}
 
 impl BlobLayout {
-    pub fn new() -> Self {
-        BlobLayout {}
-    }
-
-    pub fn layout_blob_simple(
-        &mut self,
-        prefetch: &Prefetch,
-        nodes: &[Node],
-    ) -> Result<(Vec<usize>, usize)> {
+    pub fn layout_blob_simple(prefetch: &Prefetch, nodes: &[Node]) -> Result<(Vec<usize>, usize)> {
         let mut inodes = Vec::with_capacity(nodes.len());
 
         // NOTE: Don't try to sort readahead files by their sizes,  thus to keep files

--- a/src/bin/nydus-image/core/node.rs
+++ b/src/bin/nydus-image/core/node.rs
@@ -47,7 +47,9 @@ use nydus_utils::{
 };
 
 use super::chunk_dict::{ChunkDict, DigestWithBlobIndex};
-use super::context::{BlobContext, BootstrapContext, BuildContext, RafsVersion};
+use super::context::{
+    ArtifactWriter, BlobContext, BlobManager, BootstrapContext, BuildContext, RafsVersion,
+};
 use super::tree::Tree;
 
 // Filesystem may have different algorithms to calculate `i_size` for directory entries,
@@ -334,12 +336,12 @@ impl Node {
         }
     }
 
-    pub fn dump_blob<T: ChunkDict>(
+    pub fn dump_blob(
         self: &mut Node,
         ctx: &BuildContext,
-        blob_ctx: &mut BlobContext,
-        blob_index: u32,
-        layered_chunk_dict: &mut T,
+        blob_mgr: &mut BlobManager,
+        blob_writer: &mut Option<ArtifactWriter>,
+        chunk_data_buf: &mut [u8],
     ) -> Result<u64> {
         if self.is_dir() {
             return Ok(0);
@@ -364,7 +366,7 @@ impl Node {
 
         // `child_count` of regular file is reused as `chunk_count`.
         for i in 0..self.inode.child_count() {
-            let chunk_size = blob_ctx.chunk_size;
+            let chunk_size = ctx.chunk_size;
             let file_offset = i as u64 * chunk_size as u64;
             let uncompressed_size = if i == self.inode.child_count() - 1 {
                 (self.inode.size() as u64)
@@ -376,7 +378,7 @@ impl Node {
                 chunk_size
             };
 
-            let chunk_data = &mut blob_ctx.chunk_data_buf[0..uncompressed_size as usize];
+            let chunk_data = &mut chunk_data_buf[0..uncompressed_size as usize];
             file.read_exact(chunk_data)
                 .with_context(|| format!("failed to read node file {:?}", self.path))?;
 
@@ -387,9 +389,12 @@ impl Node {
             chunk.set_id(chunk_id);
 
             // Check whether we already have the same chunk data by matching chunk digest.
-            let exist_chunk = match blob_ctx.gloabl_chunk_dict.get_chunk(&chunk_id) {
+            let exist_chunk = match blob_mgr.global_chunk_dict.get_chunk(&chunk_id) {
                 Some(v) => Some((v, true)),
-                None => layered_chunk_dict.get_chunk(&chunk_id).map(|v| (v, false)),
+                None => blob_mgr
+                    .layered_chunk_dict
+                    .get_chunk(&chunk_id)
+                    .map(|v| (v, false)),
             };
             // TODO: we should also compare the actual data to avoid chunk digest conflicts.
             if let Some((cached_chunk, from_dict)) = exist_chunk {
@@ -405,11 +410,30 @@ impl Node {
 
                     chunk.copy_from(cached_chunk);
                     chunk.set_file_offset(file_offset);
+                    // During the build process, if a blob in the chunk dict is never used
+                    // for de-duplication, the blob should not be referenced in the blob table
+                    // of final bootstrap, this logic ensure it.
                     if from_dict {
-                        let idx = blob_ctx
-                            .gloabl_chunk_dict
-                            .get_real_blob_idx(chunk.blob_index());
-                        chunk.set_blob_index(idx);
+                        let blob_index = if let Some(blob_idx) = blob_mgr
+                            .global_chunk_dict
+                            .get_real_blob_idx(chunk.blob_index())
+                        {
+                            blob_idx
+                        } else {
+                            let blob_idx = blob_mgr.alloc_index()?;
+                            blob_mgr
+                                .global_chunk_dict
+                                .set_real_blob_idx(chunk.blob_index(), blob_idx);
+                            if let Some(blob) = blob_mgr
+                                .global_chunk_dict
+                                .clone()
+                                .get_blobs_by_inner_idx(chunk.blob_index())
+                            {
+                                blob_mgr.add(BlobContext::from(ctx, blob, ChunkSource::Dict))
+                            }
+                            blob_idx
+                        };
+                        chunk.set_blob_index(blob_index);
                     }
                     trace!(
                         "\t\tbuilding duplicated chunk: {} compressor {}",
@@ -442,9 +466,10 @@ impl Node {
                 uncompressed_size
             };
 
-            // Move cursor to offset of next chunk
-            let compressed_offset = blob_ctx.compressed_offset;
-            let uncompressed_offset = blob_ctx.uncompressed_offset;
+            let (blob_index, mut blob_ctx) = blob_mgr.set_current_blob(ctx)?;
+
+            let pre_compressed_offset = blob_ctx.compressed_offset;
+            let pre_uncompressed_offset = blob_ctx.uncompressed_offset;
             blob_ctx.compressed_offset += compressed_size as u64;
             blob_ctx.uncompressed_offset += aligned_chunk_size as u64;
 
@@ -456,7 +481,7 @@ impl Node {
             // Dump compressed chunk data to blob
             event_tracer!("blob_uncompressed_size", +uncompressed_size);
             event_tracer!("blob_compressed_size", +compressed_size);
-            if let Some(writer) = &mut blob_ctx.writer {
+            if let Some(writer) = blob_writer {
                 writer
                     .write_all(&compressed)
                     .context("failed to write blob")?;
@@ -467,15 +492,15 @@ impl Node {
                 blob_index,
                 chunk_index,
                 file_offset,
-                uncompressed_offset,
+                pre_uncompressed_offset,
                 uncompressed_size,
-                compressed_offset,
+                pre_compressed_offset,
                 compressed_size,
                 is_compressed,
             )?;
 
             blob_ctx.add_chunk_meta_info(&chunk)?;
-            layered_chunk_dict.add_chunk(chunk.clone());
+            blob_mgr.layered_chunk_dict.add_chunk(chunk.clone());
             self.chunks.push(NodeChunk {
                 source: ChunkSource::Build,
                 inner: chunk,


### PR DESCRIPTION
During the build process, if a blob in the chunk dict is never used
for de-duplication, the blob is still referenced in the blob table
of final bootstrap.

This causes that the image will reference to some redundant blobs,
and these blobs will not be GC-ed properly.

This fixup is to add only the blobs actually used in the chunk dict
to blob table during the build process.