### PR TITLE
deps: fix security vulnerability for lz4-sys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -944,9 +944,9 @@ dependencies = [
 
 [[package]]
 name = "lz4-sys"
-version = "1.9.3"
+version = "1.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7be8908e2ed6f31c02db8a9fa962f03e36c53fbfde437363eae3306b85d7e17"
+checksum = "57d27b317e207b10f69f5e75494119e391a96f48861ae870d1da6edac98ca900"
 dependencies = [
  "cc",
  "libc",

--- a/rafs/Cargo.toml
+++ b/rafs/Cargo.toml
@@ -20,7 +20,7 @@ hmac = { version = "0.12.1", optional = true }
 lazy_static = "1.4.0"
 libc = "0.2"
 log = "0.4"
-lz4-sys = "1.9.2"
+lz4-sys = "1.9.4"
 nix = "0.24"
 serde = { version = "1.0.110", features = ["serde_derive", "rc"] }
 serde_json = "1.0.53"

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -14,7 +14,7 @@ flate2 = { version = "1.0", features = ["miniz-sys"], default-features = false }
 lazy_static = "1.4"
 libc = "0.2"
 log = "0.4"
-lz4-sys = "1.9.2"
+lz4-sys = "1.9.4"
 serde = { version = ">=1.0.27", features = ["serde_derive", "rc"] }
 serde_json = ">=1.0.9"
 sha2 = "0.10.0"


### PR DESCRIPTION
Upgrade to `lz4-sys 1.9.4` to fix security vulnerability detected by
`cargo deny check`:

```
error[A001]: Memory corruption in liblz4
   ┌─ /github/workspace/Cargo.lock:98:1
   │
98 │ lz4-sys 1.9.3 registry+https://github.com/rust-lang/crates.io-index
   │ ------------------------------------------------------------------- security vulnerability detected
   │
   = ID: RUSTSEC-2022-0051
   = Advisory: https://rustsec.org/advisories/RUSTSEC-2022-0051
   = lz4-sys up to v1.9.3 bundles a version of liblz4 that is vulnerable to
     [CVE-2021-3520](https://nvd.nist.gov/vuln/detail/CVE-2021-3520).

     Attackers could craft a payload that triggers an integer overflow upon
     decompression, causing an out-of-bounds write.

     The flaw has been corrected in version v1.9.4 of liblz4, which is included
     in lz4-sys 1.9.4.
   = Announcement: https://github.com/lz4/lz4/pull/972
   = Solution: Upgrade to >=1.9.4
```

Signed-off-by: Yan Song <imeoer@linux.alibaba.com>