### PR TITLE
nydusd: enlarge default fuse server threads

### DIFF
--- a/src/bin/nydusd/main.rs
+++ b/src/bin/nydusd/main.rs
@@ -263,7 +263,7 @@ fn append_fuse_options(app: App<'static, 'static>) -> App<'static, 'static> {
         Arg::with_name("threads")
             .long("thread-num")
             .short("T")
-            .default_value("1")
+            .default_value("4")
             .help("Number of worker threads to serve IO requests")
             .takes_value(true)
             .required(false)


### PR DESCRIPTION
Now the default value is only 1, it affects performance.

Signed-off-by: Changwei Ge <gechangwei@bytedance.com>