### PR TITLE
fixup! Upgrade clap to 4.0

### DIFF
--- a/src/bin/nydusd/main.rs
+++ b/src/bin/nydusd/main.rs
@@ -541,11 +541,11 @@ impl<'a> SubCmdArgs<'a> {
         }
     }
 
-    pub fn values_of(&self, key: &str) -> Option<ValuesRef<&str>> {
-        if let Some(v) = self.subargs.get_many::<&str>(key) {
+    pub fn values_of(&self, key: &str) -> Option<ValuesRef<String>> {
+        if let Some(v) = self.subargs.get_many::<String>(key) {
             Some(v)
         } else {
-            self.args.get_many::<&str>(key)
+            self.args.get_many::<String>(key)
         }
     }
 


### PR DESCRIPTION
Change ArgMatches::get_many::<&str> to
ArgMatches::get_many::<String> in values_of to fix "Could not downcast to &str, need to downcast to alloc::string::String"
issue: https://github.com/dragonflyoss/image-service/pull/822#issuecomment-1296546892
Signed-off-by: Wenyu Huang <huangwenyuu@outlook.com>