### PR TITLE
nydus-test: use url builder to query

### DIFF
--- a/contrib/nydus-test/nydusd_client.py
+++ b/contrib/nydus-test/nydusd_client.py
@@ -203,7 +203,7 @@ class NydusAPIClient:
         total = 40
         while total:
             try:
-                resp = requests.get(self.root_url + "daemon")
+                resp = requests.get(self.build_path("daemon"))
                 r = resp.json()
                 logging.info(r)
 


### PR DESCRIPTION
Other wise, it generates wrong api endpoint

[2022-08-29 17:09:30,125] INFO [nydusd_client - 208:get_wait_daemon] - {'code': 'UNDEFINED', 'message': 'NoRoute'}
[2022-08-29 17:09:30,125] ERROR [nydusd_client - 219:get_wait_daemon] - Fail to request to nydus, will  retry. 'state'
[2022-08-29 17:09:30.227280 +08:00] INFO [api/src/http.rs:778] <--- Get Uri { string: "/apidaemon" }

Signed-off-by: Changwei Ge <gechangwei@bytedance.com>