### PR TITLE
release: add npm mirror url into release note

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -204,6 +204,8 @@ jobs:
       uses: softprops/action-gh-release@v1
       with:
         name: "Nydus Image Service ${{ env.tag }}"
+        body: |
+          Mirror (update in 10 min): https://registry.npmmirror.com/binary.html?path=nydus/${{ env.tag }}/
         generate_release_notes: true
         files: |
           ${{ env.tarballs }}


### PR DESCRIPTION
For example:

```
Nydus Image Service v2.1.0-rc.3.1

Mirror (update in 10 min): https://registry.npmmirror.com/binary.html?path=nydus/v2.1.0-rc.3.1/

...
```

A successful release can be found here: https://github.com/imeoer/image-service/releases/tag/v2.1.0-rc.3.6

Signed-off-by: Yan Song <imeoer@linux.alibaba.com>