### PR TITLE
Backport 3 patches for stable/v2.1

### DIFF
--- a/contrib/nydusify/pkg/backend/oss.go
+++ b/contrib/nydusify/pkg/backend/oss.go
@@ -113,6 +113,7 @@ func (b *OSSBackend) Upload(ctx context.Context, blobID, blobPath string, size i
 	blobObjectKey := b.objectPrefix + blobID
 
 	desc := blobDesc(size, blobID)
+	desc.URLs = append(desc.URLs, b.remoteID(blobID))
 
 	if !forcePush {
 		if exist, err := b.bucket.IsObjectExist(blobObjectKey); err != nil {
@@ -253,4 +254,8 @@ func (b *OSSBackend) Check(blobID string) (bool, error) {
 
 func (b *OSSBackend) Type() Type {
 	return OssBackend
+}
+
+func (b *OSSBackend) remoteID(blobID string) string {
+	return fmt.Sprintf("oss://%s/%s%s", b.bucket.BucketName, b.objectPrefix, blobID)
 }

--- a/contrib/nydusify/pkg/packer/packer.go
+++ b/contrib/nydusify/pkg/packer/packer.go
@@ -67,7 +67,7 @@ func (cfg *BackendConfig) rawMetaBackendCfg() []byte {
 		"access_key_id":     cfg.AccessKeyID,
 		"access_key_secret": cfg.AccessKeySecret,
 		"bucket_name":       cfg.BucketName,
-		"object_prefix":     cfg.MetaPrefix + "/",
+		"object_prefix":     cfg.MetaPrefix,
 	}
 	b, _ := json.Marshal(configMap)
 	return b
@@ -79,7 +79,7 @@ func (cfg *BackendConfig) rawBlobBackendCfg() []byte {
 		"access_key_id":     cfg.AccessKeyID,
 		"access_key_secret": cfg.AccessKeySecret,
 		"bucket_name":       cfg.BucketName,
-		"object_prefix":     cfg.BlobPrefix + "/",
+		"object_prefix":     cfg.BlobPrefix,
 	}
 	b, _ := json.Marshal(configMap)
 	return b

--- a/contrib/nydusify/pkg/packer/packer.go
+++ b/contrib/nydusify/pkg/packer/packer.go
@@ -316,7 +316,7 @@ func (p *Packer) Pack(_ context.Context, req PackRequest) (PackResult, error) {
 		return PackResult{}, errors.New("can not push image to remote due to lack of backend configuration")
 	}
 	pushResult, err := p.pusher.Push(PushRequest{
-		Meta:        bootstrapPath,
+		Meta:        req.ImageName,
 		Blob:        newBlobHash,
 		ParentBlobs: parentBlobs,
 	})

--- a/contrib/nydusify/pkg/packer/pusher.go
+++ b/contrib/nydusify/pkg/packer/pusher.go
@@ -3,7 +3,6 @@ package packer
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"os"
 	"strings"
 
@@ -69,7 +68,7 @@ func NewPusher(opt NewPusherOpt) (*Pusher, error) {
 // Push will push the meta and blob file to remote backend
 // at this moment, oss is the only possible backend, the meta file name is user defined
 // and blob file name is the hash of the blobfile that is extracted from output.json
-func (p *Pusher) Push(req PushRequest) (PushResult, error) {
+func (p *Pusher) Push(req PushRequest) (pushResult PushResult, err error) {
 	p.logger.Info("start to push meta and blob to remote backend")
 	// todo: add a suitable timeout
 	ctx := context.Background()
@@ -84,18 +83,23 @@ func (p *Pusher) Push(req PushRequest) (PushResult, error) {
 
 	p.logger.Infof("push blob %s", req.Blob)
 	if req.Blob != "" {
-		if _, err := p.blobBackend.Upload(ctx, req.Blob, p.blobFilePath(req.Blob, true), 0, false); err != nil {
+		desc, err := p.blobBackend.Upload(ctx, req.Blob, p.blobFilePath(req.Blob, true), 0, false)
+		if err != nil {
 			return PushResult{}, errors.Wrap(err, "failed to put blobfile to remote")
 		}
+		if len(desc.URLs) > 0 {
+			pushResult.RemoteBlob = desc.URLs[0]
+		}
 	}
-	if _, err := p.metaBackend.Upload(ctx, req.Meta, p.bootstrapPath(req.Meta), 0, true); err != nil {
+	desc, err := p.metaBackend.Upload(ctx, req.Meta, p.bootstrapPath(req.Meta), 0, true)
+	if err != nil {
 		return PushResult{}, errors.Wrapf(err, "failed to put metafile to remote")
 	}
+	if len(desc.URLs) != 0 {
+		pushResult.RemoteMeta = desc.URLs[0]
+	}
 
-	return PushResult{
-		RemoteMeta: fmt.Sprintf("oss://%s/%s/%s", p.cfg.BucketName, p.cfg.MetaPrefix, req.Meta),
-		RemoteBlob: fmt.Sprintf("oss://%s/%s/%s", p.cfg.BucketName, p.cfg.BlobPrefix, req.Blob),
-	}, nil
+	return
 }
 
 func ParseBackendConfig(backendConfigFile string) (BackendConfig, error) {


### PR DESCRIPTION
泰友 (3):
      fix: nydusify pack fail
      refact: use specified object prefix and meta prefix directly
      fix: miss oss file of nydusify packer
