### PR TITLE
fix mirror's performance issue

### DIFF
--- a/api/src/http.rs
+++ b/api/src/http.rs
@@ -401,10 +401,17 @@ impl Default for ProxyConfig {
 /// Configuration for mirror.
 #[derive(Clone, Deserialize, Serialize, Debug)]
 pub struct MirrorConfig {
-    /// Mirror server URL, for example http://127.0.0.1:65001
+    /// Mirror server URL, for example http://127.0.0.1:65001.
     pub host: String,
-    /// HTTP request headers to be passed to mirror server
-    pub headers: Option<HashMap<String, String>>,
+    /// HTTP request headers to be passed to mirror server.
+    #[serde(default)]
+    pub headers: HashMap<String, String>,
+    /// Whether the authorization process is through mirror? default false.
+    /// true: authorization through mirror, e.g. Using normal registry as mirror.
+    /// false: authorization through original registry,
+    /// e.g. when using Dragonfly server as mirror, authorization through it will affect performance.
+    #[serde(default)]
+    pub auth_through: bool,
 }
 
 #[derive(Debug)]

--- a/docs/nydusd.md
+++ b/docs/nydusd.md
@@ -256,6 +256,9 @@ Currently, the mirror mode is only tested in the registry backend, and in theory
           {
             // Mirror server URL (including scheme), e.g. Dragonfly dfdaemon server URL
             "host": "http://dragonfly1.io:65001",
+            // true: Send the authorization request to the mirror e.g. another docker registry.
+            // false: Authorization request won't be relayed by the mirror e.g. Dragonfly.
+            "auth_through": false,
             // Headers for mirror server
             "headers": {
               // For Dragonfly dfdaemon server URL, we need to specify "X-Dragonfly-Registry" (including scheme).

--- a/storage/src/backend/oss.rs
+++ b/storage/src/backend/oss.rs
@@ -138,7 +138,15 @@ impl BlobReader for OssReader {
 
         let resp = self
             .connection
-            .call::<&[u8]>(Method::HEAD, url.as_str(), None, None, &mut headers, true)
+            .call::<&[u8]>(
+                Method::HEAD,
+                url.as_str(),
+                None,
+                None,
+                &mut headers,
+                true,
+                false,
+            )
             .map_err(OssError::Request)?;
         let content_length = resp
             .headers()
@@ -173,7 +181,15 @@ impl BlobReader for OssReader {
         // Safe because the the call() is a synchronous operation.
         let mut resp = self
             .connection
-            .call::<&[u8]>(Method::GET, url.as_str(), None, None, &mut headers, true)
+            .call::<&[u8]>(
+                Method::GET,
+                url.as_str(),
+                None,
+                None,
+                &mut headers,
+                true,
+                false,
+            )
             .map_err(OssError::Request)?;
         Ok(resp
             .copy_to(&mut buf)


### PR DESCRIPTION
In some scenarios(e.g. P2P/Dragonfly), sending an authorization request to the mirror will cause performance loss. We add parameter auth_through. When auth_through is false, nydusd will directly send non-authorization request to original registry.

Fixes https://github.com/dragonflyoss/Dragonfly2/issues/1678

Signed-off-by: Bin Tang <tangbin.bin@bytedance.com>