### PR TITLE
nydus-image/v5: prefetch table should contain inode numbers rather it…

### DIFF
--- a/src/bin/nydus-image/core/bootstrap.rs
+++ b/src/bin/nydus-image/core/bootstrap.rs
@@ -405,12 +405,13 @@ impl Bootstrap {
         let inode_table_size = inode_table.size();
 
         // Set prefetch table
-        let (prefetch_table_size, prefetch_table_entries) =
-            if let Some(prefetch_table) = ctx.prefetch.get_rafsv5_prefetch_table() {
-                (prefetch_table.size(), prefetch_table.len() as u32)
-            } else {
-                (0, 0u32)
-            };
+        let (prefetch_table_size, prefetch_table_entries) = if let Some(prefetch_table) =
+            ctx.prefetch.get_rafsv5_prefetch_table(&bootstrap_ctx.nodes)
+        {
+            (prefetch_table.size(), prefetch_table.len() as u32)
+        } else {
+            (0, 0u32)
+        };
 
         // Set blob table, use sha256 string (length 64) as blob id if not specified
         let prefetch_table_offset = super_block_size + inode_table_size;
@@ -481,7 +482,9 @@ impl Bootstrap {
             .context("failed to store inode table")?;
 
         // Dump prefetch table
-        if let Some(mut prefetch_table) = ctx.prefetch.get_rafsv5_prefetch_table() {
+        if let Some(mut prefetch_table) =
+            ctx.prefetch.get_rafsv5_prefetch_table(&bootstrap_ctx.nodes)
+        {
             prefetch_table
                 .store(bootstrap_ctx.writer.as_mut())
                 .context("failed to store prefetch table")?;

--- a/src/bin/nydus-image/core/prefetch.rs
+++ b/src/bin/nydus-image/core/prefetch.rs
@@ -178,13 +178,13 @@ impl Prefetch {
     }
 
     /// Generate filesystem layer prefetch list for RAFS v5.
-    pub fn get_rafsv5_prefetch_table(&mut self) -> Option<RafsV5PrefetchTable> {
+    pub fn get_rafsv5_prefetch_table(&mut self, nodes: &[Node]) -> Option<RafsV5PrefetchTable> {
         if self.policy == PrefetchPolicy::Fs {
             let mut prefetch_table = RafsV5PrefetchTable::new();
             for i in self.patterns.values().filter_map(|v| *v) {
-                // Rafs v5 has inode number equal to index.
+                // Rafs v5 has inode number equal to index if it is not hardlink.
                 if i < u32::MAX as u64 {
-                    prefetch_table.add_entry(i as u32);
+                    prefetch_table.add_entry(nodes[i as usize - 1].inode.ino() as u32);
                 }
             }
             Some(prefetch_table)


### PR DESCRIPTION
…s index

Nydusd is performing prefetch by mathcing inode number in prefetch table. Right now, inode's index is persisted to prefetch table though at most time they are equal.

Signed-off-by: Changwei Ge <gechangwei@bytedance.com>