### PR TITLE
rafs: refine the way to build chunk map for v6

### DIFF
--- a/rafs/src/metadata/layout/v6.rs
+++ b/rafs/src/metadata/layout/v6.rs
@@ -195,7 +195,7 @@ impl RafsV6SuperBlock {
 
         if self.s_xattr_blkaddr != 0 {
             return Err(einval!(
-                "invalid extended attribute address in Rafsv6 superblock"
+                "unsupported shared extended attribute namespace in Rafsv6 superblock"
             ));
         }
 

--- a/src/bin/nydus-image/core/node.rs
+++ b/src/bin/nydus-image/core/node.rs
@@ -1290,11 +1290,9 @@ impl Node {
         let mut chunks: Vec<u8> = Vec::new();
         for chunk in self.chunks.iter() {
             let mut v6_chunk = RafsV6InodeChunkAddr::new();
-            // Bump blob id by 1 for EROFS since device id 0 is used for the metadata blob.
             v6_chunk.set_blob_index(chunk.inner.blob_index());
             v6_chunk.set_blob_ci_index(chunk.inner.index());
             v6_chunk.set_block_addr((chunk.inner.uncompressed_offset() / EROFS_BLOCK_SIZE) as u32);
-            trace!("name {:?} chunk {}", self.name(), chunk);
             chunks.extend(v6_chunk.as_ref());
             chunk_cache.insert(
                 DigestWithBlobIndex(*chunk.inner.id(), chunk.inner.blob_index() + 1),

--- a/storage/src/cache/filecache/mod.rs
+++ b/storage/src/cache/filecache/mod.rs
@@ -211,8 +211,7 @@ impl FileCacheEntry {
         } else if cached_file_size != 0 && file_size != cached_file_size {
             let msg = format!(
                 "blob data file size doesn't match: got 0x{:x}, expect 0x{:x}",
-                file_size,
-                blob_info.uncompressed_size()
+                file_size, cached_file_size
             );
             return Err(einval!(msg));
         }


### PR DESCRIPTION
Refine the way to build chunk map for v6, avoid RefCell and thread local variables.

Signed-off-by: Jiang Liu <gerry@linux.alibaba.com>