### PR TITLE
Reduce duplicated code by using utils/filemap

### DIFF
--- a/rafs/src/lib.rs
+++ b/rafs/src/lib.rs
@@ -68,6 +68,7 @@ pub enum RafsError {
     Configure(String),
     Incompatible(u16),
     IllegalMetaStruct(MetaType, String),
+    InvalidImageData,
 }
 
 impl std::error::Error for RafsError {

--- a/rafs/src/metadata/md_v6.rs
+++ b/rafs/src/metadata/md_v6.rs
@@ -58,7 +58,7 @@ impl RafsSuper {
 
         match self.mode {
             RafsMode::Direct => {
-                let mut sb_v6 = DirectSuperBlockV6::new(&self.meta, self.validate_digest);
+                let mut sb_v6 = DirectSuperBlockV6::new(&self.meta);
                 sb_v6.load(r)?;
                 self.superblock = Arc::new(sb_v6);
                 Ok(true)

--- a/storage/src/cache/state/indexed_chunk_map.rs
+++ b/storage/src/cache/state/indexed_chunk_map.rs
@@ -210,7 +210,7 @@ mod tests {
         let map = IndexedChunkMap::new(&blob_path, 1, true).unwrap();
         assert_eq!(map.map.not_ready_count.load(Ordering::Acquire), 1);
         assert_eq!(map.map.count, 1);
-        assert_eq!(map.map.size, 0x1001);
+        assert_eq!(map.map.size(), 0x1001);
         assert!(!map.is_range_all_ready());
         assert!(!map.is_ready(chunk.as_base()).unwrap());
         map.set_ready_and_clear_pending(chunk.as_base()).unwrap();
@@ -246,7 +246,7 @@ mod tests {
         let map = IndexedChunkMap::new(&blob_path, 1, true).unwrap();
         assert_eq!(map.map.not_ready_count.load(Ordering::Acquire), 1);
         assert_eq!(map.map.count, 1);
-        assert_eq!(map.map.size, 0x1001);
+        assert_eq!(map.map.size(), 0x1001);
         assert!(!map.is_range_all_ready());
         assert!(!map.is_ready(chunk.as_base()).unwrap());
         map.set_ready_and_clear_pending(chunk.as_base()).unwrap();
@@ -292,7 +292,7 @@ mod tests {
         let map = IndexedChunkMap::new(&blob_path, 1, true).unwrap();
         assert!(map.is_range_all_ready());
         assert_eq!(map.map.count, 1);
-        assert_eq!(map.map.size, 0x1001);
+        assert_eq!(map.map.size(), 0x1001);
         assert!(map.is_ready(chunk.as_base()).unwrap());
         map.set_ready_and_clear_pending(chunk.as_base()).unwrap();
         assert!(map.is_ready(chunk.as_base()).unwrap());
@@ -337,7 +337,7 @@ mod tests {
         let map = IndexedChunkMap::new(&blob_path, 1, true).unwrap();
         assert_eq!(map.map.not_ready_count.load(Ordering::Acquire), 1);
         assert_eq!(map.map.count, 1);
-        assert_eq!(map.map.size, 0x1001);
+        assert_eq!(map.map.size(), 0x1001);
         assert!(!map.is_range_all_ready());
         assert!(!map.is_ready(chunk.as_base()).unwrap());
         map.set_ready_and_clear_pending(chunk.as_base()).unwrap();

--- a/utils/src/filemap.rs
+++ b/utils/src/filemap.rs
@@ -88,6 +88,11 @@ impl FileMapState {
         })
     }
 
+    /// Get size of mapped region.
+    pub fn size(&self) -> usize {
+        self.size
+    }
+
     /// Cast a subregion of the mapped area to an object reference.
     pub fn get_ref<T>(&self, offset: usize) -> Result<&T> {
         let start = self.base.wrapping_add(offset);


### PR DESCRIPTION
Use the generic filemap from nydus-utils crate to avoid duplicated code.

Also reduce unsafe code, now there's only two unsafe left in direct v5.

Fix a lifetime related by xattr related code.

Signed-off-by: Jiang Liu <gerry@linux.alibaba.com>