### PR TITLE
clib: introduce nydus-clib framework

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -755,9 +755,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.126"
+version = "0.2.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
+checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
 
 [[package]]
 name = "libz-sys"
@@ -965,6 +965,17 @@ dependencies = [
  "serde",
  "serde_json",
  "vm-memory",
+]
+
+[[package]]
+name = "nydus-clib"
+version = "0.1.0"
+dependencies = [
+ "fuse-backend-rs",
+ "libc",
+ "log",
+ "nydus-api",
+ "nydus-rafs",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,4 +74,4 @@ default = ["fuse-backend-rs/fusedev"]
 virtiofs = ["fuse-backend-rs/vhost-user-fs", "vm-memory", "vhost", "vhost-user-backend", "virtio-queue", "virtio-bindings"]
 
 [workspace]
-members = ["api", "app", "error", "rafs", "storage", "utils", "blobfs"]
+members = ["api", "app", "blobfs", "clib", "error", "rafs", "storage", "utils"]

--- a/clib/Cargo.toml
+++ b/clib/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "nydus-clib"
+version = "0.1.0"
+description = "C wrapper library for Nydus SDK"
+authors = ["The Nydus Developers"]
+license = "Apache-2.0"
+homepage = "https://nydus.dev/"
+repository = "https://github.com/dragonflyoss/image-service"
+edition = "2021"
+
+[lib]
+name = "nydus_clib"
+crate-type = ["cdylib", "staticlib"]
+
+[dependencies]
+libc = "0.2.137"
+log = "0.4.17"
+fuse-backend-rs = "0.10.0"
+nydus-api = { version = "0.1.0", path = "../api" }
+nydus-rafs = { version = "0.1.0", path = "../rafs" }
+
+[features]
+backend-registry = ["nydus-rafs/backend-registry"]
+backend-oss = ["nydus-rafs/backend-oss"]

--- a/clib/LICENSE-APACHE
+++ b/clib/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/clib/examples/nydus_rafs.c
+++ b/clib/examples/nydus_rafs.c
@@ -1,0 +1,20 @@
+#include <stdio.h>
+#include "../nydus.h"
+
+int main(int argc, char **argv)
+{
+    char *bootstrap = "../../tests/texture/repeatable/sha256-nocompress-repeatable";
+    char *config = "version = 2\nid = \"my_id\"\n[backend]\ntype = \"localfs\"\n[backend.localfs]\ndir = \"../../tests/texture/repeatable/blobs\"\n[cache]\ntype = \"dummycache\"\n[rafs]";
+    NydusFsHandle fs_handle;
+
+    fs_handle = nydus_open_rafs(bootstrap, config);
+    if (fs_handle == NYDUS_INVALID_FS_HANDLE) {
+        printf("failed to open rafs filesystem from ../../tests/texture/repeatable/sha256-nocompress-repeatable\n");
+        return -1;
+    }
+
+    printf("succeed to open rafs filesystem from ../../tests/texture/repeatable/sha256-nocompress-repeatable\n");
+    nydus_close_rafs(fs_handle);
+
+	return 0;
+}

--- a/clib/include/nydus.h
+++ b/clib/include/nydus.h
@@ -1,0 +1,70 @@
+#include <stdarg.h>
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+/**
+ * Magic number for Nydus file handle.
+ */
+#define NYDUS_FILE_HANDLE_MAGIC 17148644263605784967ull
+
+/**
+ * Value representing an invalid Nydus file handle.
+ */
+#define NYDUS_INVALID_FILE_HANDLE 0
+
+/**
+ * Magic number for Nydus filesystem handle.
+ */
+#define NYDUS_FS_HANDLE_MAGIC 17148643159786606983ull
+
+/**
+ * Value representing an invalid Nydus filesystem handle.
+ */
+#define NYDUS_INVALID_FS_HANDLE 0
+
+/**
+ * Handle representing a Nydus file object.
+ */
+typedef uintptr_t NydusFileHandle;
+
+/**
+ * Handle representing a Nydus filesystem object.
+ */
+typedef uintptr_t NydusFsHandle;
+
+/**
+ * Open the file with `path` in readonly mode.
+ *
+ * The `NydusFileHandle` returned should be freed by calling `nydus_close()`.
+ */
+NydusFileHandle nydus_fopen(NydusFsHandle fs_handle, const char *path);
+
+/**
+ * Close the file handle returned by `nydus_fopen()`.
+ */
+void nydus_fclose(NydusFileHandle handle);
+
+/**
+ * Open a RAFS filesystem and return a handle to the filesystem object.
+ *
+ * The returned filesystem handle should be freed by calling `nydus_close_rafs()`, otherwise
+ * it will cause memory leak.
+ */
+NydusFsHandle nydus_open_rafs(const char *bootstrap, const char *config);
+
+/**
+ * Open a RAFS filesystem with default configuration and return a handle to the filesystem object.
+ *
+ * The returned filesystem handle should be freed by calling `nydus_close_rafs()`, otherwise
+ * it will cause memory leak.
+ */
+NydusFsHandle nydus_open_rafs_default(const char *bootstrap, const char *dir_path);
+
+/**
+ * Close the RAFS filesystem returned by `nydus_open_rafs()` and friends.
+ *
+ * All `NydusFileHandle` objects created from the `NydusFsHandle` should be freed before calling
+ * `nydus_close_rafs()`, otherwise it may cause panic.
+ */
+void nydus_close_rafs(NydusFsHandle handle);

--- a/clib/src/file.rs
+++ b/clib/src/file.rs
@@ -1,0 +1,90 @@
+// Copyright (C) 2021 Alibaba Cloud. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Implement file operations for RAFS filesystem in userspace.
+//!
+//! Provide following file operation functions to access files in a RAFS filesystem:
+//! - fopen:
+//! - fclose:
+//! - fread:
+//! - fwrite:
+//! - fseek:
+//! - ftell
+
+use std::os::raw::c_char;
+use std::ptr::null_mut;
+
+use fuse_backend_rs::api::filesystem::{Context, FileSystem};
+
+use crate::{set_errno, FileSystemState, Inode, NydusFsHandle};
+
+/// Magic number for Nydus file handle.
+pub const NYDUS_FILE_HANDLE_MAGIC: u64 = 0xedfc_3919_afc3_5187;
+/// Value representing an invalid Nydus file handle.
+pub const NYDUS_INVALID_FILE_HANDLE: usize = 0;
+
+/// Handle representing a Nydus file object.
+pub type NydusFileHandle = usize;
+
+#[repr(C)]
+pub(crate) struct FileState {
+    magic: u64,
+    ino: Inode,
+    pos: u64,
+    fs_handle: NydusFsHandle,
+}
+
+/// Open the file with `path` in readonly mode.
+///
+/// The `NydusFileHandle` returned should be freed by calling `nydus_close()`.
+///
+/// # Safety
+/// Caller needs to ensure `fs_handle` and `path` are valid, otherwise it may cause memory access
+/// violation.
+#[no_mangle]
+pub unsafe extern "C" fn nydus_fopen(
+    fs_handle: NydusFsHandle,
+    path: *const c_char,
+) -> NydusFileHandle {
+    if path.is_null() {
+        set_errno(libc::EINVAL);
+        return null_mut::<FileState>() as NydusFileHandle;
+    }
+    let fs = match FileSystemState::try_from_handle(fs_handle) {
+        Err(e) => {
+            set_errno(e);
+            return null_mut::<FileState>() as NydusFileHandle;
+        }
+        Ok(v) => v,
+    };
+
+    ////////////////////////////////////////////////////////////
+    // TODO: open file;
+    //////////////////////////////////////////////////////////////////////////
+
+    let file = Box::new(FileState {
+        magic: NYDUS_FILE_HANDLE_MAGIC,
+        ino: fs.root_ino,
+        pos: 0,
+        fs_handle,
+    });
+
+    Box::into_raw(file) as NydusFileHandle
+}
+
+/// Close the file handle returned by `nydus_fopen()`.
+///
+/// # Safety
+/// Caller needs to ensure `fs_handle` is valid, otherwise it may cause memory access violation.
+#[no_mangle]
+pub unsafe extern "C" fn nydus_fclose(handle: NydusFileHandle) {
+    let mut file = Box::from_raw(handle as *mut FileState);
+    assert_eq!(file.magic, NYDUS_FILE_HANDLE_MAGIC);
+
+    let ctx = Context::default();
+    let fs = FileSystemState::from_handle(file.fs_handle);
+    fs.rafs.forget(&ctx, file.ino, 1);
+
+    file.magic -= 0x4fdf_ae34_9d9a_03cd;
+}

--- a/clib/src/fs.rs
+++ b/clib/src/fs.rs
@@ -1,0 +1,262 @@
+// Copyright (C) 2021 Alibaba Cloud. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Provide structures and functions to open/close/access a filesystem instance.
+
+use std::ffi::CStr;
+use std::fs::File;
+use std::os::raw::c_char;
+use std::path::Path;
+use std::ptr::{null, null_mut};
+use std::str::FromStr;
+use std::sync::Arc;
+
+use nydus_api::ConfigV2;
+use nydus_rafs::fs::Rafs;
+use nydus_rafs::RafsIoRead;
+
+use crate::{cstr_to_str, set_errno, Inode};
+
+/// Magic number for Nydus filesystem handle.
+pub const NYDUS_FS_HANDLE_MAGIC: u64 = 0xedfc_3818_af03_5187;
+/// Value representing an invalid Nydus filesystem handle.
+pub const NYDUS_INVALID_FS_HANDLE: usize = 0;
+
+/// Handle representing a Nydus filesystem object.
+pub type NydusFsHandle = usize;
+
+#[repr(C)]
+pub(crate) struct FileSystemState {
+    magic: u64,
+    pub(crate) root_ino: Inode,
+    pub(crate) rafs: Rafs,
+}
+
+impl FileSystemState {
+    /// Caller needs to ensure the lifetime of returned reference.
+    pub(crate) unsafe fn from_handle(hdl: NydusFsHandle) -> &'static mut Self {
+        let fs = &mut *(hdl as *const FileSystemState as *mut FileSystemState);
+        assert_eq!(fs.magic, NYDUS_FS_HANDLE_MAGIC);
+        fs
+    }
+
+    /// Caller needs to ensure the lifetime of returned reference.
+    pub(crate) unsafe fn try_from_handle(hdl: NydusFsHandle) -> Result<&'static mut Self, i32> {
+        if hdl == null::<FileSystemState>() as usize {
+            return Err(libc::EINVAL);
+        }
+        let fs = &mut *(hdl as *const FileSystemState as *mut FileSystemState);
+        assert_eq!(fs.magic, NYDUS_FS_HANDLE_MAGIC);
+        Ok(fs)
+    }
+}
+
+fn fs_error_einval() -> NydusFsHandle {
+    set_errno(libc::EINVAL);
+    null_mut::<FileSystemState>() as NydusFsHandle
+}
+
+fn default_localfs_rafs_config(dir: &str) -> String {
+    format!(
+        r#"
+        version = 2
+        id = "my_id"
+        [backend]
+        type = "localfs"
+        [backend.localfs]
+        dir = "{}"
+        [cache]
+        type = "dummycache"
+        [rafs]
+        "#,
+        dir
+    )
+}
+
+fn do_nydus_open_rafs(bootstrap: &str, config: &str) -> NydusFsHandle {
+    let cfg = match ConfigV2::from_str(config) {
+        Ok(v) => v,
+        Err(e) => {
+            warn!("failed to parse configuration info: {}", e);
+            return fs_error_einval();
+        }
+    };
+    let cfg = Arc::new(cfg);
+    let reader = match File::open(bootstrap) {
+        Ok(v) => v,
+        Err(e) => {
+            warn!("failed to open bootstrap file {}, {}", bootstrap, e);
+            return fs_error_einval();
+        }
+    };
+    let mut reader = Box::new(reader) as Box<dyn RafsIoRead>;
+
+    let mut rafs = match Rafs::new(&cfg, &cfg.id, &mut reader) {
+        Err(e) => {
+            warn!(
+                "failed to open filesystem from bootstrap {}, {}",
+                bootstrap, e
+            );
+            return fs_error_einval();
+        }
+        Ok(v) => v,
+    };
+    if let Err(e) = rafs.import(reader, None) {
+        warn!("failed to import RAFS filesystem, {}", e);
+        return fs_error_einval();
+    }
+
+    let root_ino = rafs.metadata().root_inode;
+    let fs = Box::new(FileSystemState {
+        magic: NYDUS_FS_HANDLE_MAGIC,
+        root_ino,
+        rafs,
+    });
+    Box::into_raw(fs) as NydusFsHandle
+}
+
+/// Open a RAFS filesystem and return a handle to the filesystem object.
+///
+/// The returned filesystem handle should be freed by calling `nydus_close_rafs()`, otherwise
+/// it will cause memory leak.
+///
+/// # Safety
+/// Caller needs to ensure `bootstrap` and `config` are valid, otherwise it may cause memory access
+/// violation.
+#[no_mangle]
+pub unsafe extern "C" fn nydus_open_rafs(
+    bootstrap: *const c_char,
+    config: *const c_char,
+) -> NydusFsHandle {
+    if bootstrap.is_null() || config.is_null() {
+        return fs_error_einval();
+    }
+    let bootstrap = cstr_to_str!(bootstrap, null_mut::<FileSystemState>() as NydusFsHandle);
+    let config = cstr_to_str!(config, null_mut::<FileSystemState>() as NydusFsHandle);
+
+    do_nydus_open_rafs(bootstrap, config)
+}
+
+/// Open a RAFS filesystem with default configuration and return a handle to the filesystem object.
+///
+/// The returned filesystem handle should be freed by calling `nydus_close_rafs()`, otherwise
+/// it will cause memory leak.
+///
+/// # Safety
+/// Caller needs to ensure `bootstrap` and `dir_path` are valid, otherwise it may cause memory
+/// access violation.
+#[no_mangle]
+pub unsafe extern "C" fn nydus_open_rafs_default(
+    bootstrap: *const c_char,
+    dir_path: *const c_char,
+) -> NydusFsHandle {
+    if bootstrap.is_null() || dir_path.is_null() {
+        return fs_error_einval();
+    }
+    let bootstrap = cstr_to_str!(bootstrap, null_mut::<FileSystemState>() as NydusFsHandle);
+    let dir_path = cstr_to_str!(dir_path, null_mut::<FileSystemState>() as NydusFsHandle);
+
+    let p_tmp;
+    let mut path = Path::new(bootstrap);
+    if path.parent().is_none() {
+        p_tmp = Path::new(dir_path).join(bootstrap);
+        path = &p_tmp
+    }
+    let bootstrap = match path.to_str() {
+        Some(v) => v,
+        None => {
+            warn!("invalid bootstrap path '{}'", bootstrap);
+            return fs_error_einval();
+        }
+    };
+    let config = default_localfs_rafs_config(dir_path);
+
+    do_nydus_open_rafs(bootstrap, &config)
+}
+
+/// Close the RAFS filesystem returned by `nydus_open_rafs()` and friends.
+///
+/// All `NydusFileHandle` objects created from the `NydusFsHandle` should be freed before calling
+/// `nydus_close_rafs()`, otherwise it may cause panic.
+///
+/// # Safety
+/// Caller needs to ensure `handle` is valid, otherwise it may cause memory access violation.
+#[no_mangle]
+pub unsafe extern "C" fn nydus_close_rafs(handle: NydusFsHandle) {
+    let mut fs = Box::from_raw(handle as *mut FileSystemState);
+    assert_eq!(fs.magic, NYDUS_FS_HANDLE_MAGIC);
+    fs.magic -= 0x4fdf_03cd_ae34_9d9a;
+    fs.rafs.destroy().unwrap();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::ffi::CString;
+    use std::io::Error;
+    use std::path::PathBuf;
+    use std::ptr::null;
+
+    pub(crate) fn open_file_system() -> NydusFsHandle {
+        let ret = unsafe { nydus_open_rafs(null(), null()) };
+        assert_eq!(ret, NYDUS_INVALID_FS_HANDLE);
+        assert_eq!(
+            Error::raw_os_error(&Error::last_os_error()),
+            Some(libc::EINVAL)
+        );
+
+        let root_dir = &std::env::var("CARGO_MANIFEST_DIR").expect("$CARGO_MANIFEST_DIR");
+        let bootstrap = PathBuf::from(root_dir)
+            .join("../tests/texture/repeatable/sha256-nocompress-repeatable");
+        let bootstrap = bootstrap.to_str().unwrap();
+        let bootstrap = CString::new(bootstrap).unwrap();
+        let blob_dir = PathBuf::from(root_dir).join("../tests/texture/repeatable/blobs");
+
+        let config = format!(
+            r#"
+        version = 2
+        id = "my_id"
+        [backend]
+        type = "localfs"
+        [backend.localfs]
+        dir = "{}"
+        [cache]
+        type = "dummycache"
+        [rafs]
+        "#,
+            blob_dir.display()
+        );
+        let config = CString::new(config).unwrap();
+        let fs = unsafe {
+            nydus_open_rafs(
+                bootstrap.as_ptr() as *const c_char,
+                config.as_ptr() as *const c_char,
+            )
+        };
+        assert_ne!(fs, NYDUS_INVALID_FS_HANDLE);
+
+        fs
+    }
+
+    #[test]
+    fn test_open_rafs() {
+        let fs = open_file_system();
+        unsafe { nydus_close_rafs(fs) };
+    }
+
+    #[test]
+    fn test_open_rafs_default() {
+        let root_dir = &std::env::var("CARGO_MANIFEST_DIR").expect("$CARGO_MANIFEST_DIR");
+        let bootstrap = PathBuf::from(root_dir)
+            .join("../tests/texture/repeatable/sha256-nocompress-repeatable");
+        let bootstrap = bootstrap.to_str().unwrap();
+        let bootstrap = CString::new(bootstrap).unwrap();
+        let blob_dir = PathBuf::from(root_dir).join("../tests/texture/repeatable/blobs");
+        let blob_dir = blob_dir.to_str().unwrap();
+        let fs = unsafe {
+            nydus_open_rafs_default(bootstrap.as_ptr(), blob_dir.as_ptr() as *const c_char)
+        };
+        unsafe { nydus_close_rafs(fs) };
+    }
+}

