### PR TITLE
misc: add more release archs

### DIFF
--- a/.github/workflows/it.yml
+++ b/.github/workflows/it.yml
@@ -48,20 +48,20 @@ jobs:
 
       - name: Build nydus-rs
         run: |
-          declare -A rust_arch_map=( ["amd64"]="x86_64" ["arm64"]="aarch64")
-          arch=${rust_arch_map[${{ matrix.arch }}]}
+          declare -A rust_target_map=( ["amd64"]="x86_64-unknown-linux-musl" ["arm64"]="aarch64-unknown-linux-musl")
+          RUST_TARGET=${rust_target_map[${{ matrix.arch }}]}
           cargo install --version 0.2.1 cross
           rustup component add rustfmt clippy
-          make -e ARCH=$arch -e CARGO=cross static-release
+          make -e RUST_TARGET=$RUST_TARGET -e CARGO=cross static-release
           make release  -C contrib/nydus-backend-proxy/
-          #sudo mv target-fusedev/$arch-unknown-linux-musl/release/nydusd nydusd-fusedev
-          #sudo mv target-fusedev/$arch-unknown-linux-musl/release/nydus-image .
-          #sudo mv target-fusedev/$arch-unknown-linux-musl/release/nydusctl .
-          #sudo mv target-virtiofs/$arch-unknown-linux-musl/release/nydusd nydusd-virtiofs
+          #sudo mv target-fusedev/$RUST_TARGET/release/nydusd nydusd-fusedev
+          #sudo mv target-fusedev/$RUST_TARGET/release/nydus-image .
+          #sudo mv target-fusedev/$RUST_TARGET/release/nydusctl .
+          #sudo mv target-virtiofs/$RUST_TARGET/release/nydusd nydusd-virtiofs
           sudo cp -r misc/configs .
           sudo chown -R $(id -un):$(id -gn) . ~/.cargo/
           pwd
