### PR TITLE
test: replace java image with amazoncorretto

### DIFF
--- a/contrib/nydusify/tests/image_test.go
+++ b/contrib/nydusify/tests/image_test.go
@@ -21,7 +21,10 @@ var list = []string{
 	"wordpress",
 	"mongo",
 	"debian",
-	"java",
+	// An alternative for open jdk image, see:
+	// https://hub.docker.com/_/openjdk
+	// https://github.com/docker-library/openjdk/issues/505
+	"amazoncorretto",
 	"ruby",
 	"php",
 	"tomcat",

--- a/misc/top_images/image_list.txt
+++ b/misc/top_images/image_list.txt
@@ -12,7 +12,7 @@ mongo
 mysql
 memcached
 mariadb
-openjdk
+amazoncorretto
 docker
 rabbitmq
 centos
@@ -39,7 +39,6 @@ chronograf
 gradle
 adminer
 ghost
-java
 kong
 solr
 sentry


### PR DESCRIPTION
To fix the broken test: https://github.com/dragonflyoss/image-service/actions/runs/3124279728

```
Failed to convert: Parse source image: Parse source image:
resolve image: docker.io/library/java:latest: not found
```

The java/openjdk image is officially deprecated and all users
are recommended to use suitable replacements, related info:

https://hub.docker.com/_/openjdk
https://github.com/docker-library/openjdk/issues/505

Signed-off-by: Yan Song <imeoer@linux.alibaba.com>