### PR TITLE
storage: add mirror support

### DIFF
--- a/api/src/http.rs
+++ b/api/src/http.rs
@@ -131,6 +131,8 @@ pub struct LocalFsConfig {
 pub struct OssConfig {
     /// Enable HTTP proxy for the read request.
     pub proxy: ProxyConfig,
+    /// Enable mirrors for the read request.
+    pub mirrors: Vec<MirrorConfig>,
     /// Skip SSL certificate validation for HTTPS scheme.
     pub skip_verify: bool,
     /// Drop the read request once http request timeout, in seconds.
@@ -181,6 +183,8 @@ pub struct RegistryConfig {
     pub scheme: String,
     /// Registry url host
     pub host: String,
+    /// Mirrors' configuration
+    pub mirrors: Vec<MirrorConfig>,
     /// Registry image name, like 'library/ubuntu'
     pub repo: String,
     /// Base64_encoded(username:password), the field should be
@@ -411,6 +415,15 @@ impl Default for ProxyConfig {
             check_interval: 5,
         }
     }
+}
+
+/// Configuration for mirror.
+#[derive(Clone, Deserialize, Serialize, Debug)]
+pub struct MirrorConfig {
+    /// Mirror url host.
+    pub host: String,
+    /// Request headers for mirror server.
+    pub headers: HashMap<String, String>,
 }
 
 #[derive(Debug)]

--- a/storage/src/backend/registry.rs
+++ b/storage/src/backend/registry.rs
@@ -545,6 +545,13 @@ impl Registry {
         let id = id.ok_or_else(|| einval!("Registry backend requires blob_id"))?;
         let config: RegistryConfig = serde_json::from_value(config).map_err(|e| einval!(e))?;
         let con_config: ConnectionConfig = config.clone().into();
+
+        if !config.proxy.url.is_empty() && !config.mirrors.is_empty() {
+            return Err(einval!(
+                "connection: proxy and mirrors cannot be configured at the same time."
+            ));
+        }
+
         let retry_limit = con_config.retry_limit;
         let connection = Connection::new(&con_config)?;
         let auth = trim(config.auth);


### PR DESCRIPTION
Add mirror support for nydusd, 
corresponding configurations: device.backend.config.mirrors
```json
[ {
    "host": "http://dragonfly.io",
    "headers": {
       "X-Dragonfly-Registry": "https://docker.io",
    }
  },
]
```

this PR is addressing #716

Signed-off-by: Bin Tang <tangbin.bin@bytedance.com>