### PR TITLE
makefile: unify the makefiles for contrib components

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       - name: test contrib UT
         run: |
           curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.43.0
-          make all-contrib-test
+          make contrib-test
 
   smoke:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
         RUST_TARGET=${rust_target_map[${{ matrix.arch }}]}
         cargo install --version 0.2.4 cross
         rustup component add rustfmt clippy
-        make -e RUST_TARGET=$RUST_TARGET -e CARGO=cross static-release
+        make -e RUST_TARGET_STATIC=$RUST_TARGET -e CARGO=cross static-release
         sudo mv target/$RUST_TARGET/release/nydusd nydusd
         sudo mv target/$RUST_TARGET/release/nydus-image .
         sudo mv target/$RUST_TARGET/release/nydusctl .
@@ -69,7 +69,7 @@ jobs:
         RUST_TARGET=$(test ${{ matrix.arch }} == "amd64" && echo "x86_64-apple-darwin" || echo "aarch64-apple-darwin")
         rustup component add rustfmt clippy
         rustup target install $RUST_TARGET
-        make -e RUST_TARGET=$RUST_TARGET macos
+        make -e RUST_TARGET_STATIC=$RUST_TARGET release
         sudo mv target/$RUST_TARGET/release/nydusd nydusd
         sudo mv target/$RUST_TARGET/release/nydus-image .
         sudo mv target/$RUST_TARGET/release/nydusctl .
@@ -105,7 +105,7 @@ jobs:
           ${{ runner.os }}-go
     - name: build contrib go components
       run: |
-        make -e GOARCH=${{ matrix.arch }} all-contrib-static-release
+        make -e GOARCH=${{ matrix.arch }} contrib-release
         sudo mv contrib/ctr-remote/bin/ctr-remote .
         sudo mv contrib/docker-nydus-graphdriver/bin/nydus_graphdriver .
         sudo mv contrib/nydusify/cmd/nydusify .

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,17 @@
 all: build
 
+all-build: build contrib-build
+
+all-release: release contrib-release
+
+all-static-release: static-release docker-static contrib-release
+
+all-install: install contrib-install
+
+all-clean: clean contrib-clean
+
 TEST_WORKDIR_PREFIX ?= "/tmp"
+INSTALL_DIR_PREFIX ?= "/usr/local/bin"
 DOCKER ?= "true"
 
 CARGO ?= $(shell which cargo)
@@ -9,20 +20,33 @@ SUDO = $(shell which sudo)
 CARGO_COMMON ?= 
 
 EXCLUDE_PACKAGES =
-STATIC_TARGET = $(UNAME_M)-unknown-linux-musl
 UNAME_M := $(shell uname -m)
 UNAME_S := $(shell uname -s)
+STATIC_TARGET = $(UNAME_M)-unknown-linux-musl
 ifeq ($(UNAME_S),Linux)
 	CARGO_COMMON += --features=virtiofs
+ifeq ($(UNAME_M),ppc64le)
+	STATIC_TARGET = powerpc64le-unknown-linux-gnu
+endif
+ifeq ($(UNAME_M),riscv64)
+	STATIC_TARGET = riscv64gc-unknown-linux-gnu
+endif
 endif
 ifeq ($(UNAME_S),Darwin)
 	EXCLUDE_PACKAGES += --exclude nydus-blobfs
+ifeq ($(UNAME_M),amd64)
+	STATIC_TARGET = x86_64-apple-darwin
+endif
 ifeq ($(UNAME_M),arm64)
-	UNAME_M = aarch64
 	STATIC_TARGET = aarch64-apple-darwin
 endif
 endif
 RUST_TARGET_STATIC ?= $(STATIC_TARGET)
+
+CTR-REMOTE_PATH = contrib/ctr-remote
+DOCKER-GRAPHDRIVER_PATH = contrib/docker-nydus-graphdriver
+NYDUSIFY_PATH = contrib/nydusify
+NYDUS-OVERLAYFS_PATH = contrib/nydus-overlayfs
 
 current_dir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 env_go_path := $(shell go env GOPATH 2> /dev/null)
