### PR TITLE
utils: fix a warning generated when decoding chunk data

### DIFF
--- a/storage/src/cache/cachedfile.rs
+++ b/storage/src/cache/cachedfile.rs
@@ -1160,7 +1160,9 @@ impl FileCacheEntry {
                 chunk.compressed_size() as u64
             };
             let mut reader = FileRangeReader::new(&self.file, offset, size);
-            if self.compressor() == compress::Algorithm::Lz4Block {
+            if !chunk.is_compressed() {
+                reader.read_exact(buffer)?;
+            } else if self.compressor() == compress::Algorithm::Lz4Block {
                 let mut buf = alloc_buf(size as usize);
                 reader.read_exact(&mut buf)?;
                 let size = compress::decompress(&buf, buffer, self.compressor)?;


### PR DESCRIPTION
The refactor introduced a regression which tries to decompress an uncompressed data chunk, thus generating a warning about decompression failure. Fix it by check whether the chunk data is compressed or not.

Signed-off-by: Jiang Liu <gerry@linux.alibaba.com>