### PR TITLE
workflow: refine release workflow for macos

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,14 +65,8 @@ jobs:
         key: ${{ runner.os }}-cargo-${{ matrix.arch }}
     - name: build
       run: |
-        # MacOS bash is too old to support declare -A
-        RUST_TARGET=$(test ${{ matrix.arch }} == "amd64" && echo "x86_64-apple-darwin" || echo "aarch64-apple-darwin")
         rustup component add rustfmt clippy
-        rustup target install $RUST_TARGET
-        make -e RUST_TARGET_STATIC=$RUST_TARGET release
-        sudo mv target/$RUST_TARGET/release/nydusd nydusd
-        sudo mv target/$RUST_TARGET/release/nydus-image .
-        sudo mv target/$RUST_TARGET/release/nydusctl .
+        make -e INSTALL_DIR_PREFIX=. install
         sudo cp -r misc/configs .
         sudo chown -R $(id -un):$(id -gn) . ~/.cargo/
     - name: store-artifacts
@@ -80,8 +74,9 @@ jobs:
       with:
         name: nydus-artifacts-darwin-${{ matrix.arch }}
         path: |
-          nydusd
           nydusctl
+          nydusd
+          nydus-image
           configs
 
   contrib-linux:


### PR DESCRIPTION
Refine release workflow for macos by relying on the makefile to do the actual work.

Signed-off-by: Jiang Liu <gerry@linux.alibaba.com>