### PR TITLE
nydusd: rename daemon subcommand to singleton

### DIFF
--- a/src/bin/nydusd/main.rs
+++ b/src/bin/nydusd/main.rs
@@ -324,8 +324,8 @@ fn append_virtiofs_subcmd_options(app: App<'static, 'static>) -> App<'static, 's
 }
 
 fn append_services_subcmd_options(app: App<'static, 'static>) -> App<'static, 'static> {
-    let subcmd = SubCommand::with_name("daemon")
-        .about("Run as a global daemon hosting multiple blobcache/fscache/virtiofs services.")
+    let subcmd = SubCommand::with_name("singleton")
+        .about("Run as a global daemon instance to service multiple blobcache/fscache/virtiofs services.")
         .arg(
             Arg::with_name("fscache")
                 .long("fscache")


### PR DESCRIPTION
So that it is clear that the subcommand means to run nydusd in a global single instance mode.
