### PR TITLE
nydus-test: don't assign nydusd to anchor

### DIFF
--- a/contrib/nydus-test/conftest.py
+++ b/contrib/nydus-test/conftest.py
@@ -40,7 +40,7 @@ def nydus_anchor(request):
         logging.info("Clean up scratch dir")
         shutil.rmtree(nyta.scratch_dir)
 
-    if hasattr(nyta, "nydusd"):
+    if hasattr(nyta, "nydusd") and nyta.nydusd is not None:
         nyta.nydusd.shutdown()
 
     if hasattr(nyta, "overlayfs") and os.path.ismount(nyta.overlayfs):

--- a/contrib/nydus-test/framework/nydus_anchor.py
+++ b/contrib/nydus-test/framework/nydus_anchor.py
@@ -96,7 +96,6 @@ class NydusAnchor:
 
         self.dustbin = []
         self.tmp_dirs = []
-        self.nydusd = None
 
         self.localfs_workdir = os.path.join(self.workspace, "localfs_workdir")
         self.nydusify_work_dir = os.path.join(self.workspace, "nydusify_work_dir")


### PR DESCRIPTION
When teardown, anchor decides whether to clean environment
by if nydusd is ever assigned.

Signed-off-by: Changwei Ge <gechangwei@bytedance.com>