### PR TITLE
storage: user unstable sort to reduce memory allocation

### DIFF
--- a/storage/src/cache/cachedfile.rs
+++ b/storage/src/cache/cachedfile.rs
@@ -456,7 +456,7 @@ impl BlobCache for FileCacheEntry {
         // Then handle fs prefetch
         let max_comp_size = self.prefetch_batch_size();
         let mut bios = bios.to_vec();
-        bios.sort_by_key(|entry| entry.chunkinfo.compressed_offset());
+        bios.sort_unstable_by_key(|entry| entry.chunkinfo.compressed_offset());
         self.metrics.prefetch_unmerged_chunks.add(bios.len() as u64);
         BlobIoMergeState::merge_and_issue(
             &bios,


### PR DESCRIPTION
We can bear with non-ordered equal elements when sorting.

Signed-off-by: Changwei Ge <gechangwei@bytedance.com>