### PR TITLE
fix too frequent retry

### DIFF
--- a/storage/src/cache/cachedfile.rs
+++ b/storage/src/cache/cachedfile.rs
@@ -410,7 +410,7 @@ impl BlobObject for FileCacheEntry {
     }
 
     fn fetch_range_compressed(&self, offset: u64, size: u64) -> Result<usize> {
-        let meta = self.meta.as_ref().ok_or_else(|| einval!())?;
+        let meta = self.meta.as_ref().ok_or_else(|| enoent!())?;
         let meta = meta.get_blob_meta().ok_or_else(|| einval!())?;
         let chunks = meta.get_chunks_compressed(offset, size, RAFS_DEFAULT_CHUNK_SIZE * 2)?;
         debug_assert!(!chunks.is_empty());

--- a/storage/src/cache/worker.rs
+++ b/storage/src/cache/worker.rs
@@ -5,11 +5,10 @@
 
 use std::io::Result;
 use std::num::NonZeroU32;
-use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicI32, AtomicU32, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::thread;
 use std::time::Duration;
-use tokio::time::interval;
 
 use governor::clock::QuantaClock;
 use governor::state::{InMemoryState, NotKeyed};
@@ -81,6 +80,9 @@ pub(crate) struct AsyncWorkerMgr {
     workers: AtomicU32,
     active: AtomicBool,
 
+    // Limit the total retry times to avoid unnecessary resource consumption.
+    retry_times: AtomicI32,
+
     prefetch_sema: Arc<Semaphore>,
     prefetch_channel: Arc<Channel<AsyncPrefetchMessage>>,
     prefetch_config: Arc<AsyncPrefetchConfig>,
@@ -116,6 +118,8 @@ impl AsyncWorkerMgr {
             ping_requests: AtomicU32::new(0),
             workers: AtomicU32::new(0),
             active: AtomicBool::new(false),
+
+            retry_times: AtomicI32::new(32),
 
             prefetch_sema: Arc::new(Semaphore::new(0)),
             prefetch_channel: Arc::new(Channel::new()),
@@ -338,12 +342,15 @@ impl AsyncWorkerMgr {
                     e
                 );
 
-                ASYNC_RUNTIME.spawn(async move {
-                    let mut interval = interval(Duration::from_secs(1));
-                    interval.tick().await;
-                    let msg = AsyncPrefetchMessage::new_blob_prefetch(cache.clone(), offset, size);
-                    let _ = mgr.send_prefetch_message(msg);
-                });
+                if mgr.retry_times.load(Ordering::Relaxed) > 0 {
+                    mgr.retry_times.fetch_sub(1, Ordering::Relaxed);
+                    ASYNC_RUNTIME.spawn(async move {
+                        tokio::time::sleep(Duration::from_secs(1)).await;
+                        let msg =
+                            AsyncPrefetchMessage::new_blob_prefetch(cache.clone(), offset, size);
+                        let _ = mgr.send_prefetch_message(msg);
+                    });
+                }
             }
         } else {
             warn!("prefetch blob range is not supported");


### PR DESCRIPTION
tick() will complete when the next instant reaches which is a very short time rather than 1 second.
In addition, limit the total retry times