### PR TITLE
Fix blob uncompressed size

### DIFF
--- a/src/bin/nydus-image/core/node.rs
+++ b/src/bin/nydus-image/core/node.rs
@@ -474,8 +474,7 @@ impl Node {
             blob_ctx.uncompressed_offset += aligned_chunk_size as u64;
 
             blob_ctx.compressed_blob_size += compressed_size as u64;
-            blob_ctx.uncompressed_blob_size =
-                blob_ctx.uncompressed_offset + aligned_chunk_size as u64;
+            blob_ctx.uncompressed_blob_size = pre_uncompressed_offset + aligned_chunk_size as u64;
             blob_ctx.blob_hash.update(&compressed);
 
             // Dump compressed chunk data to blob

--- a/storage/src/meta/mod.rs
+++ b/storage/src/meta/mod.rs
@@ -415,6 +415,7 @@ impl BlobMetaInfo {
 
     /// Get blob chunks covering uncompressed data range [start, start + size).
     ///
+    /// `size` also includes chunks alignment. It is a range on blob with chunks and alignments between them.
     /// The method returns error if any of following condition is true:
     /// - range [start, start + size) is invalid.
     /// - `start` is bigger than blob size.
@@ -489,9 +490,6 @@ impl BlobMetaInfo {
                 }
             }
 
-            if last_end > end {
-                return Ok(vec);
-            }
             Err(einval!(format!(
                 "entry not found index {} infos.len {}",
                 index,


### PR DESCRIPTION
The `uncompressed_offset` is the next position to write chunks to the uncompressed blob cache. It is already increased before adding blob size.

fixes https://github.com/dragonflyoss/image-service/issues/693