### PR TITLE
nydusify: beautify version print message of nydusify

### DIFF
--- a/contrib/nydusify/Makefile
+++ b/contrib/nydusify/Makefile
@@ -1,22 +1,27 @@
-GIT_COMMIT := $(shell git rev-list -1 HEAD)
-BUILD_TIME := $(shell date -u +%Y%m%d.%H%M)
 PACKAGES ?= $(shell go list ./... | grep -v /vendor/)
-GOARCH ?= amd64
+GOARCH ?= $(shell go env GOARCH)
 GOPROXY ?= https://goproxy.io
 
 ifdef GOPROXY
 PROXY := GOPROXY=${GOPROXY}
 endif
 
+# Used to populate variables in version package.
+BUILD_TIMESTAMP=$(shell date '+%Y-%m-%dT%H:%M:%S')
+VERSION=$(shell git describe --match 'v[0-9]*' --dirty='.m' --always --tags)
+REVERSION=$(shell git rev-parse HEAD)$(shell if ! git diff --no-ext-diff --quiet --exit-code; then echo .m; fi)
+
+RELEASE_INFO = -X main.reversion=${REVERSION} -X main.gitVersion=${VERSION} -X main.buildTime=${BUILD_TIMESTAMP}
+
 .PHONY: all build release plugin test clean build-smoke
 
 all: build
 
 build:
-	@CGO_ENABLED=0 ${PROXY} GOOS=linux GOARCH=${GOARCH} go build -ldflags '-X main.versionGitCommit=${GIT_COMMIT} -X main.versionBuildTime=${BUILD_TIME}' -gcflags=all="-N -l" -o ./cmd ./cmd/nydusify.go
+	@CGO_ENABLED=0 ${PROXY} GOOS=linux GOARCH=${GOARCH} go build -ldflags '${RELEASE_INFO}' -gcflags=all="-N -l" -o ./cmd ./cmd/nydusify.go
 
 release:
-	@CGO_ENABLED=0 ${PROXY} GOOS=linux GOARCH=${GOARCH} go build -ldflags '-X main.versionGitCommit=${GIT_COMMIT} -X main.versionBuildTime=${BUILD_TIME} -s -w -extldflags "-static"' -o ./cmd ./cmd/nydusify.go
+	@CGO_ENABLED=0 ${PROXY} GOOS=linux GOARCH=${GOARCH} go build -ldflags '${RELEASE_INFO} -s -w -extldflags "-static"' -o ./cmd ./cmd/nydusify.go
 
 plugin:
 	@CGO_ENABLED=0 ${PROXY} GOOS=linux GOARCH=${GOARCH} go build -ldflags '-s -w -extldflags "-static"' -o nydus-hook-plugin ./plugin

--- a/contrib/nydusify/cmd/nydusify.go
+++ b/contrib/nydusify/cmd/nydusify.go
@@ -32,8 +32,12 @@ import (
 	"github.com/dragonflyoss/image-service/contrib/nydusify/pkg/viewer"
 )
 
-var versionGitCommit string
-var versionBuildTime string
+var (
+	reversion  string
+	buildTime  string
+	gitVersion string
+)
+
 var maxCacheMaxRecords uint = 50
 
 const defaultLogLevel = logrus.InfoLevel
@@ -175,7 +179,7 @@ func main() {
 		FullTimestamp: true,
 	})
 
-	version := fmt.Sprintf("%s.%s", versionGitCommit, versionBuildTime)
+	version := fmt.Sprintf("\nVersion		: %s\nReversion	: %s\nGo version	: %s\nBuild time	: %s", gitVersion, reversion, runtime.Version(), buildTime)
 
 	app := &cli.App{
 		Name:    "Nydusify",


### PR DESCRIPTION
Print more information on git version, reversion and golang version
In addition, we rely on go arch to decide the default value of ARCH

```
./cmd/nydusify --version
Nydusify version
Version		: v2.1.0-rc.3.1-307-g522c8aac.m
Reversion	: 522c8aacef448ed9edc3c66c68250269811de7ea.m
Go version	: go1.18.7
Build time	: 2022-11-17T15:11:49
```