-          ls -lh target-virtiofs/$arch-unknown-linux-musl/release
+          ls -lh target-virtiofs/$RUST_TARGET/release
       - name: Set up anchor file
         env:
           OSS_AK_ID: ${{ secrets.OSS_TEST_AK_ID }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        arch: [amd64, arm64]
+        arch: [amd64, arm64, ppc64le, riscv64]
     steps:
     - uses: actions/checkout@v2
     - name: Cache cargo
@@ -30,15 +30,15 @@ jobs:
         key: ${{ runner.os }}-cargo-${{ matrix.arch }}
     - name: Build nydus-rs
       run: |
-        declare -A rust_arch_map=( ["amd64"]="x86_64" ["arm64"]="aarch64")
-        arch=${rust_arch_map[${{ matrix.arch }}]}
-        cargo install --version 0.2.1 cross
+        declare -A rust_target_map=( ["amd64"]="x86_64-unknown-linux-musl" ["arm64"]="aarch64-unknown-linux-musl" ["ppc64le"]="powerpc64le-unknown-linux-gnu" ["riscv64"]="riscv64gc-unknown-linux-gnu")
+        RUST_TARGET=${rust_target_map[${{ matrix.arch }}]}
+        cargo install --version 0.2.4 cross
         rustup component add rustfmt clippy
-        make -e ARCH=$arch -e CARGO=cross static-release
-        sudo mv target-fusedev/$arch-unknown-linux-musl/release/nydusd nydusd-fusedev
-        sudo mv target-fusedev/$arch-unknown-linux-musl/release/nydus-image .
-        sudo mv target-fusedev/$arch-unknown-linux-musl/release/nydusctl .
-        sudo mv target-virtiofs/$arch-unknown-linux-musl/release/nydusd nydusd-virtiofs
+        make -e RUST_TARGET=$RUST_TARGET -e CARGO=cross static-release
+        sudo mv target-fusedev/$RUST_TARGET/release/nydusd nydusd-fusedev
+        sudo mv target-fusedev/$RUST_TARGET/release/nydus-image .
+        sudo mv target-fusedev/$RUST_TARGET/release/nydusctl .
+        sudo mv target-virtiofs/$RUST_TARGET/release/nydusd nydusd-virtiofs
         sudo cp -r misc/configs .
         sudo chown -R $(id -un):$(id -gn) . ~/.cargo/
     - name: store-artifacts
@@ -69,13 +69,13 @@ jobs:
     - name: build
       run: |
         # MacOS bash is too old to support declare -A
-        arch=$(test ${{ matrix.arch }} == "amd64" && echo "x86_64" || echo "aarch64")
+        RUST_TARGET=$(test ${{ matrix.arch }} == "amd64" && echo "x86_64-apple-darwin" || echo "aarch64-apple-darwin")
         rustup component add rustfmt clippy
-        rustup target install $arch-apple-darwin
-        make -e ARCH=$arch macos-fusedev
-        sudo mv target-fusedev/$arch-apple-darwin/release/nydusd nydusd-fusedev
-        sudo mv target-fusedev/$arch-apple-darwin/release/nydus-image .
-        sudo mv target-fusedev/$arch-apple-darwin/release/nydusctl .
+        rustup target install $RUST_TARGET
+        make -e RUST_TARGET=$RUST_TARGET macos-fusedev
+        sudo mv target-fusedev/$RUST_TARGET/release/nydusd nydusd-fusedev
+        sudo mv target-fusedev/$RUST_TARGET/release/nydus-image .
+        sudo mv target-fusedev/$RUST_TARGET/release/nydusctl .
         sudo cp -r misc/configs .
         sudo chown -R $(id -un):$(id -gn) . ~/.cargo/
     - name: store-artifacts
@@ -91,7 +91,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        arch: [amd64, arm64]
+        arch: [amd64, arm64, ppc64le, riscv64]
     env:
       DOCKER: false
     steps:
@@ -128,7 +128,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        arch: [amd64, arm64]
+        arch: [amd64, arm64, ppc64le, riscv64]
         os: [linux]
     needs: [nydus-linux, contrib-linux]
     steps:

--- a/contrib/nydus-backend-proxy/Makefile
+++ b/contrib/nydus-backend-proxy/Makefile
@@ -1,10 +1,10 @@
 all:.format build
 
 current_dir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
-ARCH := $(shell uname -p)
+rust_arch := $(shell uname -p)
 
 .musl_target:
-	$(eval CARGO_BUILD_FLAGS += --target ${ARCH}-unknown-linux-musl)
+	$(eval CARGO_BUILD_FLAGS += --target ${rust_arch}-unknown-linux-musl)
 
 .release_version:
 	$(eval CARGO_BUILD_FLAGS += --release)

--- a/misc/musl-static/Dockerfile
+++ b/misc/musl-static/Dockerfile
@@ -1,10 +1,10 @@
 FROM clux/muslrust:1.61.0
 
-ARG ARCH=x86_64
+ARG RUST_TARGET=x86_64-unknown-linux-musl
 
 WORKDIR /nydus-rs
 
 CMD rustup component add clippy && \
   rustup component add rustfmt && \
-  rustup target add $ARCH-unknown-linux-musl && \
+  rustup target add $RUST_TARGET && \
   make static-release

--- a/misc/nydus-smoke/Dockerfile
+++ b/misc/nydus-smoke/Dockerfile
@@ -1,5 +1,5 @@
 FROM rust:1.61.0
-ARG ARCH=x86_64
+ARG RUST_TARGET=x86_64-unknown-linux-musl
 
 RUN mkdir /root/.cargo/
 RUN rustup component add rustfmt && rustup component add clippy


### PR DESCRIPTION
Release binaries for linux/ppc64le and linux/riscv64 arch.

A successful release: https://github.com/imeoer/image-service/actions/runs/2954225904

Signed-off-by: Yan Song <imeoer@linux.alibaba.com>