### PR TITLE
nydusctl: print rafs read op latency distribution

### DIFF
--- a/src/bin/nydusctl/commands.rs
+++ b/src/bin/nydusctl/commands.rs
@@ -284,6 +284,31 @@ impl CommandFsStats {
         if raw {
             println!("{}", metrics);
         } else {
+            let periods = vec![
+                "<1ms", "~20ms", "~50ms", "~100ms", "~500ms", "~1s", "~2s", "2s~",
+            ];
+            let latency_dist = m["read_latency_dist"].as_array().unwrap();
+            println!(
+                r#"
+{:<16}{:<8}{:<8}{:<8}{:<8}{:<8}{:<8}{:<8}{:<8}"#,
+                "Read Latency:",
+                periods[0],
+                periods[1],
+                periods[2],
+                periods[3],
+                periods[4],
+                periods[5],
+                periods[6],
+                periods[7],
+            );
+
+            print!("{:<16}", "Reads Count:");
+            for d in latency_dist {
+                print!("{:<8}", d.as_u64().unwrap());
+            }
+
+            println!();
+
             print!(
                 r#"
 FOP Counters:


### PR DESCRIPTION
It helps to analyze rafs performance

Then it shows rafs layer read latency distribution which shows that most read ops' latency is located at range [0, 1ms]. It means storage layer prefetch helps a lot.

```
Read Latency:   <1ms    ~20ms   ~50ms   ~100ms  ~500ms  ~1s     ~2s     2s~
Reads Count:    1066    4       8       0       0       0       0       0

FOP Counters:
Getattr(148) Readlink(24) Open(0) Release(0) Read(1078) Statfs(0) Getxattr(115) Listxattr(2)
Opendir(0) Lookup(215) Readdir(2) Readdirplus(2) Access(0) Forget(0) BatchForget(0)
```