### PR TITLE
Split `RafsInode` into `RafsInode` and `RafsInodeExt`

### DIFF
--- a/rafs/src/lib.rs
+++ b/rafs/src/lib.rs
@@ -45,7 +45,7 @@ use std::os::unix::io::AsRawFd;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use crate::metadata::{RafsInode, RafsSuper};
+use crate::metadata::{RafsInodeExt, RafsSuper};
 
 pub mod fs;
 pub mod metadata;
@@ -230,13 +230,13 @@ impl dyn RafsIoRead {
 ///  Iterator to walk all inodes of a Rafs filesystem.
 pub struct RafsIterator<'a> {
     _rs: &'a RafsSuper,
-    cursor_stack: Vec<(Arc<dyn RafsInode>, PathBuf)>,
+    cursor_stack: Vec<(Arc<dyn RafsInodeExt>, PathBuf)>,
 }
 
 impl<'a> RafsIterator<'a> {
     /// Create a new iterator to visit a Rafs filesystem.
     pub fn new(rs: &'a RafsSuper) -> Self {
-        let cursor_stack = match rs.get_inode(rs.superblock.root_ino(), false) {
+        let cursor_stack = match rs.get_extended_inode(rs.superblock.root_ino(), false) {
             Ok(node) => {
                 let path = PathBuf::from("/");
                 vec![(node, path)]
@@ -258,7 +258,7 @@ impl<'a> RafsIterator<'a> {
 }
 
 impl<'a> Iterator for RafsIterator<'a> {
-    type Item = (Arc<dyn RafsInode>, PathBuf);
+    type Item = (Arc<dyn RafsInodeExt>, PathBuf);
 
     fn next(&mut self) -> Option<Self::Item> {
         let (node, path) = self.cursor_stack.pop()?;

--- a/rafs/src/metadata/cached_v5.rs
+++ b/rafs/src/metadata/cached_v5.rs
@@ -643,35 +643,6 @@ impl RafsV5InodeOps for CachedInodeV5 {
     fn has_hole(&self) -> bool {
         self.i_flags.contains(RafsV5InodeFlags::HAS_HOLE)
     }
-
-    fn cast_ondisk(&self) -> Result<RafsV5Inode> {
-        let i_symlink_size = if self.is_symlink() {
-            self.get_symlink()?.byte_size() as u16
-        } else {
-            0
-        };
-        Ok(RafsV5Inode {
-            i_digest: self.i_digest,
-            i_parent: self.i_parent,
-            i_ino: self.i_ino,
-            i_projid: self.i_projid,
-            i_uid: self.i_uid,
-            i_gid: self.i_gid,
-            i_mode: self.i_mode,
-            i_size: self.i_size,
-            i_nlink: self.i_nlink,
-            i_blocks: self.i_blocks,
-            i_flags: self.i_flags,
-            i_child_index: self.i_child_idx,
-            i_child_count: self.i_child_cnt,
-            i_name_size: self.i_name.len() as u16,
-            i_symlink_size,
-            i_rdev: self.i_rdev,
-            i_mtime: self.i_mtime,
-            i_mtime_nsec: self.i_mtime_nsec,
-            i_reserved: [0; 8],
-        })
-    }
 }
 
 /// Cached information about an Rafs Data Chunk.
@@ -736,10 +707,6 @@ impl BlobChunkInfo for CachedChunkInfoV5 {
 
     fn is_compressed(&self) -> bool {
         self.flags.contains(BlobChunkFlags::COMPRESSED)
-    }
-
-    fn is_hole(&self) -> bool {
-        self.flags.contains(BlobChunkFlags::HOLECHUNK)
     }
 
     fn as_any(&self) -> &dyn Any {

--- a/rafs/src/metadata/direct_v5.rs
+++ b/rafs/src/metadata/direct_v5.rs
@@ -878,12 +878,6 @@ impl RafsV5InodeOps for OndiskInodeWrapper {
         self.mapping.state.load().meta.chunk_size
     }
 
-    fn cast_ondisk(&self) -> Result<RafsV5Inode> {
-        let state = self.state();
-
-        Ok(*self.inode(state.deref()))
-    }
-
     impl_inode_wrapper!(has_hole, bool);
 }
 
@@ -940,12 +934,6 @@ impl BlobChunkInfo for DirectChunkInfoV5 {
         self.chunk(self.state().deref())
             .flags
             .contains(BlobChunkFlags::COMPRESSED)
-    }
-
-    fn is_hole(&self) -> bool {
-        self.chunk(self.state().deref())
-            .flags
-            .contains(BlobChunkFlags::HOLECHUNK)
     }
 
     fn as_any(&self) -> &dyn Any {

--- a/rafs/src/metadata/direct_v5.rs
+++ b/rafs/src/metadata/direct_v5.rs
@@ -42,7 +42,7 @@ use crate::metadata::layout::v5::{
 };
 use crate::metadata::layout::{
     bytes_to_os_str, parse_xattr_names, parse_xattr_value, MetaRange, XattrName, XattrValue,
-    RAFS_ROOT_INODE,
+    RAFS_V5_ROOT_INODE,
 };
 use crate::metadata::{
     Attr, Entry, Inode, RafsInode, RafsInodeWalkAction, RafsInodeWalkHandler, RafsSuperBlock,
@@ -408,7 +408,7 @@ impl RafsSuperBlock for DirectSuperBlockV5 {
     }
 
     fn root_ino(&self) -> u64 {
-        RAFS_ROOT_INODE
+        RAFS_V5_ROOT_INODE
     }
 }
 

--- a/rafs/src/metadata/direct_v5.rs
+++ b/rafs/src/metadata/direct_v5.rs
@@ -180,16 +180,9 @@ impl Drop for DirectMappingState {
 }
 
 /// Direct-mapped Rafs v5 super block.
+#[derive(Clone)]
 pub struct DirectSuperBlockV5 {
-    state: ArcSwap<DirectMappingState>,
-}
-
-impl Clone for DirectSuperBlockV5 {
-    fn clone(&self) -> Self {
-        DirectSuperBlockV5 {
-            state: ArcSwap::new(self.state.load_full()),
-        }
-    }
+    state: Arc<ArcSwap<DirectMappingState>>,
 }
 
 impl DirectSuperBlockV5 {
@@ -198,7 +191,7 @@ impl DirectSuperBlockV5 {
         let state = DirectMappingState::new(meta, validate_inode);
 
         Self {
-            state: ArcSwap::new(Arc::new(state)),
+            state: Arc::new(ArcSwap::new(Arc::new(state))),
         }
     }
 

--- a/rafs/src/metadata/direct_v6.rs
+++ b/rafs/src/metadata/direct_v6.rs
@@ -1379,12 +1379,6 @@ impl BlobChunkInfo for DirectChunkInfoV6 {
             .contains(BlobChunkFlags::COMPRESSED)
     }
 
-    fn is_hole(&self) -> bool {
-        self.chunk(self.state().deref())
-            .flags
-            .contains(BlobChunkFlags::HOLECHUNK)
-    }
-
     fn as_any(&self) -> &dyn Any {
         self
     }

--- a/rafs/src/metadata/layout/mod.rs
+++ b/rafs/src/metadata/layout/mod.rs
@@ -25,8 +25,9 @@ pub const RAFS_SUPER_VERSION_V5: u32 = 0x500;
 pub const RAFS_SUPER_VERSION_V6: u32 = 0x600;
 /// Minimal version of Rafs supported.
 pub const RAFS_SUPER_MIN_VERSION: u32 = RAFS_SUPER_VERSION_V4;
+
 /// Inode number for Rafs root inode.
-pub const RAFS_ROOT_INODE: u64 = ROOT_ID;
+pub const RAFS_V5_ROOT_INODE: u64 = ROOT_ID;
 
 /// Type for filesystem xattr attribute key.
 pub type XattrName = Vec<u8>;

--- a/rafs/src/metadata/layout/v5.rs
+++ b/rafs/src/metadata/layout/v5.rs
@@ -91,48 +91,6 @@ pub(crate) trait RafsV5InodeChunkOps {
     fn get_chunk_info_v5(&self, idx: u32) -> Result<Arc<dyn BlobV5ChunkInfo>>;
 }
 
-impl From<RafsSuperFlags> for digest::Algorithm {
-    fn from(flags: RafsSuperFlags) -> Self {
-        match flags {
-            x if x.contains(RafsSuperFlags::DIGESTER_BLAKE3) => digest::Algorithm::Blake3,
-            x if x.contains(RafsSuperFlags::DIGESTER_SHA256) => digest::Algorithm::Sha256,
-            _ => digest::Algorithm::Blake3,
-        }
-    }
-}
-
-impl From<digest::Algorithm> for RafsSuperFlags {
-    fn from(d: digest::Algorithm) -> RafsSuperFlags {
-        match d {
-            digest::Algorithm::Blake3 => RafsSuperFlags::DIGESTER_BLAKE3,
-            digest::Algorithm::Sha256 => RafsSuperFlags::DIGESTER_SHA256,
-        }
-    }
-}
-
-impl From<RafsSuperFlags> for compress::Algorithm {
-    fn from(flags: RafsSuperFlags) -> Self {
-        match flags {
-            x if x.contains(RafsSuperFlags::COMPRESS_NONE) => compress::Algorithm::None,
-            x if x.contains(RafsSuperFlags::COMPRESS_LZ4_BLOCK) => compress::Algorithm::Lz4Block,
-            x if x.contains(RafsSuperFlags::COMPRESS_GZIP) => compress::Algorithm::GZip,
-            x if x.contains(RafsSuperFlags::COMPRESS_ZSTD) => compress::Algorithm::Zstd,
-            _ => compress::Algorithm::Lz4Block,
-        }
-    }
-}
-
-impl From<compress::Algorithm> for RafsSuperFlags {
-    fn from(c: compress::Algorithm) -> RafsSuperFlags {
-        match c {
-            compress::Algorithm::None => RafsSuperFlags::COMPRESS_NONE,
-            compress::Algorithm::Lz4Block => RafsSuperFlags::COMPRESS_LZ4_BLOCK,
-            compress::Algorithm::GZip => RafsSuperFlags::COMPRESS_GZIP,
-            compress::Algorithm::Zstd => RafsSuperFlags::COMPRESS_ZSTD,
-        }
-    }
-}
-
 /// Rafs v5 superblock on disk metadata, 8192 bytes.
 #[repr(C)]
 #[derive(Clone, Copy)]

--- a/rafs/src/metadata/layout/v5.rs
+++ b/rafs/src/metadata/layout/v5.rs
@@ -81,9 +81,6 @@ pub(crate) trait RafsV5InodeOps {
 
     /// Check whether the inode has hole chunk.
     fn has_hole(&self) -> bool;
-
-    /// Convert to the on disk data format.
-    fn cast_ondisk(&self) -> Result<RafsV5Inode>;
 }
 
 pub(crate) trait RafsV5InodeChunkOps {
@@ -1574,10 +1571,6 @@ pub mod tests {
 
         fn is_compressed(&self) -> bool {
             self.flags.contains(BlobChunkFlags::COMPRESSED)
-        }
-
-        fn is_hole(&self) -> bool {
-            self.flags.contains(BlobChunkFlags::HOLECHUNK)
         }
 
         fn as_any(&self) -> &dyn Any {

--- a/rafs/src/metadata/mod.rs
+++ b/rafs/src/metadata/mod.rs
@@ -344,10 +344,6 @@ pub struct RafsSuperMeta {
     pub extended_blob_table_offset: u64,
     /// Offset of the extended blob information table into the metadata blob.
     pub extended_blob_table_entries: u32,
-    /// Start of data prefetch range.
-    pub blob_readahead_offset: u32,
-    /// Size of data prefetch range.
-    pub blob_readahead_size: u32,
     /// Offset of the inode prefetch table into the metadata blob.
     pub prefetch_table_offset: u64,
     /// Size of the inode prefetch table.
@@ -429,8 +425,6 @@ impl Default for RafsSuperMeta {
             blob_table_offset: 0,
             extended_blob_table_offset: 0,
             extended_blob_table_entries: 0,
-            blob_readahead_offset: 0,
-            blob_readahead_size: 0,
             prefetch_table_offset: 0,
             prefetch_table_entries: 0,
             attr_timeout: Duration::from_secs(RAFS_DEFAULT_ATTR_TIMEOUT),
@@ -849,15 +843,6 @@ impl RafsSuper {
             }
         }
         Ok(())
-    }
-
-    /// Store RAFS metadata to backend storage.
-    pub fn store(&self, w: &mut dyn RafsIoWrite) -> Result<usize> {
-        if self.meta.is_v5() {
-            return self.store_v5(w);
-        }
-
-        Err(einval!("invalid superblock version number"))
     }
 }
 

--- a/rafs/src/metadata/mod.rs
+++ b/rafs/src/metadata/mod.rs
@@ -1,5 +1,5 @@
 // Copyright 2020 Ant Group. All rights reserved.
-// Copyright (C) 2020 Alibaba Cloud. All rights reserved.
+// Copyright (C) 2020-2022 Alibaba Cloud. All rights reserved.
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -11,6 +11,7 @@ use std::ffi::{OsStr, OsString};
 use std::fmt::{Debug, Display, Formatter, Result as FmtResult};
 use std::fs::OpenOptions;
 use std::io::{Error, Result};
+use std::ops::Deref;
 use std::os::unix::ffi::OsStrExt;
 use std::path::{Component, Path, PathBuf};
 use std::str::FromStr;
@@ -20,10 +21,10 @@ use std::time::Duration;
 use anyhow::bail;
 use fuse_backend_rs::abi::fuse_abi::Attr;
 use fuse_backend_rs::api::filesystem::Entry;
+use nydus_storage::device::{BlobChunkInfo, BlobInfo, BlobIoMerge, BlobIoVec};
 use nydus_utils::compress;
 use nydus_utils::digest::{self, RafsDigest};
 use serde::Serialize;
-use storage::device::{BlobChunkInfo, BlobInfo, BlobIoMerge, BlobIoVec};
 
 use self::layout::v5::RafsV5PrefetchTable;
 use self::layout::v6::RafsV6PrefetchTable;
@@ -65,17 +66,12 @@ pub trait RafsSuperInodes {
     /// Get the maximum inode number managed by the RAFS filesystem.
     fn get_max_ino(&self) -> Inode;
 
-    /// Get the `RafsInode` trait object corresponding to the inode number `ino`,
-    /// also validates the inode content if requested.
-    fn get_inode(&self, ino: Inode, validate_digest: bool) -> Result<Arc<dyn RafsInode>>;
+    /// Get the `RafsInode` trait object corresponding to the inode number `ino`.
+    fn get_inode(&self, ino: Inode, validate_inode: bool) -> Result<Arc<dyn RafsInode>>;
 
-    /// Validate the content of inode itself, optionally recursively validate its children.
-    fn validate_digest(
-        &self,
-        inode: Arc<dyn RafsInode>,
-        recursive: bool,
-        digester: digest::Algorithm,
-    ) -> Result<bool>;
+    /// Get the `RafsInodeExt` trait object corresponding to the 'ino`.
+    fn get_extended_inode(&self, ino: Inode, validate_inode: bool)
+        -> Result<Arc<dyn RafsInodeExt>>;
 }
 
 /// Trait to access RAFS filesystem metadata, including the RAFS super block and inodes.
@@ -129,9 +125,6 @@ pub trait RafsInode: Any {
     /// It must be validated for integrity before accessing any of its data fields .
     fn validate(&self, max_inode: Inode, chunk_size: u64) -> Result<()>;
 
-    /// RAFS: get digest value of the inode metadata.
-    fn get_digest(&self) -> RafsDigest;
-
     /// RAFS: allocate blob io vectors to read file data in range [offset, offset + size).
     fn alloc_bio_vecs(&self, offset: u64, size: usize, user_io: bool) -> Result<Vec<BlobIoVec>>;
 
@@ -140,9 +133,6 @@ pub trait RafsInode: Any {
         &self,
         descendants: &mut Vec<Arc<dyn RafsInode>>,
     ) -> Result<usize>;
-
-    /// RAFS V5: get RAFS v5 specific inode flags.
-    fn flags(&self) -> u64;
 
     /// Posix: generate a `Entry` object required by libc/fuse from the inode.
     fn get_entry(&self) -> Entry;
@@ -153,20 +143,11 @@ pub trait RafsInode: Any {
     /// Posix: get the inode number.
     fn ino(&self) -> u64;
 
-    /// Posix: get inode number of the parent inode.
-    fn parent(&self) -> u64;
-
     /// Posix: get real device number.
     fn rdev(&self) -> u32;
 
     /// Posix: get project id associated with the inode.
     fn projid(&self) -> u32;
-
-    /// Posix: get file name.
-    fn name(&self) -> OsString;
-
-    /// Posix: get file name size.
-    fn get_name_size(&self) -> u16;
 
     /// Mode: check whether the inode is a directory.
     fn is_dir(&self) -> bool;
@@ -199,10 +180,10 @@ pub trait RafsInode: Any {
     fn walk_children_inodes(&self, entry_offset: u64, handler: RafsInodeWalkHandler) -> Result<()>;
 
     /// Directory: get child inode by name.
-    fn get_child_by_name(&self, name: &OsStr) -> Result<Arc<dyn RafsInode>>;
+    fn get_child_by_name(&self, name: &OsStr) -> Result<Arc<dyn RafsInodeExt>>;
 
     /// Directory: get child inode by child index, child index starts from 0.
-    fn get_child_by_index(&self, idx: u32) -> Result<Arc<dyn RafsInode>>;
+    fn get_child_by_index(&self, idx: u32) -> Result<Arc<dyn RafsInodeExt>>;
 
     /// Directory: get number of child inodes.
     fn get_child_count(&self) -> u32;
@@ -221,10 +202,31 @@ pub trait RafsInode: Any {
     /// Regular: get number of data chunks.
     fn get_chunk_count(&self) -> u32;
 
-    /// Regular: get chunk info object by chunk index, chunk index starts from 0.
-    fn get_chunk_info(&self, idx: u32) -> Result<Arc<dyn BlobChunkInfo>>;
-
     fn as_any(&self) -> &dyn Any;
+}
+
+/// Extended inode information for builder and directory walker.
+pub trait RafsInodeExt: RafsInode {
+    /// Convert to the base type `RafsInode`.
+    fn as_inode(&self) -> &dyn RafsInode;
+
+    /// Posix: get inode number of the parent inode.
+    fn parent(&self) -> u64;
+
+    /// Posix: get file name.
+    fn name(&self) -> OsString;
+
+    /// Posix: get file name size.
+    fn get_name_size(&self) -> u16;
+
+    /// RAFS V5: get RAFS v5 specific inode flags.
+    fn flags(&self) -> u64;
+
+    /// RAFS v5: get digest value of the inode metadata.
+    fn get_digest(&self) -> RafsDigest;
+
+    /// RAFS v5: get chunk info object by chunk index, chunk index starts from 0.
+    fn get_chunk_info(&self, idx: u32) -> Result<Arc<dyn BlobChunkInfo>>;
 }
 
 /// Trait to write out RAFS filesystem meta objects into the metadata blob.
@@ -335,6 +337,7 @@ impl RafsSuperMeta {
         self.version == RAFS_SUPER_VERSION_V6
     }
 
+    /// Check whether the RAFS instance is a chunk dictionary.
     pub fn is_chunk_dict(&self) -> bool {
         self.is_chunk_dict
     }
@@ -404,8 +407,14 @@ impl Default for RafsSuperMeta {
 pub enum RafsMode {
     /// Directly mapping and accessing metadata into process by mmap().
     Direct,
-    /// Read metadata into memory before using.
+    /// Read metadata into memory before using, for RAFS v5.
     Cached,
+}
+
+impl Default for RafsMode {
+    fn default() -> Self {
+        RafsMode::Direct
+    }
 }
 
 impl FromStr for RafsMode {
@@ -492,22 +501,6 @@ impl RafsSuper {
         Ok(rs)
     }
 
-    pub fn load_chunk_dict_from_metadata(path: &Path) -> Result<Self> {
-        // open bootstrap file
-        let file = OpenOptions::new().read(true).write(false).open(path)?;
-        let mut rs = RafsSuper {
-            mode: RafsMode::Direct,
-            validate_digest: true,
-            ..Default::default()
-        };
-        let mut reader = Box::new(file) as RafsIoReader;
-
-        rs.meta.is_chunk_dict = true;
-        rs.load(&mut reader)?;
-
-        Ok(rs)
-    }
-
     /// Load RAFS metadata and optionally cache inodes.
     pub fn load(&mut self, r: &mut RafsIoReader) -> Result<()> {
         // Try to load the filesystem as Rafs v5
@@ -532,62 +525,33 @@ impl RafsSuper {
         self.superblock.update(r)
     }
 
-    /// Store RAFS metadata to backend storage.
-    pub fn store(&self, w: &mut dyn RafsIoWrite) -> Result<usize> {
-        if self.meta.is_v5() {
-            return self.store_v5(w);
-        }
-
-        Err(einval!("invalid superblock version number"))
-    }
-
-    /// Get an inode from an inode number, optionally validating the inode metadata.
-    pub fn get_inode(&self, ino: Inode, digest_validate: bool) -> Result<Arc<dyn RafsInode>> {
-        self.superblock.get_inode(ino, digest_validate)
-    }
-
     /// Get the maximum inode number supported by the filesystem instance.
     pub fn get_max_ino(&self) -> Inode {
         self.superblock.get_max_ino()
     }
 
-    /// Convert an inode number to a file path.
-    pub fn path_from_ino(&self, ino: Inode) -> Result<PathBuf> {
-        if ino == self.superblock.root_ino() {
-            return Ok(self.get_inode(ino, false)?.name().into());
-        }
+    /// Get the `RafsInode` object corresponding to `ino`.
+    pub fn get_inode(&self, ino: Inode, validate_inode: bool) -> Result<Arc<dyn RafsInode>> {
+        self.superblock.get_inode(ino, validate_inode)
+    }
 
-        let mut path = PathBuf::new();
-        let mut cur_ino = ino;
-        let mut inode;
-
-        loop {
-            inode = self.get_inode(cur_ino, false)?;
-            let e: PathBuf = inode.name().into();
-            path = e.join(path);
-
-            if inode.ino() == self.superblock.root_ino() {
-                break;
-            } else {
-                cur_ino = inode.parent();
-            }
-        }
-
-        Ok(path)
+    /// Get the `RafsInodeExt` object corresponding to `ino`.
+    pub fn get_extended_inode(
+        &self,
+        ino: Inode,
+        validate_inode: bool,
+    ) -> Result<Arc<dyn RafsInodeExt>> {
+        self.superblock.get_extended_inode(ino, validate_inode)
     }
 
     /// Convert a file path to an inode number.
-    pub fn ino_from_path(&self, f: &Path) -> Result<u64> {
+    pub fn ino_from_path(&self, f: &Path) -> Result<Inode> {
         let root_ino = self.superblock.root_ino();
         if f == Path::new("/") {
             return Ok(root_ino);
-        }
-
-        if !f.starts_with("/") {
+        } else if !f.starts_with("/") {
             return Err(einval!());
         }
-
-        let mut parent = self.get_inode(root_ino, self.validate_digest)?;
 
         let entries = f
             .components()
@@ -599,24 +563,23 @@ impl RafsSuper {
                 _ => None,
             })
             .collect::<Vec<_>>();
-
         if entries.is_empty() {
             warn!("Path can't be parsed {:?}", f);
             return Err(enoent!());
         }
 
+        let mut parent = self.get_extended_inode(root_ino, self.validate_digest)?;
         for p in entries {
-            if p.is_none() {
-                error!("Illegal specified path {:?}", f);
-                return Err(einval!());
-            }
-
-            // Safe because it already checks if p is None above.
-            match parent.get_child_by_name(p.unwrap()) {
-                Ok(p) => parent = p,
-                Err(_) => {
-                    warn!("File {:?} not in rafs", p.unwrap());
-                    return Err(enoent!());
+            match p {
+                None => {
+                    error!("Illegal specified path {:?}", f);
+                    return Err(einval!());
+                }
+                Some(name) => {
+                    parent = parent.get_child_by_name(name).map_err(|e| {
+                        warn!("File {:?} not in RAFS filesystem, {}", name, e);
+                        enoent!()
+                    })?;
                 }
             }
         }
@@ -743,6 +706,51 @@ impl RafsSuper {
 
         Ok(())
     }
+}
+
+// For nydus-image
+impl RafsSuper {
+    /// Load Rafs super block from a metadata file for a chunk dictionary.
+    pub fn load_chunk_dict_from_metadata(path: &Path) -> Result<Self> {
+        // open bootstrap file
+        let file = OpenOptions::new().read(true).write(false).open(path)?;
+        let mut rs = RafsSuper {
+            mode: RafsMode::Direct,
+            validate_digest: true,
+            ..Default::default()
+        };
+        let mut reader = Box::new(file) as RafsIoReader;
+
+        rs.meta.is_chunk_dict = true;
+        rs.load(&mut reader)?;
+
+        Ok(rs)
+    }
+
+    /// Convert an inode number to a file path.
+    pub fn path_from_ino(&self, ino: Inode) -> Result<PathBuf> {
+        if ino == self.superblock.root_ino() {
+            return Ok(self.get_extended_inode(ino, false)?.name().into());
+        }
+
+        let mut path = PathBuf::new();
+        let mut cur_ino = ino;
+        let mut inode;
+
+        loop {
+            inode = self.get_extended_inode(cur_ino, false)?;
+            let e: PathBuf = inode.name().into();
+            path = e.join(path);
+
+            if inode.ino() == self.superblock.root_ino() {
+                break;
+            } else {
+                cur_ino = inode.parent();
+            }
+        }
+
+        Ok(path)
+    }
 
     /// Get prefetched inos
     pub fn get_prefetched_inos(&self, bootstrap: &mut RafsIoReader) -> Result<Vec<u32>> {
@@ -765,42 +773,49 @@ impl RafsSuper {
         }
     }
 
-    /// Walkthrough the file tree rooted at ino, calling cb for each file or directory
+    /// Walk through the file tree rooted at ino, calling cb for each file or directory
     /// in the tree by DFS order, including ino, please ensure ino is a directory.
-    pub fn walk_dir(
+    pub fn walk_directory<P: AsRef<Path>>(
         &self,
         ino: Inode,
-        parent: Option<&PathBuf>,
-        cb: &mut dyn FnMut(&dyn RafsInode, &Path) -> anyhow::Result<()>,
+        parent: Option<P>,
+        cb: &mut dyn FnMut(&dyn RafsInodeExt, &Path) -> anyhow::Result<()>,
     ) -> anyhow::Result<()> {
-        let inode = self.get_inode(ino, false)?;
+        let inode = self.get_extended_inode(ino, false)?;
         if !inode.is_dir() {
             bail!("inode {} is not a directory", ino);
         }
-        self.walk_dir_inner(inode.as_ref(), parent, cb)
+        self.do_walk_directory(inode.deref(), parent, cb)
     }
 
-    fn walk_dir_inner(
+    fn do_walk_directory<P: AsRef<Path>>(
         &self,
-        inode: &dyn RafsInode,
-        parent: Option<&PathBuf>,
-        cb: &mut dyn FnMut(&dyn RafsInode, &Path) -> anyhow::Result<()>,
+        inode: &dyn RafsInodeExt,
+        parent: Option<P>,
+        cb: &mut dyn FnMut(&dyn RafsInodeExt, &Path) -> anyhow::Result<()>,
     ) -> anyhow::Result<()> {
         let path = if let Some(parent) = parent {
-            parent.join(inode.name())
+            parent.as_ref().join(inode.name())
         } else {
             PathBuf::from("/")
         };
         cb(inode, &path)?;
-        if !inode.is_dir() {
-            return Ok(());
-        }
-        let child_count = inode.get_child_count();
-        for idx in 0..child_count {
-            let child = inode.get_child_by_index(idx)?;
-            self.walk_dir_inner(child.as_ref(), Some(&path), cb)?;
+        if inode.is_dir() {
+            for idx in 0..inode.get_child_count() {
+                let child = inode.get_child_by_index(idx)?;
+                self.do_walk_directory(child.deref(), Some(&path), cb)?;
+            }
         }
         Ok(())
+    }
+
+    /// Store RAFS metadata to backend storage.
+    pub fn store(&self, w: &mut dyn RafsIoWrite) -> Result<usize> {
+        if self.meta.is_v5() {
+            return self.store_v5(w);
+        }
+
+        Err(einval!("invalid superblock version number"))
     }
 }
 

--- a/rafs/src/metadata/noop.rs
+++ b/rafs/src/metadata/noop.rs
@@ -7,11 +7,10 @@
 use std::io::Result;
 use std::sync::Arc;
 
-use nydus_utils::digest;
 use storage::device::BlobInfo;
 
 use crate::metadata::{Inode, RafsInode, RafsSuperBlock, RafsSuperInodes};
-use crate::{RafsIoReader, RafsResult};
+use crate::{RafsInodeExt, RafsIoReader, RafsResult};
 
 #[derive(Default)]
 pub struct NoopSuperBlock {}
@@ -31,12 +30,11 @@ impl RafsSuperInodes for NoopSuperBlock {
         unimplemented!()
     }
 
-    fn validate_digest(
+    fn get_extended_inode(
         &self,
-        _inode: Arc<dyn RafsInode>,
-        _recursive: bool,
-        _digester: digest::Algorithm,
-    ) -> Result<bool> {
+        _ino: Inode,
+        _validate_digest: bool,
+    ) -> Result<Arc<dyn RafsInodeExt>> {
         unimplemented!()
     }
 }

--- a/rafs/src/mock/mock_chunk.rs
+++ b/rafs/src/mock/mock_chunk.rs
@@ -54,10 +54,6 @@ impl BlobChunkInfo for MockChunkInfo {
         self.c_flags.contains(BlobChunkFlags::COMPRESSED)
     }
 
-    fn is_hole(&self) -> bool {
-        self.c_flags.contains(BlobChunkFlags::HOLECHUNK)
-    }
-
     fn chunk_id(&self) -> &RafsDigest {
         &self.c_block_id
     }

--- a/rafs/src/mock/mock_inode.rs
+++ b/rafs/src/mock/mock_inode.rs
@@ -19,8 +19,7 @@ use nydus_utils::{digest::RafsDigest, ByteSize};
 use super::mock_chunk::MockChunkInfo;
 use super::mock_super::CHUNK_SIZE;
 use crate::metadata::layout::v5::{
-    rafsv5_alloc_bio_vecs, RafsV5BlobTable, RafsV5InodeChunkOps, RafsV5InodeFlags,
-    RafsV5InodeOps,
+    rafsv5_alloc_bio_vecs, RafsV5BlobTable, RafsV5InodeChunkOps, RafsV5InodeFlags, RafsV5InodeOps,
 };
 use crate::metadata::{
     layout::{XattrName, XattrValue},

--- a/rafs/src/mock/mock_inode.rs
+++ b/rafs/src/mock/mock_inode.rs
@@ -19,7 +19,7 @@ use nydus_utils::{digest::RafsDigest, ByteSize};
 use super::mock_chunk::MockChunkInfo;
 use super::mock_super::CHUNK_SIZE;
 use crate::metadata::layout::v5::{
-    rafsv5_alloc_bio_vecs, RafsV5BlobTable, RafsV5Inode, RafsV5InodeChunkOps, RafsV5InodeFlags,
+    rafsv5_alloc_bio_vecs, RafsV5BlobTable, RafsV5InodeChunkOps, RafsV5InodeFlags,
     RafsV5InodeOps,
 };
 use crate::metadata::{
@@ -280,9 +280,5 @@ impl RafsV5InodeOps for MockInode {
 
     fn has_hole(&self) -> bool {
         false
-    }
-
-    fn cast_ondisk(&self) -> Result<RafsV5Inode> {
-        unimplemented!()
     }
 }

--- a/rafs/src/mock/mock_super.rs
+++ b/rafs/src/mock/mock_super.rs
@@ -7,15 +7,15 @@ use std::collections::HashMap;
 use std::io::Result;
 use std::sync::Arc;
 
-use nydus_utils::digest;
-use storage::device::BlobInfo;
+use nydus_storage::device::BlobInfo;
 
 use crate::metadata::{Inode, RafsInode, RafsSuperBlock, RafsSuperInodes};
-use crate::{RafsIoReader, RafsResult};
+use crate::mock::MockInode;
+use crate::{RafsInodeExt, RafsIoReader, RafsResult};
 
 #[derive(Default)]
 pub struct MockSuperBlock {
-    pub inodes: HashMap<Inode, Arc<dyn RafsInode + Send + Sync>>,
+    pub inodes: HashMap<Inode, Arc<MockInode>>,
 }
 
 pub const CHUNK_SIZE: u32 = 200;
@@ -32,18 +32,21 @@ impl RafsSuperInodes for MockSuperBlock {
     fn get_max_ino(&self) -> Inode {
         unimplemented!()
     }
-    fn get_inode(&self, ino: Inode, _digest_validate: bool) -> Result<Arc<dyn RafsInode>> {
+
+    fn get_inode(&self, ino: Inode, _validate_inode: bool) -> Result<Arc<dyn RafsInode>> {
         self.inodes
             .get(&ino)
             .map_or(Err(enoent!()), |i| Ok(i.clone()))
     }
-    fn validate_digest(
+
+    fn get_extended_inode(
         &self,
-        _inode: Arc<dyn RafsInode>,
-        _recursive: bool,
-        _digester: digest::Algorithm,
-    ) -> Result<bool> {
-        unimplemented!()
+        ino: Inode,
+        _validate_inode: bool,
+    ) -> Result<Arc<dyn RafsInodeExt>> {
+        self.inodes
+            .get(&ino)
+            .map_or(Err(enoent!()), |i| Ok(i.clone()))
     }
 }
 

--- a/src/bin/nydus-image/core/bootstrap.rs
+++ b/src/bin/nydus-image/core/bootstrap.rs
@@ -20,7 +20,7 @@ use rafs::metadata::layout::v6::{
 };
 use rafs::metadata::layout::RafsBlobTable;
 
-use rafs::metadata::layout::RAFS_ROOT_INODE;
+use rafs::metadata::layout::RAFS_V5_ROOT_INODE;
 use rafs::metadata::{RafsMode, RafsStore, RafsSuper};
 
 use super::context::{BlobManager, BootstrapContext, BootstrapManager, BuildContext, SourceType};
@@ -60,10 +60,10 @@ impl Bootstrap {
         bootstrap_ctx: &mut BootstrapContext,
         tree: &mut Tree,
     ) -> Result<()> {
-        tree.node.index = RAFS_ROOT_INODE;
+        tree.node.index = RAFS_V5_ROOT_INODE;
         // Rafs v6 root inode number can't be decided until the end of dumping.
         if ctx.fs_version.is_v5() {
-            tree.node.inode.set_ino(RAFS_ROOT_INODE);
+            tree.node.inode.set_ino(RAFS_V5_ROOT_INODE);
         }
         // Filesystem walking skips root inode within subsequent while loop, however, we allow
         // user to pass the source root as prefetch hint. Check it here.

--- a/src/bin/nydus-image/core/node.rs
+++ b/src/bin/nydus-image/core/node.rs
@@ -36,7 +36,7 @@ use nydus_rafs::metadata::layout::v6::{
     EROFS_INODE_CHUNK_BASED, EROFS_INODE_FLAT_INLINE, EROFS_INODE_FLAT_PLAIN,
 };
 use nydus_rafs::metadata::layout::RafsXAttrs;
-use nydus_rafs::metadata::{Inode, RafsInode, RafsStore};
+use nydus_rafs::metadata::{Inode, RafsInodeExt, RafsStore};
 use nydus_rafs::RafsIoWrite;
 use nydus_storage::device::v5::BlobV5ChunkInfo;
 use nydus_storage::device::{BlobChunkFlags, BlobChunkInfo};
@@ -1383,7 +1383,7 @@ impl InodeWrapper {
         }
     }
 
-    pub fn from_inode_info(inode: &dyn RafsInode) -> Self {
+    pub fn from_inode_info(inode: &dyn RafsInodeExt) -> Self {
         if let Some(inode) = inode.as_any().downcast_ref::<CachedInodeV5>() {
             InodeWrapper::V5(to_rafsv5_inode(inode))
         } else if let Some(inode) = inode.as_any().downcast_ref::<OndiskInodeWrapperV5>() {
@@ -1940,7 +1940,7 @@ impl Display for ChunkWrapper {
 }
 
 /// Construct a `RafsV5Inode` object from a `Arc<dyn RafsInode>` object.
-fn to_rafsv5_inode(inode: &dyn RafsInode) -> RafsV5Inode {
+fn to_rafsv5_inode(inode: &dyn RafsInodeExt) -> RafsV5Inode {
     let attr = inode.get_attr();
 
     RafsV5Inode {

--- a/src/bin/nydus-image/merge.rs
+++ b/src/bin/nydus-image/merge.rs
@@ -4,13 +4,14 @@
 
 use std::collections::HashSet;
 use std::convert::TryFrom;
+use std::ops::Deref;
 use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result};
 
 use nydus_utils::compress;
 use nydus_utils::digest::{self};
-use rafs::metadata::{RafsInode, RafsMode, RafsSuper, RafsSuperMeta};
+use rafs::metadata::{RafsInodeExt, RafsMode, RafsSuper, RafsSuperMeta};
 
 use crate::core::bootstrap::Bootstrap;
 use crate::core::chunk_dict::HashChunkDict;
@@ -141,12 +142,12 @@ impl Merger {
 
             if let Some(tree) = &mut tree {
                 let mut nodes = Vec::new();
-                rs.walk_dir(
+                rs.walk_directory::<PathBuf>(
                     rs.superblock.root_ino(),
                     None,
-                    &mut |inode: &dyn RafsInode, path: &Path| -> Result<()> {
+                    &mut |inode: &dyn RafsInodeExt, path: &Path| -> Result<()> {
                         let mut node =
-                            MetadataTreeBuilder::parse_node(&rs, inode, path.to_path_buf())
+                            MetadataTreeBuilder::parse_node(&rs, inode.deref(), path.to_path_buf())
                                 .context(format!(
                                     "parse node from bootstrap {:?}",
                                     bootstrap_path

--- a/src/bin/nydus-image/unpack/mod.rs
+++ b/src/bin/nydus-image/unpack/mod.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use anyhow::{Context, Result};
 use nydus_api::http::LocalFsConfig;
 use nydus_rafs::{
-    metadata::{RafsInode, RafsMode, RafsSuper},
+    metadata::{RafsInodeExt, RafsMode, RafsSuper},
     RafsIoReader, RafsIterator,
 };
 use storage::{
@@ -100,7 +100,7 @@ impl Unpacker for OCIUnpacker {
 }
 
 trait TarBuilder {
-    fn append(&mut self, node: &dyn RafsInode, path: &Path) -> Result<()>;
+    fn append(&mut self, node: &dyn RafsInodeExt, path: &Path) -> Result<()>;
 }
 
 struct TarSection {
@@ -109,8 +109,8 @@ struct TarSection {
 }
 
 trait SectionBuilder {
-    fn can_handle(&mut self, inode: &dyn RafsInode, path: &Path) -> bool;
-    fn build(&self, inode: &dyn RafsInode, path: &Path) -> Result<Vec<TarSection>>;
+    fn can_handle(&mut self, inode: &dyn RafsInodeExt, path: &Path) -> bool;
+    fn build(&self, inode: &dyn RafsInodeExt, path: &Path) -> Result<Vec<TarSection>>;
 }
 
 struct OCITarBuilderFactory {}
@@ -243,7 +243,7 @@ impl OCITarBuilder {
 }
 
 impl TarBuilder for OCITarBuilder {
-    fn append(&mut self, inode: &dyn RafsInode, path: &Path) -> Result<()> {
+    fn append(&mut self, inode: &dyn RafsInodeExt, path: &Path) -> Result<()> {
         for builder in &mut self.builders {
             // Useless one, just go !!!!!
             if !builder.can_handle(inode, path) {

--- a/src/bin/nydus-image/unpack/pax/test.rs
+++ b/src/bin/nydus-image/unpack/pax/test.rs
@@ -98,10 +98,6 @@ impl BlobChunkInfo for MockChunkInfo {
         todo!();
     }
 
-    fn is_hole(&self) -> bool {
-        todo!();
-    }
-
     fn blob_index(&self) -> u32 {
         todo!();
     }

--- a/storage/src/cache/state/blob_state_map.rs
+++ b/storage/src/cache/state/blob_state_map.rs
@@ -433,10 +433,6 @@ pub(crate) mod tests {
             unimplemented!();
         }
 
-        fn is_hole(&self) -> bool {
-            unimplemented!();
-        }
-
         fn as_any(&self) -> &dyn Any {
             self
         }

--- a/storage/src/device.rs
+++ b/storage/src/device.rs
@@ -346,7 +346,7 @@ bitflags! {
         /// Chunk data is compressed.
         const COMPRESSED = 0x0000_0001;
         /// Chunk is a hole, with all data as zero.
-        const HOLECHUNK = 0x0000_0002;
+        const _HOLECHUNK = 0x0000_0002;
     }
 }
 
@@ -397,9 +397,6 @@ pub trait BlobChunkInfo: Any + Sync + Send {
     /// Some chunk may become bigger after compression, so plain data instead of compressed
     /// data may be stored in the compressed data blob for those chunks.
     fn is_compressed(&self) -> bool;
-
-    /// Check whether the chunk is a hole, containing all zeros.
-    fn is_hole(&self) -> bool;
 
     fn as_any(&self) -> &dyn Any;
 }
@@ -483,10 +480,6 @@ impl BlobChunkInfo for BlobIoChunk {
 
     fn is_compressed(&self) -> bool {
         self.as_base().is_compressed()
-    }
-
-    fn is_hole(&self) -> bool {
-        self.as_base().is_hole()
     }
 
     fn as_any(&self) -> &dyn Any {
@@ -1219,7 +1212,6 @@ mod tests {
         assert_eq!(iochunk.uncompressed_offset(), 0x2000);
         assert_eq!(iochunk.uncompressed_size(), 0x200);
         assert!(!iochunk.is_compressed());
-        assert!(!iochunk.is_hole());
     }
 
     #[test]

--- a/storage/src/meta/mod.rs
+++ b/storage/src/meta/mod.rs
@@ -829,10 +829,6 @@ impl BlobChunkInfo for BlobMetaChunk {
         self.meta.chunks[self.chunk_index].is_compressed()
     }
 
-    fn is_hole(&self) -> bool {
-        false
-    }
-
     fn as_any(&self) -> &dyn Any {
         self
     }
@@ -973,7 +969,6 @@ mod tests {
         assert_eq!(vec[0].uncompressed_offset(), 0);
         assert_eq!(vec[0].uncompressed_size(), 0x1001);
         assert!(vec[0].is_compressed());
-        assert!(!vec[0].is_hole());
 
         let vec = info.get_chunks_uncompressed(0x0, 0x4000, 0).unwrap();
         assert_eq!(vec.len(), 2);
@@ -984,7 +979,6 @@ mod tests {
         assert_eq!(vec[1].uncompressed_offset(), 0x2000);
         assert_eq!(vec[1].uncompressed_size(), 0x2000);
         assert!(!vec[1].is_compressed());
-        assert!(!vec[1].is_hole());
 
         let vec = info.get_chunks_uncompressed(0x0, 0x4001, 0).unwrap();
         assert_eq!(vec.len(), 3);

--- a/storage/src/test.rs
+++ b/storage/src/test.rs
@@ -86,9 +86,6 @@ impl BlobChunkInfo for MockChunkInfo {
     fn is_compressed(&self) -> bool {
         self.flags.contains(BlobChunkFlags::COMPRESSED)
     }
-    fn is_hole(&self) -> bool {
-        self.flags.contains(BlobChunkFlags::HOLECHUNK)
-    }
 
     fn as_any(&self) -> &dyn Any {
         self

--- a/tests/builder.rs
+++ b/tests/builder.rs
@@ -2,15 +2,15 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use nix::sys::stat::{dev_t, mknod, Mode, SFlag};
-use nydus_utils::compact::makedev;
 use std::fs::{self, File};
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::os::unix::fs as unix_fs;
 use std::path::{Path, PathBuf};
-use tar::Header;
 
+use nix::sys::stat::{dev_t, mknod, Mode, SFlag};
+use nydus_utils::compact::makedev;
 use nydus_utils::exec;
+use tar::Header;
 
 pub struct Builder<'a> {
     builder: String,

--- a/utils/src/compress/mod.rs
+++ b/utils/src/compress/mod.rs
@@ -73,6 +73,24 @@ impl TryFrom<u32> for Algorithm {
     }
 }
 
+impl TryFrom<u64> for Algorithm {
+    type Error = ();
+
+    fn try_from(value: u64) -> std::result::Result<Self, Self::Error> {
+        if value == Algorithm::None as u64 {
+            Ok(Algorithm::None)
+        } else if value == Algorithm::Lz4Block as u64 {
+            Ok(Algorithm::Lz4Block)
+        } else if value == Algorithm::GZip as u64 {
+            Ok(Algorithm::GZip)
+        } else if value == Algorithm::Zstd as u64 {
+            Ok(Algorithm::Zstd)
+        } else {
+            Err(())
+        }
+    }
+}
+
 impl Algorithm {
     pub fn is_none(self) -> bool {
         self == Self::None

--- a/utils/src/digest.rs
+++ b/utils/src/digest.rs
@@ -51,10 +51,24 @@ impl FromStr for Algorithm {
 impl TryFrom<u32> for Algorithm {
     type Error = ();
 
-    fn try_from(value: u32) -> std::result::Result<Self, Self::Error> {
+    fn try_from(value: u32) -> Result<Self, Self::Error> {
         if value == Algorithm::Sha256 as u32 {
             Ok(Algorithm::Sha256)
         } else if value == Algorithm::Blake3 as u32 {
+            Ok(Algorithm::Blake3)
+        } else {
+            Err(())
+        }
+    }
+}
+
+impl TryFrom<u64> for Algorithm {
+    type Error = ();
+
+    fn try_from(value: u64) -> Result<Self, Self::Error> {
+        if value == Algorithm::Sha256 as u64 {
+            Ok(Algorithm::Sha256)
+        } else if value == Algorithm::Blake3 as u64 {
             Ok(Algorithm::Blake3)
         } else {
             Err(())


### PR DESCRIPTION
The `RafsInode` is designed according to Rafs v5, which causes some problems when enabling Rafs v6.
So split it into `RafsInode` and `RafsInodeExt. Among those, `RafsInode` is used to provide methods which are generic to v5/v6 and runtime/builder, `RafsInodeExt` provides version specific methods or methods for builder.

Along the way also do:
1) clean up some unused code
2) rename RAFS_ROOT_INODE to RAFS_V5_ROOT_INODE
3) add more unit test cases
4) add some helpers function related to v5 to simplify implementation