### PR TITLE
builder: use chunk v1 for native directory build

### DIFF
--- a/src/bin/nydus-image/main.rs
+++ b/src/bin/nydus-image/main.rs
@@ -699,12 +699,7 @@ impl Command {
         };
 
         let mut builder: Box<dyn Builder> = match conversion_type {
-            ConversionType::DirectoryToRafs => {
-                if version.is_v6() {
-                    build_ctx.blob_meta_features |= BLOB_META_FEATURE_CHUNK_INFO_V2;
-                }
-                Box::new(DirectoryBuilder::new())
-            }
+            ConversionType::DirectoryToRafs => Box::new(DirectoryBuilder::new()),
             ConversionType::DirectoryToStargz => unimplemented!(),
             ConversionType::DirectoryToTargz => unimplemented!(),
             ConversionType::EStargzToRafs => Box::new(TarballBuilder::new(conversion_type)),


### PR DESCRIPTION
Keep backward compatibility for old nydusd, otherwise the old nydusd will throw a panic like:

```
ERROR [error/src/error.rs:21] Error:
        "blob metadata size is too big!"
        at storage/src/meta/mod.rs:344
        note: enable `RUST_BACKTRACE=1` env to display a backtrace
```

Try to fix: https://github.com/dragonflyoss/image-service/issues/903

Signed-off-by: Yan Song <imeoer@linux.alibaba.com>