### PR TITLE
nydusify: output nydus & oci manifest index for check

### DIFF
--- a/contrib/nydusify/pkg/checker/output.go
+++ b/contrib/nydusify/pkg/checker/output.go
@@ -32,12 +32,21 @@ func (checker *Checker) Output(
 ) error {
 	logrus.Infof("Dumping OCI and Nydus manifests to %s", outputPath)
 
+	if sourceParsed.Index != nil {
+		if err := prettyDump(
+			sourceParsed.Index,
+			filepath.Join(outputPath, "oci_index.json"),
+		); err != nil {
+			return errors.Wrap(err, "output oci index file")
+		}
+	}
+
 	if targetParsed.Index != nil {
 		if err := prettyDump(
 			targetParsed.Index,
-			filepath.Join(outputPath, "index.json"),
+			filepath.Join(outputPath, "nydus_index.json"),
 		); err != nil {
-			return errors.Wrap(err, "output index file")
+			return errors.Wrap(err, "output nydus index file")
 		}
 	}
 


### PR DESCRIPTION
In order to debug oci and nydus image more friendly when use `nydusify check` command, we'd better output `oci_index.json` and `nydus_index.json` file.

Signed-off-by: Yan Song <imeoer@linux.alibaba.com>