### PR TITLE
nydusify: fix overlay error for image with single layer

### DIFF
--- a/contrib/nydusify/pkg/checker/rule/filesystem.go
+++ b/contrib/nydusify/pkg/checker/rule/filesystem.go
@@ -205,14 +205,15 @@ func (rule *FilesystemRule) pullSourceImage() (*tool.Image, error) {
 func (rule *FilesystemRule) mountSourceImage() (*tool.Image, error) {
 	logrus.Infof("Mounting source image to %s", rule.SourceMountPath)
 
-	if err := os.MkdirAll(rule.SourceMountPath, 0755); err != nil {
-		return nil, errors.Wrap(err, "create mountpoint directory of source image")
-	}
-
 	image, err := rule.pullSourceImage()
 	if err != nil {
 		return nil, errors.Wrap(err, "pull source image")
 	}
+
+	if err := image.Umount(); err != nil {
+		return nil, errors.Wrap(err, "umount previous rootfs")
+	}
+
 	if err := image.Mount(); err != nil {
 		return nil, errors.Wrap(err, "mount source image")
 	}

--- a/contrib/nydusify/pkg/checker/tool/image.go
+++ b/contrib/nydusify/pkg/checker/tool/image.go
@@ -7,18 +7,42 @@ package tool
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
+	"github.com/containerd/containerd/mount"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
 )
 
-func run(cmd string, args ...string) error {
-	_cmd := exec.Command("sh", "-c", cmd)
-	_cmd.Stdout = os.Stdout
-	_cmd.Stderr = os.Stderr
-	return _cmd.Run()
+func mkMounts(dirs []string) []mount.Mount {
+	var options []string
+
+	if len(dirs) == 0 {
+		return nil
+	}
+
+	if len(dirs) == 1 {
+		return []mount.Mount{
+			{
+				Source: dirs[0],
+				Type:   "bind",
+				Options: []string{
+					"ro",
+					"rbind",
+				},
+			},
+		}
+	}
+
+	options = append(options, fmt.Sprintf("lowerdir=%s", strings.Join(dirs, ":")))
+	return []mount.Mount{
+		{
+			Type:    "overlay",
+			Source:  "overlay",
+			Options: options,
+		},
+	}
 }
 
 type Image struct {
@@ -30,41 +54,20 @@ type Image struct {
 
 // Mount mounts rootfs of OCI image.
 func (image *Image) Mount() error {
-	image.Umount()
+	if err := os.MkdirAll(image.Rootfs, 0750); err != nil {
+		return errors.Wrap(err, "create rootfs dir")
+	}
 
 	var dirs []string
-	layerLen := len(image.Layers)
+	count := len(image.Layers)
 	for i := range image.Layers {
-		layerDir := filepath.Join(image.SourcePath, image.Layers[layerLen-i-1].Digest.Encoded())
+		layerDir := filepath.Join(image.SourcePath, image.Layers[count-i-1].Digest.Encoded())
 		dirs = append(dirs, strings.ReplaceAll(layerDir, ":", "\\:"))
 	}
 
-	lowerOption := strings.Join(dirs, ":")
-	// Handle long options string overed 4096 chars, split them to
-	// two overlay mounts.
-	if len(lowerOption) >= 4096 {
-		half := (len(dirs) - 1) / 2
-		upperDirs := dirs[half+1:]
-		lowerDirs := dirs[:half+1]
-		lowerOverlay := image.Rootfs + "_lower"
-		if err := os.MkdirAll(lowerOverlay, 0755); err != nil {
-			return err
-		}
-		if err := run(fmt.Sprintf(
-			"mount -t overlay overlay -o lowerdir='%s' %s",
-			strings.Join(upperDirs, ":"), lowerOverlay,
-		)); err != nil {
-			return err
-		}
-		lowerDirs = append(lowerDirs, lowerOverlay)
-		lowerOption = strings.Join(lowerDirs, ":")
-	}
-
-	if err := run(fmt.Sprintf(
-		"mount -t overlay overlay -o lowerdir='%s' %s",
-		lowerOption, image.Rootfs,
-	)); err != nil {
-		return err
+	mounts := mkMounts(dirs)
+	if err := mount.All(mounts, image.Rootfs); err != nil {
+		return errors.Wrap(err, "mount source layer")
 	}
 
 	return nil
@@ -72,21 +75,19 @@ func (image *Image) Mount() error {
 
 // Umount umounts rootfs mountpoint of OCI image.
 func (image *Image) Umount() error {
-	lowerOverlay := image.Rootfs + "_lower"
-	if _, err := os.Stat(lowerOverlay); err == nil {
-		if err := run(fmt.Sprintf("umount %s", lowerOverlay)); err != nil {
-			return err
+	if _, err := os.Stat(image.Rootfs); err != nil {
+		if os.IsNotExist(err) {
+			return nil
 		}
+		return errors.Wrap(err, "stat rootfs")
 	}
 
-	if _, err := os.Stat(image.Rootfs); err == nil {
-		if err := run(fmt.Sprintf("umount %s", image.Rootfs)); err != nil {
-			return err
-		}
+	if err := mount.Unmount(image.Rootfs, 0); err != nil {
+		return errors.Wrap(err, "umount rootfs")
 	}
 
-	if err := os.RemoveAll(image.SourcePath); err != nil {
-		return err
+	if err := os.RemoveAll(image.Rootfs); err != nil {
+		return errors.Wrap(err, "remove rootfs")
 	}
 
 	return nil


### PR DESCRIPTION
```
Nydusify check subcommand will check the consistency of
OCI image and nydus image by mounting (overlayfs or nydusd).

For the OCI image with a single layer, we should use bind
mount instead of overlay to mount rootfs, otherwise an error
will be thrown like:

wrong fs type, bad option, bad superblock on overlay, missing
codepage or helper program, or other error.

This commit also refine the codes for image.Mount/image.Umount.
```

Signed-off-by: Yan Song <imeoer@linux.alibaba.com>