### PR TITLE
Some minor fixes

### DIFF
--- a/rafs/README.md
+++ b/rafs/README.md
@@ -1,4 +1,4 @@
-# nydus-storage
+# nydus-rafs
 
 The RAFS Fuse filesystem for [Nydus Image Service](https://nydus.dev/).
 

--- a/src/bin/nydusd/fs_service.rs
+++ b/src/bin/nydusd/fs_service.rs
@@ -10,7 +10,7 @@ use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::{Arc, MutexGuard};
 
-use fuse_backend_rs::api::{BackendFileSystem, Vfs};
+use fuse_backend_rs::api::{BackFileSystem, Vfs};
 #[cfg(target_os = "linux")]
 use fuse_backend_rs::passthrough::{Config, PassthroughFs};
 use nydus::{FsBackendDesc, FsBackendType};
@@ -22,9 +22,6 @@ use storage::factory::BLOB_FACTORY;
 use crate::daemon::DaemonResult;
 use crate::upgrade::{self, UpgradeManager};
 use crate::DaemonError;
-
-//TODO: Try to public below type from fuse-rs thus no need to redefine it here.
-type BackFileSystem = Box<dyn BackendFileSystem<Inode = u64, Handle = u64> + Send + Sync>;
 
 /// Command to mount a filesystem.
 #[derive(Clone)]

--- a/src/bin/nydusd/main.rs
+++ b/src/bin/nydusd/main.rs
@@ -75,9 +75,9 @@ pub struct DaemonController {
 
 impl DaemonController {
     fn new() -> Self {
-        let poller = Poll::new().expect("Failed to create `ServiceController` instance");
+        let poller = Poll::new().expect("Failed to create poller for DaemonController");
         let waker = Waker::new(poller.registry(), Token(1))
-            .expect("Failed to create waker for ServiceController");
+            .expect("Failed to create waker for DaemonController");
 
         Self {
             active: AtomicBool::new(true),
@@ -706,7 +706,7 @@ fn process_fs_service(
         DAEMON_CONTROLLER.set_daemon(daemon);
     } else {
         #[cfg(feature = "virtiofs")]
-        if !is_fuse {
+        {
             let vu_sock = args.value_of("sock").ok_or_else(|| {
                 DaemonError::InvalidArguments("vhost socket must be provided!".to_string())
             })?;


### PR DESCRIPTION
Includes 3 minor fixes:

- nydusd: use BackFileSystem in fuse_backend_rs crate
- nydusd: fix log message
- rafs: fix crate name in readme
