### PR TITLE
nydusify: fix incorrect http scheme for checker

### DIFF
--- a/contrib/nydusify/pkg/checker/checker.go
+++ b/contrib/nydusify/pkg/checker/checker.go
@@ -157,6 +157,7 @@ func (checker *Checker) check(ctx context.Context) error {
 			SourceMountPath: filepath.Join(checker.WorkDir, "fs/source_mounted"),
 			Target:          checker.Target,
 			TargetInsecure:  checker.TargetInsecure,
+			PlainHTTP:       checker.targetParser.Remote.IsWithHTTP(),
 			NydusdConfig: tool.NydusdConfig{
 				NydusdPath:     checker.NydusdPath,
 				BackendType:    checker.BackendType,

--- a/contrib/nydusify/pkg/remote/remote.go
+++ b/contrib/nydusify/pkg/remote/remote.go
@@ -60,6 +60,10 @@ func (remote *Remote) MaybeWithHTTP(err error) {
 	}
 }
 
+func (remote *Remote) IsWithHTTP() bool {
+	return remote.retryWithHTTP
+}
+
 // Push pushes blob to registry
 func (remote *Remote) Push(ctx context.Context, desc ocispec.Descriptor, byDigest bool, reader io.Reader) error {
 	// Concurrently push blob with same digest using containerd


### PR DESCRIPTION
Based on the patch https://github.com/dragonflyoss/image-service/pull/616, for nydusify check subcommand, its option 
`--target-insecure` only enable `skip_verify` field of nydusd backend
config, it no longer affects `scheme` field to use `http` or `https`.

So we should populate the `scheme` field based on whether or not we
retried HTTP in parser.

Signed-off-by: Yan Song <imeoer@linux.alibaba.com>