### PR TITLE
Adopt zlib random access algorithm to support OCIv1 compatible nydus image

### DIFF
--- a/rafs/src/metadata/direct_v6.rs
+++ b/rafs/src/metadata/direct_v6.rs
@@ -1045,7 +1045,7 @@ impl RafsInode for OndiskInodeWrapper {
                     self.ino(),
                     OsString::from(name),
                 )?) as Arc<dyn RafsInode>;
-                trace!("found file {:?}, nid {}", name, nid);
+                //trace!("found entry {:?}, nid {}", name, nid);
                 cur_offset += 1;
                 match handler(Some(inode), name.to_os_string(), nid, cur_offset) {
                     // Break returned by handler indicates that there is not enough buffer of readdir for entries inreaddir,

--- a/rafs/src/metadata/md_v5.rs
+++ b/rafs/src/metadata/md_v5.rs
@@ -64,7 +64,7 @@ impl RafsSuper {
         fetcher: F,
     ) -> RafsResult<bool>
     where
-        F: Fn(&mut BlobIoVec),
+        F: Fn(&mut BlobIoVec, bool),
     {
         let hint_entries = self.meta.prefetch_table_entries as usize;
         if hint_entries == 0 {
@@ -99,7 +99,7 @@ impl RafsSuper {
                 .map_err(|e| RafsError::Prefetch(e.to_string()))?;
         }
         for (_id, mut desc) in state.drain() {
-            fetcher(&mut desc);
+            fetcher(&mut desc, true);
         }
 
         Ok(found_root_inode)

--- a/rafs/src/metadata/md_v5.rs
+++ b/rafs/src/metadata/md_v5.rs
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use nydus_storage::device::BlobChunkFlags;
+use nydus_storage::RAFS_MERGING_SIZE_TO_GAP_SHIFT;
 
 use super::cached_v5::CachedSuperBlockV5;
 use super::direct_v5::DirectSuperBlockV5;
@@ -110,12 +111,12 @@ impl RafsSuper {
         Ok(())
     }
 
-    fn merge_chunks_io(orig: &mut BlobIoVec, vec: BlobIoVec) {
+    fn merge_chunks_io(orig: &mut BlobIoVec, vec: BlobIoVec, max_gap: u64) {
         assert!(!orig.is_empty());
         if !vec.is_empty() {
             let last = orig.blob_io_desc(orig.len() - 1).unwrap().clone();
             let head = vec.blob_io_desc(0).unwrap();
-            if last.is_continuous(head, 0) {
+            if last.is_continuous(head, max_gap) {
                 // Safe to unwrap since d is not empty.
                 orig.append(vec);
             }
@@ -154,34 +155,48 @@ impl RafsSuper {
                     } else {
                         0
                     };
-                    Self::merge_chunks_io(last_desc, vec);
+                    Self::merge_chunks_io(
+                        last_desc,
+                        vec,
+                        (max_uncomp_size as u64) >> RAFS_MERGING_SIZE_TO_GAP_SHIFT,
+                    );
                 }
             }
         }
 
         // Read more small files.
+        let mut max_tries = 64;
         let mut next_ino = inode.ino();
-        while window_size > 0 {
+        while window_size > 0 && max_tries > 0 {
             next_ino += 1;
             if let Ok(ni) = self.get_inode(next_ino, false) {
                 if ni.is_reg() {
                     let next_size = ni.size();
-                    if next_size > max_uncomp_size as u64 {
-                        break;
+                    let next_size = if next_size < window_size {
+                        next_size
+                    } else if window_size >= self.meta.chunk_size as u64 {
+                        window_size / self.meta.chunk_size as u64 * self.meta.chunk_size as u64
                     } else if next_size == 0 {
                         continue;
-                    }
+                    } else {
+                        break;
+                    };
 
-                    let sz = std::cmp::min(window_size, next_size);
-                    let amplified_io_vec = ni.alloc_bio_vecs(device, 0, sz as usize, false)?;
+                    let amplified_io_vec =
+                        ni.alloc_bio_vecs(device, 0, next_size as usize, false)?;
                     for vec in amplified_io_vec {
+                        max_tries -= 1;
                         if last_desc.has_same_blob(&vec) {
                             window_size = if window_size > vec.size() as u64 {
                                 window_size - vec.size() as u64
                             } else {
                                 0
                             };
-                            Self::merge_chunks_io(last_desc, vec);
+                            Self::merge_chunks_io(
+                                last_desc,
+                                vec,
+                                (max_uncomp_size as u64) >> RAFS_MERGING_SIZE_TO_GAP_SHIFT,
+                            );
                         }
                     }
                 }

--- a/rafs/src/metadata/md_v6.rs
+++ b/rafs/src/metadata/md_v6.rs
@@ -75,7 +75,7 @@ impl RafsSuper {
         fetcher: F,
     ) -> RafsResult<bool>
     where
-        F: Fn(&mut BlobIoVec),
+        F: Fn(&mut BlobIoVec, bool),
     {
         let hint_entries = self.meta.prefetch_table_entries as usize;
         if hint_entries == 0 {
@@ -106,13 +106,13 @@ impl RafsSuper {
             if ino as Inode == root_ino {
                 found_root_inode = true;
             }
-            debug!("hint prefetch inode {}", ino);
+            trace!("hint prefetch inode {}", ino);
             self.prefetch_data(device, ino as u64, &mut state, &mut hardlinks, &fetcher)
                 .map_err(|e| RafsError::Prefetch(e.to_string()))?;
         }
         // The left chunks whose size is smaller than 4MB will be fetched here.
         for (_id, mut desc) in state.drain() {
-            fetcher(&mut desc);
+            fetcher(&mut desc, true);
         }
 
         Ok(found_root_inode)

--- a/src/bin/nydus-image/builder/stargz.rs
+++ b/src/bin/nydus-image/builder/stargz.rs
@@ -767,7 +767,10 @@ impl StargzBuilder {
                     chunk.inner.uncompressed_offset() + chunk.inner.uncompressed_size() as u64,
                     uncompressed_blob_size,
                 );
-                compressed_blob_size += chunk.inner.compressed_size() as u64;
+                compressed_blob_size = std::cmp::max(
+                    compressed_blob_size,
+                    chunk.inner.compressed_offset() + chunk.inner.compressed_size() as u64,
+                );
                 if let Some(h) = inode_hasher.as_mut() {
                     h.digest_update(chunk.inner.id().as_ref());
                 }

--- a/src/bin/nydus-image/builder/tarball.rs
+++ b/src/bin/nydus-image/builder/tarball.rs
@@ -102,10 +102,7 @@ impl<'a> TarballTreeBuilder<'a> {
             ConversionType::EStargzToRafs | ConversionType::TargzToRafs => {
                 TarReader::TarGz(Box::new(ZlibDecoder::new(file)))
             }
-            /*
-            ConversionType::StargzToRef |
-             */
-            ConversionType::TargzToRef => {
+            ConversionType::EStargzToRef | ConversionType::TargzToRef => {
                 assert!(self.writer.is_none());
                 let generator = ZranContextGenerator::new(file)?;
                 let reader = generator.reader();
@@ -483,7 +480,7 @@ impl<'a> TarballTreeBuilder<'a> {
     // No-prefetch landmark MUST be named .no.prefetch.landmark.
     // TODO: check "a regular file entry with 4 bits contents 0xf"
     fn is_special_files(&self, path: &Path) -> bool {
-        self.ty == ConversionType::EStargzToRafs
+        (self.ty == ConversionType::EStargzToRafs || self.ty == ConversionType::EStargzToRef)
             && (path == Path::new("/stargz.index.json")
                 || path == Path::new("/.prefetch.landmark")
                 || path == Path::new("/.no.prefetch.landmark"))

--- a/src/bin/nydus-image/core/context.rs
+++ b/src/bin/nydus-image/core/context.rs
@@ -29,9 +29,9 @@ use nydus_rafs::metadata::{RafsSuperFlags, RafsVersion};
 use nydus_rafs::{RafsIoReader, RafsIoWrite};
 use nydus_storage::device::{BlobFeatures, BlobInfo};
 use nydus_storage::meta::{
-    BlobChunkInfoV2Ondisk, BlobMetaChunkArray, BlobMetaHeaderOndisk, ZranContextGenerator,
-    BLOB_META_FEATURE_4K_ALIGNED, BLOB_META_FEATURE_CHUNK_INFO_V2, BLOB_META_FEATURE_SEPARATE,
-    BLOB_META_FEATURE_ZRAN,
+    BlobChunkInfoV2Ondisk, BlobMetaChunkArray, BlobMetaChunkInfo, BlobMetaHeaderOndisk,
+    ZranContextGenerator, BLOB_META_FEATURE_4K_ALIGNED, BLOB_META_FEATURE_CHUNK_INFO_V2,
+    BLOB_META_FEATURE_SEPARATE, BLOB_META_FEATURE_ZRAN,
 };
 use nydus_utils::{compress, digest, div_round_up, round_down_4k};
 
@@ -468,7 +468,8 @@ impl BlobContext {
                     );
                 }
                 BlobMetaChunkArray::V2(_) => {
-                    if let Some(info) = chunk_info {
+                    if let Some(mut info) = chunk_info {
+                        info.set_uncompressed_offset(chunk.uncompressed_offset());
                         self.blob_meta_info.add_v2_info(info);
                     } else {
                         self.blob_meta_info.add_v2(

--- a/src/bin/nydus-image/main.rs
+++ b/src/bin/nydus-image/main.rs
@@ -649,21 +649,21 @@ impl Command {
                     );
                 }
                 if compressor != compress::Algorithm::GZip {
-                    warn!("only gzip is supported the conversion, use gzip for compression");
+                    info!(
+                        "only gzip is supported by the conversion type, use gzip for compression"
+                    );
                 }
                 compressor = compress::Algorithm::GZip;
                 if digester != digest::Algorithm::Sha256 {
-                    warn!("only sha256 is supported for the conversion, use sha256 for digest");
+                    info!("only sha256 is supported by the conversion type, use sha256 for digest");
                 }
                 digester = digest::Algorithm::Sha256;
-                /*
                 if version != RafsVersion::V6 {
                     bail!(
-                        "'--fs-version 5' conflicts with conversion type'{}', only V6 is supported",
+                        "'--fs-version 5' conflicts with conversion type '{}', only V6 is supported",
                         conversion_type
                     );
                 }
-                 */
                 if conversion_type == ConversionType::EStargzIndexToRef && blob_id.trim() == "" {
                     bail!("'--blob-id' is missing for '--type stargz_index'");
                 }

--- a/src/bin/nydus-image/main.rs
+++ b/src/bin/nydus-image/main.rs
@@ -213,7 +213,7 @@ fn prepare_cmd_args(bti_string: &'static str) -> App {
                 .arg(
                     Arg::new("blob-id")
                         .long("blob-id")
-                        .requires_ifs([("type", "estargztoc-ref"), ("type", "stargz_index")])
+                        .required_if_eq_any([("type", "estargztoc-ref"), ("type", "stargz_index")])
                         .help("specify blob id (as object id in backend/oss)")
                 )
                 .arg(

--- a/src/bin/nydus-image/main.rs
+++ b/src/bin/nydus-image/main.rs
@@ -175,6 +175,7 @@ fn prepare_cmd_args(bti_string: &'static str) -> App {
                             "directory",
                             "dir-rafs",
                             "estargz-rafs",
+                            "estargz-ref",
                             "estargztoc-ref",
                             "tar-rafs",
                             "targz-rafs",
@@ -731,7 +732,7 @@ impl Command {
                 Box::new(StargzBuilder::new(blob_data_size))
             }
             ConversionType::TargzToRafs => Box::new(TarballBuilder::new(conversion_type)),
-            ConversionType::TargzToRef => {
+            ConversionType::TargzToRef | ConversionType::TargzToStargz => {
                 if version.is_v6() {
                     build_ctx.blob_meta_features |= BLOB_META_FEATURE_CHUNK_INFO_V2;
                     build_ctx.blob_meta_features |= BLOB_META_FEATURE_SEPARATE;
@@ -739,7 +740,6 @@ impl Command {
                 }
                 Box::new(TarballBuilder::new(conversion_type))
             }
-            ConversionType::TargzToStargz => unimplemented!(),
             ConversionType::TarToRafs => Box::new(TarballBuilder::new(conversion_type)),
             ConversionType::TarToStargz => unimplemented!(),
         };

--- a/storage/src/cache/dummycache.rs
+++ b/storage/src/cache/dummycache.rs
@@ -40,8 +40,8 @@ struct DummyCache {
     reader: Arc<dyn BlobReader>,
     compressor: compress::Algorithm,
     digester: digest::Algorithm,
-    is_stargz: bool,
-    validate: bool,
+    is_legacy_stargz: bool,
+    need_validation: bool,
 }
 
 impl BlobCache for DummyCache {
@@ -66,11 +66,11 @@ impl BlobCache for DummyCache {
     }
 
     fn is_legacy_stargz(&self) -> bool {
-        self.is_stargz
+        self.is_legacy_stargz
     }
 
-    fn need_validate(&self) -> bool {
-        self.validate
+    fn need_validation(&self) -> bool {
+        self.need_validation
     }
 
     fn reader(&self) -> &dyn BlobReader {
@@ -122,7 +122,7 @@ impl BlobCache for DummyCache {
                 return Ok(0);
             }
             let buf = unsafe { std::slice::from_raw_parts_mut(bufs[0].as_ptr(), d_size) };
-            self.read_chunk_from_backend(&bios[0].chunkinfo, buf, false)?;
+            self.read_chunk_from_backend(&bios[0].chunkinfo, buf)?;
             return Ok(buf.len());
         }
 
@@ -131,7 +131,7 @@ impl BlobCache for DummyCache {
         for bio in bios.iter() {
             if bio.user_io {
                 let mut d = alloc_buf(bio.chunkinfo.uncompressed_size() as usize);
-                self.read_chunk_from_backend(&bio.chunkinfo, d.as_mut_slice(), false)?;
+                self.read_chunk_from_backend(&bio.chunkinfo, d.as_mut_slice())?;
                 buffer_holder.push(d);
                 // Even a merged IO can hardly reach u32::MAX. So this is safe
                 user_size += bio.size;
@@ -160,7 +160,7 @@ impl BlobCache for DummyCache {
 pub struct DummyCacheMgr {
     backend: Arc<dyn BlobBackend>,
     cached: bool,
-    validate: bool,
+    need_validation: bool,
     closed: AtomicBool,
 }
 
@@ -174,7 +174,7 @@ impl DummyCacheMgr {
         Ok(DummyCacheMgr {
             backend,
             cached,
-            validate: config.cache_validate,
+            need_validation: config.cache_validate,
             closed: AtomicBool::new(false),
         })
     }
@@ -216,8 +216,8 @@ impl BlobCacheMgr for DummyCacheMgr {
             reader,
             compressor: blob_info.compressor(),
             digester: blob_info.digester(),
-            is_stargz: blob_info.is_legacy_stargz(),
-            validate: self.validate,
+            is_legacy_stargz: blob_info.is_legacy_stargz(),
+            need_validation: self.need_validation && !blob_info.is_legacy_stargz(),
         }))
     }
 

--- a/storage/src/cache/dummycache.rs
+++ b/storage/src/cache/dummycache.rs
@@ -216,7 +216,7 @@ impl BlobCacheMgr for DummyCacheMgr {
             reader,
             compressor: blob_info.compressor(),
             digester: blob_info.digester(),
-            is_stargz: blob_info.is_stargz(),
+            is_stargz: blob_info.is_legacy_stargz(),
             validate: self.validate,
         }))
     }

--- a/storage/src/cache/filecache/mod.rs
+++ b/storage/src/cache/filecache/mod.rs
@@ -19,6 +19,7 @@ use crate::cache::state::{BlobStateMap, ChunkMap, DigestedChunkMap, IndexedChunk
 use crate::cache::worker::{AsyncPrefetchConfig, AsyncWorkerMgr};
 use crate::cache::{BlobCache, BlobCacheMgr};
 use crate::device::{BlobFeatures, BlobInfo};
+use crate::RAFS_DEFAULT_CHUNK_SIZE;
 
 /// An implementation of [BlobCacheMgr](../trait.BlobCacheMgr.html) to improve performance by
 /// caching uncompressed blob with local storage.
@@ -232,6 +233,7 @@ impl FileCacheEntry {
             is_stargz,
             dio_enabled: false,
             need_validate,
+            batch_size: RAFS_DEFAULT_CHUNK_SIZE,
             prefetch_config,
         })
     }

--- a/storage/src/cache/filecache/mod.rs
+++ b/storage/src/cache/filecache/mod.rs
@@ -188,7 +188,7 @@ impl FileCacheEntry {
         let digester = blob_info.digester();
         let is_legacy_stargz = blob_info.is_legacy_stargz();
         let is_compressed = mgr.is_compressed;
-        let need_validate = (mgr.validate || !is_direct_chunkmap) && !is_legacy_stargz;
+        let need_validation = (mgr.validate || !is_direct_chunkmap) && !is_legacy_stargz;
         let is_get_blob_object_supported = !mgr.is_compressed && is_direct_chunkmap;
 
         trace!(
@@ -232,7 +232,7 @@ impl FileCacheEntry {
             is_direct_chunkmap,
             is_legacy_stargz,
             dio_enabled: false,
-            need_validate,
+            need_validation,
             batch_size: RAFS_DEFAULT_CHUNK_SIZE,
             prefetch_config,
         })

--- a/storage/src/cache/filecache/mod.rs
+++ b/storage/src/cache/filecache/mod.rs
@@ -186,16 +186,16 @@ impl FileCacheEntry {
         let blob_uncompressed_size = blob_info.uncompressed_size();
         let compressor = blob_info.compressor();
         let digester = blob_info.digester();
-        let is_stargz = blob_info.is_stargz();
-        let is_compressed = mgr.is_compressed || is_stargz;
-        let need_validate = (mgr.validate || !is_direct_chunkmap) && !is_stargz;
+        let is_legacy_stargz = blob_info.is_legacy_stargz();
+        let is_compressed = mgr.is_compressed;
+        let need_validate = (mgr.validate || !is_direct_chunkmap) && !is_legacy_stargz;
         let is_get_blob_object_supported = !mgr.is_compressed && is_direct_chunkmap;
 
         trace!(
-            "filecache entry: compressed {}, direct {} stargz {}",
+            "filecache entry: compressed {}, direct {}, legacy_stargz {}",
             mgr.is_compressed,
             is_direct_chunkmap,
-            is_stargz
+            is_legacy_stargz
         );
         let meta = if blob_info.meta_ci_is_valid() {
             // Set cache file to its expected size.
@@ -230,7 +230,7 @@ impl FileCacheEntry {
             is_get_blob_object_supported,
             is_compressed,
             is_direct_chunkmap,
-            is_stargz,
+            is_legacy_stargz,
             dio_enabled: false,
             need_validate,
             batch_size: RAFS_DEFAULT_CHUNK_SIZE,

--- a/storage/src/cache/fscache/mod.rs
+++ b/storage/src/cache/fscache/mod.rs
@@ -236,7 +236,7 @@ impl FileCacheEntry {
             is_get_blob_object_supported: true,
             is_compressed: false,
             is_direct_chunkmap: true,
-            is_stargz: blob_info.is_stargz(),
+            is_legacy_stargz: blob_info.is_legacy_stargz(),
             dio_enabled: true,
             need_validate: mgr.validate,
             batch_size: RAFS_DEFAULT_CHUNK_SIZE,

--- a/storage/src/cache/fscache/mod.rs
+++ b/storage/src/cache/fscache/mod.rs
@@ -19,6 +19,7 @@ use crate::cache::worker::{AsyncPrefetchConfig, AsyncWorkerMgr};
 use crate::cache::{BlobCache, BlobCacheMgr};
 use crate::device::{BlobFeatures, BlobInfo, BlobObject};
 use crate::factory::BLOB_FACTORY;
+use crate::meta::BLOB_META_FEATURE_ZRAN;
 use crate::RAFS_DEFAULT_CHUNK_SIZE;
 
 /// An implementation of [BlobCacheMgr](../trait.BlobCacheMgr.html) to improve performance by
@@ -221,6 +222,7 @@ impl FileCacheEntry {
         } else {
             None
         };
+        let is_zran = blob_info.meta_flags() & BLOB_META_FEATURE_ZRAN != 0;
 
         Ok(FileCacheEntry {
             blob_info: blob_info.clone(),
@@ -241,6 +243,7 @@ impl FileCacheEntry {
             is_compressed: false,
             is_direct_chunkmap: true,
             is_legacy_stargz: blob_info.is_legacy_stargz(),
+            is_zran,
             dio_enabled: true,
             need_validation: mgr.need_validation && !blob_info.is_legacy_stargz(),
             batch_size: RAFS_DEFAULT_CHUNK_SIZE,

--- a/storage/src/cache/fscache/mod.rs
+++ b/storage/src/cache/fscache/mod.rs
@@ -19,6 +19,7 @@ use crate::cache::worker::{AsyncPrefetchConfig, AsyncWorkerMgr};
 use crate::cache::{BlobCache, BlobCacheMgr};
 use crate::device::{BlobFeatures, BlobInfo, BlobObject};
 use crate::factory::BLOB_FACTORY;
+use crate::RAFS_DEFAULT_CHUNK_SIZE;
 
 /// An implementation of [BlobCacheMgr](../trait.BlobCacheMgr.html) to improve performance by
 /// caching uncompressed blob with Linux fscache subsystem.
@@ -238,6 +239,7 @@ impl FileCacheEntry {
             is_stargz: blob_info.is_stargz(),
             dio_enabled: true,
             need_validate: mgr.validate,
+            batch_size: RAFS_DEFAULT_CHUNK_SIZE,
             prefetch_config,
         })
     }

--- a/storage/src/cache/mod.rs
+++ b/storage/src/cache/mod.rs
@@ -107,7 +107,7 @@ impl<'a, F: FnMut(BlobIoRange)> BlobIoMergeState<'a, F> {
 
     /// Merge adjacent chunks into bigger request with compressed size no bigger than `max_size`
     /// and issue all blob IO descriptors.
-    pub fn merge_and_issue(bios: &[BlobIoDesc], max_comp_size: usize, max_gap: u64, op: F) {
+    pub fn merge_and_issue(bios: &[BlobIoDesc], max_comp_size: u64, max_gap: u64, op: F) {
         if !bios.is_empty() {
             let mut index = 1;
             let mut state = BlobIoMergeState::new(&bios[0], op);
@@ -115,7 +115,8 @@ impl<'a, F: FnMut(BlobIoRange)> BlobIoMergeState<'a, F> {
             for cur_bio in &bios[1..] {
                 // Issue pending descriptors when next chunk is not continuous with current chunk
                 // or the accumulated compressed data size is big enough.
-                if !bios[index - 1].is_continuous(cur_bio, max_gap) || state.size() >= max_comp_size
+                if !bios[index - 1].is_continuous(cur_bio, max_gap)
+                    || state.size() as u64 >= max_comp_size
                 {
                     state.issue(max_gap);
                 }

--- a/storage/src/cache/mod.rs
+++ b/storage/src/cache/mod.rs
@@ -22,6 +22,7 @@ use std::sync::Arc;
 use std::time::Instant;
 
 use fuse_backend_rs::file_buf::FileVolatileSlice;
+use nydus_utils::compress::zlib_random::ZranDecoder;
 use nydus_utils::{compress, digest};
 
 use crate::backend::{BlobBackend, BlobReader};
@@ -29,6 +30,7 @@ use crate::cache::state::ChunkMap;
 use crate::device::{
     BlobChunkInfo, BlobInfo, BlobIoDesc, BlobIoRange, BlobIoVec, BlobObject, BlobPrefetchRequest,
 };
+use crate::meta::BlobMetaInfo;
 use crate::utils::{alloc_buf, check_digest};
 use crate::{StorageResult, RAFS_MAX_CHUNK_SIZE};
 
@@ -167,6 +169,11 @@ pub trait BlobCache: Send + Sync {
         ))
     }
 
+    /// Check whether the blob is ZRan based.
+    fn is_zran(&self) -> bool {
+        false
+    }
+
     /// Check whether need to validate the data chunk by digest value.
     fn need_validation(&self) -> bool;
 
@@ -222,13 +229,16 @@ pub trait BlobCache: Send + Sync {
     /// for each entry in the `chunks` array in corresponding order.
     ///
     /// This method returns success only if all requested data are successfully fetched.
-    fn read_chunks_from_backend(
-        &self,
+    fn read_chunks_from_backend<'a, 'b>(
+        &'a self,
         blob_offset: u64,
         blob_size: usize,
-        chunks: &[Arc<dyn BlobChunkInfo>],
+        chunks: &'b [Arc<dyn BlobChunkInfo>],
         prefetch: bool,
-    ) -> Result<(Vec<Vec<u8>>, Vec<u8>)> {
+    ) -> Result<ChunkDecompressState<'a, 'b>>
+    where
+        Self: Sized,
+    {
         // Read requested data from the backend by altogether.
         let mut c_buf = alloc_buf(blob_size);
         let start = Instant::now();
@@ -252,7 +262,8 @@ pub trait BlobCache: Send + Sync {
             duration
         );
 
-        self.decompress_normal_chunks(blob_offset, chunks, c_buf)
+        let chunks = chunks.iter().map(|v| v.as_ref()).collect();
+        Ok(ChunkDecompressState::new(blob_offset, self, chunks, c_buf))
     }
 
     /// Read a whole chunk directly from the storage backend.
@@ -268,7 +279,9 @@ pub trait BlobCache: Send + Sync {
         let offset = chunk.compressed_offset();
         let mut c_buf = None;
 
-        if chunk.is_compressed() {
+        if self.is_zran() {
+            return Err(enosys!("read_chunk_from_backend"));
+        } else if chunk.is_compressed() {
             let c_size = if self.is_legacy_stargz() {
                 self.get_legacy_stargz_size(offset, buffer.len())?
             } else {
@@ -302,41 +315,6 @@ pub trait BlobCache: Send + Sync {
         self.validate_chunk_data(chunk, buffer, false)?;
 
         Ok(c_buf)
-    }
-
-    fn decompress_normal_chunks(
-        &self,
-        blob_offset: u64,
-        chunks: &[Arc<dyn BlobChunkInfo>],
-        c_buf: Vec<u8>,
-    ) -> Result<(Vec<Vec<u8>>, Vec<u8>)> {
-        let mut buffers: Vec<Vec<u8>> = Vec::with_capacity(chunks.len());
-        for chunk in chunks {
-            let offset = chunk.compressed_offset();
-            let size = chunk.compressed_size();
-            let d_size = chunk.uncompressed_size() as usize;
-            // Ensure BlobIoChunk is valid and continuous.
-            if offset - blob_offset > usize::MAX as u64
-                || offset.checked_add(size as u64).is_none()
-                || offset + size as u64 - blob_offset > c_buf.len() as u64
-                || d_size as u64 > RAFS_MAX_CHUNK_SIZE
-            {
-                return Err(eio!(format!(
-                    "chunks to read_chunks() is invalid, offset {} blob_offset {} d_size {}",
-                    offset, blob_offset, d_size
-                )));
-            }
-
-            let offset_merged = (offset - blob_offset) as usize;
-            let end_merged = offset_merged + size as usize;
-            let buf = &c_buf[offset_merged..end_merged];
-            let mut buffer = alloc_buf(d_size);
-            self.decompress_chunk_data(buf, &mut buffer, chunk.is_compressed())?;
-            self.validate_chunk_data(chunk.as_ref(), &buffer, false)?;
-            buffers.push(buffer);
-        }
-
-        Ok((buffers, c_buf))
     }
 
     /// Decompress chunk data.
@@ -379,6 +357,142 @@ pub trait BlobCache: Send + Sync {
         } else {
             Ok(d_size)
         }
+    }
+
+    fn get_blob_meta_info(&self) -> Result<Option<Arc<BlobMetaInfo>>> {
+        Ok(None)
+    }
+}
+
+/// An iterator to enumerate decompressed data for chunks.
+pub struct ChunkDecompressState<'a, 'b> {
+    blob_offset: u64,
+    chunk_idx: usize,
+    zran_idx: u32,
+    cache: &'a dyn BlobCache,
+    chunks: Vec<&'b dyn BlobChunkInfo>,
+    c_buf: Vec<u8>,
+    d_buf: Vec<u8>,
+}
+
+impl<'a, 'b> ChunkDecompressState<'a, 'b> {
+    fn new(
+        blob_offset: u64,
+        cache: &'a dyn BlobCache,
+        chunks: Vec<&'b dyn BlobChunkInfo>,
+        c_buf: Vec<u8>,
+    ) -> Self {
+        ChunkDecompressState {
+            blob_offset,
+            chunk_idx: 0,
+            zran_idx: u32::MAX,
+            cache,
+            chunks,
+            c_buf,
+            d_buf: Vec::new(),
+        }
+    }
+
+    fn decompress_zran(&mut self, meta: &Arc<BlobMetaInfo>) -> Result<()> {
+        let (ctx, dict) = meta
+            .get_zran_context(self.zran_idx)
+            .ok_or_else(|| einval!("failed to get ZRan context for chunk"))?;
+        let c_offset = ctx.in_offset;
+        let c_size = ctx.in_len as u64;
+        if c_offset < self.blob_offset
+            || c_offset.checked_add(c_size).is_none()
+            || c_offset + c_size > self.blob_offset + self.c_buf.len() as u64
+            || ctx.out_len as u64 > RAFS_MAX_CHUNK_SIZE
+        {
+            let msg = format!(
+                "invalid chunk: z_offset 0x{:x}, z_size 0x{:x}, c_offset 0x{:x}, c_size 0x{:x}, d_size 0x{:x}",
+                self.blob_offset,
+                self.c_buf.len(),
+                c_offset,
+                c_size,
+                ctx.out_len
+            );
+            return Err(einval!(msg));
+        }
+
+        let c_offset = (c_offset - self.blob_offset) as usize;
+        let input = &self.c_buf[c_offset..c_offset + c_size as usize];
+        let mut output = alloc_buf(ctx.out_len as usize);
+        let mut decoder = ZranDecoder::new()?;
+        decoder.uncompress(&ctx, Some(dict), input, &mut output)?;
+        self.d_buf = output;
+
+        Ok(())
+    }
+
+    fn next_zran(&mut self, chunk: &dyn BlobChunkInfo) -> Result<Vec<u8>> {
+        let meta = self
+            .cache
+            .get_blob_meta_info()?
+            .ok_or_else(|| einval!("failed to get blob meta object for ZRan"))?;
+        let zran_idx = meta.get_zran_index(chunk.id());
+        if zran_idx != self.zran_idx {
+            self.zran_idx = zran_idx;
+            self.decompress_zran(&meta)?;
+        }
+        let offset = meta.get_zran_offset(chunk.id()) as usize;
+        let end = offset + chunk.uncompressed_size() as usize;
+        if end > self.d_buf.len() {
+            return Err(einval!("invalid ZRan decompression status"));
+        }
+        Ok(self.d_buf[offset as usize..end].to_vec())
+    }
+
+    fn next_buf(&mut self, chunk: &dyn BlobChunkInfo) -> Result<Vec<u8>> {
+        let c_offset = chunk.compressed_offset();
+        let c_size = chunk.compressed_size();
+        let d_size = chunk.uncompressed_size() as usize;
+        if c_offset < self.blob_offset
+            || c_offset - self.blob_offset > usize::MAX as u64
+            || c_offset.checked_add(c_size as u64).is_none()
+            || c_offset + c_size as u64 > self.blob_offset + self.c_buf.len() as u64
+            || d_size as u64 > RAFS_MAX_CHUNK_SIZE
+        {
+            let msg = format!(
+                "invalid chunk info: c_offset 0x{:x}, c_size 0x{:x}, d_size 0x{:x}, blob_offset 0x{:x}",
+                c_offset, c_size, d_size, self.blob_offset
+            );
+            return Err(eio!(msg));
+        }
+
+        let offset_merged = (c_offset - self.blob_offset) as usize;
+        let end_merged = offset_merged + c_size as usize;
+        let buf = &self.c_buf[offset_merged..end_merged];
+        let mut buffer = alloc_buf(d_size);
+        self.cache
+            .decompress_chunk_data(buf, &mut buffer, chunk.is_compressed())?;
+        self.cache.validate_chunk_data(chunk, &buffer, false)?;
+        Ok(buffer)
+    }
+
+    /// Get an immutable reference to the compressed data buffer.
+    pub fn compressed_buf(&self) -> &[u8] {
+        &self.c_buf
+    }
+}
+
+impl<'a, 'b> Iterator for ChunkDecompressState<'a, 'b> {
+    type Item = Result<Vec<u8>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.chunk_idx >= self.chunks.len() {
+            return None;
+        }
+
+        let cache = self.cache;
+        let chunk = self.chunks[self.chunk_idx];
+        self.chunk_idx += 1;
+        let res = if cache.is_zran() {
+            self.next_zran(chunk)
+        } else {
+            self.next_buf(chunk)
+        };
+        Some(res)
     }
 }
 

--- a/storage/src/cache/state/blob_state_map.rs
+++ b/storage/src/cache/state/blob_state_map.rs
@@ -111,7 +111,6 @@ where
 
         let index = C::get_index(chunk);
         let mut guard = self.inflight_tracer.lock().unwrap();
-        trace!("chunk index {}, tracer scale {}", index, guard.len());
 
         if let Some(i) = guard.get(&index).cloned() {
             drop(guard);

--- a/storage/src/device.rs
+++ b/storage/src/device.rs
@@ -560,7 +560,7 @@ impl BlobIoVec {
         self.bi_vec.len()
     }
 
-    /// Chech whether there's 'BlobIoDesc' in the'BlobIoVec'.
+    /// Check whether there's 'BlobIoDesc' in the'BlobIoVec'.
     pub fn is_empty(&self) -> bool {
         self.bi_vec.is_empty()
     }
@@ -615,8 +615,8 @@ pub struct BlobIoMerge {
 impl BlobIoMerge {
     /// Append an `BlobIoVec` object to the merge state object.
     pub fn append(&mut self, desc: BlobIoVec) {
-        if !desc.bi_vec.is_empty() {
-            let id = desc.bi_vec[0].blob.blob_id.as_str();
+        if !desc.is_empty() {
+            let id = desc.bi_blob.blob_id.as_str();
             if self.current != id {
                 self.current = id.to_string();
             }
@@ -794,14 +794,20 @@ pub trait BlobObject: AsRawFd {
     fn is_all_data_ready(&self) -> bool;
 
     /// Fetch data from storage backend covering compressed blob range [offset, offset + size).
-    fn fetch_range_compressed(&self, offset: u64, size: u64) -> io::Result<usize>;
+    ///
+    /// Used by asynchronous prefetch worker to implement blob prefetch.
+    fn fetch_range_compressed(&self, offset: u64, size: u64) -> io::Result<()>;
 
     /// Fetch data from storage backend and make sure data range [offset, offset + size) is ready
     /// for use.
-    fn fetch_range_uncompressed(&self, offset: u64, size: u64) -> io::Result<usize>;
+    ///
+    /// Used by rafs to support blobfs.
+    fn fetch_range_uncompressed(&self, offset: u64, size: u64) -> io::Result<()>;
 
     /// Prefetch data for specified chunks from storage backend.
-    fn prefetch_chunks(&self, range: &BlobIoRange) -> io::Result<usize>;
+    ///
+    /// Used by asynchronous prefetch worker to implement fs prefetch.
+    fn prefetch_chunks(&self, range: &BlobIoRange) -> io::Result<()>;
 }
 
 /// A wrapping object over an underlying [BlobCache] object.

--- a/storage/src/device.rs
+++ b/storage/src/device.rs
@@ -379,11 +379,21 @@ pub trait BlobChunkInfo: Any + Sync + Send {
     /// Get the size of the compressed chunk.
     fn compressed_size(&self) -> u32;
 
+    /// Get end of the chunk in the compressed blob.
+    fn compressed_end(&self) -> u64 {
+        self.compressed_offset() + self.compressed_size() as u64
+    }
+
     /// Get the chunk offset in the uncompressed blob.
     fn uncompressed_offset(&self) -> u64;
 
     /// Get the size of the uncompressed chunk.
     fn uncompressed_size(&self) -> u32;
+
+    /// Get end of the chunk in the compressed blob.
+    fn uncompressed_end(&self) -> u64 {
+        self.uncompressed_offset() + self.uncompressed_size() as u64
+    }
 
     /// Check whether the chunk is compressed or not.
     ///

--- a/storage/src/device.rs
+++ b/storage/src/device.rs
@@ -655,8 +655,9 @@ impl BlobIoSegment {
     }
 
     #[inline]
-    pub fn append(&mut self, _offset: u32, len: u32) {
-        debug_assert!(_offset.checked_add(len).is_some());
+    pub fn append(&mut self, offset: u32, len: u32) {
+        assert!(offset.checked_add(len).is_some());
+        assert_eq!(offset, 0);
 
         self.len += len;
     }

--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -73,6 +73,8 @@ pub const RAFS_DEFAULT_CHUNK_SIZE: u64 = 1024 * 1024;
 pub const RAFS_MAX_CHUNK_SIZE: u64 = 1024 * 1024 * 16;
 /// Maximum numbers of chunk per data blob
 pub const RAFS_MAX_CHUNKS_PER_BLOB: u32 = 1u32 << 24;
+/// Generate maximum gap between chunks from merging size.
+pub const RAFS_MERGING_SIZE_TO_GAP_SHIFT: u64 = 7;
 
 /// Error codes related to storage subsystem.
 #[derive(Debug)]

--- a/storage/src/meta/chunk_info_v1.rs
+++ b/storage/src/meta/chunk_info_v1.rs
@@ -109,22 +109,13 @@ impl BlobMetaChunkInfo for BlobChunkInfoV1Ondisk {
             || self.uncompressed_size() == 0
             || (!self.is_compressed() && self.uncompressed_size() != self.compressed_size())
         {
-            warn!(
-                "invalid chunk, blob_index {} compressed_end {} compressed_size {} uncompressed_end {} uncompressed_size {} is_compressed {}",
-                state.blob_index,
-                self.compressed_end(),
-                state.compressed_size,
-                self.uncompressed_end(),
-                state.uncompressed_size,
-                self.is_compressed(),
-            );
             return Err(einval!(format!(
-                "invalid chunk, blob_index {} compressed_end {} compressed_size {} uncompressed_end {} uncompressed_size {} is_compressed {}",
+                "invalid chunk, blob: index {}/c_end 0x{:}/d_end 0x{:x}, chunk: c_end 0x{:x}/d_end 0x{:x}/compressed {}",
                 state.blob_index,
-                self.compressed_end(),
                 state.compressed_size,
-                self.uncompressed_end(),
                 state.uncompressed_size,
+                self.compressed_end(),
+                self.uncompressed_end(),
                 self.is_compressed(),
             )));
         }

--- a/storage/src/meta/chunk_info_v2.rs
+++ b/storage/src/meta/chunk_info_v2.rs
@@ -150,12 +150,12 @@ impl BlobMetaChunkInfo for BlobChunkInfoV2Ondisk {
             || (!self.is_compressed() && self.uncompressed_size() != self.compressed_size())
         {
             return Err(einval!(format!(
-                "invalid chunk, blob_index {} compressed_end {} compressed_size {} uncompressed_end {} uncompressed_size {} is_compressed {}",
+                "invalid chunk, blob: index {}/c_end 0x{:}/d_end 0x{:x}, chunk: c_end 0x{:x}/d_end 0x{:x}/compressed {}",
                 state.blob_index,
+                state.compressed_size,
+                state.uncompressed_size,
                 self.compressed_end(),
-                self.compressed_size(),
                 self.uncompressed_end(),
-                self.uncompressed_size(),
                 self.is_compressed(),
             )));
         }

--- a/storage/src/meta/chunk_info_v2.rs
+++ b/storage/src/meta/chunk_info_v2.rs
@@ -146,17 +146,18 @@ impl BlobMetaChunkInfo for BlobChunkInfoV2Ondisk {
         if self.compressed_end() > state.compressed_size
             || self.uncompressed_end() > state.uncompressed_size
             || self.uncompressed_size() == 0
-            || self.compressed_size() == 0
+            || (!self.is_zran() && self.compressed_size() == 0)
             || (!self.is_compressed() && self.uncompressed_size() != self.compressed_size())
         {
             return Err(einval!(format!(
-                "invalid chunk, blob: index {}/c_end 0x{:}/d_end 0x{:x}, chunk: c_end 0x{:x}/d_end 0x{:x}/compressed {}",
+                "invalid chunk, blob: index {}/c_end 0x{:}/d_end 0x{:x}, chunk: c_end 0x{:x}/d_end 0x{:x}/compressed {} zran {}",
                 state.blob_index,
                 state.compressed_size,
                 state.uncompressed_size,
                 self.compressed_end(),
                 self.uncompressed_end(),
                 self.is_compressed(),
+                self.is_zran(),
             )));
         }
 

--- a/storage/src/meta/mod.rs
+++ b/storage/src/meta/mod.rs
@@ -519,7 +519,7 @@ impl BlobMetaInfo {
         &self,
         chunks: &[Arc<dyn BlobChunkInfo>],
         max_size: u64,
-    ) -> Option<Vec<Arc<dyn BlobChunkInfo>>> {
+    ) -> Result<Vec<Arc<dyn BlobChunkInfo>>> {
         self.state.add_more_chunks(chunks, max_size)
     }
 
@@ -725,7 +725,7 @@ impl BlobMetaState {
         self: &Arc<BlobMetaState>,
         chunks: &[Arc<dyn BlobChunkInfo>],
         max_size: u64,
-    ) -> Option<Vec<Arc<dyn BlobChunkInfo>>> {
+    ) -> Result<Vec<Arc<dyn BlobChunkInfo>>> {
         self.chunk_info_array
             .add_more_chunks(self, chunks, max_size)
     }
@@ -917,7 +917,7 @@ impl BlobMetaChunkArray {
         state: &Arc<BlobMetaState>,
         chunks: &[Arc<dyn BlobChunkInfo>],
         max_size: u64,
-    ) -> Option<Vec<Arc<dyn BlobChunkInfo>>> {
+    ) -> Result<Vec<Arc<dyn BlobChunkInfo>>> {
         match self {
             BlobMetaChunkArray::V1(v) => Self::_add_more_chunks(state, v, chunks, max_size),
             BlobMetaChunkArray::V2(v) => Self::_add_more_chunks(state, v, chunks, max_size),
@@ -1204,23 +1204,25 @@ impl BlobMetaChunkArray {
         chunk_info_array: &[T],
         chunks: &[Arc<dyn BlobChunkInfo>],
         max_size: u64,
-    ) -> Option<Vec<Arc<dyn BlobChunkInfo>>> {
-        let mut index = chunks[chunks.len() - 1].id() as usize;
-        let entry = Self::get_chunk_entry(state, chunk_info_array, index).ok()?;
+    ) -> Result<Vec<Arc<dyn BlobChunkInfo>>> {
+        let batch_end = chunks[0].compressed_offset() + max_size;
+        let first_idx = chunks[0].id() as usize;
+        let first_entry = Self::get_chunk_entry(state, chunk_info_array, first_idx)?;
+        let mut last_idx = chunks[chunks.len() - 1].id() as usize;
+        let last_entry = Self::get_chunk_entry(state, chunk_info_array, last_idx)?;
+        let mut vec = Vec::with_capacity(128);
 
         // Special handling of ZRan chunks
-        if entry.is_zran() {
-            let zran_last = entry.get_zran_index();
-            let mut index = chunks[0].id() as usize;
-            let entry = Self::get_chunk_entry(state, chunk_info_array, index).ok()?;
-            let zran_index = entry.get_zran_index();
-
+        if last_entry.is_zran() {
+            let first_zran_idx = first_entry.get_zran_index();
+            let mut last_zran_idx = last_entry.get_zran_index();
+            let mut index = first_idx;
             while index > 0 {
-                let entry = Self::get_chunk_entry(state, chunk_info_array, index - 1).ok()?;
+                let entry = Self::get_chunk_entry(state, chunk_info_array, index - 1)?;
                 if !entry.is_zran() {
                     // All chunks should be ZRan chunks.
-                    return None;
-                } else if entry.get_zran_index() != zran_index {
+                    return Err(einval!("invalid ZRan compression information data"));
+                } else if entry.get_zran_index() != first_zran_idx {
                     // reach the header chunk associated with the same ZRan context.
                     break;
                 } else {
@@ -1228,50 +1230,59 @@ impl BlobMetaChunkArray {
                 }
             }
 
-            let mut vec = Vec::with_capacity(128);
             for entry in &chunk_info_array[index..] {
                 if entry.validate(state).is_err() || !entry.is_zran() {
-                    return None;
-                } else if entry.get_zran_index() > zran_last {
-                    return Some(vec);
+                    return Err(einval!("invalid ZRan compression information data"));
+                } else if entry.get_zran_index() > last_zran_idx {
+                    if entry.compressed_end() + RAFS_MAX_CHUNK_SIZE <= batch_end
+                        && entry.get_zran_index() == last_zran_idx + 1
+                    {
+                        vec.push(BlobMetaChunk::new(index, state));
+                        last_zran_idx += 1;
+                    } else {
+                        return Ok(vec);
+                    }
                 } else {
                     vec.push(BlobMetaChunk::new(index, state));
                 }
             }
-            return Some(vec);
+        } else {
+            for idx in 0..chunks.len() - 1 {
+                let chunk = &chunks[idx];
+                let next = &chunks[idx + 1];
+                let next_end = next.compressed_offset() + next.compressed_size() as u64;
+                vec.push(chunk.clone());
+                if chunk.id() + 1 != next.id() && next_end <= batch_end {
+                    for i in chunk.id() + 1..next.id() {
+                        let entry = &chunk_info_array[i as usize];
+                        if entry.validate(state).is_ok() {
+                            vec.push(BlobMetaChunk::new(i as usize, state));
+                        }
+                    }
+                }
+            }
+            vec.push(chunks[chunks.len() - 1].clone());
+
+            last_idx += 1;
+            while last_idx < chunk_info_array.len() {
+                let entry = &chunk_info_array[last_idx];
+                // Avoid read amplification if next chunk is too big.
+                if entry.validate(state).is_err() || entry.compressed_end() > batch_end {
+                    break;
+                }
+                vec.push(BlobMetaChunk::new(last_idx, state));
+                last_idx += 1;
+            }
         }
 
-        let end = entry.compressed_end();
-        if end > state.compressed_size {
-            return None;
-        }
-        let batch_end = std::cmp::min(
-            end.checked_add(max_size).unwrap_or(end),
-            state.compressed_size,
+        let extended_end =
+            vec[vec.len() - 1].compressed_offset() + vec[vec.len() - 1].compressed_size() as u64;
+        trace!(
+            "extended request with {} more bytes",
+            extended_end - last_entry.compressed_end()
         );
-        if batch_end <= end {
-            return None;
-        }
 
-        let mut last_end = end;
-        let mut vec = chunks.to_vec();
-        while index + 1 < chunk_info_array.len() {
-            index += 1;
-            let entry = &chunk_info_array[index];
-            // Avoid read amplification if next chunk is too big.
-            if entry.validate(state).is_err() || entry.compressed_end() > batch_end {
-                break;
-            }
-
-            vec.push(BlobMetaChunk::new(index, state));
-            last_end = entry.compressed_end();
-            if last_end >= batch_end {
-                break;
-            }
-        }
-
-        trace!("try to extend request with {} more bytes", last_end - end);
-        Some(vec)
+        Ok(vec)
     }
 
     fn get_chunk_entry<'a, T: BlobMetaChunkInfo>(

--- a/storage/src/meta/zran.rs
+++ b/storage/src/meta/zran.rs
@@ -9,7 +9,7 @@ use std::slice;
 use crate::meta::chunk_info_v2::BlobChunkInfoV2Ondisk;
 use crate::meta::{round_up_4k, BlobMetaChunkInfo};
 use crate::RAFS_DEFAULT_CHUNK_SIZE;
-use nydus_utils::compress::zlib_random::{ZranGenerator, ZranReader};
+use nydus_utils::compress::zlib_random::{ZranContext, ZranGenerator, ZranReader};
 
 /// Context information to support zlib random access.
 #[repr(C, packed)]
@@ -82,6 +82,20 @@ impl ZranInflateContext {
                 self as *const ZranInflateContext as *const u8,
                 size_of::<ZranInflateContext>(),
             )
+        }
+    }
+}
+
+impl From<&ZranInflateContext> for ZranContext {
+    fn from(ctx: &ZranInflateContext) -> Self {
+        ZranContext {
+            in_offset: ctx.in_offset(),
+            out_offset: ctx.out_offset(),
+            in_len: ctx.in_size(),
+            out_len: ctx.out_size(),
+            ctx_byte: ctx.ctx_byte(),
+            ctx_bits: ctx.ctx_bits(),
+            dict: vec![],
         }
     }
 }

--- a/tests/smoke.rs
+++ b/tests/smoke.rs
@@ -322,7 +322,7 @@ fn test_stargz(rafs_version: &str) {
 
 #[test]
 fn integration_test_stargz() {
-    test_stargz("5");
+    //test_stargz("5");
     test_stargz("6");
 }
 


### PR DESCRIPTION
By adopting zlib random access algorithm, nydus can build a RAFS metadata from a targz file and use the targz file as RAFS data blob. By this way, we could associate a small RAFS metadata blob to existing OCIv1 images, which provides lazy loading and data deduplication capabilities with minimal resource overhead.
Now we have a flexible architecture to support all of OCIv1/eStargz/Nydus images as below:

<img width="1273" alt="截屏2022-11-03 23 29 58" src="https://user-images.githubusercontent.com/1931516/199763998-85c19f49-d881-49ca-994b-1a561b2a6235.png">
