### PR TITLE
Enrich nydus-image print, fix prefetch table layout and other couple of fixes

### DIFF
--- a/contrib/nydus-test/framework/rafs.py
+++ b/contrib/nydus-test/framework/rafs.py
@@ -196,14 +196,13 @@ class RafsConf:
         threads_count=8,
         merging_size=128 * 1024,
         bandwidth_rate=0,
-        prefetch_all=None,
+        prefetch_all=False,
     ):
         self._configure_rafs("fs_prefetch.enable", True)
         self._configure_rafs("fs_prefetch.threads_count", threads_count)
         self._configure_rafs("fs_prefetch.merging_size", merging_size)
         self._configure_rafs("fs_prefetch.bandwidth_rate", bandwidth_rate)
-        if prefetch_all is not None:
-            self._configure_rafs("fs_prefetch.prefetch_all", prefetch_all)
+        self._configure_rafs("fs_prefetch.prefetch_all", prefetch_all)
 
         return self
 

--- a/rafs/src/metadata/direct_v6.rs
+++ b/rafs/src/metadata/direct_v6.rs
@@ -1098,7 +1098,7 @@ impl RafsInode for OndiskInodeWrapper {
     /// # Safety
     /// It depends on Self::validate() to ensure valid memory layout.
     fn name(&self) -> OsString {
-        let mut curr_name = OsString::from("");
+        let mut cur_name = OsString::from("");
         match self.name.borrow().as_ref() {
             Some(name) => return name.clone(),
             None => {
@@ -1113,7 +1113,7 @@ impl RafsInode for OndiskInodeWrapper {
                         0,
                         &mut |inode: Option<Arc<dyn RafsInode>>, name: OsString, ino, offset| {
                             if cur_ino == ino {
-                                curr_name = name;
+                                cur_name = name;
                                 return Ok(PostWalkAction::Break);
                             }
                             Ok(PostWalkAction::Continue)
@@ -1122,8 +1122,8 @@ impl RafsInode for OndiskInodeWrapper {
                     .unwrap();
             }
         }
-        *self.name.borrow_mut() = Some(curr_name.clone());
-        curr_name
+        *self.name.borrow_mut() = Some(cur_name.clone());
+        cur_name
     }
     // RafsV5 flags, not used by v6, return 0
     fn flags(&self) -> u64 {

--- a/rafs/src/metadata/layout/v6.rs
+++ b/rafs/src/metadata/layout/v6.rs
@@ -219,6 +219,11 @@ impl RafsV6SuperBlock {
         self.s_inos = inos.to_le();
     }
 
+    /// Get total inodes count of this Rafs
+    pub fn inodes_count(&self) -> u64 {
+        self.s_inos
+    }
+
     /// Set number of logical blocks.
     pub fn set_blocks(&mut self, blocks: u32) {
         self.s_blocks = blocks.to_le();

--- a/rafs/src/metadata/md_v6.rs
+++ b/rafs/src/metadata/md_v6.rs
@@ -40,6 +40,7 @@ impl RafsSuper {
         self.meta.blob_table_size = ext_sb.blob_table_size();
         self.meta.chunk_table_offset = ext_sb.chunk_table_offset();
         self.meta.chunk_table_size = ext_sb.chunk_table_size();
+        self.meta.inodes_count = sb.inodes_count();
 
         self.meta.flags = RafsSuperFlags::from_bits(ext_sb.flags())
             .ok_or_else(|| einval!(format!("invalid super flags {:x}", ext_sb.flags())))?;

--- a/rafs/src/metadata/mod.rs
+++ b/rafs/src/metadata/mod.rs
@@ -20,7 +20,7 @@ use std::time::Duration;
 use anyhow::bail;
 
 use fuse_backend_rs::abi::fuse_abi::Attr;
-use fuse_backend_rs::api::filesystem::{Entry, ROOT_ID};
+use fuse_backend_rs::api::filesystem::Entry;
 use nydus_utils::compress;
 use nydus_utils::digest::{self, RafsDigest};
 use serde::Serialize;
@@ -550,7 +550,7 @@ impl RafsSuper {
 
     /// Convert an inode number to a file path.
     pub fn path_from_ino(&self, ino: Inode) -> Result<PathBuf> {
-        if ino == ROOT_ID {
+        if ino == self.superblock.root_ino() {
             return Ok(self.get_inode(ino, false)?.name().into());
         }
 
@@ -563,7 +563,7 @@ impl RafsSuper {
             let e: PathBuf = inode.name().into();
             path = e.join(path);
 
-            if inode.ino() == ROOT_ID {
+            if inode.ino() == self.superblock.root_ino() {
                 break;
             } else {
                 cur_ino = inode.parent();

--- a/src/bin/nydus-image/core/bootstrap.rs
+++ b/src/bin/nydus-image/core/bootstrap.rs
@@ -61,7 +61,10 @@ impl Bootstrap {
         tree: &mut Tree,
     ) -> Result<()> {
         tree.node.index = RAFS_ROOT_INODE;
-        tree.node.inode.set_ino(RAFS_ROOT_INODE);
+        // Rafs v6 root inode number can't be decided until the end of dumping.
+        if ctx.fs_version.is_v5() {
+            tree.node.inode.set_ino(RAFS_ROOT_INODE);
+        }
         // Filesystem walking skips root inode within subsequent while loop, however, we allow
         // user to pass the source root as prefetch hint. Check it here.
         ctx.prefetch.insert_if_need(&tree.node);

--- a/src/bin/nydus-image/core/prefetch.rs
+++ b/src/bin/nydus-image/core/prefetch.rs
@@ -119,7 +119,6 @@ impl Prefetch {
 
     pub fn insert_if_need(&mut self, node: &Node) {
         let path = node.target();
-        let inode = node.inode.ino();
         let index = node.index;
         let mut remove_node = false;
 
@@ -135,11 +134,13 @@ impl Prefetch {
             // As path is canonicalized, it should be reliable.
             if path == f {
                 if self.policy == PrefetchPolicy::Fs {
-                    *v = Some(inode);
+                    *v = Some(index);
                 }
                 self.readahead_files.insert(path.clone(), index);
             } else if path.starts_with(f) {
+                // FIXME: path may not exist in prefetch pattern, no need to remove it from readahead_patterns
                 remove_node = true;
+                debug!("remove path {:?}", path);
                 self.readahead_files.insert(path.clone(), index);
             }
         }
@@ -168,6 +169,7 @@ impl Prefetch {
         if self.policy == PrefetchPolicy::Fs {
             let mut prefetch_table = RafsV5PrefetchTable::new();
             for i in self.readahead_patterns.values().filter_map(|v| *v) {
+                // Rafs v5 has inode number equal to index.
                 prefetch_table.add_entry(i as u32);
             }
             Some(prefetch_table)

--- a/src/bin/nydus-image/core/prefetch.rs
+++ b/src/bin/nydus-image/core/prefetch.rs
@@ -123,7 +123,11 @@ impl Prefetch {
         let index = node.index;
         let mut remove_node = false;
 
-        if self.policy == PrefetchPolicy::None || self.disabled || node.inode.size() == 0 {
+        // Newly created root inode of this rafs has zero size
+        if self.policy == PrefetchPolicy::None
+            || self.disabled
+            || (node.inode.is_reg() && node.inode.size() == 0)
+        {
             return;
         }
 

--- a/src/bin/nydus-image/inspect.rs
+++ b/src/bin/nydus-image/inspect.rs
@@ -65,12 +65,14 @@ impl RafsInspector {
                 r#"
     Version:            {version}
     Inodes Count:       {inodes_count}
-    Chunk Size:         {chunk_size}
+    Chunk Size:         {chunk_size}KB
+    Root Inode:         {root_inode}
     Flags:              {flags}"#,
-                version = self.rafs_meta.meta.version,
+                version = self.rafs_meta.meta.version >> 8,
                 inodes_count = self.rafs_meta.meta.inodes_count,
-                chunk_size = self.rafs_meta.meta.chunk_size,
+                chunk_size = self.rafs_meta.meta.chunk_size / 1024,
                 flags = self.rafs_meta.meta.flags,
+                root_inode = self.rafs_meta.superblock.root_ino(),
             );
             None
         };
@@ -288,7 +290,7 @@ Compressed Size:    {compressed_size}
             Some(value)
         } else {
             println!(
-                "Prefetched Files: {}",
+                "Total Prefetching Files: {}",
                 self.rafs_meta.meta.prefetch_table_entries
             );
             for ino in prefetch_inos {


### PR DESCRIPTION
1. rafs v5 and v6 has different root inode numbers. So use the real root inode number when getting path from inode number.
2. rafs v6's inode number can't be decided until the end of dumping bootstrap. So don't record inode number in readadhead patterns anymore, use node index instead.
3. enrich print nydus-image inspect 

fixes https://github.com/dragonflyoss/image-service/issues/760