### PR TITLE
cargo: update fuse-backend-rs dependency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,13 +157,12 @@ checksum = "f0b3de4a0c5e67e16066a0715723abd91edc2f9001d09c46e1dca929351e130e"
 
 [[package]]
 name = "caps"
-version = "0.3.4"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf6a638a1f7f409f1e545ff0036b8aa5541692c775dd36b48b75bbde50d83d1c"
+checksum = "938c50180feacea622ef3b8f4a496057c868dcf8ac7a64d781dd8f3f51a9c143"
 dependencies = [
- "errno",
- "error-chain",
  "libc",
+ "thiserror",
 ]
 
 [[package]]
@@ -370,36 +369,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "errno"
-version = "0.2.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f639046355ee4f37944e44f60642c6f3a7efa3cf6b78c78a0d989a8ce6c396a1"
-dependencies = [
- "errno-dragonfly",
- "libc",
- "winapi",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
-name = "error-chain"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
-dependencies = [
- "version_check",
-]
-
-[[package]]
 name = "fastrand"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -480,9 +449,9 @@ dependencies = [
 
 [[package]]
 name = "fuse-backend-rs"
-version = "0.9.5"
+version = "0.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c7297c10aeb8fc608581a33e6a7ba46245076add7851b7e473cb837fef48da2"
+checksum = "994a3bfb694ee52bf8f3bca80d784b723f150810998219337e429cc5dbe92717"
 dependencies = [
  "arc-swap",
  "bitflags",
@@ -2132,9 +2101,9 @@ dependencies = [
 
 [[package]]
 name = "vm-memory"
-version = "0.8.0"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "767ed8aaebbff902e02e6d3749dc2baef55e46565f8a6414a065e5baee4b4a81"
+checksum = "583f213899e8a5eea23d9c507252d4bed5bc88f0ecbe0783262f80034630744b"
 dependencies = [
  "arc-swap",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ nix = "0.24.0"
 anyhow = "1.0.35"
 base64 = "0.13.0"
 rust-fsm = "0.6.0"
-vm-memory = { version = "0.8.0", features = ["backend-mmap"], optional = true }
+vm-memory = { version = "0.9.0", features = ["backend-mmap"], optional = true }
 chrono = "0.4.19"
 openssl = { version = "0.10.40", features = ["vendored"] }
 # pin openssl-src to bring in fix for https://rustsec.org/advisories/RUSTSEC-2022-0032
@@ -51,7 +51,7 @@ rand_core = "0.6.2"
 tar = "0.4.38"
 mio = { version = "0.8", features = ["os-poll", "os-ext"] }
 
-fuse-backend-rs = { version = "0.9.5" }
+fuse-backend-rs = { version = "0.9" }
 vhost = { version = "0.4.0", features = ["vhost-user-slave"], optional = true }
 vhost-user-backend = { version = "0.5.1", optional = true }
 virtio-bindings = { version = "0.1", features = ["virtio-v5_0_0"], optional = true }

--- a/blobfs/Cargo.toml
+++ b/blobfs/Cargo.toml
@@ -9,13 +9,13 @@ repository = "https://github.com/dragonflyoss/image-service"
 edition = "2018"
 
 [dependencies]
-fuse-backend-rs = { version = "0.9.0" }
+fuse-backend-rs = { version = "0.9" }
 libc = "0.2"
 log = "0.4.8"
 serde = { version = "1.0.110", features = ["serde_derive", "rc"] }
 serde_json = "1.0.53"
 serde_with = { version = "1.6.0", features = ["macros"] }
-vm-memory = { version = "0.8" }
+vm-memory = { version = "0.9" }
 
 nydus-error = { version = "0.2", path = "../error" }
 nydus-rafs = { version = "0.1", path = "../rafs" }

--- a/rafs/Cargo.toml
+++ b/rafs/Cargo.toml
@@ -29,8 +29,8 @@ sha2 = { version = "0.10.2" }
 sha-1 = { version = "0.10.0", optional = true }
 spmc = "0.3.0"
 url = { version = "2.1.1", optional = true }
-vm-memory = "0.8"
-fuse-backend-rs = { version = "0.9.0" }
+vm-memory = "0.9"
+fuse-backend-rs = { version = "0.9" }
 
 nydus-api = { version = "0.1", path = "../api" }
 nydus-error = { version = "0.2", path = "../error" }

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -31,9 +31,9 @@ sha2 = { version = "0.10.2", optional = true }
 sha-1 = { version = "0.10.0", optional = true }
 tokio = { version = "1.19.0", features = ["rt", "rt-multi-thread", "sync"] }
 url = { version = "2.1.1", optional = true }
-vm-memory = "0.8"
+vm-memory = "0.9"
 vmm-sys-util = "0.10"
-fuse-backend-rs = { version = "0.9.0" }
+fuse-backend-rs = { version = "0.9" }
 
 nydus-api = { version = "0.1", path = "../api" }
 nydus-utils = { version = "0.3", path = "../utils" }

--- a/storage/src/device.rs
+++ b/storage/src/device.rs
@@ -33,7 +33,7 @@ use arc_swap::ArcSwap;
 use fuse_backend_rs::api::filesystem::ZeroCopyWriter;
 use fuse_backend_rs::file_buf::FileVolatileSlice;
 use fuse_backend_rs::file_traits::FileReadWriteVolatile;
-use vm_memory::Bytes;
+use vm_memory::bytes::Bytes;
 
 use nydus_api::http::FactoryConfig;
 use nydus_utils::compress;

--- a/storage/src/utils.rs
+++ b/storage/src/utils.rs
@@ -18,7 +18,7 @@ use nydus_utils::{
     digest::{self, RafsDigest},
     round_down_4k,
 };
-use vm_memory::Bytes;
+use vm_memory::bytes::Bytes;
 
 use crate::{StorageError, StorageResult};
 


### PR DESCRIPTION
Update it to 0.9.6 to get a fix for vfs no_opendir option handling.
