### PR TITLE
action/nydus-test: stop on the first test failure

### DIFF
--- a/.github/workflows/it.yml
+++ b/.github/workflows/it.yml
@@ -102,11 +102,9 @@ jobs:
               "target": "musl"
           }
           EOF
-      - name: run test_api
+      - name: run e2e tests
         run: |
           cd /home/runner/work/image-service/image-service/contrib/nydus-test
           sudo mkdir -p /blobdir
           sudo python3 nydus_test_config.py --dist fs_structure.yaml
-          sudo pytest -vs --durations=0  functional-test/test_api.py \
-                                         functional-test/test_nydus.py \
-                                         functional-test/test_layered_image.py
+          sudo pytest -vs -x --durations=0 functional-test/test_api.py functional-test/test_nydus.py functional-test/test_layered_image.py


### PR DESCRIPTION
By default, pytest will continue executing test even current test fails. It's hard to tell what to happen on such a environment. And it makes it hard to investigate the first failed case.

Signed-off-by: Changwei Ge <gechangwei@bytedance.com>