### PR TITLE
Change default value of nydus-image and optimize output

### DIFF
--- a/contrib/nydusify/pkg/checker/tool/builder.go
+++ b/contrib/nydusify/pkg/checker/tool/builder.go
@@ -34,12 +34,11 @@ func NewBuilder(binaryPath string) *Builder {
 func (builder *Builder) Check(option BuilderOption) error {
 	args := []string{
 		"check",
-		"--bootstrap",
-		option.BootstrapPath,
 		"--log-level",
 		"warn",
 		"--output-json",
 		option.DebugOutputPath,
+		option.BootstrapPath,
 	}
 
 	cmd := exec.Command(builder.binaryPath, args...)

--- a/contrib/nydusify/pkg/checker/tool/inspector.go
+++ b/contrib/nydusify/pkg/checker/tool/inspector.go
@@ -55,7 +55,6 @@ func (p *Inspector) Inspect(option InspectOption) (interface{}, error) {
 	)
 	args = []string{
 		"inspect",
-		"--bootstrap",
 		option.Bootstrap,
 		"--request",
 	}

--- a/rafs/src/metadata/layout/v5.rs
+++ b/rafs/src/metadata/layout/v5.rs
@@ -223,10 +223,10 @@ impl RafsV5SuperBlock {
     pub fn set_compressor(&mut self, compressor: compress::Algorithm) {
         let c: RafsSuperFlags = compressor.into();
 
-        self.s_flags &= !RafsSuperFlags::COMPRESS_NONE.bits();
-        self.s_flags &= !RafsSuperFlags::COMPRESS_LZ4_BLOCK.bits();
-        self.s_flags &= !RafsSuperFlags::COMPRESS_GZIP.bits();
-        self.s_flags &= !RafsSuperFlags::COMPRESS_ZSTD.bits();
+        self.s_flags &= !RafsSuperFlags::COMPRESSION_NONE.bits();
+        self.s_flags &= !RafsSuperFlags::COMPRESSION_LZ4.bits();
+        self.s_flags &= !RafsSuperFlags::COMPRESSION_GZIP.bits();
+        self.s_flags &= !RafsSuperFlags::COMPRESSION_ZSTD.bits();
         self.s_flags |= c.bits();
     }
 
@@ -234,8 +234,8 @@ impl RafsV5SuperBlock {
     pub fn set_digester(&mut self, digester: digest::Algorithm) {
         let c: RafsSuperFlags = digester.into();
 
-        self.s_flags &= !RafsSuperFlags::DIGESTER_BLAKE3.bits();
-        self.s_flags &= !RafsSuperFlags::DIGESTER_SHA256.bits();
+        self.s_flags &= !RafsSuperFlags::HASH_BLAKE3.bits();
+        self.s_flags &= !RafsSuperFlags::HASH_SHA256.bits();
         self.s_flags |= c.bits();
     }
 
@@ -1726,51 +1726,51 @@ pub mod tests {
     fn test_rafsv5_superflags() {
         assert_eq!(
             RafsSuperFlags::from(digest::Algorithm::Blake3),
-            RafsSuperFlags::DIGESTER_BLAKE3
+            RafsSuperFlags::HASH_BLAKE3
         );
         assert_eq!(
             RafsSuperFlags::from(digest::Algorithm::Sha256),
-            RafsSuperFlags::DIGESTER_SHA256
+            RafsSuperFlags::HASH_SHA256
         );
         assert_eq!(
-            digest::Algorithm::from(RafsSuperFlags::DIGESTER_BLAKE3),
+            digest::Algorithm::from(RafsSuperFlags::HASH_BLAKE3),
             digest::Algorithm::Blake3
         );
         assert_eq!(
-            digest::Algorithm::from(RafsSuperFlags::DIGESTER_SHA256),
+            digest::Algorithm::from(RafsSuperFlags::HASH_SHA256),
             digest::Algorithm::Sha256
         );
 
         assert_eq!(
             RafsSuperFlags::from(compress::Algorithm::Zstd),
-            RafsSuperFlags::COMPRESS_ZSTD
+            RafsSuperFlags::COMPRESSION_ZSTD
         );
         assert_eq!(
             RafsSuperFlags::from(compress::Algorithm::GZip),
-            RafsSuperFlags::COMPRESS_GZIP
+            RafsSuperFlags::COMPRESSION_GZIP
         );
         assert_eq!(
             RafsSuperFlags::from(compress::Algorithm::Lz4Block),
-            RafsSuperFlags::COMPRESS_LZ4_BLOCK
+            RafsSuperFlags::COMPRESSION_LZ4
         );
         assert_eq!(
             RafsSuperFlags::from(compress::Algorithm::None),
-            RafsSuperFlags::COMPRESS_NONE
+            RafsSuperFlags::COMPRESSION_NONE
         );
         assert_eq!(
-            compress::Algorithm::from(RafsSuperFlags::COMPRESS_ZSTD),
+            compress::Algorithm::from(RafsSuperFlags::COMPRESSION_ZSTD),
             compress::Algorithm::Zstd
         );
         assert_eq!(
-            compress::Algorithm::from(RafsSuperFlags::COMPRESS_GZIP),
+            compress::Algorithm::from(RafsSuperFlags::COMPRESSION_GZIP),
             compress::Algorithm::GZip
         );
         assert_eq!(
-            compress::Algorithm::from(RafsSuperFlags::COMPRESS_LZ4_BLOCK),
+            compress::Algorithm::from(RafsSuperFlags::COMPRESSION_LZ4),
             compress::Algorithm::Lz4Block
         );
         assert_eq!(
-            compress::Algorithm::from(RafsSuperFlags::COMPRESS_NONE),
+            compress::Algorithm::from(RafsSuperFlags::COMPRESSION_NONE),
             compress::Algorithm::None
         );
     }

--- a/rafs/src/metadata/layout/v6.rs
+++ b/rafs/src/metadata/layout/v6.rs
@@ -342,10 +342,10 @@ impl RafsV6SuperBlockExt {
     /// Validate the Rafs v6 super block.
     pub fn validate(&self) -> Result<()> {
         let mut flags = self.flags();
-        flags &= RafsSuperFlags::COMPRESS_NONE.bits()
-            | RafsSuperFlags::COMPRESS_LZ4_BLOCK.bits()
-            | RafsSuperFlags::COMPRESS_GZIP.bits()
-            | RafsSuperFlags::COMPRESS_ZSTD.bits();
+        flags &= RafsSuperFlags::COMPRESSION_NONE.bits()
+            | RafsSuperFlags::COMPRESSION_LZ4.bits()
+            | RafsSuperFlags::COMPRESSION_GZIP.bits()
+            | RafsSuperFlags::COMPRESSION_ZSTD.bits();
         if flags.count_ones() != 1 {
             return Err(einval!(format!(
                 "invalid flags {:#x} related to compression algorithm in Rafs v6 extended superblock",
@@ -354,7 +354,7 @@ impl RafsV6SuperBlockExt {
         }
 
         let mut flags = self.flags();
-        flags &= RafsSuperFlags::DIGESTER_BLAKE3.bits() | RafsSuperFlags::DIGESTER_SHA256.bits();
+        flags &= RafsSuperFlags::HASH_BLAKE3.bits() | RafsSuperFlags::HASH_SHA256.bits();
         if flags.count_ones() != 1 {
             return Err(einval!(format!(
                 "invalid flags {:#x} related to digest algorithm in Rafs v6 extended superblock",
@@ -384,10 +384,10 @@ impl RafsV6SuperBlockExt {
     pub fn set_compressor(&mut self, compressor: compress::Algorithm) {
         let c: RafsSuperFlags = compressor.into();
 
-        self.s_flags &= !RafsSuperFlags::COMPRESS_NONE.bits();
-        self.s_flags &= !RafsSuperFlags::COMPRESS_LZ4_BLOCK.bits();
-        self.s_flags &= !RafsSuperFlags::COMPRESS_GZIP.bits();
-        self.s_flags &= !RafsSuperFlags::COMPRESS_ZSTD.bits();
+        self.s_flags &= !RafsSuperFlags::COMPRESSION_NONE.bits();
+        self.s_flags &= !RafsSuperFlags::COMPRESSION_LZ4.bits();
+        self.s_flags &= !RafsSuperFlags::COMPRESSION_GZIP.bits();
+        self.s_flags &= !RafsSuperFlags::COMPRESSION_ZSTD.bits();
         self.s_flags |= c.bits();
     }
 
@@ -405,8 +405,8 @@ impl RafsV6SuperBlockExt {
     pub fn set_digester(&mut self, digester: digest::Algorithm) {
         let c: RafsSuperFlags = digester.into();
 
-        self.s_flags &= !RafsSuperFlags::DIGESTER_BLAKE3.bits();
-        self.s_flags &= !RafsSuperFlags::DIGESTER_SHA256.bits();
+        self.s_flags &= !RafsSuperFlags::HASH_BLAKE3.bits();
+        self.s_flags &= !RafsSuperFlags::HASH_SHA256.bits();
         self.s_flags |= c.bits();
     }
 

--- a/src/bin/nydus-image/core/context.rs
+++ b/src/bin/nydus-image/core/context.rs
@@ -10,8 +10,7 @@ use std::convert::TryFrom;
 use std::fmt;
 use std::fs::{remove_file, rename, File, OpenOptions};
 use std::io::{BufWriter, Cursor, Read, Seek, Write};
-use std::path::PathBuf;
-use std::path::{Display, Path};
+use std::path::{Display, Path, PathBuf};
 use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 
@@ -944,6 +943,23 @@ pub struct BuildOutput {
     pub blob_size: Option<u64>,
     /// File path for the metadata blob.
     pub bootstrap_path: Option<String>,
+}
+
+impl fmt::Display for BuildOutput {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(
+            f,
+            "meta blob path: {}",
+            self.bootstrap_path.as_deref().unwrap_or("<none>")
+        )?;
+        writeln!(
+            f,
+            "data blob size: 0x{:x}",
+            self.blob_size.unwrap_or_default()
+        )?;
+        write!(f, "data blobs: {:?}", self.blobs)?;
+        Ok(())
+    }
 }
 
 impl BuildOutput {

--- a/src/bin/nydus-image/main.rs
+++ b/src/bin/nydus-image/main.rs
@@ -255,7 +255,7 @@ fn prepare_cmd_args(bti_string: &'static str) -> App {
                         .short('d')
                         .help("algorithm to digest inodes and data chunks:")
                         .required(false)
-                        .default_value("blake3")
+                        .default_value("sha256")
                         .value_parser(["blake3", "sha256"]),
                 )
                 .arg(

--- a/src/bin/nydus-image/main.rs
+++ b/src/bin/nydus-image/main.rs
@@ -64,6 +64,8 @@ const BLOB_ID_MAXIMUM_LENGTH: usize = 255;
 pub struct OutputSerializer {
     /// The binary version of builder (nydus-image).
     version: String,
+    /// RAFS meta data file path.
+    bootstrap: String,
     /// Represents all blob in blob table ordered by blob index, this field
     /// only include the layer that does have a blob, and should be deprecated
     /// in future, use `artifacts` field to replace.
@@ -93,6 +95,7 @@ impl OutputSerializer {
             let version = format!("{}-{}", build_info.package_ver, build_info.git_commit);
             let output = Self {
                 version,
+                bootstrap: build_output.bootstrap_path.unwrap_or_default(),
                 blobs: build_output.blobs,
                 trace,
             };
@@ -107,6 +110,7 @@ impl OutputSerializer {
         matches: &clap::ArgMatches,
         build_info: &BuildTimeInfo,
         blob_ids: Vec<String>,
+        bootstrap: &Path,
     ) -> Result<()> {
         let output_json: Option<PathBuf> = matches
             .get_one::<String>("output-json")
@@ -123,6 +127,7 @@ impl OutputSerializer {
             let version = format!("{}-{}", build_info.package_ver, build_info.git_commit);
             let output = Self {
                 version,
+                bootstrap: bootstrap.display().to_string(),
                 blobs: blob_ids,
                 trace,
             };
@@ -866,7 +871,7 @@ impl Command {
             blob_ids.push(blob.blob_id().to_string());
         }
 
-        OutputSerializer::dump_with_check(matches, build_info, blob_ids)?;
+        OutputSerializer::dump_with_check(matches, build_info, blob_ids, bootstrap_path)?;
 
         Ok(())
     }

--- a/src/bin/nydus-image/main.rs
+++ b/src/bin/nydus-image/main.rs
@@ -100,7 +100,8 @@ impl OutputSerializer {
                 trace,
             };
 
-            serde_json::to_writer(w, &output).context("failed to write result to output file")?;
+            serde_json::to_writer_pretty(w, &output)
+                .context("failed to write result to output file")?;
         }
 
         Ok(())

--- a/src/bin/nydus-image/main.rs
+++ b/src/bin/nydus-image/main.rs
@@ -263,7 +263,7 @@ fn prepare_cmd_args(bti_string: &'static str) -> App {
                         .long("fs-version")
                         .short('v')
                         .help("RAFS filesystem format version number:")
-                        .default_value("5")
+                        .default_value("6")
                         .value_parser(["5", "6"]),
                 )
                 .arg(
@@ -280,7 +280,7 @@ fn prepare_cmd_args(bti_string: &'static str) -> App {
                     Arg::new("aligned-chunk")
                         .long("aligned-chunk")
                         .short('A')
-                        .help("Align uncompressed data chunk to 4K")
+                        .help("Align uncompressed data chunk to 4K, apply to RAFS V5 only")
                         .action(ArgAction::SetTrue)
                 )
                 .arg(
@@ -578,7 +578,6 @@ impl Command {
         let version = Self::get_fs_version(matches)?;
         let chunk_size = Self::get_chunk_size(matches, conversion_type)?;
         let aligned_chunk = if version.is_v6() {
-            info!("v6 enforces to use \"aligned-chunk\".");
             true
         } else {
             // get_fs_version makes sure it's either v6 or v5.

--- a/src/bin/nydus-image/main.rs
+++ b/src/bin/nydus-image/main.rs
@@ -246,7 +246,7 @@ fn prepare_cmd_args(bti_string: &'static str) -> App {
                         .short('c')
                         .help("algorithm to compress image data blob:")
                         .required(false)
-                        .default_value("lz4_block")
+                        .default_value("zstd")
                         .value_parser(["none", "lz4_block", "gzip", "zstd"]),
                 )
                 .arg(

--- a/src/bin/nydus-image/main.rs
+++ b/src/bin/nydus-image/main.rs
@@ -213,7 +213,7 @@ fn prepare_cmd_args(bti_string: &'static str) -> App {
                         .long("blob")
                         .short('b')
                         .help("path to store generated RAFS filesystem data blob")
-                        .required_unless_present_any(&["backend-type", "type", "blob-dir"]),
+                        .required_unless_present_any(&["type", "blob-dir"]),
                 )
                 .arg(
                     Arg::new("blob-id")
@@ -316,18 +316,6 @@ fn prepare_cmd_args(bti_string: &'static str) -> App {
                 )
                 .arg(
                     arg_output_json.clone(),
-                )
-                .arg(
-                    Arg::new("backend-type")
-                        .long("backend-type")
-                        .help("[deprecated!] Blob storage backend type, only support localfs for compatibility. Try use --blob instead.")
-                        .requires("backend-config")
-                        .value_parser(["localfs"]),
-                )
-                .arg(
-                    Arg::new("backend-config")
-                        .long("backend-config")
-                        .help("[deprecated!] Blob storage backend config - JSON string, only support localfs for compatibility"),
                 )
         )
         .subcommand(

--- a/src/bin/nydus-image/main.rs
+++ b/src/bin/nydus-image/main.rs
@@ -356,9 +356,7 @@ fn prepare_cmd_args(bti_string: &'static str) -> App {
                 .about("Validate RAFS filesystem metadata")
                 .arg(
                     Arg::new("bootstrap")
-                        .long("bootstrap")
-                        .short('B')
-                        .help("path to RAFS metadata blob (required)")
+                        .help("path to RAFS metadata blob file (required)")
                         .required(true),
                 )
                 .arg(
@@ -375,19 +373,17 @@ fn prepare_cmd_args(bti_string: &'static str) -> App {
         )
         .subcommand(
             App::new("inspect")
-                .about("Inspects nydus image's filesystem metadata")
+                .about("Inspect RAFS filesystem metadata")
                 .arg(
                     Arg::new("bootstrap")
-                        .long("bootstrap")
-                        .short('B')
-                        .help("path to nydus image's metadata blob (required)")
+                        .help("path to RAFS metadata file)")
                         .required(true),
                 )
                 .arg(
                     Arg::new("request")
                         .long("request")
                         .short('R')
-                        .help("inspect nydus image's filesystem metadata in request mode")
+                        .help("inspect RAFS filesystem metadata in request mode")
                         .required(false),
                 )
         )

--- a/src/bin/nydus-image/main.rs
+++ b/src/bin/nydus-image/main.rs
@@ -759,7 +759,7 @@ impl Command {
             }
         }
 
-        info!("build successfully: {:?}", build_output,);
+        info!("successfully built RAFS filesystem: \n{}", build_output);
         OutputSerializer::dump(matches, build_output, build_info)
     }
 

--- a/tests/builder.rs
+++ b/tests/builder.rs
@@ -363,7 +363,7 @@ impl<'a> Builder<'a> {
 
         exec(
             format!(
-                "{:?} create --bootstrap {:?} --backend-type localfs --backend-config '{{\"blob_file\": {:?}}}' --log-level info --compressor {} --whiteout-spec {} {:?}",
+                "{:?} create --bootstrap {:?} --backend-type localfs --backend-config '{{\"blob_file\": {:?}}}' --fs-version 5 --log-level info --compressor {} --whiteout-spec {} {:?}",
                 self.builder,
                 self.work_dir.join("bootstrap-specialfiles"),
                 self.work_dir.join("smoke-localfs-blob"),

--- a/tests/builder.rs
+++ b/tests/builder.rs
@@ -363,7 +363,7 @@ impl<'a> Builder<'a> {
 
         exec(
             format!(
-                "{:?} create --bootstrap {:?} --backend-type localfs --backend-config '{{\"blob_file\": {:?}}}' --fs-version 5 --log-level info --compressor {} --whiteout-spec {} {:?}",
+                "{:?} create --bootstrap {:?} --blob {:?} --log-level info --compressor {} --fs-version 5 --whiteout-spec {} {:?}",
                 self.builder,
                 self.work_dir.join("bootstrap-specialfiles"),
                 self.work_dir.join("smoke-localfs-blob"),

--- a/tests/inspect.rs
+++ b/tests/inspect.rs
@@ -8,7 +8,7 @@ pub fn test_image_inspect_cmd(cmd: &str, bootstrap_path: &str) {
         std::env::var("NYDUS_IMAGE").unwrap_or_else(|_| String::from(default_nydus_image));
 
     let output = exec(
-        format!("{} inspect -B {} -R {}", nydus_image, bootstrap_path, cmd).as_str(),
+        format!("{} inspect -R {} {}", nydus_image, cmd, bootstrap_path).as_str(),
         true,
         b"",
     )


### PR DESCRIPTION
Change default configuration for `nydus-image create` by
1) change default compressor from lz4_block to zstd
2) change default hash algorithm from blake3 to sha256
3) change default fs-version from 5 to 6
4) limit aligned-chunk to RAFS v5

Also tune output of `nydus-image create`  and now it becomes readable:
```
root@5ad838c8bf7b:/nydus# target/debug/nydus-image create -t directory -D images/ -J output.json src/
[2022-10-17 16:04:52.787992 +00:00] INFO rafs superblock features: HASH_SHA256 | EXPLICIT_UID_GID | COMPRESSION_ZSTD
[2022-10-17 16:04:52.824325 +00:00] INFO successfully build RAFS filesystem: 
meta blob path: images/6fb4d603307df0e8c523a14825181cc0c9c3de4c2797b5e341c7c489b40ab13c
data blob size: 0x22de7
data blobs: ["c508580ee90cbd543713067cb22c28b7bf444c457de5e4a53b797e5575307b7a"]
root@5ad838c8bf7b:/nydus# cat output.json 
{
  "version": "v2.1.0-rc.3.1-162-g231296a4a-231296a4ad78fa0ec1f68fa565935c9ef58a32e1",
  "bootstrap": "images/6fb4d603307df0e8c523a14825181cc0c9c3de4c2797b5e341c7c489b40ab13c",
  "blobs": [
    "c508580ee90cbd543713067cb22c28b7bf444c457de5e4a53b797e5575307b7a"
  ],
  "trace": {
    "consumed_time": {
      "build_bootstrap": 0.006259500049054623,
      "dump_blob": 0.11847899854183197,
      "dump_bootstrap": 0.07097754627466202,
      "load_from_directory": 0.005598959047347307,
      "load_tree_from_bootstrap": 0.01346754189580679,
      "total_build": 0.2859921157360077,
      "validate_bootstrap": 0.024069499224424362
    },
    "registered_events": {
      "blob_compressed_size": 142823,
      "blob_uncompressed_size": 528544,
      "egid": "0",
      "euid": "0",
      "load_from_directory": 44,
      "load_from_parent_bootstrap": 44
    }
  }
}
```
