### PR TITLE
nydus-test: add the missing parameter 'artifacts'

### DIFF
--- a/contrib/nydus-test/README.md
+++ b/contrib/nydus-test/README.md
@@ -47,6 +47,9 @@ Nydus-test is controlled and configured by `anchor_conf.json`. Nydus-test will t
             "busybox:latest"
         ]
     },
+    "artifacts": {
+        "containerd": "/usr/bin/containerd"
+    },
     "logging_file": "stderr",
     "target": "gnu"
 }


### PR DESCRIPTION
Add the missing parameter 'artifacts' for anchor_conf.json in README.md,
which will cause an error when generating rootfs. KeyError: 'artifacts'

Signed-off-by: Bin Tang <tangbin.bin@bytedance.com>