### PR TITLE
nydus-image: use blake3 as default digester

### DIFF
--- a/src/bin/nydus-image/main.rs
+++ b/src/bin/nydus-image/main.rs
@@ -258,7 +258,7 @@ fn prepare_cmd_args(bti_string: &'static str) -> App {
                         .long("digester")
                         .help("Set algorithm to digest inodes and chunks:")
                         .required(false)
-                        .default_value("sha256")
+                        .default_value("blake3")
                         .value_parser(["blake3", "sha256"]),
                 )
                 .arg(


### PR DESCRIPTION
Blake3 is much faster than sha256, so use it as default.

Signed-off-by: Jiang Liu <gerry@linux.alibaba.com>