@@ -49,7 +73,8 @@ define build_golang
 	fi
 endef
 
-.PHONY: all .release_version .format .musl_target build release static-release
+.PHONY: .release_version .format .musl_target \
+	all all-build all-release all-static-release build release static-release
 
 .release_version:
 	$(eval CARGO_BUILD_FLAGS += --release)
@@ -74,20 +99,15 @@ clean:
 	${CARGO} clean
 
 install: release
-	@sudo install -D -m 755 target/release/nydusd /usr/local/bin/nydusd
-	@sudo install -D -m 755 target/release/nydus-image /usr/local/bin/nydus-image
-	@sudo install -D -m 755 target/release/nydusctl /usr/local/bin/nydusctl
+	@sudo install -D -m 755 target/release/nydusd $(INSTALL_DIR_PREFIX)/nydusd
+	@sudo install -D -m 755 target/release/nydus-image $(INSTALL_DIR_PREFIX)/nydus-image
+	@sudo install -D -m 755 target/release/nydusctl $(INSTALL_DIR_PREFIX)/nydusctl
 
 ut:
 	TEST_WORKDIR_PREFIX=$(TEST_WORKDIR_PREFIX) RUST_BACKTRACE=1 ${CARGO} test --workspace $(EXCLUDE_PACKAGES) $(CARGO_COMMON) -- --skip integration --nocapture --test-threads=8
 
 smoke: ut
-	# TODO: Put each test function into separated rs file.
 	$(SUDO) TEST_WORKDIR_PREFIX=$(TEST_WORKDIR_PREFIX) $(CARGO) test --test '*' $(CARGO_COMMON) -- --nocapture --test-threads=8
-
-docker-static:
-	docker build -t nydus-rs-static --build-arg RUST_TARGET=${RUST_TARGET_STATIC} misc/musl-static
-	docker run --rm ${CARGO_BUILD_GEARS} -e RUST_TARGET=${RUST_TARGET_STATIC} --workdir /nydus-rs -v ${current_dir}:/nydus-rs nydus-rs-static
 
 docker-nydus-smoke:
 	docker build -t nydus-smoke --build-arg RUST_TARGET=${RUST_TARGET_STATIC} misc/nydus-smoke
@@ -98,10 +118,9 @@ docker-nydus-smoke:
 		-v ${current_dir}:/nydus-rs \
 		nydus-smoke
 
-NYDUSIFY_PATH = contrib/nydusify
 # TODO: Nydusify smoke has to be time consuming for a while since it relies on musl nydusd and nydus-image.
-# So musl compliation must be involved.
-# And docker-in-docker deployment invovles image buiding?
+# So musl compilation must be involved.
+# And docker-in-docker deployment involves image building?
 docker-nydusify-smoke: docker-static
 	$(call build_golang,$(NYDUSIFY_PATH),make build-smoke)
 	docker build -t nydusify-smoke misc/nydusify-smoke
@@ -118,56 +137,78 @@ docker-nydusify-image-test: docker-static
 		-e BACKEND_CONFIG=$(BACKEND_CONFIG) \
 		-v $(current_dir):/nydus-rs $(dind_cache_mount) nydusify-smoke TestDockerHubImage
 
+# Run integration smoke test in docker-in-docker container. It requires some special settings,
+# refer to `misc/example/README.md` for details.
 docker-smoke: docker-nydus-smoke docker-nydusify-smoke
