### PR TITLE
nydus-image: keep compatibility with "nydus-image check --bootstrap"

### DIFF
--- a/contrib/nydusify/pkg/checker/tool/builder.go
+++ b/contrib/nydusify/pkg/checker/tool/builder.go
@@ -38,6 +38,7 @@ func (builder *Builder) Check(option BuilderOption) error {
 		"warn",
 		"--output-json",
 		option.DebugOutputPath,
+		"--bootstrap",
 		option.BootstrapPath,
 	}
 

--- a/src/bin/nydus-image/main.rs
+++ b/src/bin/nydus-image/main.rs
@@ -341,9 +341,17 @@ fn prepare_cmd_args(bti_string: &'static str) -> App {
             App::new("check")
                 .about("Validate RAFS filesystem metadata")
                 .arg(
-                    Arg::new("bootstrap")
+                    Arg::new("BOOTSTRAP")
                         .help("Path to RAFS metadata file")
-                        .required(true),
+                        .required_unless_present("bootstrap"),
+                )
+                .arg(
+                    Arg::new("bootstrap")
+                        .short('B')
+                        .long("bootstrap")
+                        .help("Path to RAFS metadata file")
+                        .conflicts_with("BOOTSTRAP")
+                        .required(false),
                 )
                 .arg(
                     Arg::new("verbose")
@@ -926,8 +934,11 @@ impl Command {
 
     fn get_bootstrap(matches: &clap::ArgMatches) -> Result<&Path> {
         match matches.get_one::<String>("bootstrap") {
-            None => bail!("missing parameter `bootstrap`"),
             Some(s) => Ok(Path::new(s)),
+            None => match matches.get_one::<String>("BOOTSTRAP") {
+                Some(s) => Ok(Path::new(s)),
+                None => bail!("missing parameter `bootstrap`"),
+            },
         }
     }
 


### PR DESCRIPTION
Tween the "nydus-image check" subcommand to keep compatibility with "nydus-image check --bootstrap".

Signed-off-by: Jiang Liu <gerry@linux.alibaba.com>