### PR TITLE
storage: get blob size from blob info object

### DIFF
--- a/storage/src/cache/cachedfile.rs
+++ b/storage/src/cache/cachedfile.rs
@@ -132,7 +132,7 @@ impl FileCacheEntry {
         let size = if blob_info.is_legacy_stargz() {
             reader.blob_size().map_err(|e| einval!(e))?
         } else {
-            0
+            blob_info.compressed_size()
         };
 
         Ok(size)

--- a/storage/src/cache/dummycache.rs
+++ b/storage/src/cache/dummycache.rs
@@ -36,7 +36,7 @@ use crate::utils::{alloc_buf, copyv};
 use crate::{StorageError, StorageResult};
 
 struct DummyCache {
-    blob_id: String,
+    blob_info: Arc<BlobInfo>,
     chunk_map: Arc<dyn ChunkMap>,
     reader: Arc<dyn BlobReader>,
     compressor: compress::Algorithm,
@@ -47,11 +47,11 @@ struct DummyCache {
 
 impl BlobCache for DummyCache {
     fn blob_id(&self) -> &str {
-        &self.blob_id
+        self.blob_info.blob_id()
     }
 
     fn blob_uncompressed_size(&self) -> Result<u64> {
-        unimplemented!();
+        Ok(self.blob_info.uncompressed_size())
     }
 
     fn blob_compressed_size(&self) -> Result<u64> {
@@ -212,7 +212,7 @@ impl BlobCacheMgr for DummyCacheMgr {
         let reader = self.backend.get_reader(&blob_id).map_err(|e| eother!(e))?;
 
         Ok(Arc::new(DummyCache {
-            blob_id,
+            blob_info: blob_info.clone(),
             chunk_map: Arc::new(NoopChunkMap::new(self.cached)),
             reader,
             compressor: blob_info.compressor(),


### PR DESCRIPTION
Get blob size from blob info object instead of returning invalid value.

Signed-off-by: Jiang Liu <gerry@linux.alibaba.com>