### PR TITLE
misc: add a volume in nydus-smoke test

### DIFF
--- a/misc/nydus-smoke/Dockerfile
+++ b/misc/nydus-smoke/Dockerfile
@@ -9,4 +9,6 @@ RUN apt update && apt install -y tree
 
 WORKDIR /nydus-rs
 
+VOLUME /tmp
+
 CMD make release smoke


### PR DESCRIPTION
The smoke test requires a non-overlayfs-upperlayer /tmp directory, otherwise it fails at mknod char device (0,0). Let's create a volume for it.