### PR TITLE
rafs: unify meta-flags and blob-features

### DIFF
--- a/rafs/src/metadata/cached_v5.rs
+++ b/rafs/src/metadata/cached_v5.rs
@@ -946,7 +946,7 @@ mod cached_tests {
             0,
             0,
             0,
-            BlobFeatures::V5_NO_EXT_BLOB_TABLE,
+            BlobFeatures::_V5_NO_EXT_BLOB_TABLE,
             meta.flags,
         );
         let mut cached_inode = CachedInodeV5::new(blob_table, meta.clone());

--- a/rafs/src/metadata/layout/v5.rs
+++ b/rafs/src/metadata/layout/v5.rs
@@ -638,7 +638,7 @@ impl RafsV5BlobTable {
                     let entry = &self.extended.entries[index];
                     (entry.chunk_count, entry.uncompressed_size, entry.compressed_size, BlobFeatures::empty())
                 } else {
-                    (0, 0, 0, BlobFeatures::V5_NO_EXT_BLOB_TABLE)
+                    (0, 0, 0, BlobFeatures::_V5_NO_EXT_BLOB_TABLE)
                 };
 
             let mut blob_info = BlobInfo::new(
@@ -1653,7 +1653,7 @@ pub mod tests {
                 0,
                 0,
                 0,
-                BlobFeatures::V5_NO_EXT_BLOB_TABLE,
+                BlobFeatures::_V5_NO_EXT_BLOB_TABLE,
             ));
             let mut desc = BlobIoVec::new(blob.clone());
             let res = add_chunk_to_bio_desc(&mut desc, *offset, *end, Arc::new(chunk), blob, true);

--- a/rafs/src/metadata/layout/v6.rs
+++ b/rafs/src/metadata/layout/v6.rs
@@ -14,11 +14,7 @@ use std::sync::Arc;
 
 use lazy_static::lazy_static;
 use nydus_storage::device::{BlobFeatures, BlobInfo};
-use nydus_storage::meta::{
-    BlobChunkInfoV1Ondisk, BlobChunkInfoV2Ondisk, BlobMetaHeaderOndisk,
-    BLOB_META_FEATURE_4K_ALIGNED, BLOB_META_FEATURE_CHUNK_INFO_V2, BLOB_META_FEATURE_MASK,
-    BLOB_META_FEATURE_SEPARATE, BLOB_META_FEATURE_ZRAN,
-};
+use nydus_storage::meta::{BlobChunkInfoV1Ondisk, BlobChunkInfoV2Ondisk, BlobMetaHeaderOndisk};
 use nydus_storage::{RAFS_MAX_CHUNKS_PER_BLOB, RAFS_MAX_CHUNK_SIZE};
 use nydus_utils::{compress, digest, round_up, ByteSize};
 
