### PR TITLE
builder: output blob list for merge subcommand

### DIFF
--- a/src/bin/nydus-image/builder/directory.rs
+++ b/src/bin/nydus-image/builder/directory.rs
@@ -180,6 +180,6 @@ impl Builder for DirectoryBuilder {
             }
         }
 
-        BuildOutput::new(blob_mgr, bootstrap_mgr)
+        BuildOutput::new(blob_mgr)
     }
 }

--- a/src/bin/nydus-image/builder/stargz.rs
+++ b/src/bin/nydus-image/builder/stargz.rs
@@ -726,6 +726,6 @@ impl Builder for StargzBuilder {
         let blob_table = blob_mgr.to_blob_table(ctx)?;
         bootstrap.dump(ctx, &mut bootstrap_ctx, &blob_table)?;
 
-        BuildOutput::new(blob_mgr, bootstrap_mgr)
+        BuildOutput::new(blob_mgr)
     }
 }

--- a/src/bin/nydus-image/core/blob_compact.rs
+++ b/src/bin/nydus-image/core/blob_compact.rs
@@ -625,9 +625,6 @@ impl BlobCompactor {
         // blobs have already been dumped, dump bootstrap only
         let blob_table = compactor.new_blob_mgr.to_blob_table(&build_ctx)?;
         bootstrap.dump(&mut build_ctx, &mut bootstrap_ctx, &blob_table)?;
-        Ok(Some(BuildOutput::new(
-            &compactor.new_blob_mgr,
-            &bootstrap_mgr,
-        )?))
+        Ok(Some(BuildOutput::new(&compactor.new_blob_mgr)?))
     }
 }

--- a/src/bin/nydus-image/core/context.rs
+++ b/src/bin/nydus-image/core/context.rs
@@ -884,7 +884,7 @@ pub struct BuildOutput {
 }
 
 impl BuildOutput {
-    pub fn new(blob_mgr: &BlobManager, _bootstrap_mgr: &BootstrapManager) -> Result<BuildOutput> {
+    pub fn new(blob_mgr: &BlobManager) -> Result<BuildOutput> {
         let blobs = blob_mgr.get_blob_ids();
         let blob_size = blob_mgr.get_last_blob().map(|b| b.compressed_blob_size);
 

--- a/src/bin/nydus-image/merge.rs
+++ b/src/bin/nydus-image/merge.rs
@@ -14,8 +14,10 @@ use rafs::metadata::{RafsInode, RafsMode, RafsSuper, RafsSuperMeta};
 
 use crate::core::bootstrap::Bootstrap;
 use crate::core::chunk_dict::HashChunkDict;
-use crate::core::context::{ArtifactStorage, RafsVersion};
-use crate::core::context::{BlobContext, BlobManager, BootstrapContext, BuildContext};
+use crate::core::context::{
+    ArtifactStorage, BlobContext, BlobManager, BootstrapContext, BuildContext, BuildOutput,
+    RafsVersion,
+};
 use crate::core::node::{ChunkSource, Overlay, WhiteoutSpec};
 use crate::core::tree::{MetadataTreeBuilder, Tree};
 
@@ -62,7 +64,7 @@ impl Merger {
         sources: Vec<PathBuf>,
         target: PathBuf,
         chunk_dict: Option<PathBuf>,
-    ) -> Result<()> {
+    ) -> Result<BuildOutput> {
         if sources.is_empty() {
             bail!("please provide at least one source bootstrap path");
         }
@@ -199,7 +201,8 @@ impl Merger {
         bootstrap
             .dump(ctx, &mut bootstrap_ctx, &blob_table)
             .context(format!("dump bootstrap to {:?}", target))?;
+        let build_output = BuildOutput::new(&blob_mgr)?;
 
-        Ok(())
+        Ok(build_output)
     }
 }


### PR DESCRIPTION
So that we can inspect real blob list referenced by final
bootstrap after the merge is complete.

For these blobs, when chunk dict is enabled, part of them
are from original layers, part from chunk dict bootstrap.

Signed-off-by: Yan Song <imeoer@linux.alibaba.com>