### PR TITLE
nydusd: remove unix socket before exiting

### DIFF
--- a/src/bin/nydusd/api_server_glue.rs
+++ b/src/bin/nydusd/api_server_glue.rs
@@ -443,5 +443,8 @@ impl ApiServerController {
                 );
             }
         }
+        if let Some(apisock) = self.sock.as_ref() {
+            std::fs::remove_file(apisock).unwrap_or_default();
+        }
     }
 }


### PR DESCRIPTION
remove unix socket before exiting,
it also works when getting SIGINT & SIGTERM signals.

This PR addressing #704 

Signed-off-by: Bin Tang <tangbin.bin@bytedance.com>