### PR TITLE
storage: fix registry to avoid print bearer auth

### DIFF
--- a/storage/src/backend/registry.rs
+++ b/storage/src/backend/registry.rs
@@ -226,8 +226,7 @@ impl RegistryState {
             self.refresh_token_time
                 .store(Some(Arc::new(now_timestamp.as_secs() + ret.expires_in)));
             info!(
-                "cached_bearer_auth: {:?}, next time: {}",
-                auth,
+                "cached bearer auth, next time: {}",
                 now_timestamp.as_secs() + ret.expires_in
             );
         }


### PR DESCRIPTION
This is a bug, we should backport it to `stable/v2.1` as well.

Signed-off-by: Bin Tang <tangbin.bin@bytedance.com>