### PR TITLE
storage: support configure proxy use_http

### DIFF
--- a/api/src/http.rs
+++ b/api/src/http.rs
@@ -404,6 +404,9 @@ pub struct ProxyConfig {
     pub fallback: bool,
     /// Interval of P2P proxy health checking, in seconds.
     pub check_interval: u64,
+    /// Replace URL to http to request source registry with proxy, and allow fallback to https if the proxy is unhealthy.
+    #[serde(default)]
+    pub use_http: bool,
 }
 
 impl Default for ProxyConfig {
@@ -413,6 +416,7 @@ impl Default for ProxyConfig {
             ping_url: String::new(),
             fallback: true,
             check_interval: 5,
+            use_http: false,
         }
     }
 }


### PR DESCRIPTION
Dragonfly supports configuration `useHTTPS` while
work as a http proxy. In this mode, nydusd can access dfdaemon via http while dfdaemon is accessing registry using https. So CA is not needed to be passed to dfdaemon.

The limit is that registry scheme must be set to http ending up with reading the original registry failure when fallback.

With configuring proxy with use_http, it will replace the scheme when sending requests to dfdaemon.

Addressing https://github.com/dragonflyoss/image-service/issues/723

Signed-off-by: Changwei Ge <gechangwei@bytedance.com>