### PR TITLE
storage: remove readahead configuration from LocalFsConfig

### DIFF
--- a/api/src/http.rs
+++ b/api/src/http.rs
@@ -114,12 +114,6 @@ impl BackendConfig {
 #[derive(Clone, Default, Deserialize, Serialize)]
 #[serde(default)]
 pub struct LocalFsConfig {
-    /// Enable fadvise based readahead.
-    #[serde(default)]
-    pub readahead: bool,
-    /// Trace based readahead record duration.
-    #[serde(default = "default_readahead_sec")]
-    pub readahead_sec: u32,
     /// Blob file to access.
     #[serde(default)]
     pub blob_file: String,
@@ -936,10 +930,6 @@ fn default_http_timeout() -> u32 {
     5
 }
 
-fn default_readahead_sec() -> u32 {
-    10
-}
-
 fn default_work_dir() -> String {
     ".".to_string()
 }
@@ -1203,15 +1193,11 @@ mod tests {
     #[test]
     fn test_localfs_config() {
         let content = r#"{
-            "readahead": true,
-            "readahead_sec": 100,
             "blob_file": "blob_file",
             "dir": "blob_dir",
             "alt_dirs": ["dir1", "dir2"]
         }"#;
         let config: LocalFsConfig = serde_json::from_str(content).unwrap();
-        assert!(config.readahead);
-        assert_eq!(config.readahead_sec, 100);
         assert_eq!(config.blob_file, "blob_file");
         assert_eq!(config.dir, "blob_dir");
         assert_eq!(config.alt_dirs, vec!["dir1", "dir2"]);

--- a/src/bin/nydus-image/unpack/mod.rs
+++ b/src/bin/nydus-image/unpack/mod.rs
@@ -292,8 +292,6 @@ impl OCITarBuilderFactory {
     fn create_blob_reader(&self, blob_path: &Path) -> Result<Arc<dyn BlobReader>> {
         let config = LocalFsConfig {
             blob_file: blob_path.to_str().unwrap().to_owned(),
-            readahead: false,
-            readahead_sec: Default::default(),
             dir: Default::default(),
             alt_dirs: Default::default(),
         };

--- a/storage/src/backend/localfs.rs
+++ b/storage/src/backend/localfs.rs
@@ -207,8 +207,6 @@ mod tests {
     #[test]
     fn test_invalid_localfs_new() {
         let config = LocalFsConfig {
-            readahead: true,
-            readahead_sec: 20,
             blob_file: "".to_string(),
             dir: "".to_string(),
             alt_dirs: Vec::new(),
@@ -217,8 +215,6 @@ mod tests {
         assert!(LocalFs::new(json, Some("test")).is_err());
 
         let config = LocalFsConfig {
-            readahead: true,
-            readahead_sec: 20,
             blob_file: "/a/b/c".to_string(),
             dir: "/a/b".to_string(),
             alt_dirs: Vec::new(),
@@ -230,8 +226,6 @@ mod tests {
     #[test]
     fn test_localfs_get_blob_path() {
         let config = LocalFsConfig {
-            readahead: true,
-            readahead_sec: 20,
             blob_file: "/a/b/cxxxxxxxxxxxxxxxxxxxxxxx".to_string(),
             dir: "/a/b".to_string(),
             alt_dirs: Vec::new(),
@@ -245,8 +239,6 @@ mod tests {
         let filename = path.file_name().unwrap().to_str().unwrap();
 
         let config = LocalFsConfig {
-            readahead: true,
-            readahead_sec: 20,
             blob_file: path.to_str().unwrap().to_owned(),
             dir: path.parent().unwrap().to_str().unwrap().to_owned(),
             alt_dirs: Vec::new(),
@@ -256,8 +248,6 @@ mod tests {
         assert_eq!(fs.get_blob_path("test").unwrap().to_str(), path.to_str());
 
         let config = LocalFsConfig {
-            readahead: true,
-            readahead_sec: 20,
             blob_file: "".to_string(),
             dir: path.parent().unwrap().to_str().unwrap().to_owned(),
             alt_dirs: Vec::new(),
@@ -267,8 +257,6 @@ mod tests {
         assert_eq!(fs.get_blob_path(filename).unwrap().to_str(), path.to_str());
 
         let config = LocalFsConfig {
-            readahead: true,
-            readahead_sec: 20,
             blob_file: "".to_string(),
             dir: "/a/b".to_string(),
             alt_dirs: vec![
@@ -287,8 +275,6 @@ mod tests {
         let path = tempfile.as_path();
         let filename = path.file_name().unwrap().to_str().unwrap();
         let config = LocalFsConfig {
-            readahead: true,
-            readahead_sec: 20,
             blob_file: "".to_string(),
             dir: path.parent().unwrap().to_str().unwrap().to_owned(),
             alt_dirs: Vec::new(),
@@ -314,8 +300,6 @@ mod tests {
         }
 
         let config = LocalFsConfig {
-            readahead: true,
-            readahead_sec: 20,
             blob_file: "".to_string(),
             dir: path.parent().unwrap().to_str().unwrap().to_owned(),
             alt_dirs: Vec::new(),


### PR DESCRIPTION
The readehead functionality in localfs backend has been removed, so clean up the configuration.

Signed-off-by: Jiang Liu <gerry@linux.alibaba.com>