### PR TITLE
nydusd: fix fscache prefetch threads can't exit in shared domain mode

### DIFF
--- a/src/bin/nydusd/blob_cache.rs
+++ b/src/bin/nydusd/blob_cache.rs
@@ -205,26 +205,11 @@ impl BlobCacheState {
     fn get(&self, key: &str) -> Option<BlobCacheObjectConfig> {
         self.id_to_config_map.get(key).cloned()
     }
-
-    /// get DataBlob number for a domain_id
-    fn get_blobs_num(&self, domain_id: &str) -> usize {
-        let scoped_blob_prefix = format!("{}{}", domain_id, ID_SPLITTER);
-        return self
-            .id_to_config_map
-            .values()
-            .filter(|v| {
-                if let BlobCacheObjectConfig::DataBlob(o) = v {
-                    o.scoped_blob_id.starts_with(&scoped_blob_prefix)
-                } else {
-                    false
-                }
-            })
-            .count();
-    }
 }
 
 /// Manager for cached file objects.
 #[derive(Default)]
+
 pub struct BlobCacheMgr {
     state: Mutex<BlobCacheState>,
 }
@@ -280,10 +265,6 @@ impl BlobCacheMgr {
     /// Get configuration information for the blob with `key`.
     pub fn get_config(&self, key: &str) -> Option<BlobCacheObjectConfig> {
         self.get_state().get(key)
-    }
-
-    pub fn get_blobs_num(&self, domain_id: &str) -> usize {
-        self.get_state().get_blobs_num(domain_id)
     }
 
     #[inline]

--- a/storage/src/device.rs
+++ b/storage/src/device.rs
@@ -838,7 +838,7 @@ impl BlobDevice {
     ) -> io::Result<BlobDevice> {
         let mut blobs = Vec::with_capacity(blob_infos.len());
         for blob_info in blob_infos.iter() {
-            let blob = BLOB_FACTORY.new_blob_cache(config, blob_info, blob_infos.len())?;
+            let blob = BLOB_FACTORY.new_blob_cache(config, blob_info)?;
             blobs.push(blob);
         }
 
@@ -866,7 +866,7 @@ impl BlobDevice {
 
         let mut blobs = Vec::with_capacity(blob_infos.len());
         for blob_info in blob_infos.iter() {
-            let blob = BLOB_FACTORY.new_blob_cache(config, blob_info, blob_infos.len())?;
+            let blob = BLOB_FACTORY.new_blob_cache(config, blob_info)?;
             blobs.push(blob);
         }
 

--- a/storage/src/factory.rs
+++ b/storage/src/factory.rs
@@ -105,7 +105,6 @@ impl BlobFactory {
         &self,
         config: &Arc<FactoryConfig>,
         blob_info: &Arc<BlobInfo>,
-        blobs_need: usize,
     ) -> IOResult<Arc<dyn BlobCache>> {
         let key = BlobCacheMgrKey {
             config: config.clone(),
@@ -133,7 +132,6 @@ impl BlobFactory {
                     backend,
                     ASYNC_RUNTIME.clone(),
                     &config.id,
-                    blobs_need,
                 )?;
                 mgr.init()?;
                 Arc::new(mgr) as Arc<dyn BlobCacheMgr>


### PR DESCRIPTION
We check if all blobs were created before stop prefetch threads for fscache, but FsCacheMgr is a pre-image struct, in shared domain mode, we don't know how many blobs will be created. So do not check the number of blobs.

Signed-off-by: Xin Yin <yinxin.x@bytedance.com>