### PR TITLE
Backoff retry

### DIFF
--- a/src/bin/nydusctl/commands.rs
+++ b/src/bin/nydusctl/commands.rs
@@ -401,31 +401,28 @@ Commit:                 {git_commit}
                 if let Some(b) = i.get("backend_collection") {
                     if let Some(fs_backends) = b.as_object() {
                         if !fs_backends.is_empty() {
-                            println!("Backend list:")
+                            println!("Instances:")
                         }
 
                         for (mount_point, backend_obj) in fs_backends {
                             let backend: FsBackendDesc =
                                 serde_json::from_value(backend_obj.clone()).unwrap();
-                            println!("  {}", mount_point);
-                            println!("    type:                   {}", backend.backend_type);
-                            println!("    mountpoint:             {}", backend.mountpoint);
-                            println!("    mounted_time:           {}", backend.mounted_time);
+                            println!("\tInstance Mountpoint:  {}", mount_point);
+                            println!("\tType:  {}", backend.backend_type);
+                            println!("\tMounted Time:  {}", backend.mounted_time);
                             match backend.backend_type {
                                 FsBackendType::PassthroughFs => {}
                                 FsBackendType::Rafs => {
                                     let cfg = backend.config.unwrap();
                                     let cache_cfg = cfg.get_cache_config()?;
                                     let rafs_cfg = cfg.get_rafs_config()?;
+                                    print!("\tMode:  {}", rafs_cfg.mode);
+                                    print!("\tPrefetch:  {}", cache_cfg.prefetch.enable);
                                     print!(
-                                        r#"    Mode:                   {meta_mode}
-            Prefetch:               {enabled}
-            Prefetch Merging Size:  {merging_size}
-        "#,
-                                        meta_mode = rafs_cfg.mode,
-                                        enabled = cache_cfg.prefetch.enable,
-                                        merging_size = cache_cfg.prefetch.batch_size,
+                                        "\tPrefetch Merging Size:  {}",
+                                        cache_cfg.prefetch.batch_size
                                     );
+                                    print!("")
                                 }
                             }
                         }

--- a/storage/src/cache/cachedfile.rs
+++ b/storage/src/cache/cachedfile.rs
@@ -22,7 +22,7 @@ use fuse_backend_rs::file_buf::FileVolatileSlice;
 use nix::sys::uio;
 use nydus_utils::compress::Decoder;
 use nydus_utils::metrics::{BlobcacheMetrics, Metric};
-use nydus_utils::{compress, digest, FileRangeReader};
+use nydus_utils::{compress, digest, DelayType, Delayer, FileRangeReader};
 use tokio::runtime::Runtime;
 
 use crate::backend::BlobReader;
@@ -37,8 +37,8 @@ use crate::meta::{BlobMetaChunk, BlobMetaInfo};
 use crate::utils::{alloc_buf, copyv, readv, MemSliceCursor};
 use crate::{StorageError, StorageResult, RAFS_BATCH_SIZE_TO_GAP_SHIFT, RAFS_DEFAULT_CHUNK_SIZE};
 
-const DOWNLOAD_META_RETRY_COUNT: u32 = 20;
-const DOWNLOAD_META_RETRY_DELAY: u64 = 500;
+const DOWNLOAD_META_RETRY_COUNT: u32 = 5;
+const DOWNLOAD_META_RETRY_DELAY: u64 = 400;
 
 #[derive(Default, Clone)]
 pub(crate) struct FileCacheMeta {
@@ -60,6 +60,10 @@ impl FileCacheMeta {
 
         std::thread::spawn(move || {
             let mut retry = 0;
+            let mut delayer = Delayer::new(
+                DelayType::BackOff,
+                Duration::from_millis(DOWNLOAD_META_RETRY_DELAY),
+            );
             while retry < DOWNLOAD_META_RETRY_COUNT {
                 match BlobMetaInfo::new(&blob_file, &blob_info, reader.as_ref()) {
                     Ok(m) => {
@@ -68,7 +72,7 @@ impl FileCacheMeta {
                     }
                     Err(e) => {
                         info!("temporarily failed to get blob.meta, {}", e);
-                        std::thread::sleep(Duration::from_millis(DOWNLOAD_META_RETRY_DELAY));
+                        delayer.delay();
                         retry += 1;
                     }
                 }


### PR DESCRIPTION
Introduce BackOff delayer to mitigate backend pressure

Don't retry immediately since the registry can return "too many requests" error. We'd better to be slow to retry.