### PR TITLE
storage: correctly setup size for compressed cache file

### DIFF
--- a/storage/src/cache/fscache/mod.rs
+++ b/storage/src/cache/fscache/mod.rs
@@ -220,7 +220,9 @@ impl FileCacheEntry {
             let meta = FileCacheMeta::new(blob_file_path, blob_info.clone(), Some(reader.clone()))?;
             Some(meta)
         } else {
-            None
+            return Err(enosys!(
+                "fscache doesn't support blobs without blob meta information"
+            ));
         };
         let is_zran = blob_info.meta_flags() & BLOB_META_FEATURE_ZRAN != 0;
 


### PR DESCRIPTION
When cache file is compressed, file size is incorrectly set to uncompressed file size.

Signed-off-by: Jiang Liu <gerry@linux.alibaba.com>