### PR TITLE
nydus-image: fix rafs v6 to get file's parent inode

### DIFF
--- a/rafs/src/metadata/cached_v5.rs
+++ b/rafs/src/metadata/cached_v5.rs
@@ -606,6 +606,10 @@ impl RafsInode for CachedInodeV5 {
         self
     }
 
+    fn file_parent_inode(&self) -> Result<Inode> {
+        Ok(self.i_parent)
+    }
+
     impl_getter!(ino, i_ino, u64);
     impl_getter!(parent, i_parent, u64);
     impl_getter!(size, i_size, u64);

--- a/rafs/src/metadata/direct_v5.rs
+++ b/rafs/src/metadata/direct_v5.rs
@@ -842,6 +842,12 @@ impl RafsInode for OndiskInodeWrapper {
         self
     }
 
+    fn file_parent_inode(&self) -> Result<Inode> {
+        let state = self.state();
+        let inode = self.inode(state.deref());
+        Ok(inode.i_parent)
+    }
+
     impl_inode_wrapper!(is_dir, bool);
     impl_inode_wrapper!(is_reg, bool);
     impl_inode_wrapper!(is_symlink, bool);

--- a/rafs/src/metadata/mod.rs
+++ b/rafs/src/metadata/mod.rs
@@ -225,6 +225,9 @@ pub trait RafsInode: Any {
         }
         Ok(())
     }
+
+    // Get parent inode of the file inode
+    fn file_parent_inode(&self) -> Result<Inode>;
 }
 
 /// Trait to store Rafs meta block and validate alignment.

--- a/rafs/src/mock/mock_inode.rs
+++ b/rafs/src/mock/mock_inode.rs
@@ -245,6 +245,10 @@ impl RafsInode for MockInode {
         self
     }
 
+    fn file_parent_inode(&self) -> Result<Inode> {
+        Ok(self.i_parent)
+    }
+
     impl_getter!(ino, i_ino, u64);
     impl_getter!(parent, i_parent, u64);
     impl_getter!(size, i_size, u64);


### PR DESCRIPTION
Currently, the parent of file is None,
we can set the parent inode by traversing root directory.
This PR is addressing #768 

Signed-off-by: Bin Tang <tangbin.bin@bytedance.com>