### PR TITLE
Adapt nydus test

### DIFF
--- a/contrib/nydus-test/conftest.py
+++ b/contrib/nydus-test/conftest.py
@@ -167,7 +167,7 @@ def nydusify_converter():
 
     nydusify_source_dir = os.path.join(ANCHOR.nydus_project, "contrib/nydusify")
     with utils.pushd(nydusify_source_dir):
-        ret, _ = utils.execute(["make", "static-release"])
+        ret, _ = utils.execute(["make", "release"])
         assert ret
 
 

--- a/contrib/nydus-test/framework/rafs.py
+++ b/contrib/nydus-test/framework/rafs.py
@@ -585,7 +585,6 @@ class NydusDaemon(utils.ArtifactProcess):
         self.param_value_prefix = " "
         self.params = RafsMountParam(anchor.nydusd_bin if bin is None else bin)
         self.params.set_subcommand(mode)
-        self.is_daemon_mode = True if mode == "daemon" else False
         if with_defaults:
             self._set_default_mount_param()
 

--- a/contrib/nydus-test/functional-test/test_erofs.py
+++ b/contrib/nydus-test/functional-test/test_erofs.py
@@ -17,7 +17,7 @@ logging_setup()
 def test_basic(nydus_anchor: NydusAnchor, nydus_image: RafsImage):
 
     nydus_image.set_backend(Backend.BACKEND_PROXY).create_image()
-    daemon = NydusDaemon(nydus_anchor, None, None, mode="daemon")
+    daemon = NydusDaemon(nydus_anchor, None, None, mode="singleton")
     daemon.set_fscache().start()
 
     nc = NydusAPIClient(daemon.get_apisock())
@@ -54,7 +54,7 @@ def test_prefetch(nydus_anchor: NydusAnchor, nydus_scratch_image: RafsImage):
 
     nydus_scratch_image.set_backend(Backend.BACKEND_PROXY).create_image()
 
-    daemon = NydusDaemon(nydus_anchor, None, None, mode="daemon")
+    daemon = NydusDaemon(nydus_anchor, None, None, mode="singleton")
     daemon.set_fscache().start()
 
     time.sleep(1)


### PR DESCRIPTION
Adapts to recent mainline changes:
1. nydusify makefile target has renamed to `make release`
2. nydusd subcommand daemon has renamed to singleton