### PR TITLE
nydusd: fix a bug in handling singleton subcommand

### DIFF
--- a/src/bin/nydusd/main.rs
+++ b/src/bin/nydusd/main.rs
@@ -142,6 +142,7 @@ impl DaemonController {
     fn shutdown(&self) {
         // Marking exiting state.
         self.active.store(false, Ordering::Release);
+        DAEMON_CONTROLLER.set_singleton_mode(false);
         // Signal the `run_loop()` working thread to exit.
         let _ = self.waker.wake();
 


### PR DESCRIPTION
Let the singleton daemon exits when received SIGINT.

Signed-off-by: Jiang Liu <gerry@linux.alibaba.com>