### PR TITLE
add log rotation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -438,6 +438,7 @@ checksum = "33ab94b6ac8eb69f1496a6993f26f785b5fd6d99b7416023eb2a6175c0b242b1"
 dependencies = [
  "atty",
  "chrono",
+ "flate2",
  "glob",
  "lazy_static",
  "log",

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -15,7 +15,7 @@ built = { version = "=0.4.3", features = ["chrono", "git2"] }
 [dependencies]
 # pin regex to fix RUSTSEC-2022-0013
 regex = "1.5.5"
-flexi_logger = { version = "0.17" }
+flexi_logger = { version = "0.17", features = ["compress"] }
 libc = "0.2"
 log = "0.4"
 nix = "0.24"

--- a/blobfs/src/lib.rs
+++ b/blobfs/src/lib.rs
@@ -330,7 +330,7 @@ mod tests {
     // #[test]
     // #[cfg(feature = "virtiofs")]
     // fn test_blobfs_new() {
-    //     setup_logging(None, log::LevelFilter::Trace).unwrap();
+    //     setup_logging(None, log::LevelFilter::Trace, 0).unwrap();
     //     let config = r#"
     //     {
     //         "device": {
@@ -428,7 +428,7 @@ mod tests {
 
     #[test]
     fn test_blobfs_setupmapping() {
-        setup_logging(None, log::LevelFilter::Trace).unwrap();
+        setup_logging(None, log::LevelFilter::Trace, 0).unwrap();
         let config = r#"
 {
         "rafs_conf": {

--- a/src/bin/nydus-image/main.rs
+++ b/src/bin/nydus-image/main.rs
@@ -545,7 +545,7 @@ fn init_log(matches: &ArgMatches) -> Result<()> {
     // Safe to unwrap because it has a default value and possible values are defined.
     let level = matches.value_of("log-level").unwrap().parse().unwrap();
 
-    setup_logging(log_file, level).context("failed to setup logging")
+    setup_logging(log_file, level, 0).context("failed to setup logging")
 }
 
 fn main() -> Result<()> {

--- a/src/bin/nydusd/main.rs
+++ b/src/bin/nydusd/main.rs
@@ -405,6 +405,15 @@ fn prepare_commandline_options() -> App<'static, 'static> {
                 .global(true),
         )
         .arg(
+            Arg::with_name("log-rotation-size")
+                .long("log-rotation-size")
+                .help("Specify log rotation size(MB), 0 to disable")
+                .default_value("0")
+                .takes_value(true)
+                .required(false)
+                .global(true),
+        )
+        .arg(
             Arg::with_name("rlimit-nofile")
                 .long("rlimit-nofile")
                 .short("R")
@@ -715,8 +724,13 @@ fn main() -> Result<()> {
     // Safe to unwrap because it has default value and possible values are defined
     let level = args.value_of("log-level").unwrap().parse().unwrap();
     let apisock = args.value_of("apisock");
+    let rotation_size = args
+        .value_of("log-rotation-size")
+        .unwrap()
+        .parse::<u64>()
+        .map_err(|e| einval!(format!("Invalid log rotation size: {}", e)))?;
 
-    setup_logging(logging_file, level)?;
+    setup_logging(logging_file, level, rotation_size)?;
 
     dump_program_info(crate_version!());
     handle_rlimit_nofile_option(&args, "rlimit-nofile")?;

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -172,7 +172,7 @@ fn test(
 
 #[test]
 fn integration_test_init() {
-    setup_logging(None, log::LevelFilter::Trace).unwrap()
+    setup_logging(None, log::LevelFilter::Trace, 0).unwrap()
 }
 
 #[test]


### PR DESCRIPTION
add log rotation to nydusd and nydus-image,
default set to 0 (disable log rotation).

This PR is addressing #668 

Signed-off-by: Bin Tang <tangbin.bin@bytedance.com>