### PR TITLE
rafs: prefetch based on blob chunks rather than files

### DIFF
--- a/rafs/src/metadata/mod.rs
+++ b/rafs/src/metadata/mod.rs
@@ -635,6 +635,7 @@ impl RafsSuper {
     ///
     /// Each inode passed into should correspond to directory. And it already does the file type
     /// check inside.
+    /// Return Ok(true) means root inode is found during performing prefetching and all files should be prefetched.
     pub fn prefetch_files(
         &self,
         r: &mut RafsIoReader,


### PR DESCRIPTION
Perform different policy for v5 format and v6 format as rafs v6's blobs are capable to download chunks and decompress them all by themselves. For rafs v6, directly perform chunk based full prefetch to reduce requests to container registry and P2P cluster.

From benchmark test results, we can see that this PR has the same performance as the master code with significantly decreased registry requests (440->219)

--- master code
```
{"repo": "golang", "bench": "golang:latestnydusv6zstd", "pull_time": " 1.675706", "create_time": " 0.857444", "run_time": " 5.065474", "elapsed": " 7.598624"}

Backend Type:       "registry"
Read Amount:        358525072 Bytes (341.91615295410156 MB)
Read Count:         440
Read Errors:        0

Block Sizes:             <1K     1K~     4K~     16K~    64K~    128K~   512K~   1M~
Average Latency(millis): 116     118     113     112     122     134     162     165

Block Sizes:             <1K     1K~     4K~     16K~    64K~    128K~   512K~   1M~
Request Count:           5       6       12      22      23      61      130     181
```

--- current v2.1
```
{"repo": "golang", "bench": "golang:latestnydusv6zstd", "pull_time": " 1.677908", "create_time": " 0.745518", "run_time": " 8.033772", "elapsed": " 10.457198"}

Backend Type:       "registry"
Read Amount:        355171173 Bytes (338.71762561798096 MB)
Read Count:         536
Read Errors:        0

Block Sizes:             <1K     1K~     4K~     16K~    64K~    128K~   512K~   1M~
Average Latency(millis): 117     115     115     121     137     148     163     180

Block Sizes:             <1K     1K~     4K~     16K~    64K~    128K~   512K~   1M~
Request Count:           57      45      21      9       5       48      266     85
```

--- This PR optimized
```
{"repo": "golang", "bench": "golang:latestnydusv6zstd", "pull_time": " 1.673026", "create_time": " 0.840420", "run_time": " 5.023351", "elapsed": " 7.536797"}
Backend Type:       "registry"
Read Amount:        350684863 Bytes (334.43914699554443 MB)
Read Count:         219
Read Errors:        0

Block Sizes:             <1K     1K~     4K~     16K~    64K~    128K~   512K~   1M~
Average Latency(millis): 113     149     118     140     185     153     169     179

Block Sizes:             <1K     1K~     4K~     16K~    64K~    128K~   512K~   1M~
Request Count:           14      6       10      4       2       13      5       165
```

Signed-off-by: Changwei Ge <gechangwei@bytedance.com>