@@ -1261,8 +1257,8 @@ struct RafsV6Blob {
     compression_algo: u32,
     // Digest algorithm for chunks in the blob.
     digest_algo: u32,
-    // Flags for the compression information array.
-    meta_features: u32,
+    // Feature flags.
+    features: u32,
     // Size of the compressed blob, not including CI array and header.
     compressed_size: u64,
     // Size of the uncompressed blob, not including CI array and header.
@@ -1297,7 +1293,7 @@ impl Default for RafsV6Blob {
             chunk_count: 0u32,
             compression_algo: (compress::Algorithm::None as u32).to_le(),
             digest_algo: (digest::Algorithm::Blake3 as u32).to_le(),
-            meta_features: 0u32,
+            features: 0u32,
             compressed_size: 0u64,
             uncompressed_size: 0u64,
             reserved1: 0u32,
@@ -1325,6 +1321,7 @@ impl RafsV6Blob {
 
         let blob_id = String::from_utf8(self.blob_id.to_vec())
             .map_err(|e| einval!(format!("invalid blob id, {}", e)))?;
+        let blob_features = BlobFeatures::try_from(u32::from_le(self.features))?;
         let mut blob_info = BlobInfo::new(
             u32::from_le(self.blob_index),
             blob_id,
@@ -1332,7 +1329,7 @@ impl RafsV6Blob {
             u64::from_le(self.compressed_size),
             u32::from_le(self.chunk_size),
             u32::from_le(self.chunk_count),
-            BlobFeatures::empty(),
+            blob_features,
         );
 
         let comp = compress::Algorithm::try_from(u32::from_le(self.compression_algo))
@@ -1342,7 +1339,6 @@ impl RafsV6Blob {
             .map_err(|_| einval!("invalid digest algorithm in Rafs v6 blob entry"))?;
         blob_info.set_digester(digest);
         blob_info.set_blob_meta_info(
-            u32::from_le(self.meta_features),
             u64::from_le(self.ci_offset),
             u64::from_le(self.ci_compressed_size),
             u64::from_le(self.ci_uncompressed_size),
@@ -1374,7 +1370,7 @@ impl RafsV6Blob {
             reserved1: 0u32.to_le(),
             compressed_size: blob_info.compressed_size().to_le(),
             uncompressed_size: blob_info.uncompressed_size().to_le(),
-            meta_features: blob_info.meta_flags().to_le(),
+            features: blob_info.features().bits().to_le(),
             ci_compressor: (blob_info.meta_ci_compressor() as u32).to_le(),
             ci_offset: blob_info.meta_ci_offset().to_le(),
             ci_compressed_size: blob_info.meta_ci_compressed_size().to_le(),
@@ -1468,14 +1464,11 @@ impl RafsV6Blob {
             return false;
         }
 
-        let meta_features = u32::from_le(self.meta_features);
-        if meta_features & !BLOB_META_FEATURE_MASK != 0 {
-            error!(
-                "RafsV6Blob: idx {} unknown blob feature bits {:x}",
-                blob_index, meta_features
-            );
-            return false;
-        } else if meta_features & BLOB_META_FEATURE_4K_ALIGNED == 0 {
+        let blob_features = match BlobFeatures::try_from(self.features) {
+            Ok(v) => v,
+            Err(_) => return false,
+        };
+        if !blob_features.contains(BlobFeatures::ALIGNED) {
             error!(
                 "RafsV6Blob: idx {} should have 4K-aligned feature bit",
                 blob_index
@@ -1494,7 +1487,7 @@ impl RafsV6Blob {
             return false;
         }
 
-        if meta_features & BLOB_META_FEATURE_SEPARATE != 0 && ci_offset != 0 {
+        if blob_features.contains(BlobFeatures::SEPARATE_BLOB_META) && ci_offset != 0 {
             error!(
                 "RafsV6Blob: idx {} invalid fields for separate CI, ci_offset {:x}",
                 blob_index, ci_offset
@@ -1503,42 +1496,37 @@ impl RafsV6Blob {
         }
 
         let count = chunk_count as u64;
-        const ZRAN_FLAGS: u32 = BLOB_META_FEATURE_CHUNK_INFO_V2 | BLOB_META_FEATURE_ZRAN;
-        match meta_features & (BLOB_META_FEATURE_CHUNK_INFO_V2 | BLOB_META_FEATURE_ZRAN) {
-            ZRAN_FLAGS => {
-                if ci_uncompr_size < count * size_of::<BlobChunkInfoV2Ondisk>() as u64 {
-                    error!(
-                        "RafsV6Blob: idx {} invalid ci_d_size {}",
-                        blob_index, ci_uncompr_size
-                    );
-                    return false;
-                }
-            }
-            BLOB_META_FEATURE_CHUNK_INFO_V2 => {
-                if ci_uncompr_size != count * size_of::<BlobChunkInfoV2Ondisk>() as u64 {
-                    error!(
-                        "RafsV6Blob: idx {} invalid ci_d_size {}",
-                        blob_index, ci_uncompr_size
-                    );
-                    return false;
-                }
-            }
-            0 => {
-                if ci_uncompr_size != count * size_of::<BlobChunkInfoV1Ondisk>() as u64 {
-                    error!(
-                        "RafsV6Blob: idx {} invalid fields, ci_d_size {:x}, chunk_count {:x}",
-                        blob_index, ci_uncompr_size, chunk_count
-                    );
-                    return false;
-                }
-            }
-            _ => {
+        if blob_features.contains(BlobFeatures::CHUNK_INFO_V2)
+            && blob_features.contains(BlobFeatures::ZRAN)
+        {
+            if ci_uncompr_size < count * size_of::<BlobChunkInfoV2Ondisk>() as u64 {
                 error!(
-                    "RafsV6Blob: idx {} invalid feature bits {}",
-                    blob_index, meta_features
+                    "RafsV6Blob: idx {} invalid ci_d_size {}",
+                    blob_index, ci_uncompr_size
                 );
                 return false;
             }
+        } else if blob_features.contains(BlobFeatures::CHUNK_INFO_V2) {
+            if ci_uncompr_size != count * size_of::<BlobChunkInfoV2Ondisk>() as u64 {
+                error!(
+                    "RafsV6Blob: idx {} invalid ci_d_size {}",
+                    blob_index, ci_uncompr_size
+                );
+                return false;
+            }
+        } else if blob_features.contains(BlobFeatures::ZRAN) {
+            error!(
+                "RafsV6Blob: idx {} invalid feature bits {}",
+                blob_index,
+                blob_features.bits()
+            );
+            return false;
+        } else if ci_uncompr_size != count * size_of::<BlobChunkInfoV1Ondisk>() as u64 {
+            error!(
+                "RafsV6Blob: idx {} invalid fields, ci_d_size {:x}, chunk_count {:x}",
+                blob_index, ci_uncompr_size, chunk_count
+            );
+            return false;
         }
 
         true
@@ -1591,7 +1579,6 @@ impl RafsV6BlobTable {
         chunk_count: u32,
         uncompressed_size: u64,
         compressed_size: u64,
-        blob_features: BlobFeatures,
         flags: RafsSuperFlags,
         rafs_blob_digest: [u8; 32],
         rafs_blob_toc_digest: [u8; 32],
@@ -1599,6 +1586,7 @@ impl RafsV6BlobTable {
         header: BlobMetaHeaderOndisk,
     ) -> u32 {
         let blob_index = self.entries.len() as u32;
+        let blob_features = BlobFeatures::try_from(header.features()).unwrap();
         let mut blob_info = BlobInfo::new(
             blob_index,
             blob_id,
@@ -1613,7 +1601,6 @@ impl RafsV6BlobTable {
         blob_info.set_digester(flags.into());
         blob_info.set_prefetch_info(prefetch_offset as u64, prefetch_size as u64);
         blob_info.set_blob_meta_info(
-            header.meta_flags(),
             header.ci_compressed_offset(),
             header.ci_compressed_size(),
             header.ci_uncompressed_size(),

--- a/src/bin/nydus-image/builder/stargz.rs
+++ b/src/bin/nydus-image/builder/stargz.rs
@@ -821,7 +821,7 @@ impl Builder for StargzBuilder {
             build_bootstrap(ctx, bootstrap_mgr, &mut bootstrap_ctx, blob_mgr, tree)?;
 
         // Generate node chunks and digest
-        let mut blob_ctx = BlobContext::new(ctx.blob_id.clone(), 0, ctx.blob_meta_features);
+        let mut blob_ctx = BlobContext::new(ctx.blob_id.clone(), 0, ctx.blob_features);
         self.generate_nodes(ctx, &mut bootstrap_ctx, &mut blob_ctx, blob_mgr)?;
 
         // Dump blob meta

--- a/src/bin/nydus-image/core/blob.rs
+++ b/src/bin/nydus-image/core/blob.rs
@@ -10,7 +10,8 @@ use sha2::digest::Digest;
 
 use nydus_rafs::metadata::layout::toc;
 use nydus_rafs::metadata::RAFS_MAX_CHUNK_SIZE;
-use nydus_storage::meta::{BlobMetaChunkArray, BLOB_META_FEATURE_ZRAN};
+use nydus_storage::device::BlobFeatures;
+use nydus_storage::meta::BlobMetaChunkArray;
 use nydus_utils::{compress, digest, try_round_up_4k};
 
 use super::context::{ArtifactWriter, BlobContext, BlobManager, BuildContext, ConversionType};
@@ -135,7 +136,7 @@ impl Blob {
         let mut header = blob_ctx.blob_meta_header;
         let blob_meta_info = &blob_ctx.blob_meta_info;
         let ci_data = blob_meta_info.as_byte_slice();
-        let uncompressed_data = if ctx.blob_meta_features & BLOB_META_FEATURE_ZRAN != 0 {
+        let uncompressed_data = if ctx.blob_features.contains(BlobFeatures::ZRAN) {
             let zran = ctx.blob_zran_generator.as_ref().unwrap();
             let (zran_data, zran_count) = zran.lock().unwrap().to_vec()?;
             header.set_ci_zran_count(zran_count);

--- a/src/bin/nydus-image/core/blob_compact.rs
+++ b/src/bin/nydus-image/core/blob_compact.rs
@@ -522,7 +522,7 @@ impl BlobCompactor {
                 State::Rebuild(cs) => {
                     let blob_storage = ArtifactStorage::FileDir(PathBuf::from(dir));
                     let mut blob_ctx =
-                        BlobContext::new(String::from(""), 0, build_ctx.blob_meta_features);
+                        BlobContext::new(String::from(""), 0, build_ctx.blob_features);
                     blob_ctx.set_meta_info_enabled(self.is_v6());
                     let blob_idx = self.new_blob_mgr.alloc_index()?;
                     let new_chunks = cs.dump(

--- a/src/bin/nydus-image/core/node.rs
+++ b/src/bin/nydus-image/core/node.rs
@@ -31,7 +31,8 @@ use nydus_rafs::metadata::layout::v6::{
 use nydus_rafs::metadata::layout::RafsXAttrs;
 use nydus_rafs::metadata::{Inode, RafsStore, RafsVersion};
 use nydus_rafs::RafsIoWrite;
-use nydus_storage::meta::{BlobChunkInfoV2Ondisk, BlobMetaChunkInfo, BLOB_META_FEATURE_ZRAN};
+use nydus_storage::device::BlobFeatures;
+use nydus_storage::meta::{BlobChunkInfoV2Ondisk, BlobMetaChunkInfo};
 use nydus_utils::compress;
 use nydus_utils::digest::{DigestHasher, RafsDigest};
 use nydus_utils::{div_round_up, round_down_4k, round_up, try_round_up_4k, ByteSize};
@@ -580,7 +581,7 @@ impl Node {
         chunk.set_uncompressed_offset(pre_uncompressed_offset);
         chunk.set_uncompressed_size(uncompressed_size);
 
-        let compressed_size = if ctx.blob_meta_features & BLOB_META_FEATURE_ZRAN != 0 {
+        let compressed_size = if ctx.blob_features.contains(BlobFeatures::ZRAN) {
             chunk.compressed_size()
         } else {
             let (compressed, is_compressed) = compress::compress(chunk_data, ctx.compressor)

--- a/storage/src/cache/dummycache.rs
+++ b/storage/src/cache/dummycache.rs
@@ -29,8 +29,9 @@ use nydus_utils::{compress, digest};
 use crate::backend::{BlobBackend, BlobReader};
 use crate::cache::state::{ChunkMap, NoopChunkMap};
 use crate::cache::{BlobCache, BlobCacheMgr};
-use crate::device::{BlobChunkInfo, BlobInfo, BlobIoDesc, BlobIoVec, BlobPrefetchRequest};
-use crate::meta::BLOB_META_FEATURE_ZRAN;
+use crate::device::{
+    BlobChunkInfo, BlobFeatures, BlobInfo, BlobIoDesc, BlobIoVec, BlobPrefetchRequest,
+};
 use crate::utils::{alloc_buf, copyv};
 use crate::{StorageError, StorageResult};
 
@@ -201,7 +202,7 @@ impl BlobCacheMgr for DummyCacheMgr {
     }
 
     fn get_blob_cache(&self, blob_info: &Arc<BlobInfo>) -> Result<Arc<dyn BlobCache>> {
-        if blob_info.meta_flags() & BLOB_META_FEATURE_ZRAN != 0 {
+        if blob_info.has_feature(BlobFeatures::ZRAN) {
             return Err(einval!(
                 "BlobCacheMgr doesn't support ZRan based RAFS data blobs"
             ));

--- a/storage/src/cache/filecache/mod.rs
+++ b/storage/src/cache/filecache/mod.rs
@@ -21,7 +21,6 @@ use crate::cache::state::{BlobStateMap, ChunkMap, DigestedChunkMap, IndexedChunk
 use crate::cache::worker::{AsyncPrefetchConfig, AsyncWorkerMgr};
 use crate::cache::{BlobCache, BlobCacheMgr};
 use crate::device::{BlobFeatures, BlobInfo};
-use crate::meta::BLOB_META_FEATURE_ZRAN;
 use crate::RAFS_DEFAULT_CHUNK_SIZE;
 
 /// An implementation of [BlobCacheMgr](../trait.BlobCacheMgr.html) to improve performance by
@@ -198,7 +197,7 @@ impl FileCacheEntry {
         let digester = blob_info.digester();
         let is_legacy_stargz = blob_info.is_legacy_stargz();
         let is_compressed = mgr.is_compressed && compressor != compress::Algorithm::None;
-        let is_zran = blob_info.meta_flags() & BLOB_META_FEATURE_ZRAN != 0;
+        let is_zran = blob_info.has_feature(BlobFeatures::ZRAN);
         let need_validation = (mgr.validate || !is_direct_chunkmap) && !is_legacy_stargz;
         trace!(
             "filecache entry: compressed {}, direct {}, legacy_stargz {}, zran {}",
@@ -271,7 +270,7 @@ impl FileCacheEntry {
         let is_v5 = !blob_info.meta_ci_is_valid();
         let mut direct_chunkmap = true;
         let chunk_map: Arc<dyn ChunkMap> = if (is_v5 && mgr.disable_indexed_map)
-            || blob_info.has_feature(BlobFeatures::V5_NO_EXT_BLOB_TABLE)
+            || blob_info.has_feature(BlobFeatures::_V5_NO_EXT_BLOB_TABLE)
         {
             direct_chunkmap = false;
             Arc::new(BlobStateMap::from(DigestedChunkMap::new()))

--- a/storage/src/cache/fscache/mod.rs
+++ b/storage/src/cache/fscache/mod.rs
@@ -19,7 +19,6 @@ use crate::cache::worker::{AsyncPrefetchConfig, AsyncWorkerMgr};
 use crate::cache::{BlobCache, BlobCacheMgr};
 use crate::device::{BlobFeatures, BlobInfo, BlobObject};
 use crate::factory::BLOB_FACTORY;
-use crate::meta::BLOB_META_FEATURE_ZRAN;
 use crate::RAFS_DEFAULT_CHUNK_SIZE;
 
 pub const FSCACHE_BLOBS_CHECK_NUM: u8 = 1;
@@ -197,7 +196,7 @@ impl FileCacheEntry {
         runtime: Arc<Runtime>,
         workers: Arc<AsyncWorkerMgr>,
     ) -> Result<Self> {
-        if blob_info.has_feature(BlobFeatures::V5_NO_EXT_BLOB_TABLE) {
+        if blob_info.has_feature(BlobFeatures::_V5_NO_EXT_BLOB_TABLE) {
             return Err(einval!("fscache does not support Rafs v5 blobs"));
         }
         let file = blob_info
@@ -232,7 +231,7 @@ impl FileCacheEntry {
                 "fscache doesn't support blobs without blob meta information"
             ));
         };
-        let is_zran = blob_info.meta_flags() & BLOB_META_FEATURE_ZRAN != 0;
+        let is_zran = blob_info.has_feature(BlobFeatures::ZRAN);
 
         Ok(FileCacheEntry {
             blob_info: blob_info.clone(),

--- a/storage/src/cache/mod.rs
+++ b/storage/src/cache/mod.rs
@@ -538,7 +538,7 @@ mod tests {
             0x100000,
             0x100000,
             512,
-            BlobFeatures::V5_NO_EXT_BLOB_TABLE,
+            BlobFeatures::_V5_NO_EXT_BLOB_TABLE,
         ));
         let chunk1 = Arc::new(MockChunkInfo {
             block_id: Default::default(),

--- a/storage/src/meta/chunk_info_v1.rs
+++ b/storage/src/meta/chunk_info_v1.rs
@@ -192,7 +192,7 @@ mod tests {
     fn test_get_chunk_index_with_hole() {
         let state = BlobMetaState {
             blob_index: 0,
-            meta_flags: 0,
+            blob_features: 0,
             compressed_size: 0,
             uncompressed_size: 0,
             chunk_info_array: ManuallyDrop::new(BlobMetaChunkArray::V1(vec![
@@ -256,7 +256,7 @@ mod tests {
     fn test_get_chunks() {
         let state = BlobMetaState {
             blob_index: 1,
-            meta_flags: 0,
+            blob_features: 0,
             compressed_size: 0x6001,
             uncompressed_size: 0x102001,
             chunk_info_array: ManuallyDrop::new(BlobMetaChunkArray::V1(vec![
@@ -374,7 +374,6 @@ mod tests {
             BlobFeatures::default(),
         );
         blob_info.set_blob_meta_info(
-            0,
             pos,
             data.len() as u64,
             data.len() as u64,
@@ -443,7 +442,6 @@ mod tests {
             BlobFeatures::default(),
         );
         blob_info.set_blob_meta_info(
-            0,
             pos,
             compressed_size as u64,
             uncompressed_size as u64,

--- a/storage/src/meta/chunk_info_v2.rs
+++ b/storage/src/meta/chunk_info_v2.rs
@@ -2,11 +2,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::device::BlobFeatures;
 use std::fmt::{Display, Formatter};
 
-use crate::meta::{
-    BlobMetaChunkInfo, BlobMetaState, BLOB_METADATA_CHUNK_SIZE_MASK, BLOB_META_FEATURE_ZRAN,
-};
+use crate::meta::{BlobMetaChunkInfo, BlobMetaState, BLOB_METADATA_CHUNK_SIZE_MASK};
 
 const CHUNK_V2_COMP_OFFSET_MASK: u64 = 0xff_ffff_ffff;
 const CHUNK_V2_COMP_SIZE_SHIFT: u64 = 40;
@@ -166,7 +165,7 @@ impl BlobMetaChunkInfo for BlobChunkInfoV2Ondisk {
             return Err(einval!(format!("unknown chunk flags {:x}", invalid_flags)));
         }
 
-        if state.meta_flags & BLOB_META_FEATURE_ZRAN == 0 && self.is_zran() {
+        if state.blob_features & BlobFeatures::ZRAN.bits() == 0 && self.is_zran() {
             return Err(einval!("invalid chunk flag ZRan for non-ZRan blob"));
         } else if self.is_zran() {
             let index = self.get_zran_index() as usize;
@@ -272,7 +271,7 @@ mod tests {
     fn test_get_chunk_index_with_hole() {
         let state = BlobMetaState {
             blob_index: 0,
-            meta_flags: 0,
+            blob_features: 0,
             compressed_size: 0,
             uncompressed_size: 0,
             chunk_info_array: ManuallyDrop::new(BlobMetaChunkArray::V2(vec![


### PR DESCRIPTION
There are two sets of flags to control blob features: meta-flag and blob-features. Unify them into one blob-features.

Signed-off-by: Jiang Liu <gerry@linux.alibaba.com>