### PR TITLE
release: update version on build automatically

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -960,7 +960,7 @@ dependencies = [
 
 [[package]]
 name = "nydus-rs"
-version = "2.1.0-rc.3.1"
+version = "0.0.0-git"
 dependencies = [
  "anyhow",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "nydus-rs"
-version = "2.1.0-rc.3.1"
+# will be overridden by real git tag during cargo build
+version = "0.0.0-git"
 description = "Nydus Image Service"
 authors = ["The Nydus Developers"]
 license = "Apache-2.0 OR BSD-3-Clause"

--- a/app/README.md
+++ b/app/README.md
@@ -39,7 +39,7 @@ use nydus_app::{BuildTimeInfo, setup_logging};
 
 fn main() -> Result<()> {
     let level = cmd.value_of("log-level").unwrap().parse().unwrap();
-    let (bti_string, build_info) = BuildTimeInfo::dump(crate_version!());
+    let (bti_string, build_info) = BuildTimeInfo::dump();
     let _cmd = App::new("")
         .version(bti_string.as_str())
         .author(crate_authors!())

--- a/app/build.rs
+++ b/app/build.rs
@@ -28,7 +28,17 @@ fn get_git_commit_hash() -> String {
             return commit.to_string();
         }
     }
-    "Unknown".to_string()
+    "unknown".to_string()
+}
+
+fn get_git_commit_version() -> String {
+    let tag = Command::new("git").args(&["describe", "--tags"]).output();
+    if let Ok(tag) = tag {
+        if let Some(tag) = String::from_utf8_lossy(&tag.stdout).lines().next() {
+            return tag.to_string();
+        }
+    }
+    "unknown".to_string()
 }
 
 fn main() {
@@ -43,10 +53,12 @@ fn main() {
         .format(&time::format_description::well_known::Iso8601::DEFAULT)
         .unwrap();
     let git_commit_hash = get_git_commit_hash();
+    let git_commit_version = get_git_commit_version();
 
     println!("cargo:rerun-if-changed=../git/HEAD");
     println!("cargo:rustc-env=RUSTC_VERSION={}", rustc_ver);
     println!("cargo:rustc-env=PROFILE={}", profile);
     println!("cargo:rustc-env=BUILT_TIME_UTC={}", build_time);
     println!("cargo:rustc-env=GIT_COMMIT_HASH={}", git_commit_hash);
+    println!("cargo:rustc-env=GIT_COMMIT_VERSION={}", git_commit_version);
 }

--- a/app/src/lib.rs
+++ b/app/src/lib.rs
@@ -22,7 +22,7 @@
 //!
 //! fn main() -> Result<()> {
 //!     let level = cmd.value_of("log-level").unwrap().parse().unwrap();
-//!     let (bti_string, build_info) = BuildTimeInfo::dump(crate_version!());
+//!     let (bti_string, build_info) = BuildTimeInfo::dump();
 //!     let _cmd = App::new("")
 //!                 .version(bti_string.as_str())
 //!                 .author(crate_authors!())
@@ -65,14 +65,15 @@ pub mod built_info {
     pub const PROFILE: &str = env!("PROFILE");
     pub const RUSTC_VERSION: &str = env!("RUSTC_VERSION");
     pub const BUILT_TIME_UTC: &str = env!("BUILT_TIME_UTC");
+    pub const GIT_COMMIT_VERSION: &str = env!("GIT_COMMIT_VERSION");
     pub const GIT_COMMIT_HASH: &str = env!("GIT_COMMIT_HASH");
 }
 
 /// Dump program build and version information.
-pub fn dump_program_info(prog_version: &str) {
+pub fn dump_program_info() {
     info!(
         "Program Version: {}, Git Commit: {:?}, Build Time: {:?}, Profile: {:?}, Rustc Version: {:?}",
-        prog_version,
+        built_info::GIT_COMMIT_VERSION,
         built_info::GIT_COMMIT_HASH,
         built_info::BUILT_TIME_UTC,
         built_info::PROFILE,
@@ -91,10 +92,10 @@ pub struct BuildTimeInfo {
 }
 
 impl BuildTimeInfo {
-    pub fn dump(package_ver: &str) -> (String, Self) {
+    pub fn dump() -> (String, Self) {
         let info_string = format!(
             "\rVersion: \t{}\nGit Commit: \t{}\nBuild Time: \t{}\nProfile: \t{}\nRustc: \t\t{}\n",
-            package_ver,
+            built_info::GIT_COMMIT_VERSION,
             built_info::GIT_COMMIT_HASH,
             built_info::BUILT_TIME_UTC,
             built_info::PROFILE,
@@ -102,7 +103,7 @@ impl BuildTimeInfo {
         );
 
         let info = Self {
-            package_ver: package_ver.to_string(),
+            package_ver: built_info::GIT_COMMIT_VERSION.to_string(),
             git_commit: built_info::GIT_COMMIT_HASH.to_string(),
             build_time: built_info::BUILT_TIME_UTC.to_string(),
             profile: built_info::PROFILE.to_string(),

--- a/src/bin/nydus-image/main.rs
+++ b/src/bin/nydus-image/main.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #![deny(warnings)]
-#[macro_use(crate_authors, crate_version)]
+#[macro_use(crate_authors)]
 extern crate clap;
 #[macro_use]
 extern crate anyhow;
@@ -542,7 +542,7 @@ fn init_log(matches: &ArgMatches) -> Result<()> {
 }
 
 fn main() -> Result<()> {
-    let (bti_string, build_info) = BuildTimeInfo::dump(crate_version!());
+    let (bti_string, build_info) = BuildTimeInfo::dump();
 
     let cmd = prepare_cmd_args(bti_string);
 

--- a/src/bin/nydusctl/main.rs
+++ b/src/bin/nydusctl/main.rs
@@ -4,7 +4,7 @@
 
 #![deny(warnings)]
 
-#[macro_use(crate_authors, crate_version)]
+#[macro_use(crate_authors)]
 extern crate clap;
 #[macro_use]
 extern crate anyhow;
@@ -25,11 +25,13 @@ mod commands;
 use commands::{
     CommandBackend, CommandCache, CommandDaemon, CommandFsStats, CommandMount, CommandUmount,
 };
+use nydus_app::BuildTimeInfo;
 
 #[tokio::main]
 async fn main() -> Result<()> {
+    let (_, build_info) = BuildTimeInfo::dump();
     let app = App::new("A client to query and configure the nydusd daemon\n")
-        .version(crate_version!())
+        .version(build_info.package_ver.as_str())
         .author(crate_authors!())
         .arg(
             Arg::with_name("sock")

--- a/src/bin/nydusd/main.rs
+++ b/src/bin/nydusd/main.rs
@@ -5,7 +5,6 @@
 // SPDX-License-Identifier: (Apache-2.0 AND BSD-3-Clause)
 #![deny(warnings)]
 #![allow(dead_code)]
-#[macro_use(crate_version)]
 extern crate clap;
 #[macro_use]
 extern crate log;
@@ -707,7 +706,7 @@ fn process_singleton_arguments(
 }
 
 fn main() -> Result<()> {
-    let (bti_string, bti) = BuildTimeInfo::dump(crate_version!());
+    let (bti_string, bti) = BuildTimeInfo::dump();
     let cmd_options = prepare_commandline_options().version(bti_string.as_str());
     let args = cmd_options.clone().get_matches();
     let logging_file = args.value_of("log-file").map(|l| l.into());
@@ -722,7 +721,7 @@ fn main() -> Result<()> {
 
     setup_logging(logging_file, level, rotation_size)?;
 
-    dump_program_info(crate_version!());
+    dump_program_info();
     handle_rlimit_nofile_option(&args, "rlimit-nofile")?;
 
     match args.subcommand_name() {


### PR DESCRIPTION
We only need to git tag to release a version without modifying
the version field in Cargo.toml and Cargo.lock.

Signed-off-by: Yan Song <imeoer@linux.alibaba.com>