+
+contrib-build: nydusify ctr-remote nydus-overlayfs docker-nydus-graphdriver
+
+contrib-release: nydusify-release ctr-remote-release \
+			    nydus-overlayfs-release docker-nydus-graphdriver-release
+
+contrib-test: nydusify-test ctr-remote-test \
+				nydus-overlayfs-test docker-nydus-graphdriver-test
+
+contrib-clean: nydusify-clean ctr-remote-clean \
+				nydus-overlayfs-clean docker-nydus-graphdriver-clean
+
+contrib-install:
+	@sudo install -D -m 755 contrib/ctr-remote/bin/ctr-remote $(INSTALL_DIR_PREFIX)/ctr-remote
+	@sudo install -D -m 755 contrib/docker-nydus-graphdriver/bin/nydus-graphdriver $(INSTALL_DIR_PREFIX)/nydus-overlayfs
+	@sudo install -D -m 755 contrib/nydus-overlayfs/bin/nydus-overlayfs $(INSTALL_DIR_PREFIX)/nydus-overlayfs
+	@sudo install -D -m 755 contrib/nydusify/cmd/nydusify $(INSTALL_DIR_PREFIX)/nydusify
 
 nydusify:
 	$(call build_golang,${NYDUSIFY_PATH},make)
 
+nydusify-release:
+	$(call build_golang,${NYDUSIFY_PATH},make release)
+
 nydusify-test:
 	$(call build_golang,${NYDUSIFY_PATH},make test)
 
-nydusify-static:
-	$(call build_golang,${NYDUSIFY_PATH},make static-release)
+nydusify-clean:
+	$(call build_golang,${NYDUSIFY_PATH},make clean)
 
-CTR-REMOTE_PATH = contrib/ctr-remote
 ctr-remote:
 	$(call build_golang,${CTR-REMOTE_PATH},make)
+
+ctr-remote-release:
+	$(call build_golang,${CTR-REMOTE_PATH},make release)
 
 ctr-remote-test:
 	$(call build_golang,${CTR-REMOTE_PATH},make test)
 
-ctr-remote-static:
-	$(call build_golang,${CTR-REMOTE_PATH},make static-release)
+ctr-remote-clean:
+	$(call build_golang,${CTR-REMOTE_PATH},make clean)
 
-NYDUS-OVERLAYFS_PATH = contrib/nydus-overlayfs
 nydus-overlayfs:
 	$(call build_golang,${NYDUS-OVERLAYFS_PATH},make)
+
+nydus-overlayfs-release:
+	$(call build_golang,${NYDUS-OVERLAYFS_PATH},make release)
 
 nydus-overlayfs-test:
 	$(call build_golang,${NYDUS-OVERLAYFS_PATH},make test)
 
-nydus-overlayfs-static:
-	$(call build_golang,${NYDUS-OVERLAYFS_PATH},make static-release)
+nydus-overlayfs-clean:
+	$(call build_golang,${NYDUS-OVERLAYFS_PATH},make clean)
 
-DOCKER-GRAPHDRIVER_PATH = contrib/docker-nydus-graphdriver
 docker-nydus-graphdriver:
 	$(call build_golang,${DOCKER-GRAPHDRIVER_PATH},make)
+
+docker-nydus-graphdriver-release:
+	$(call build_golang,${DOCKER-GRAPHDRIVER_PATH},make release)
 
 docker-nydus-graphdriver-test:
 	$(call build_golang,${DOCKER-GRAPHDRIVER_PATH},make test)
 
-docker-nydus-graphdriver-static:
-	$(call build_golang,${DOCKER-GRAPHDRIVER_PATH},make static-release)
+docker-nydus-graphdriver-clean:
+	$(call build_golang,${DOCKER-GRAPHDRIVER_PATH},make clean)
 
-# Run integration smoke test in docker-in-docker container. It requires some special settings,
-# refer to `misc/example/README.md` for details.
-all-static-release: docker-static all-contrib-static-release
-
-all-contrib-static-release: nydusify-static ctr-remote-static \
-			    nydus-overlayfs-static docker-nydus-graphdriver-static
-
-all-contrib-test: nydusify-test ctr-remote-test \
-				nydus-overlayfs-test docker-nydus-graphdriver-test
+docker-static:
+	docker build -t nydus-rs-static --build-arg RUST_TARGET=${RUST_TARGET_STATIC} misc/musl-static
+	docker run --rm ${CARGO_BUILD_GEARS} -e RUST_TARGET=${RUST_TARGET_STATIC} --workdir /nydus-rs -v ${current_dir}:/nydus-rs nydus-rs-static
 
 docker-example: all-static-release
 	cp ${current_dir}/target/${RUST_TARGET_STATIC}/release/nydusd misc/example

