### PR TITLE
optimize prefetch table for workload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -982,6 +982,7 @@ dependencies = [
  "fuse-backend-rs",
  "hyper",
  "hyperlocal",
+ "indexmap",
  "lazy_static",
  "libc",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ nydus-rafs = { version = "0.1.0", path = "rafs", features = ["backend-registry",
 nydus-storage = { version = "0.5.0", path = "storage" }
 nydus-utils = { version = "0.3.0", path = "utils" }
 nydus-blobfs = { version = "0.1.0", path = "blobfs", features = ["virtiofs"], optional = true }
+indexmap = "1.9.1"
 
 [dev-dependencies]
 sendfd = "0.3.3"

--- a/rafs/src/metadata/layout/v5.rs
+++ b/rafs/src/metadata/layout/v5.rs
@@ -478,10 +478,6 @@ impl RafsV5PrefetchTable {
 
     /// Store the inode prefetch table to a writer.
     pub fn store(&mut self, w: &mut dyn RafsIoWrite) -> Result<usize> {
-        // Sort prefetch table by inode index, hopefully, it can save time when mounting rafs
-        // Because file data is dumped in the order of inode index.
-        self.inodes.sort_unstable();
-
         let (_, data, _) = unsafe { self.inodes.align_to::<u8>() };
         w.write_all(data.as_ref())?;
 

--- a/rafs/src/metadata/layout/v6.rs
+++ b/rafs/src/metadata/layout/v6.rs
@@ -1799,10 +1799,6 @@ impl RafsV6PrefetchTable {
 
     /// Store the inode prefetch table to a writer.
     pub fn store(&mut self, w: &mut dyn RafsIoWrite) -> Result<usize> {
-        // Sort prefetch table by inode index, hopefully, it can save time when mounting rafs
-        // Because file data is dumped in the order of inode index.
-        self.inodes.sort_unstable();
-
         let (_, data, _) = unsafe { self.inodes.align_to::<u8>() };
         w.write_all(data.as_ref())?;
 


### PR DESCRIPTION
Now, nydus prefetch files with the order of index. This method is not accurate. We already get accessed files list for workload. Hence, we can prefetch files based on the order they are accessed.

Prefetch table for rafs v5 image (`nydus-image inspect` for rafs v6 is not work, repairing...):
![image](https://user-images.githubusercontent.com/20137756/197762887-a4909fd6-85f7-4310-b4a4-67f8014eb766.png)
Accessed files:
![image](https://user-images.githubusercontent.com/20137756/197751991-3520b0e0-40ca-433d-a323-416f8b55137c.png)

Now, we avoid sorting prefetch table, maybe add a parameter for this option.

This PR is addressing the step 1 of #807 
Related to https://github.com/containerd/nydus-snapshotter/pull/228

Signed-off-by: Bin Tang <tangbin.bin@bytedance.com>