### PR TITLE
builder: fix redundant blob for inline bootstrap

### DIFF
--- a/src/bin/nydus-image/builder/directory.rs
+++ b/src/bin/nydus-image/builder/directory.rs
@@ -126,10 +126,6 @@ impl Builder for DirectoryBuilder {
             ));
         };
 
-        if ctx.inline_bootstrap {
-            let (_, _) = blob_mgr.get_or_create_current_blob(ctx)?;
-        }
-
         // Scan source directory to build upper layer tree.
         let tree = timing_tracer!(
             { self.build_tree(ctx, &mut bootstrap_ctx, layer_idx) },

--- a/src/bin/nydus-image/builder/mod.rs
+++ b/src/bin/nydus-image/builder/mod.rs
@@ -5,7 +5,7 @@
 use std::io::Write;
 
 use anyhow::Result;
-use sha2::Digest;
+use sha2::{Digest, Sha256};
 
 use crate::core::bootstrap::Bootstrap;
 use crate::core::context::{
@@ -79,35 +79,42 @@ fn dump_bootstrap(
         &blob_table,
     )?;
 
-    if let Some((_, blob_ctx)) = blob_mgr.get_current_blob() {
-        if let Some(blob_writer) = blob_writer.as_mut() {
-            if ctx.inline_bootstrap {
+    if let Some(blob_writer) = blob_writer.as_mut() {
+        let mut blob_hash = blob_mgr
+            .get_current_blob()
+            .map(|(_, blob_ctx)| blob_ctx.blob_hash.clone())
+            .unwrap_or_else(Sha256::new);
+        if ctx.inline_bootstrap {
+            if blob_mgr.get_current_blob().is_some() {
                 let header = blob_writer.write_tar_header(TAR_BLOB_NAME, blob_writer.pos()?)?;
-                blob_ctx.blob_hash.update(header.as_bytes());
+                blob_hash.update(header.as_bytes());
+            };
 
-                let reader = bootstrap_ctx.writer.as_reader()?;
-                let mut size = 0;
-                let mut buf = vec![0u8; 16384];
-                loop {
-                    let sz = reader.read(&mut buf)?;
-                    if sz == 0 {
-                        break;
-                    }
-                    blob_writer.write_all(&buf[..sz])?;
-                    blob_ctx.blob_hash.update(&buf[..sz]);
-                    size += sz;
+            let reader = bootstrap_ctx.writer.as_reader()?;
+            let mut size = 0;
+            let mut buf = vec![0u8; 16384];
+            loop {
+                let sz = reader.read(&mut buf)?;
+                if sz == 0 {
+                    break;
                 }
-
-                let header = blob_writer.write_tar_header(TAR_BOOTSTRAP_NAME, size as u64)?;
-                blob_ctx.blob_hash.update(header.as_bytes());
-
-                if ctx.blob_id.is_empty() {
-                    ctx.blob_id = format!("{:x}", blob_ctx.blob_hash.clone().finalize());
-                }
-                blob_writer.finalize(Some(ctx.blob_id.clone()))?;
-            } else {
-                blob_writer.finalize(blob_ctx.blob_id())?;
+                blob_writer.write_all(&buf[..sz])?;
+                blob_hash.update(&buf[..sz]);
+                size += sz;
             }
+
+            let header = blob_writer.write_tar_header(TAR_BOOTSTRAP_NAME, size as u64)?;
+            blob_hash.update(header.as_bytes());
+
+            if ctx.blob_id.is_empty() {
+                ctx.blob_id = format!("{:x}", blob_hash.finalize());
+            }
+            blob_writer.finalize(Some(ctx.blob_id.clone()))?;
+        } else {
+            let blob_id = blob_mgr
+                .get_current_blob()
+                .map(|(_, blob_ctx)| blob_ctx.blob_id().unwrap_or_default());
+            blob_writer.finalize(blob_id)?;
         }
     }
 


### PR DESCRIPTION
The previous code generates a new empty blob for inline bootstrap mode:

```
if ctx.inline_bootstrap {
    let (_, _) = blob_mgr.get_or_create_current_blob(ctx)?;
}
```

And then the empty blob will be appended to blob table although
no chunk data be generated in the current build.

This patch avoids generating this kind of redundant blob.

Signed-off-by: Yan Song <imeoer@linux.alibaba.com>