### PR TITLE
2.1 prefetch metrics

### DIFF
--- a/storage/src/cache/worker.rs
+++ b/storage/src/cache/worker.rs
@@ -356,7 +356,7 @@ impl AsyncWorkerMgr {
         // So the average backend merged request size will be prefetch_data_amount/prefetch_mr_count.
         // We can measure merging possibility by this.
         let metrics = mgr.metrics.clone();
-        metrics.prefetch_mr_count.inc();
+        metrics.prefetch_requests_count.inc();
         metrics.prefetch_data_amount.add(size);
 
         if let Some(obj) = cache.get_blob_object() {
@@ -414,7 +414,7 @@ impl AsyncWorkerMgr {
         // Record how much prefetch data is requested from storage backend.
         // So the average backend merged request size will be prefetch_data_amount/prefetch_mr_count.
         // We can measure merging possibility by this.
-        mgr.metrics.prefetch_mr_count.inc();
+        mgr.metrics.prefetch_requests_count.inc();
         mgr.metrics.prefetch_data_amount.add(blob_size);
 
         if let Some(obj) = cache.get_blob_object() {

--- a/utils/src/metrics.rs
+++ b/utils/src/metrics.rs
@@ -590,6 +590,8 @@ pub trait Metric {
     fn dec(&self) {
         self.sub(1);
     }
+
+    fn set(&self, value: u64);
 }
 
 /// Basic 64-bit metric counter.
@@ -607,6 +609,10 @@ impl Metric for BasicMetric {
 
     fn sub(&self, value: u64) {
         self.0.fetch_sub(value, Ordering::Relaxed);
+    }
+
+    fn set(&self, value: u64) {
+        self.0.store(value, Ordering::Relaxed);
     }
 }
 

--- a/utils/src/metrics.rs
+++ b/utils/src/metrics.rs
@@ -739,13 +739,24 @@ pub struct BlobcacheMetrics {
     // to estimate the possibility to merge backend IOs.
     // In unit of Bytes
     pub prefetch_data_amount: BasicMetric,
-    pub prefetch_mr_count: BasicMetric,
+    // Total prefetch requests issued from storage/blobs or rafs filesystem layer for each file that needs prefetch
+    pub prefetch_requests_count: BasicMetric,
     pub prefetch_workers: AtomicUsize,
     pub prefetch_unmerged_chunks: BasicMetric,
+    // Cumulative time latencies of each prefetch request which can be handled in parallel.
+    // It starts when the request is born including nydusd processing and schedule and end when the chunk is downloaded and stored.
+    // Then the average prefetch latency can be calculated by
+    // `prefetch_cumulative_time_millis / prefetch_requests_count`
     pub prefetch_cumulative_time_millis: BasicMetric,
+    // The time seconds part when nydusd begins to prefetch
+    // We can calculate prefetch average bandwidth by
+    // `prefetch_data_amount / (prefetch_end_time_secs - prefetch_begin_time_secs)`. Note, it does not take milliseconds into account yet.s
     pub prefetch_begin_time_secs: BasicMetric,
+    // The time milliseconds part when nydusd begins to prefetch
     pub prefetch_begin_time_millis: BasicMetric,
+    // The time seconds part when nydusd ends prefetching
     pub prefetch_end_time_secs: BasicMetric,
+    // The time milliseconds part when nydusd ends prefetching
     pub prefetch_end_time_millis: BasicMetric,
     pub buffered_backend_size: BasicMetric,
     pub data_all_ready: AtomicBool,


### PR DESCRIPTION
Record prefetch request average latency.
Calculate prefetch average bandwidth.

```json
{
  "buffered_backend_size": 0,
  "data_all_ready": false,
  "entries_count": 0,
  "partial_hits": 2657,
  "prefetch_begin_time_millis": 892,
  "prefetch_begin_time_secs": 1669262928,
  "prefetch_cumulative_time_millis": 391525,
  "prefetch_data_amount": 350224384,
  "prefetch_end_time_millis": 601,
  "prefetch_end_time_secs": 1669262933,
  "prefetch_mr_count": 167,
  "prefetch_unmerged_chunks": 0,
  "prefetch_workers": 8,
  "store_path": "/var/lib/containerd-nydus/cache",
  "total": 2682,
  "underlying_files": [
    "18798c2c51ee3c0cb84f4e8dbfa3ac5b9116cfac315e3af08405363ea97a2ef7",
    "d6a08dd25b46d4701c0f3221f20160563fb4b5866b6f4c915a982914adfc00de",
    "3355a6911228a3502a61b1a53ce9265be17fb07934e6511fbcfdb83438e42de9",
    "948f80e95f4ab83ae5a202f987fee81f0c860f2e42d82689a758b57887678601",
    "9957fc0906f7b4b2b1e1fc4a7a6049380bb06d72ac6919e0c06e4134ae70941e",
    "004656def9b233af509fc65aa91b824071a2ed3c2ee7b1361866b9c06a403949"
  ],
  "whole_hits": 0
}

```