### PR TITLE
rafs: fix bug in handling extended attributes

### DIFF
--- a/rafs/src/metadata/cached_v5.rs
+++ b/rafs/src/metadata/cached_v5.rs
@@ -774,8 +774,12 @@ mod cached_tests {
         let mut ondisk_inode = RafsV5Inode::new();
         let file_name = OsString::from("c_inode_1");
         let mut xattr = RafsXAttrs::default();
-        xattr.add2("user.k1", vec![1u8, 2u8, 3u8, 4u8]).unwrap();
-        xattr.add2("user.k2", vec![10u8, 11u8, 12u8]).unwrap();
+        xattr
+            .add(OsString::from("user.k1"), vec![1u8, 2u8, 3u8, 4u8])
+            .unwrap();
+        xattr
+            .add(OsString::from("user.k2"), vec![10u8, 11u8, 12u8])
+            .unwrap();
         ondisk_inode.i_name_size = file_name.byte_size() as u16;
         ondisk_inode.i_child_count = 1;
         ondisk_inode.i_ino = 3;

--- a/rafs/src/metadata/layout/v5.rs
+++ b/rafs/src/metadata/layout/v5.rs
@@ -1888,11 +1888,11 @@ pub mod tests {
         assert_eq!(xattrs.size(), 0);
 
         xattrs
-            .add2("user.key1", vec![0x1u8, 0x2, 0x3, 0x4])
+            .add(OsString::from("user.key1"), vec![0x1u8, 0x2, 0x3, 0x4])
             .unwrap();
         assert_eq!(xattrs.size(), 18);
         xattrs
-            .add2("user.key21", vec![0x1u8, 0x2, 0x3, 0x4])
+            .add(OsString::from("user.key21"), vec![0x1u8, 0x2, 0x3, 0x4])
             .unwrap();
         assert_eq!(xattrs.size(), 37);
         xattrs.remove(&OsString::from("user.key1"));

--- a/rafs/src/metadata/layout/v6.rs
+++ b/rafs/src/metadata/layout/v6.rs
@@ -2003,8 +2003,8 @@ mod tests {
     #[test]
     fn test_rafs_xattr_count_v6() {
         let mut xattrs = RafsXAttrs::new();
-        xattrs.add2("user.a", vec![1u8]).unwrap();
-        xattrs.add2("trusted.b", vec![2u8]).unwrap();
+        xattrs.add(OsString::from("user.a"), vec![1u8]).unwrap();
+        xattrs.add(OsString::from("trusted.b"), vec![2u8]).unwrap();
 
         assert_eq!(xattrs.count_v6(), 5);
 
@@ -2015,8 +2015,8 @@ mod tests {
     #[test]
     fn test_rafs_xattr_size_v6() {
         let mut xattrs = RafsXAttrs::new();
-        xattrs.add2("user.a", vec![1u8]).unwrap();
-        xattrs.add2("trusted.b", vec![2u8]).unwrap();
+        xattrs.add(OsString::from("user.a"), vec![1u8]).unwrap();
+        xattrs.add(OsString::from("trusted.b"), vec![2u8]).unwrap();
 
         let size = 12 + 8 + 8;
         assert_eq!(xattrs.aligned_size_v6(), size);
@@ -2025,8 +2025,10 @@ mod tests {
         assert_eq!(xattrs2.aligned_size_v6(), 0);
 
         let mut xattrs2 = RafsXAttrs::new();
-        xattrs2.add2("user.a", vec![1u8]).unwrap();
-        xattrs2.add2("unknown.b", vec![2u8]).unwrap_err();
+        xattrs2.add(OsString::from("user.a"), vec![1u8]).unwrap();
+        xattrs2
+            .add(OsString::from("unknown.b"), vec![2u8])
+            .unwrap_err();
     }
 
     #[test]
@@ -2046,8 +2048,10 @@ mod tests {
         let mut reader: Box<dyn RafsIoRead> = Box::new(r);
 
         let mut xattrs = RafsXAttrs::new();
-        xattrs.add2("user.nydus", vec![1u8]).unwrap();
-        xattrs.add2("security.rafs", vec![2u8, 3u8]).unwrap();
+        xattrs.add(OsString::from("user.nydus"), vec![1u8]).unwrap();
+        xattrs
+            .add(OsString::from("security.rafs"), vec![2u8, 3u8])
+            .unwrap();
         xattrs.store_v6(&mut writer).unwrap();
         writer.flush().unwrap();
 

--- a/src/bin/nydus-image/builder/stargz.rs
+++ b/src/bin/nydus-image/builder/stargz.rs
@@ -502,7 +502,7 @@ impl StargzIndexTreeBuilder {
                         entry_path, name,
                     )
                 })?;
-                xattrs.add2(name, value)?;
+                xattrs.add(OsString::from(name), value)?;
             }
         }
 


### PR DESCRIPTION
Extended attribute's key/name may not be UTF-8 encoded, so don't assume that.

Signed-off-by: Jiang Liu <gerry@linux.alibaba.com>