--- a/contrib/ctr-remote/Makefile
+++ b/contrib/ctr-remote/Makefile
@@ -1,22 +1,27 @@
+GIT_COMMIT := $(shell git rev-list -1 HEAD)
+BUILD_TIME := $(shell date -u +%Y%m%d.%H%M)
 PACKAGES ?= $(shell go list ./... | grep -v /vendor/)
 GOARCH ?= amd64
+GOPROXY ?= https://goproxy.io
 
-all:clear build
+ifdef GOPROXY
+PROXY := GOPROXY=${GOPROXY}
+endif
 
-.PHONY: build
+.PHONY: all build release test clean
+
+all: build
+
 build:
-	GOOS=linux GOARCH=${GOARCH} go build -v -o bin/ctr-remote ./cmd/main.go
+	@CGO_ENABLED=0 ${PROXY} GOOS=linux GOARCH=${GOARCH} go build -v -o bin/ctr-remote ./cmd/main.go
 
-.PHONY: clear
-clear:
-	rm -f bin/*
+release:
+	@CGO_ENABLED=0 ${PROXY} GOOS=linux GOARCH=${GOARCH} go build -ldflags '-s -w -extldflags "-static"' -v -o bin/ctr-remote ./cmd/main.go
 
-.PHONY: static-release
-static-release:
-	GOOS=linux GOARCH=${GOARCH} go build -ldflags '-s -w -extldflags "-static"' -v -o bin/ctr-remote ./cmd/main.go
-
-.PHONY: test
 test: build
 	go vet $(PACKAGES)
 	golangci-lint run
 	go test -v -cover ${PACKAGES}
+
+clean:
+	rm -f bin/*

--- a/contrib/docker-nydus-graphdriver/Makefile
+++ b/contrib/docker-nydus-graphdriver/Makefile
@@ -1,22 +1,27 @@
+GIT_COMMIT := $(shell git rev-list -1 HEAD)
+BUILD_TIME := $(shell date -u +%Y%m%d.%H%M)
 PACKAGES ?= $(shell go list ./... | grep -v /vendor/)
 GOARCH ?= amd64
+GOPROXY ?= https://goproxy.io
 
-all:clear build
+ifdef GOPROXY
+PROXY := GOPROXY=${GOPROXY}
+endif
 
-.PHONY: build
+.PHONY: all build release test clean
+
+all: build
+
 build:
-	GOOS=linux GOARCH=${GOARCH} go build -v -o bin/nydus_graphdriver .
+	@CGO_ENABLED=0 ${PROXY} GOOS=linux GOARCH=${GOARCH} go build -v -o bin/nydus_graphdriver .
 
-.PHONY: clear
-clear:
-	rm -f bin/*
+release:
+	@CGO_ENABLED=0 ${PROXY} GOOS=linux GOARCH=${GOARCH} go build -ldflags '-s -w -extldflags "-static"' -v -o bin/nydus_graphdriver .
 
-.PHONY: static-release
-static-release:
-	GOOS=linux GOARCH=${GOARCH} go build -ldflags '-s -w -extldflags "-static"' -v -o bin/nydus_graphdriver .
-
-.PHONY: test
 test: build
 	go vet $(PACKAGES)
 	golangci-lint run
 	go test -v -cover ${PACKAGES}
+
+clean:
+	rm -f bin/*

--- a/contrib/nydus-overlayfs/Makefile
+++ b/contrib/nydus-overlayfs/Makefile
@@ -1,24 +1,27 @@
-all:clear build
-
 GIT_COMMIT := $(shell git rev-parse --verify HEAD --short=7)
 BUILD_TIME := $(shell date -u +%Y%m%d.%H%M)
 PACKAGES ?= $(shell go list ./... | grep -v /vendor/)
 GOARCH ?= amd64
+GOPROXY ?= https://goproxy.io
 
-.PHONY: build
+ifdef GOPROXY
+PROXY := GOPROXY=${GOPROXY}
+endif
+
+.PHONY: all build release test clean
+
+all: build
+
 build:
-	GOOS=linux GOARCH=${GOARCH} go build  -ldflags="-s -w -X 'main.Version=${GIT_COMMIT}' -X 'main.BuildTime=${BUILD_TIME}'" -v -o bin/nydus-overlayfs ./cmd/main.go
+	@CGO_ENABLED=0 ${PROXY} GOOS=linux GOARCH=${GOARCH} go build  -ldflags="-s -w -X 'main.Version=${GIT_COMMIT}' -X 'main.BuildTime=${BUILD_TIME}'" -v -o bin/nydus-overlayfs ./cmd/main.go
 
-.PHONY: clear
-clear:
-	rm -f bin/*
+release:
+	@CGO_ENABLED=0 ${PROXY} GOOS=linux GOARCH=${GOARCH} go build -ldflags '-s -w -extldflags "-static"' -v -o bin/nydus-overlayfs ./cmd/main.go
 
-.PHONY: static-release
-static-release:
-	GOOS=linux GOARCH=${GOARCH} go build -ldflags '-s -w -extldflags "-static"' -v -o bin/nydus-overlayfs ./cmd/main.go
-
-.PHONY: test
 test: build
 	go vet $(PACKAGES)
 	golangci-lint run
 	go test -v -cover ${PACKAGES}
+
+clean:
+	rm -f bin/*

--- a/contrib/nydusify/Makefile
+++ b/contrib/nydusify/Makefile
@@ -1,27 +1,30 @@
 GIT_COMMIT := $(shell git rev-list -1 HEAD)
 BUILD_TIME := $(shell date -u +%Y%m%d.%H%M)
-CURRENT_DIR := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 PACKAGES ?= $(shell go list ./... | grep -v /vendor/)
 GOARCH ?= amd64
-#GOPROXY ?= https://goproxy.io
+GOPROXY ?= https://goproxy.io
 
 ifdef GOPROXY
 PROXY := GOPROXY=${GOPROXY}
 endif
 
-.PHONY: build
+.PHONY: all build release test clean build-smoke
+
+all: build
+
 build:
 	@CGO_ENABLED=0 ${PROXY} GOOS=linux GOARCH=${GOARCH} go build -ldflags '-X main.versionGitCommit=${GIT_COMMIT} -X main.versionBuildTime=${BUILD_TIME}' -gcflags=all="-N -l" -o ./cmd ./cmd/nydusify.go
 
-.PHONY: static-release
-static-release:
-	@CGO_ENABLED=0 ${PROXY} GOOS=linux GOARCH=${GOARCH} go build -ldflags '-X main.versionGitCommit=${GIT_COMMIT} -X main.versionBuildTime=${BUILD_TIME}' -o ./cmd ./cmd/nydusify.go
+release:
+	@CGO_ENABLED=0 ${PROXY} GOOS=linux GOARCH=${GOARCH} go build -ldflags '-X main.versionGitCommit=${GIT_COMMIT} -X main.versionBuildTime=${BUILD_TIME} -s -w -extldflags "-static"' -o ./cmd ./cmd/nydusify.go
 
-.PHONY: test
 test: build build-smoke
 	@go vet $(PACKAGES)
 	golangci-lint run
 	@go test -count=1 -v -timeout 20m -race ./pkg/...
+
+clean:
+	rm -f cmd/nydusify
 
 build-smoke:
 	${PROXY} go test -race -v -c -o ./nydusify-smoke ./tests


### PR DESCRIPTION
Unify the makefiles for contrib components by use the same template. Also refine the global makefile targets to make them symmetric.

Signed-off-by: Jiang Liu <gerry@linux.alibaba.com>