### PR TITLE
Fix opendir cache issue for rafs, passthroughfs, and the hybrid mode

### DIFF
--- a/rafs/src/fs.rs
+++ b/rafs/src/fs.rs
@@ -910,7 +910,7 @@ impl FileSystem for Rafs {
         _flags: u32,
     ) -> Result<(Option<Self::Handle>, OpenOptions)> {
         // Cache dir since we are readonly
-        Ok((None, OpenOptions::CACHE_DIR))
+        Ok((None, OpenOptions::CACHE_DIR | OpenOptions::KEEP_CACHE))
     }
 
     fn releasedir(&self, _ctx: &Context, _inode: u64, _flags: u32, _handle: u64) -> Result<()> {

--- a/src/bin/nydusd/main.rs
+++ b/src/bin/nydusd/main.rs
@@ -586,6 +586,7 @@ fn process_default_fs_service(
 
         // passthroughfs requires !no_open
         opts.no_open = false;
+        opts.no_opendir = false;
         opts.killpriv_v2 = true;
 
         Some(cmd)
@@ -617,6 +618,7 @@ fn process_default_fs_service(
     // Enable all options required by passthroughfs
     if args.is_present("hybrid-mode") {
         opts.no_open = false;
+        opts.no_opendir = false;
         opts.killpriv_v2 = true;
     }
 


### PR DESCRIPTION
The 2nd commit relies on the fuse-backend-rs PR https://github.com/cloud-hypervisor/fuse-backend-rs/pull/91 .