--- a/clib/src/lib.rs
+++ b/clib/src/lib.rs
@@ -1,0 +1,80 @@
+// Copyright (C) 2021 Alibaba Cloud. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! SDK C wrappers to access `nydus-rafs` and `nydus-storage` functionalities.
+//!
+//! # Generate Header File
+//! Please use cbindgen to generate `nydus.h` header file from rust source code by:
+//! ```
+//! cargo install cbindgen
+//! cbindgen -l c -v -o include/nydus.h
+//! ```
+//!
+//! # Run C Test
+//! ```
+//! gcc -o nydus -L ../../target/debug/ -lnydus_clib nydus_rafs.c
+//! ```
+
+#[macro_use]
+extern crate log;
+extern crate core;
+
+pub use file::*;
+pub use fs::*;
+
+mod file;
+mod fs;
+
+/// Type for RAFS filesystem inode number.
+pub type Inode = u64;
+
+/// Helper to set libc::errno
+#[cfg(target_os = "linux")]
+fn set_errno(errno: i32) {
+    unsafe { *libc::__errno_location() = errno };
+}
+
+/// Helper to set libc::errno
+#[cfg(target_os = "macos")]
+fn set_errno(errno: i32) {
+    unsafe { *libc::__error() = errno };
+}
+
+/// Macro to convert C `char *` into rust `&str`.
+#[macro_export]
+macro_rules! cstr_to_str {
+    ($var: ident, $ret: expr) => {{
+        let s = CStr::from_ptr($var);
+        match s.to_str() {
+            Ok(v) => v,
+            Err(_e) => {
+                set_errno(libc::EINVAL);
+                return $ret;
+            }
+        }
+    }};
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Error;
+
+    #[test]
+    fn test_set_errno() {
+        assert_eq!(Error::raw_os_error(&Error::last_os_error()), Some(0));
+        set_errno(libc::EINVAL);
+        assert_eq!(
+            Error::raw_os_error(&Error::last_os_error()),
+            Some(libc::EINVAL)
+        );
+        set_errno(libc::ENOSYS);
+        assert_eq!(
+            Error::raw_os_error(&Error::last_os_error()),
+            Some(libc::ENOSYS)
+        );
+        set_errno(0);
+        assert_eq!(Error::raw_os_error(&Error::last_os_error()), Some(0));
+    }
+}


### PR DESCRIPTION
Introduce nydus-clib framework, which provides static/dynamic to integrate nydus functionality into C programs.

Signed-off-by: Jiang Liu <gerry@linux.alibaba.com>