### PR TITLE
Fix nydusify checker panic

### DIFF
--- a/contrib/nydusify/pkg/checker/checker.go
+++ b/contrib/nydusify/pkg/checker/checker.go
@@ -157,7 +157,6 @@ func (checker *Checker) check(ctx context.Context) error {
 			SourceMountPath: filepath.Join(checker.WorkDir, "fs/source_mounted"),
 			SourceParsed:    sourceParsed,
 			SourcePath:      filepath.Join(checker.WorkDir, "fs/source"),
-			SourceRemote:    checker.sourceParser.Remote,
 			Target:          checker.Target,
 			TargetInsecure:  checker.TargetInsecure,
 			PlainHTTP:       checker.targetParser.Remote.IsWithHTTP(),

--- a/contrib/nydusify/pkg/checker/tool/builder.go
+++ b/contrib/nydusify/pkg/checker/tool/builder.go
@@ -36,9 +36,10 @@ func (builder *Builder) Check(option BuilderOption) error {
 		"check",
 		"--log-level",
 		"warn",
+		"--bootstrap",
+		option.BootstrapPath,
 		"--output-json",
 		option.DebugOutputPath,
-		option.BootstrapPath,
 	}
 
 	cmd := exec.Command(builder.binaryPath, args...)


### PR DESCRIPTION
Fix 2 `nydusify check` bugs:
- panic in `Checker.check` due to alternate case `sourceParser`being `nil`. Case is partly handled.
- call to `nydus-image check` in `Builder.Check` does not use the `--bootstrap` arg

```
$ sudo nydusify -l debug check --target 127.0.0.1:5000/ubuntu-nydus:latest
....
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x88b346]

goroutine 1 [running]:
github.com/dragonflyoss/image-service/contrib/nydusify/pkg/checker.(*Checker).check(0xc0000f43c0, {0xcafba0, 0xc0000340b0})
        /home/runner/work/image-service/image-service/contrib/nydusify/pkg/checker/checker.go:160 +0xae6
github.com/dragonflyoss/image-service/contrib/nydusify/pkg/checker.(*Checker).Check(0xc0000f43c0, {0xcafba0, 0xc0000340b0})
        /home/runner/work/image-service/image-service/contrib/nydusify/pkg/checker/checker.go:88 +0x9e
main.main.func2(0xc00022c000?)
        /home/runner/work/image-service/image-service/contrib/nydusify/cmd/nydusify.go:591 +0x374
github.com/urfave/cli/v2.(*Command).Run(0xc0001fe120, 0xc000467700)
        /home/runner/go/pkg/mod/github.com/urfave/cli/v2@v2.3.0/command.go:163 +0x5bb
github.com/urfave/cli/v2.(*App).RunContext(0xc0005a29c0, {0xcafba0?, 0xc0000340b0}, {0xc0000301e0, 0x6, 0x6})
        /home/runner/go/pkg/mod/github.com/urfave/cli/v2@v2.3.0/app.go:313 +0xb48
github.com/urfave/cli/v2.(*App).Run(...)
        /home/runner/go/pkg/mod/github.com/urfave/cli/v2@v2.3.0/app.go:224
main.main()
        /home/runner/work/image-service/image-service/contrib/nydusify/cmd/nydusify.go:857 +0x36f6
```

Signed-off-by: Hugo Larcher <hugo.larcher@ovhcloud.com>