### PR TITLE
storage: simplify implementation of cachefile

### DIFF
--- a/storage/src/cache/dummycache.rs
+++ b/storage/src/cache/dummycache.rs
@@ -58,11 +58,11 @@ impl BlobCache for DummyCache {
         self.reader.blob_size().map_err(|e| eother!(e))
     }
 
-    fn compressor(&self) -> compress::Algorithm {
+    fn blob_compressor(&self) -> compress::Algorithm {
         self.compressor
     }
 
-    fn digester(&self) -> digest::Algorithm {
+    fn blob_digester(&self) -> digest::Algorithm {
         self.digester
     }
 

--- a/storage/src/cache/fscache/mod.rs
+++ b/storage/src/cache/fscache/mod.rs
@@ -246,10 +246,8 @@ impl FileCacheEntry {
 
             blob_compressed_size,
             blob_uncompressed_size: blob_info.uncompressed_size(),
-            compressor: blob_info.compressor(),
-            digester: blob_info.digester(),
             is_get_blob_object_supported: true,
-            is_compressed: false,
+            is_raw_data: false,
             is_direct_chunkmap: true,
             is_legacy_stargz: blob_info.is_legacy_stargz(),
             is_zran,


### PR DESCRIPTION
Simplify implementation of cachefile by:
1) remove compressor and digester and directly get those info from
   blob info object.
2) rename is_compressed to is_raw_data, the cache data may be
   uncompressed and encrypted in future.

Signed-off-by: Jiang Liu <gerry@linux.alibaba.com>