### PR TITLE
storage: nydusd supports s3 backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -571,6 +571,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
 name = "hmac-sha1-compact"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1074,7 +1083,9 @@ dependencies = [
  "bitflags",
  "fuse-backend-rs",
  "hex",
+ "hmac",
  "hmac-sha1-compact",
+ "http",
  "httpdate",
  "lazy_static",
  "leaky-bucket",
@@ -1084,10 +1095,13 @@ dependencies = [
  "nydus-api",
  "nydus-error",
  "nydus-utils",
+ "regex",
  "reqwest",
  "serde",
  "serde_json",
+ "sha2",
  "tar",
+ "time",
  "tokio",
  "url",
  "vm-memory",
@@ -1349,9 +1363,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.6.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
+checksum = "e076559ef8e241f2ae3479e36f97bd5741c0330689e217ad51ce2c76808b868a"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ rlimit = "0.8.3"
 log = "0.4.8"
 libc = "0.2"
 vmm-sys-util = "0.10.0"
-clap = {version = "4.0.18", features = ["derive", "cargo"]}
+clap = { version = "4.0.18", features = ["derive", "cargo"] }
 serde = { version = "1.0.110", features = ["serde_derive", "rc"] }
 serde_json = "1.0.51"
 sha2 = "0.10.2"
@@ -53,16 +53,24 @@ hex = "0.4.3"
 fuse-backend-rs = "0.10"
 vhost = { version = "0.5.0", features = ["vhost-user-slave"], optional = true }
 vhost-user-backend = { version = "0.7.0", optional = true }
-virtio-bindings = { version = "0.1", features = ["virtio-v5_0_0"], optional = true }
+virtio-bindings = { version = "0.1", features = [
+    "virtio-v5_0_0",
+], optional = true }
 virtio-queue = { version = "0.6.0", optional = true }
 
 nydus-api = { version = "0.1.0", path = "api", features = ["handler"] }
 nydus-app = { version = "0.3.0", path = "app" }
 nydus-error = { version = "0.2.1", path = "error" }
-nydus-rafs = { version = "0.1.0", path = "rafs", features = ["backend-registry", "backend-oss"] }
+nydus-rafs = { version = "0.1.0", path = "rafs", features = [
+    "backend-registry",
+    "backend-oss",
+    "backend-s3",
+] }
 nydus-storage = { version = "0.5.0", path = "storage" }
 nydus-utils = { version = "0.3.0", path = "utils" }
-nydus-blobfs = { version = "0.1.0", path = "blobfs", features = ["virtiofs"], optional = true }
+nydus-blobfs = { version = "0.1.0", path = "blobfs", features = [
+    "virtiofs",
+], optional = true }
 indexmap = "1.9.1"
 
 [dev-dependencies]
@@ -72,7 +80,14 @@ rand = "0.8.5"
 
 [features]
 default = ["fuse-backend-rs/fusedev"]
-virtiofs = ["fuse-backend-rs/vhost-user-fs", "vm-memory", "vhost", "vhost-user-backend", "virtio-queue", "virtio-bindings"]
+virtiofs = [
+    "fuse-backend-rs/vhost-user-fs",
+    "vm-memory",
+    "vhost",
+    "vhost-user-backend",
+    "virtio-queue",
+    "virtio-bindings",
+]
 
 [workspace]
 members = ["api", "app", "blobfs", "clib", "error", "rafs", "storage", "utils"]

--- a/blobfs/Cargo.toml
+++ b/blobfs/Cargo.toml
@@ -19,13 +19,16 @@ vm-memory = { version = "0.9" }
 nydus-error = { version = "0.2", path = "../error" }
 nydus-api = { version = "0.1", path = "../api" }
 nydus-rafs = { version = "0.1", path = "../rafs" }
-nydus-storage = { version = "0.5", path = "../storage", features = ["backend-localfs"] }
+nydus-storage = { version = "0.5", path = "../storage", features = [
+    "backend-localfs",
+] }
 
 [dev-dependencies]
 nydus-app = { version = "0.3", path = "../app" }
 
 [features]
-virtiofs = [ "fuse-backend-rs/virtiofs", "nydus-rafs/virtio-fs" ]
+virtiofs = ["fuse-backend-rs/virtiofs", "nydus-rafs/virtio-fs"]
+baekend-s3 = ["nydus-rafs/backend-s3"]
 backend-oss = ["nydus-rafs/backend-oss"]
 backend-registry = ["nydus-rafs/backend-registry"]
 

--- a/contrib/nydusify/tests/e2e_test.go
+++ b/contrib/nydusify/tests/e2e_test.go
@@ -131,7 +131,7 @@ func testConvertWithS3Backend(t *testing.T, fsVersion string) {
 	minioPort := 9000
 	minioContainerName := "minio"
 	minioDataDir := "/tmp/minio-data"
-	endpoint := fmt.Sprintf("http://localhost:%d", minioPort)
+	endpoint := fmt.Sprintf("localhost:%d", minioPort)
 	createMinioContainerCmd := fmt.Sprintf(`
 		docker run -p %d:9000 -d -v %s:/data \
 	    	-e "MINIO_ACCESS_KEY=%s" \
@@ -151,7 +151,7 @@ func testConvertWithS3Backend(t *testing.T, fsVersion string) {
 
 	// create bucket
 	s3Client := s3.NewFromConfig(aws.Config{}, func(o *s3.Options) {
-		o.EndpointResolver = s3.EndpointResolverFromURL(endpoint)
+		o.EndpointResolver = s3.EndpointResolverFromURL("http://" + endpoint)
 		o.Region = region
 		o.UsePathStyle = true
 		o.Credentials = credentials.NewStaticCredentialsProvider(accessKey, accessSecret, "")
@@ -169,6 +169,7 @@ func testConvertWithS3Backend(t *testing.T, fsVersion string) {
 		AccessKeyID:     accessKey,
 		AccessKeySecret: accessSecret,
 		Endpoint:        endpoint,
+		Scheme:          "http",
 		BucketName:      bucketName,
 		Region:          region,
 		ObjectPrefix:    "path/to/registry",
@@ -195,15 +196,14 @@ func testConvertWithS3Backend(t *testing.T, fsVersion string) {
 
 	nydusify := NewNydusify(registry, "image-basic", "image-basic-nydus", "", "", fsVersion)
 	nydusify.Convert(t)
-	// TODO nydusd doesn't support s3 backend for now, skip the checker
-	// nydusify.Check(t)
+	nydusify.Check(t)
 }
 
 func TestSmoke(t *testing.T) {
 	fsVersions := [2]string{"5", "6"}
 	for _, v := range fsVersions {
-		testBasicAuth(t, v)
 		testBasicConvert(t, v)
+		testBasicAuth(t, v)
 		testReproducableBuild(t, v)
 		testConvertWithCache(t, v)
 		testConvertWithChunkDict(t, v)

--- a/contrib/nydusify/tests/registry.go
+++ b/contrib/nydusify/tests/registry.go
@@ -42,6 +42,7 @@ type Registry struct {
 	id         string
 	host       string
 	authFile   string
+	authString string // base64(username:password)
 	configFile string
 }
 
@@ -55,8 +56,9 @@ func NewAuthRegistry(t *testing.T) *Registry {
 
 	err = os.Mkdir(".docker", 0755)
 	assert.Nil(t, err)
+	base64AuthString := base64.StdEncoding.EncodeToString([]byte("testuser:testpassword"))
 	configString := fmt.Sprintf(`{"auths": { "localhost:%d": { "auth": "%s" }}}`,
-		registryPort, base64.StdEncoding.EncodeToString([]byte("testuser:testpassword")))
+		registryPort, base64AuthString)
 	configFile, _ := filepath.Abs(filepath.Join(".docker", "config.json"))
 	err = os.Setenv("DOCKER_CONFIG", path.Dir(configFile))
 	assert.Nil(t, err)
@@ -72,6 +74,7 @@ func NewAuthRegistry(t *testing.T) *Registry {
 		id:         containerID,
 		host:       fmt.Sprintf("localhost:%d", registryPort),
 		authFile:   authFile,
+		authString: base64AuthString,
 		configFile: configFile,
 	}
 }

--- a/docs/nydusify.md
+++ b/docs/nydusify.md
@@ -57,7 +57,8 @@ The `endpoint` field of the `backend-config.json` is optional when using aws s3 
 ``` shell
 cat /path/to/backend-config.json
 {
-  "endpoint": "http://localhost:9000",
+  "endpoint": "localhost:9000",
+  "scheme": "http",
   "access_key_id": "",
   "access_key_secret": "",
   "bucket_name": ""

--- a/misc/nydusify-smoke/entrypoint.sh
+++ b/misc/nydusify-smoke/entrypoint.sh
@@ -4,6 +4,6 @@ set -e
 
 TEST_NAME=$1
 
-dockerd-entrypoint.sh & sleep 5
+dockerd-entrypoint.sh & sleep 50
 mkdir /lib64 && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2
 ../nydusify-smoke -test.run $TEST_NAME

--- a/rafs/Cargo.toml
+++ b/rafs/Cargo.toml
@@ -40,6 +40,7 @@ fusedev = ["fuse-backend-rs/fusedev"]
 virtio-fs = ["fuse-backend-rs/virtiofs", "vm-memory/backend-mmap"]
 vhost-user-fs = ["fuse-backend-rs/vhost-user-fs"]
 backend-oss = ["nydus-storage/backend-oss"]
+backend-s3 = ["nydus-storage/backend-s3"]
 backend-registry = ["nydus-storage/backend-registry"]
 
 [package.metadata.docs.rs]

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -12,7 +12,9 @@ edition = "2018"
 arc-swap = "1.5"
 base64 = { version = "0.13.0", optional = true }
 bitflags = "1.2.1"
+hmac = { version = "0.12.1", optional = true }
 hmac-sha1-compact = { version = "1.1.1", optional = true }
+http = { version = "0.2.8", optional = true }
 httpdate = { version = "1.0", optional = true }
 lazy_static = "1.4.0"
 leaky-bucket = "0.12.1"
@@ -22,6 +24,8 @@ nix = "0.24"
 reqwest = { version = "0.11.11", features = ["blocking", "json"], optional = true }
 serde = { version = "1.0.110", features = ["serde_derive", "rc"], optional = true }
 serde_json = "1.0.53"
+sha2 = { version = "0.10.2", optional = true }
+time = { version = "0.3.14", features = ["formatting"], optional = true }
 tokio = { version = "1.19.0", features = ["rt", "rt-multi-thread", "sync", "time"] }
 url = { version = "2.1.1", optional = true }
 hex = "0.4.3"
@@ -35,11 +39,13 @@ nydus-error = { version = "0.2", path = "../error" }
 [dev-dependencies]
 vmm-sys-util = "0.10"
 tar = "0.4.38"
+regex = "1.7.0"
 
 [features]
 backend-localfs = []
 backend-oss = ["base64", "httpdate", "hmac-sha1-compact", "reqwest", "url"]
 backend-registry = ["base64", "reqwest", "serde", "url"]
+backend-s3 = ["base64", "hmac", "http", "reqwest", "sha2", "time", "url"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/storage/README.md
+++ b/storage/README.md
@@ -1,7 +1,7 @@
 # nydus-storage
 
 The core storage subsystem for [Nydus Image Service](https://nydus.dev/) to:
-- Fetch blob objects from storage backend such as Registry, OSS and file systems etc.
+- Fetch blob objects from storage backend such as Registry, OSS, S3 and file systems etc.
 - Load data from storage backend on demand.
 - Cache blob objects on local storage.
 

--- a/storage/src/backend/connection.rs
+++ b/storage/src/backend/connection.rs
@@ -23,7 +23,7 @@ use reqwest::{
     Method, StatusCode, Url,
 };
 
-use nydus_api::{MirrorConfig, OssConfig, ProxyConfig, RegistryConfig};
+use nydus_api::{MirrorConfig, OssConfig, ProxyConfig, RegistryConfig, S3Config};
 use url::ParseError;
 
 const HEADER_AUTHORIZATION: &str = "Authorization";
@@ -76,6 +76,19 @@ impl Default for ConnectionConfig {
 
 impl From<OssConfig> for ConnectionConfig {
     fn from(c: OssConfig) -> ConnectionConfig {
+        ConnectionConfig {
+            proxy: c.proxy,
+            mirrors: c.mirrors,
+            skip_verify: c.skip_verify,
+            timeout: c.timeout,
+            connect_timeout: c.connect_timeout,
+            retry_limit: c.retry_limit,
+        }
+    }
+}
+
+impl From<S3Config> for ConnectionConfig {
+    fn from(c: S3Config) -> ConnectionConfig {
         ConnectionConfig {
             proxy: c.proxy,
             mirrors: c.mirrors,

--- a/storage/src/backend/mod.rs
+++ b/storage/src/backend/mod.rs
@@ -21,14 +21,22 @@ use nydus_utils::metrics::{BackendMetrics, ERROR_HOLDER};
 use crate::utils::{alloc_buf, copyv};
 use crate::StorageError;
 
-#[cfg(any(feature = "backend-oss", feature = "backend-registry"))]
+#[cfg(any(
+    feature = "backend-oss",
+    feature = "backend-registry",
+    feature = "backend-s3"
+))]
 pub mod connection;
 #[cfg(feature = "backend-localfs")]
 pub mod localfs;
+#[cfg(any(feature = "backend-oss", feature = "backend-s3"))]
+pub mod object_storage;
 #[cfg(feature = "backend-oss")]
 pub mod oss;
 #[cfg(feature = "backend-registry")]
 pub mod registry;
+#[cfg(feature = "backend-s3")]
+pub mod s3;
 
 /// Error codes related to storage backend operations.
 #[derive(Debug)]
@@ -43,9 +51,9 @@ pub enum BackendError {
     #[cfg(feature = "backend-localfs")]
     /// Error from LocalFs storage backend.
     LocalFs(self::localfs::LocalFsError),
-    #[cfg(feature = "backend-oss")]
-    /// Error from OSS storage backend.
-    Oss(self::oss::OssError),
+    #[cfg(any(feature = "backend-oss", feature = "backend-s3"))]
+    /// Error from object storage backend.
+    ObjectStorage(self::object_storage::ObjectStorageError),
 }
 
 /// Specialized `Result` for storage backends.

--- a/storage/src/backend/object_storage.rs
+++ b/storage/src/backend/object_storage.rs
@@ -1,0 +1,220 @@
+// Copyright 2022 Ant Group. All rights reserved.
+// Copyright (C) 2022 Alibaba Cloud. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Base module used to implement object storage backend drivers (such as oss, s3, etc.).
+
+use std::fmt::Debug;
+use std::io::{Error, Result};
+use std::marker::Send;
+use std::sync::Arc;
+
+use reqwest::header::{HeaderMap, CONTENT_LENGTH};
+use reqwest::Method;
+
+use nydus_utils::metrics::BackendMetrics;
+
+use super::connection::{Connection, ConnectionError};
+use super::{BackendError, BackendResult, BlobBackend, BlobReader};
+
+/// Error codes related to object storage backend.
+#[derive(Debug)]
+pub enum ObjectStorageError {
+    Auth(Error),
+    Url(String),
+    Request(ConnectionError),
+    ConstructHeader(String),
+    Transport(reqwest::Error),
+    Response(String),
+}
+
+impl From<ObjectStorageError> for BackendError {
+    fn from(err: ObjectStorageError) -> Self {
+        BackendError::ObjectStorage(err)
+    }
+}
+
+pub trait ObjectStorageState: Send + Sync + Debug {
+    // `url` builds the resource path and full url for the object.
+    fn url(&self, object_key: &str, query: &[&str]) -> (String, String);
+
+    // `sign` signs the request with the access key and secret key.
+    fn sign(
+        &self,
+        verb: Method,
+        headers: &mut HeaderMap,
+        canonicalized_resource: &str,
+        full_resource_url: &str,
+    ) -> Result<()>;
+
+    fn retry_limit(&self) -> u8;
+}
+
+struct ObjectStorageReader<T>
+where
+    T: ObjectStorageState,
+{
+    blob_id: String,
+    connection: Arc<Connection>,
+    state: Arc<T>,
+    metrics: Arc<BackendMetrics>,
+}
+
+impl<T> BlobReader for ObjectStorageReader<T>
+where
+    T: ObjectStorageState,
+{
+    fn blob_size(&self) -> BackendResult<u64> {
+        let (resource, url) = self.state.url(&self.blob_id, &[]);
+        let mut headers = HeaderMap::new();
+
+        self.state
+            .sign(Method::HEAD, &mut headers, resource.as_str(), url.as_str())
+            .map_err(ObjectStorageError::Auth)?;
+
+        let resp = self
+            .connection
+            .call::<&[u8]>(
+                Method::HEAD,
+                url.as_str(),
+                None,
+                None,
+                &mut headers,
+                true,
+                false,
+            )
+            .map_err(ObjectStorageError::Request)?;
+        let content_length = resp
+            .headers()
+            .get(CONTENT_LENGTH)
+            .ok_or_else(|| ObjectStorageError::Response("invalid content length".to_string()))?;
+
+        Ok(content_length
+            .to_str()
+            .map_err(|err| {
+                ObjectStorageError::Response(format!("invalid content length: {:?}", err))
+            })?
+            .parse::<u64>()
+            .map_err(|err| {
+                ObjectStorageError::Response(format!("invalid content length: {:?}", err))
+            })?)
+    }
+
+    fn try_read(&self, mut buf: &mut [u8], offset: u64) -> BackendResult<usize> {
+        let query = &[];
+        let (resource, url) = self.state.url(&self.blob_id, query);
+        let mut headers = HeaderMap::new();
+        let end_at = offset + buf.len() as u64 - 1;
+        let range = format!("bytes={}-{}", offset, end_at);
+
+        headers.insert(
+            "Range",
+            range
+                .as_str()
+                .parse()
+                .map_err(|e| ObjectStorageError::ConstructHeader(format!("{}", e)))?,
+        );
+        self.state
+            .sign(Method::GET, &mut headers, resource.as_str(), url.as_str())
+            .map_err(ObjectStorageError::Auth)?;
+
+        // Safe because the the call() is a synchronous operation.
+        let mut resp = self
+            .connection
+            .call::<&[u8]>(
+                Method::GET,
+                url.as_str(),
+                None,
+                None,
+                &mut headers,
+                true,
+                false,
+            )
+            .map_err(ObjectStorageError::Request)?;
+        Ok(resp
+            .copy_to(&mut buf)
+            .map_err(ObjectStorageError::Transport)
+            .map(|size| size as usize)?)
+    }
+
+    fn metrics(&self) -> &BackendMetrics {
+        &self.metrics
+    }
+
+    fn retry_limit(&self) -> u8 {
+        self.state.retry_limit()
+    }
+}
+
+#[derive(Debug)]
+pub struct ObjectStorage<T>
+where
+    T: ObjectStorageState,
+{
+    connection: Arc<Connection>,
+    state: Arc<T>,
+    metrics: Option<Arc<BackendMetrics>>,
+    #[allow(unused)]
+    id: Option<String>,
+}
+
+impl<T> ObjectStorage<T>
+where
+    T: ObjectStorageState,
+{
+    pub(crate) fn new_object_storage(
+        connection: Arc<Connection>,
+        state: Arc<T>,
+        metrics: Option<Arc<BackendMetrics>>,
+        id: Option<String>,
+    ) -> Self {
+        ObjectStorage {
+            connection,
+            state,
+            metrics,
+            id,
+        }
+    }
+}
+
+impl<T: 'static> BlobBackend for ObjectStorage<T>
+where
+    T: ObjectStorageState,
+{
+    fn shutdown(&self) {
+        self.connection.shutdown();
+    }
+
+    fn metrics(&self) -> &BackendMetrics {
+        // `metrics()` is only used for nydusd, which will always provide valid `blob_id`, thus
+        // `self.metrics` has valid value.
+        self.metrics.as_ref().unwrap()
+    }
+
+    fn get_reader(&self, blob_id: &str) -> BackendResult<Arc<dyn BlobReader>> {
+        if let Some(metrics) = self.metrics.as_ref() {
+            Ok(Arc::new(ObjectStorageReader {
+                blob_id: blob_id.to_string(),
+                state: self.state.clone(),
+                connection: self.connection.clone(),
+                metrics: metrics.clone(),
+            }))
+        } else {
+            Err(BackendError::Unsupported(
+                "no metrics object available for OssReader".to_string(),
+            ))
+        }
+    }
+}
+
+impl<T> Drop for ObjectStorage<T>
+where
+    T: ObjectStorageState,
+{
+    fn drop(&mut self) {
+        if let Some(metrics) = self.metrics.as_ref() {
+            metrics.release().unwrap_or_else(|e| error!("{:?}", e));
+        }
+    }
+}

--- a/storage/src/backend/s3.rs
+++ b/storage/src/backend/s3.rs
@@ -1,0 +1,337 @@
+// Copyright 2022 Ant Group. All rights reserved.
+// Copyright (C) 2022 Alibaba Cloud. All rights reserved.
+
+// SPDX-License-Identifier: Apache-2.0
+
+// ! Storage backend driver to access blobs on s3.
+
+use std::collections::BTreeMap;
+use std::fmt::Debug;
+use std::io::Result;
+use std::sync::Arc;
+
+use hmac::{Hmac, Mac};
+use http::Uri;
+use nydus_api::S3Config;
+use nydus_utils::metrics::BackendMetrics;
+use reqwest::header::HeaderMap;
+use reqwest::Method;
+use sha2::{Digest, Sha256};
+use time::{format_description, OffsetDateTime};
+
+use crate::backend::connection::{Connection, ConnectionConfig};
+use crate::backend::object_storage::{ObjectStorage, ObjectStorageState};
+
+const EMPTY_SHA256: &str = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+const HEADER_HOST: &str = "Host";
+const HEADER_AWZ_DATE: &str = "x-amz-date";
+const HEADER_AWZ_CONTENT_SHA256: &str = "x-amz-content-sha256";
+const S3_DEFAULT_ENDPOINT: &str = "s3.amazonaws.com";
+
+#[derive(Debug)]
+pub struct S3State {
+    region: String,
+    access_key_id: String,
+    access_key_secret: String,
+    scheme: String,
+    object_prefix: String,
+    endpoint: String,
+    bucket_name: String,
+    retry_limit: u8,
+}
+
+/// Storage backend to access data stored in S3.
+pub type S3 = ObjectStorage<S3State>;
+
+impl S3 {
+    /// Create a new S3 storage backend.
+    pub fn new(s3_config: &S3Config, id: Option<&str>) -> Result<S3> {
+        let con_config: ConnectionConfig = s3_config.clone().into();
+        let retry_limit = con_config.retry_limit;
+        let connection = Connection::new(&con_config)?;
+        let final_endpoint = if s3_config.endpoint.is_empty() {
+            S3_DEFAULT_ENDPOINT.to_string()
+        } else {
+            s3_config.endpoint.clone()
+        };
+
+        let state = Arc::new(S3State {
+            region: s3_config.region.clone(),
+            scheme: s3_config.scheme.clone(),
+            object_prefix: s3_config.object_prefix.clone(),
+            endpoint: final_endpoint,
+            access_key_id: s3_config.access_key_id.clone(),
+            access_key_secret: s3_config.access_key_secret.clone(),
+            bucket_name: s3_config.bucket_name.clone(),
+            retry_limit,
+        });
+        let metrics = id.map(|i| BackendMetrics::new(i, "oss"));
+
+        Ok(ObjectStorage::new_object_storage(
+            connection,
+            state,
+            metrics,
+            id.map(|i| i.to_string()),
+        ))
+    }
+}
+
+impl S3State {
+    // modified based on https://github.com/minio/minio-rs/blob/5fea81d68d381fd2a4c27e4d259f7012de08ab77/src/s3/utils.rs#L155-L200
+    // under apache 2.0 license
+    fn get_canonical_headers(&self, map: &HeaderMap) -> (String, String) {
+        let mut btmap: BTreeMap<String, String> = BTreeMap::new();
+
+        for (k, values) in map.iter() {
+            let key = k.as_str().to_lowercase();
+            if "authorization" == key || "user-agent" == key {
+                continue;
+            }
+            btmap.insert(key.clone(), values.to_str().unwrap().to_string());
+        }
+
+        let mut signed_headers = String::new();
+        let mut canonical_headers = String::new();
+        let mut add_delim = false;
+        for (key, value) in &btmap {
+            if add_delim {
+                signed_headers.push(';');
+                canonical_headers.push('\n');
+            }
+
+            signed_headers.push_str(key);
+
+            canonical_headers.push_str(key);
+            canonical_headers.push(':');
+            canonical_headers.push_str(value);
+
+            add_delim = true;
+        }
+
+        (signed_headers, canonical_headers)
+    }
+
+    // modified based on https://github.com/minio/minio-rs/blob/5fea81d68d381fd2a4c27e4d259f7012de08ab77/src/s3/signer.rs#L44-L64
+    // under apache 2.0 license
+    fn get_canonical_request_hash(
+        &self,
+        method: &Method,
+        uri: &str,
+        query_string: &str,
+        headers: &str,
+        signed_headers: &str,
+        content_sha256: &str,
+    ) -> String {
+        let canonical_request = format!(
+            "{}\n{}\n{}\n{}\n\n{}\n{}",
+            method, uri, query_string, headers, signed_headers, content_sha256
+        );
+        return sha256_hash(canonical_request.as_bytes());
+    }
+
+    // modified based on https://github.com/minio/minio-rs/blob/5fea81d68d381fd2a4c27e4d259f7012de08ab77/src/s3/signer.rs#L75-88
+    // under apache 2.0 license
+    pub fn get_signing_key(&self, date: &OffsetDateTime) -> Vec<u8> {
+        let mut key: Vec<u8> = b"AWS4".to_vec();
+        key.extend(self.access_key_secret.as_bytes());
+
+        let date_key = hmac_hash(key.as_slice(), to_signer_date(date).as_bytes());
+        let date_region_key = hmac_hash(date_key.as_slice(), self.region.as_bytes());
+        let date_region_service_key = hmac_hash(date_region_key.as_slice(), "s3".as_bytes());
+        return hmac_hash(date_region_service_key.as_slice(), b"aws4_request");
+    }
+}
+
+impl ObjectStorageState for S3State {
+    fn url(&self, obj_key: &str, query_str: &[&str]) -> (String, String) {
+        let query_str = if query_str.is_empty() {
+            "".to_string()
+        } else {
+            format!("?{}", query_str.join("&"))
+        };
+        let resource = format!(
+            "/{}/{}{}{}",
+            self.bucket_name, self.object_prefix, obj_key, query_str
+        );
+        let url = format!("{}://{}{}", self.scheme, self.endpoint, resource,);
+        (resource, url)
+    }
+
+    // modified based on https://github.com/minio/minio-rs/blob/5fea81d68d381fd2a4c27e4d259f7012de08ab77/src/s3/signer.rs#L106-L135
+    // under apache 2.0 license
+    /// generate s3 request signature
+    fn sign(
+        &self,
+        verb: Method,
+        headers: &mut HeaderMap,
+        _: &str,
+        full_resource_url: &str,
+    ) -> Result<()> {
+        let date = OffsetDateTime::now_utc();
+        let content_sha256 = EMPTY_SHA256;
+        let parsed_uri = full_resource_url
+            .to_string()
+            .parse::<Uri>()
+            .map_err(|e| einval!(e))?;
+        let uri_path = parsed_uri.path();
+        let query = parsed_uri.query().unwrap_or("");
+        let host = parsed_uri.host().unwrap_or(self.endpoint.as_str());
+
+        headers.insert(HEADER_HOST, host.parse().map_err(|e| einval!(e))?);
+        headers.insert(
+            HEADER_AWZ_DATE,
+            to_awz_date(&date).parse().map_err(|e| einval!(e))?,
+        );
+        headers.insert(
+            HEADER_AWZ_CONTENT_SHA256,
+            EMPTY_SHA256.parse().map_err(|e| einval!(e))?,
+        );
+        let scope = format!(
+            "{}/{}/{}/aws4_request",
+            to_signer_date(&date),
+            self.region,
+            "s3",
+        );
+        let (signed_headers, canonical_headers) = self.get_canonical_headers(headers);
+        let canonical_request_hash = self.get_canonical_request_hash(
+            &verb,
+            uri_path,
+            query,
+            &canonical_headers,
+            &signed_headers,
+            content_sha256,
+        );
+        let string_to_sign = format!(
+            "AWS4-HMAC-SHA256\n{}\n{}\n{}",
+            to_awz_date(&date),
+            scope,
+            canonical_request_hash
+        );
+        let signing_key = self.get_signing_key(&date);
+        let signature = hmac_hash_hex(signing_key.as_slice(), string_to_sign.as_bytes());
+        let authorization = format!(
+            "AWS4-HMAC-SHA256 Credential={}/{}, SignedHeaders={}, Signature={}",
+            self.access_key_id, scope, signed_headers, signature
+        );
+        headers.insert(
+            "Authorization",
+            authorization.parse().map_err(|e| einval!(e))?,
+        );
+
+        Ok(())
+    }
+
+    fn retry_limit(&self) -> u8 {
+        self.retry_limit
+    }
+}
+
+// modified based on https://github.com/minio/minio-rs/blob/5fea81d68d381fd2a4c27e4d259f7012de08ab77/src/s3/utils.rs#L52-L56
+// under apache 2.0 license
+fn sha256_hash(data: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(data);
+    return format!("{:x}", hasher.finalize());
+}
+
+// modified based on https://github.com/minio/minio-rs/blob/5fea81d68d381fd2a4c27e4d259f7012de08ab77/src/s3/signer.rs#L25-L29
+// under apache 2.0 license
+fn hmac_hash(key: &[u8], data: &[u8]) -> Vec<u8> {
+    let mut hasher = Hmac::<Sha256>::new_from_slice(key).expect("HMAC can take key of any size");
+    hasher.update(data);
+    hasher.finalize().into_bytes().to_vec()
+}
+
+// modified based on https://github.com/minio/minio-rs/blob/5fea81d68d381fd2a4c27e4d259f7012de08ab77/src/s3/signer.rs#L31-L33
+// under apache 2.0 license
+fn hmac_hash_hex(key: &[u8], data: &[u8]) -> String {
+    hex::encode(hmac_hash(key, data))
+}
+
+// modified based on https://github.com/minio/minio-rs/blob/5fea81d68d381fd2a4c27e4d259f7012de08ab77/src/s3/utils.rs#L66-L68
+// under apache 2.0 license
+fn to_signer_date(date: &OffsetDateTime) -> String {
+    let format = format_description::parse("[year][month][day]").unwrap();
+    date.format(&format).unwrap()
+}
+
+// modified based on https://github.com/minio/minio-rs/blob/5fea81d68d381fd2a4c27e4d259f7012de08ab77/src/s3/utils.rs#L70-L72
+// under apache 2.0 license
+fn to_awz_date(date: &OffsetDateTime) -> String {
+    let format = format_description::parse("[year][month][day]T[hour][minute][second]Z").unwrap();
+    date.format(&format).unwrap()
+}
+
+#[cfg(test)]
+mod tests {
+    use http::{HeaderMap, Method};
+    use nydus_api::S3Config;
+
+    use crate::backend::object_storage::ObjectStorageState;
+    use crate::backend::s3::S3State;
+    use crate::backend::BlobBackend;
+
+    use super::S3;
+
+    fn get_test_s3_state() -> (S3State, String, String) {
+        let state = S3State {
+            region: "us-east-1".to_string(),
+            access_key_id: "test-key".to_string(),
+            access_key_secret: "test-key-secret".to_string(),
+            scheme: "http".to_string(),
+            object_prefix: "test-prefix-".to_string(),
+            endpoint: "localhost:9000".to_string(),
+            bucket_name: "test-bucket".to_string(),
+            retry_limit: 6,
+        };
+        let (resource, url) = state.url("test-object", &["a=b", "c=d"]);
+        (state, resource, url)
+    }
+
+    #[test]
+    fn test_s3_new() {
+        let config_str = r#"{
+            "endpoint": "https://test.com",
+            "region": "us-east-1",
+            "access_key_id": "test",
+            "access_key_secret": "test",
+            "bucket_name": "antsys-nydus",
+            "object_prefix":"nydus_v2/",
+            "retry_limit": 6
+        }"#;
+        let config: S3Config = serde_json::from_str(config_str).unwrap();
+        let s3 = S3::new(&config, Some("test-image")).unwrap();
+
+        s3.metrics();
+
+        let reader = s3.get_reader("test").unwrap();
+        assert_eq!(reader.retry_limit(), 6);
+
+        s3.shutdown();
+    }
+
+    #[test]
+    fn test_s3_state_url() {
+        let (_, resource, url) = get_test_s3_state();
+        assert_eq!(resource, "/test-bucket/test-prefix-test-object?a=b&c=d");
+        assert_eq!(
+            url,
+            "http://localhost:9000/test-bucket/test-prefix-test-object?a=b&c=d"
+        );
+    }
+
+    #[test]
+    fn test_s3_state_sign() {
+        let (state, resource, url) = get_test_s3_state();
+        println!("{}", url);
+        let mut headers = HeaderMap::new();
+        headers.append("Range", "bytes=5242900-".parse().unwrap());
+        let result = state.sign(Method::GET, &mut headers, &resource, &url);
+        assert!(result.is_ok());
+
+        use regex::Regex;
+        let re = Regex::new(r"^AWS4-HMAC-SHA256 Credential=test-key/[0-9]{8}/us-east-1/s3/aws4_request, SignedHeaders=host;range;x-amz-content-sha256;x-amz-date, Signature=[A-Fa-f0-9]{64}$").unwrap();
+        let authorization = headers.get("Authorization").unwrap();
+        assert!(re.is_match(authorization.to_str().unwrap()));
+    }
+}

--- a/storage/src/factory.rs
+++ b/storage/src/factory.rs
@@ -27,6 +27,8 @@ use crate::backend::localfs;
 use crate::backend::oss;
 #[cfg(feature = "backend-registry")]
 use crate::backend::registry;
+#[cfg(feature = "backend-s3")]
+use crate::backend::s3;
 use crate::backend::BlobBackend;
 use crate::cache::{BlobCache, BlobCacheMgr, DummyCacheMgr, FileCacheMgr, FsCacheMgr};
 use crate::device::BlobInfo;
@@ -188,6 +190,11 @@ impl BlobFactory {
             #[cfg(feature = "backend-oss")]
             "oss" => Ok(Arc::new(oss::Oss::new(
                 config.get_oss_config()?,
+                Some(blob_id),
+            )?)),
+            #[cfg(feature = "backend-s3")]
+            "s3" => Ok(Arc::new(s3::S3::new(
+                config.get_s3_config()?,
                 Some(blob_id),
             )?)),
             #[cfg(feature = "backend-registry")]


### PR DESCRIPTION
As we have supported nydusify using s3 services as the storage backend to store blobs, this patch supports nydusd fetching blobs from s3 services.

By now, using s3 backend, we can use `nydusify convert` to convert an oci image to nydus image and use `nydusify check` to verify the conversion.

Signed-off-by: Nan Li <loheagn@icloud.com>