### PR TITLE
 Let nydusd show prefetch bandwidth and latency

### DIFF
--- a/src/bin/nydusctl/commands.rs
+++ b/src/bin/nydusctl/commands.rs
@@ -82,11 +82,11 @@ Persister Buffer:       {buffered}
                 prefetch_amount_kb = m["prefetch_data_amount"].as_u64().unwrap() / 1024,
                 files = m["underlying_files"],
                 directory = m["store_path"],
-                requests = m["prefetch_mr_count"],
+                requests = m["prefetch_requests_count"],
                 avg_prefetch_size = m["prefetch_data_amount"]
                     .as_u64()
                     .unwrap()
-                    .checked_div(m["prefetch_mr_count"].as_u64().unwrap())
+                    .checked_div(m["prefetch_requests_count"].as_u64().unwrap())
                     .unwrap_or_default(),
                 workers = m["prefetch_workers"],
                 unmerged_blocks = m["prefetch_unmerged_chunks"],

--- a/src/bin/nydusctl/commands.rs
+++ b/src/bin/nydusctl/commands.rs
@@ -58,28 +58,39 @@ impl CommandCache {
         let metrics = client.get("v1/metrics/blobcache").await?;
         let m = metrics.as_object().unwrap();
 
+        let prefetch_duration = m["prefetch_end_time_secs"].as_f64().unwrap()
+            + m["prefetch_end_time_millis"].as_f64().unwrap() / 1000.0
+            - (m["prefetch_begin_time_secs"].as_f64().unwrap()
+                + m["prefetch_begin_time_millis"].as_f64().unwrap() / 1000.0);
+
+        let prefetch_data_amount = m["prefetch_data_amount"].as_f64().unwrap();
+
         if raw {
             println!("{}", metrics);
         } else {
             print!(
                 r#"
-Partial Hits:           {partial_hits}
-Whole Hits:             {whole_hits}
-Total Read:             {total_read}
-Directory:              {directory}
-Files:                  {files}
-Prefetch Workers:       {workers}
-Prefetch Amount:        {prefetch_amount} = {prefetch_amount_kb} KB
-Prefetch Requests:      {requests}
-Prefetch Average Size:  {avg_prefetch_size} Bytes
-Prefetch Unmerged:      {unmerged_blocks}
-Persister Buffer:       {buffered}
+Partial Hits:               {partial_hits}
+Whole Hits:                 {whole_hits}
+Total Read:                 {total_read}
+Directory:                  {directory}
+Files:                      {files}
+Persister Buffer:           {buffered}
+
+Prefetch Workers:           {workers}
+Prefetch Amount:            {prefetch_amount} = {prefetch_amount_kb} KB
+Prefetch Requests:          {requests}
+Prefetch Average Size:      {avg_prefetch_size} Bytes
+Prefetch Duration:          {prefetch_duration} Seconds
+Prefetch Bandwidth:         {prefetch_bandwidth} MB/S
+Prefetch Request Latency:   {prefetch_request_latency} Seconds
+Prefetch Unmerged:          {unmerged_blocks}
 "#,
                 partial_hits = m["partial_hits"],
                 whole_hits = m["whole_hits"],
                 total_read = m["total"],
-                prefetch_amount = m["prefetch_data_amount"],
-                prefetch_amount_kb = m["prefetch_data_amount"].as_u64().unwrap() / 1024,
+                prefetch_amount = prefetch_data_amount,
+                prefetch_amount_kb = prefetch_data_amount / 1024.0,
                 files = m["underlying_files"],
                 directory = m["store_path"],
                 requests = m["prefetch_requests_count"],
@@ -91,6 +102,11 @@ Persister Buffer:       {buffered}
                 workers = m["prefetch_workers"],
                 unmerged_blocks = m["prefetch_unmerged_chunks"],
                 buffered = m["buffered_backend_size"],
+                prefetch_duration = prefetch_duration,
+                prefetch_bandwidth = prefetch_data_amount / 1024.0 / 1024.0 / prefetch_duration,
+                prefetch_request_latency = m["prefetch_cumulative_time_millis"].as_f64().unwrap()
+                    / m["prefetch_requests_count"].as_f64().unwrap()
+                    / 1000.0
             );
         }
 

--- a/storage/src/cache/worker.rs
+++ b/storage/src/cache/worker.rs
@@ -353,7 +353,7 @@ impl AsyncWorkerMgr {
         }
 
         // Record how much prefetch data is requested from storage backend.
-        // So the average backend merged request size will be prefetch_data_amount/prefetch_mr_count.
+        // So the average backend merged request size will be prefetch_data_amount/prefetch_requests_count.
         // We can measure merging possibility by this.
         let metrics = mgr.metrics.clone();
         metrics.prefetch_requests_count.inc();
@@ -412,7 +412,7 @@ impl AsyncWorkerMgr {
         }
 
         // Record how much prefetch data is requested from storage backend.
-        // So the average backend merged request size will be prefetch_data_amount/prefetch_mr_count.
+        // So the average backend merged request size will be prefetch_data_amount/prefetch_requests_count.
         // We can measure merging possibility by this.
         mgr.metrics.prefetch_requests_count.inc();
         mgr.metrics.prefetch_data_amount.add(blob_size);


### PR DESCRIPTION
We already add more metrics for the prefetch procedure. Make nydusctl calculate the metrics and show them in a human-readable way

Example:
```
Partial Hits:               2626
Whole Hits:                 0
Total Read:                 2684
Directory:                  "/var/lib/containerd-nydus/cache"
Files:                      ["948f80e95f4ab83ae5a202f987fee81f0c860f2e42d82689a758b57887678601","18798c2c51ee3c0cb84f4e8dbfa3ac5b9116cfac315e3af08405363ea97a2ef7","d6a08dd25b46d4701c0f3221f20160563fb4b5866b6f4c915a982914adfc00de","3355a6911228a3502a61b1a53ce9265be17fb07934e6511fbcfdb83438e42de9","004656def9b233af509fc65aa91b824071a2ed3c2ee7b1361866b9c06a403949","9957fc0906f7b4b2b1e1fc4a7a6049380bb06d72ac6919e0c06e4134ae70941e"]
Persister Buffer:           0

Prefetch Workers:           8
Prefetch Amount:            350224384 = 342016 KB
Prefetch Requests:          167
Prefetch Average Size:      2097152 Bytes
Prefetch Duration:          5.7769999504089355 Seconds
Prefetch Bandwidth:         57.81547565641873 MB/S
Prefetch Request Latency:   2.868149700598803 Seconds
Prefetch Unmerged:          0
```
