### PR TITLE
nydusd: make DELETE /api/v2/blobs API support cull fscache blob

### DIFF
--- a/api/openapi/nydus-api-v2.yaml
+++ b/api/openapi/nydus-api-v2.yaml
@@ -44,7 +44,7 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ErrorMsg"
-  /blob_objects:
+  /blobs:
     summary: Manage cached blob objects
     ####################################################################
     get:
@@ -92,6 +92,21 @@ paths:
           description: "Successfully deleted the blob object!"
         "500":
           description: "Can't delete the blob object!"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ErrorMsg"
+      operationId: deleteBlobFile
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/BlobId"
+      responses:
+        "204":
+          description: "Successfully deleted the blob file!"
+        "500":
+          description: "Can't delete the blob file!"
           content:
             application/json:
               schema:

--- a/api/src/http.rs
+++ b/api/src/http.rs
@@ -158,6 +158,8 @@ pub enum ApiRequest {
     GetBlobObject(BlobCacheObjectId),
     /// Delete a blob cache entry
     DeleteBlobObject(BlobCacheObjectId),
+    /// Delete a blob cache file
+    DeleteBlobFile(String),
 }
 
 /// Kinds for daemon related error messages.
@@ -291,6 +293,8 @@ pub enum HttpError {
     CreateBlobObject(ApiError),
     /// Failed to delete blob object
     DeleteBlobObject(ApiError),
+    /// Failed to delete blob file
+    DeleteBlobFile(ApiError),
     /// Failed to list existing blob objects
     GetBlobObjects(ApiError),
 }

--- a/api/src/http_endpoint_v2.rs
+++ b/api/src/http_endpoint_v2.rs
@@ -100,6 +100,10 @@ impl EndpointHandler for BlobObjectListHandlerV2 {
                     let r = kicker(ApiRequest::DeleteBlobObject(param));
                     return Ok(convert_to_response(r, HttpError::DeleteBlobObject));
                 }
+                if let Some(blob_id) = extract_query_part(req, "blob_id") {
+                    let r = kicker(ApiRequest::DeleteBlobFile(blob_id));
+                    return Ok(convert_to_response(r, HttpError::DeleteBlobFile));
+                }
                 Err(HttpError::BadRequest)
             }
             _ => Err(HttpError::BadRequest),

--- a/src/bin/nydusd/api_server_glue.rs
+++ b/src/bin/nydusd/api_server_glue.rs
@@ -87,6 +87,7 @@ impl ApiServer {
             ApiRequest::GetBlobObject(_param) => todo!(),
             ApiRequest::CreateBlobObject(entry) => self.create_blob_cache_entry(&entry),
             ApiRequest::DeleteBlobObject(param) => self.remove_blob_cache_entry(&param),
+            ApiRequest::DeleteBlobFile(blob_id) => self.blob_cache_gc(blob_id),
         };
 
         self.respond(resp);
@@ -324,6 +325,13 @@ impl ApiServer {
                 }
             }
         }
+    }
+
+    fn blob_cache_gc(&self, blob_id: String) -> ApiResponse {
+        self.get_daemon_object()?
+            .delete_blob(blob_id)
+            .map_err(|e| ApiError::DaemonAbnormal(e.into()))
+            .map(|_| ApiResponsePayload::Empty)
     }
 
     fn do_start(&self) -> ApiResponse {

--- a/src/bin/nydusd/daemon.rs
+++ b/src/bin/nydusd/daemon.rs
@@ -243,6 +243,10 @@ pub trait NydusDaemon: DaemonStateMachineSubscriber + Send + Sync {
 
     // For backward compatibility.
     fn get_default_fs_service(&self) -> Option<Arc<dyn FsService>>;
+
+    fn delete_blob(&self, _blob_id: String) -> DaemonResult<()> {
+        Ok(())
+    }
 }
 
 // State machine for Nydus daemon workflow.


### PR DESCRIPTION
If only set blob_id parameter in DELETE /api/v2/blobs, will try to cull fscache blob. Then snapshotter can use this to delete fscache blob files.

Signed-off-by: Xin Yin <yinxin.x@bytedance.com>


https://github.com/containerd/nydus-snapshotter/pull/262