### PR TITLE
nydusify: abort oss blob upload if conversion failed

### DIFF
--- a/contrib/nydusify/pkg/backend/backend.go
+++ b/contrib/nydusify/pkg/backend/backend.go
@@ -22,6 +22,7 @@ type Backend interface {
 	// TODO: Hopefully, we can pass `Layer` struct in, thus to be able to cook both
 	// file handle and file path.
 	Upload(ctx context.Context, blobID, blobPath string, blobSize int64, forcePush bool) (*ocispec.Descriptor, error)
+	Finalize(cancel bool) error
 	Check(blobID string) (bool, error)
 	Type() Type
 }

--- a/contrib/nydusify/pkg/backend/registry.go
+++ b/contrib/nydusify/pkg/backend/registry.go
@@ -32,11 +32,13 @@ func (r *Registry) Upload(
 	}
 
 	return &desc, nil
+}
 
+func (r *Registry) Finalize(cancel bool) error {
+	return nil
 }
 
 func (r *Registry) Check(blobID string) (bool, error) {
-
 	return true, nil
 }
 

--- a/contrib/nydusify/pkg/converter/converter.go
+++ b/contrib/nydusify/pkg/converter/converter.go
@@ -181,6 +181,9 @@ func (cvt *Converter) convert(ctx context.Context) (retErr error) {
 
 	defer func() {
 		if retErr != nil {
+			if err := cvt.storageBackend.Finalize(true); err != nil {
+				logrus.WithError(err).Warnf("Cancel backend upload")
+			}
 			if repo != "" {
 				metrics.ConversionFailureCount(repo, "unknown")
 			}
@@ -345,6 +348,10 @@ func (cvt *Converter) convert(ctx context.Context) (retErr error) {
 			Reference: cvt.SourceRemote.Ref,
 			Digest:    sourceManifest.Digest.String(),
 		})
+	}
+
+	if err := cvt.storageBackend.Finalize(false); err != nil {
+		return errors.Wrap(err, "Finalize backend upload")
 	}
 
 	// Push OCI manifest, Nydus manifest and manifest index

--- a/contrib/nydusify/pkg/packer/pusher_test.go
+++ b/contrib/nydusify/pkg/packer/pusher_test.go
@@ -23,6 +23,10 @@ func (m *mockBackend) Upload(ctx context.Context, blobID, blobPath string, blobS
 	return nil, args.Error(0)
 }
 
+func (m *mockBackend) Finalize(cancel bool) error {
+	return nil
+}
+
 func (m *mockBackend) Check(_ string) (bool, error) {
 	return false, nil
 }


### PR DESCRIPTION
We have used `PutObject` to upload oss before, so if there is any failure during
conversion process, it will cause the uploaded blob to be left on oss, and these
blobs are hard to be GC-ed, so we need always to use the multipart upload, and should
call the `AbortMultipartUpload` method to prevent blob residue as much as possible
once any error happens during conversion process.