### PR TITLE
nydus-image: fix prefetch table size for rafs v6

### DIFF
--- a/src/bin/nydus-image/core/bootstrap.rs
+++ b/src/bin/nydus-image/core/bootstrap.rs
@@ -697,7 +697,7 @@ impl Bootstrap {
         if let Some(mut pt) = prefetch_table {
             // Device slots are very close to extended super block.
             ext_sb.set_prefetch_table_offset(prefetch_table_offset);
-            ext_sb.set_prefetch_table_size(prefetch_table_size);
+            ext_sb.set_prefetch_table_size(pt.len() as u32 * size_of::<u32>() as u32);
             bootstrap_ctx
                 .writer
                 .seek_offset(prefetch_table_offset as u64)


### PR DESCRIPTION
Now, the prefetch table size in rafs v6 SuperBlock is the number of prefetch files list. It is incorrect when the prefetch files list contains a path that does not exist.

This PR is addressing #817 

Signed-off-by: Bin Tang <tangbin.bin@bytedance.com>