### PR TITLE
nydusify: replaces the io/ioutil API which was deprecated in go 1.16

### DIFF
--- a/contrib/nydusify/cmd/nydusify.go
+++ b/contrib/nydusify/cmd/nydusify.go
@@ -10,7 +10,7 @@ package main
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -58,7 +58,7 @@ func parseBackendConfig(backendConfigJSON, backendConfigFile string) (string, er
 	}
 
 	if backendConfigFile != "" {
-		_backendConfigJSON, err := ioutil.ReadFile(backendConfigFile)
+		_backendConfigJSON, err := os.ReadFile(backendConfigFile)
 		if err != nil {
 			return "", errors.Wrap(err, "parse backend config file")
 		}
@@ -156,7 +156,7 @@ func getPrefetchPatterns(c *cli.Context) (string, error) {
 	var patterns string
 
 	if prefetchPatterns {
-		bytes, err := ioutil.ReadAll(os.Stdin)
+		bytes, err := io.ReadAll(os.Stdin)
 		if err != nil {
 			return "", errors.Wrap(err, "read prefetch patterns from STDIN")
 		}

--- a/contrib/nydusify/pkg/build/workflow.go
+++ b/contrib/nydusify/pkg/build/workflow.go
@@ -7,7 +7,6 @@ package build
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -51,7 +50,7 @@ func (workflow *Workflow) buildOutputJSONPath() string {
 // Get latest built blob from blobs directory
 func (workflow *Workflow) getLatestBlobPath() (string, error) {
 	var data debugJSON
-	jsonBytes, err := ioutil.ReadFile(workflow.buildOutputJSONPath())
+	jsonBytes, err := os.ReadFile(workflow.buildOutputJSONPath())
 	if err != nil {
 		return "", err
 	}

--- a/contrib/nydusify/pkg/cache/cache.go
+++ b/contrib/nydusify/pkg/cache/cache.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"strconv"
 
 	"github.com/dragonflyoss/image-service/contrib/nydusify/pkg/backend"
@@ -446,7 +445,7 @@ func (cache *Cache) Import(ctx context.Context) error {
 	}
 	defer manifestReader.Close()
 
-	manifestBytes, err := ioutil.ReadAll(manifestReader)
+	manifestBytes, err := io.ReadAll(manifestReader)
 	if err != nil {
 		return errors.Wrap(err, "Read cache manifest")
 	}

--- a/contrib/nydusify/pkg/checker/output.go
+++ b/contrib/nydusify/pkg/checker/output.go
@@ -7,7 +7,7 @@ package checker
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -22,7 +22,7 @@ func prettyDump(obj interface{}, name string) error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(name, bytes, 0644)
+	return os.WriteFile(name, bytes, 0644)
 }
 
 // Output outputs OCI and Nydus image manifest, index, config to JSON file.

--- a/contrib/nydusify/pkg/checker/rule/bootstrap.go
+++ b/contrib/nydusify/pkg/checker/rule/bootstrap.go
@@ -7,7 +7,7 @@ package rule
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -64,7 +64,7 @@ func (rule *BootstrapRule) Validate() error {
 
 	// Parse blob list from blob table of bootstrap
 	var bootstrap bootstrapDebug
-	bootstrapBytes, err := ioutil.ReadFile(rule.DebugOutputPath)
+	bootstrapBytes, err := os.ReadFile(rule.DebugOutputPath)
 	if err != nil {
 		return errors.Wrap(err, "read bootstrap debug json")
 	}

--- a/contrib/nydusify/pkg/checker/tool/nydusd.go
+++ b/contrib/nydusify/pkg/checker/tool/nydusd.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"os"
@@ -87,7 +87,7 @@ func makeConfig(conf NydusdConfig) error {
 		return errors.New("failed to prepare configuration file for Nydusd")
 	}
 
-	if err := ioutil.WriteFile(conf.ConfigPath, ret.Bytes(), 0644); err != nil {
+	if err := os.WriteFile(conf.ConfigPath, ret.Bytes(), 0644); err != nil {
 		return errors.New("write config file for Nydusd")
 	}
 
@@ -130,7 +130,7 @@ func checkReady(ctx context.Context, sock string) (<-chan bool, error) {
 			}
 			defer resp.Body.Close()
 
-			body, err := ioutil.ReadAll(resp.Body)
+			body, err := io.ReadAll(resp.Body)
 			if err != nil {
 				continue
 			}

--- a/contrib/nydusify/pkg/converter/manifest.go
+++ b/contrib/nydusify/pkg/converter/manifest.go
@@ -8,7 +8,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 
 	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/images"
@@ -54,7 +54,7 @@ func (mm *manifestManager) getExistsManifests(ctx context.Context) ([]ocispec.De
 		}
 		defer reader.Close()
 
-		indexBytes, err := ioutil.ReadAll(reader)
+		indexBytes, err := io.ReadAll(reader)
 		if err != nil {
 			return nil, errors.Wrap(err, "Read image manifest index")
 		}

--- a/contrib/nydusify/pkg/packer/packer.go
+++ b/contrib/nydusify/pkg/packer/packer.go
@@ -3,7 +3,6 @@ package packer
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -181,7 +180,7 @@ func (p *Packer) getNewBlobsHash(exists []string) (string, error) {
 	for _, blob := range exists {
 		m[blob] = true
 	}
-	content, err := ioutil.ReadFile(p.outputJSONPath())
+	content, err := os.ReadFile(p.outputJSONPath())
 	if err != nil {
 		return "", err
 	}

--- a/contrib/nydusify/pkg/packer/pusher_test.go
+++ b/contrib/nydusify/pkg/packer/pusher_test.go
@@ -2,7 +2,6 @@ package packer
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -75,8 +74,8 @@ func TestPusher_Push(t *testing.T) {
 
 	os.Create(filepath.Join(tmpDir, "mock.meta"))
 	os.Create(filepath.Join(tmpDir, "mock.blob"))
-	content, _ := ioutil.ReadFile(filepath.Join("testdata", "output.json"))
-	ioutil.WriteFile(filepath.Join(tmpDir, "output.json"), content, 0755)
+	content, _ := os.ReadFile(filepath.Join("testdata", "output.json"))
+	os.WriteFile(filepath.Join(tmpDir, "output.json"), content, 0755)
 
 	artifact, err := NewArtifact(tmpDir)
 	assert.Nil(t, err)

--- a/contrib/nydusify/pkg/parser/parser.go
+++ b/contrib/nydusify/pkg/parser/parser.go
@@ -9,7 +9,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 
 	"github.com/dragonflyoss/image-service/contrib/nydusify/pkg/remote"
 	"github.com/dragonflyoss/image-service/contrib/nydusify/pkg/utils"
@@ -81,7 +80,7 @@ func (parser *Parser) pull(ctx context.Context, desc *ocispec.Descriptor, res in
 	}
 	defer reader.Close()
 
-	bytes, err := ioutil.ReadAll(reader)
+	bytes, err := io.ReadAll(reader)
 	if err != nil {
 		return errors.Wrap(err, "read image resource")
 	}

--- a/contrib/nydusify/pkg/utils/archive_test.go
+++ b/contrib/nydusify/pkg/utils/archive_test.go
@@ -5,7 +5,6 @@
 package utils
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -13,11 +12,11 @@ import (
 )
 
 func TestPackTargzInfo(t *testing.T) {
-	file, err := ioutil.TempFile("", "nydusify-archive-test")
+	file, err := os.CreateTemp("", "nydusify-archive-test")
 	assert.Nil(t, err)
 	defer os.RemoveAll(file.Name())
 
-	err = ioutil.WriteFile(file.Name(), make([]byte, 1024*200), 0666)
+	err = os.WriteFile(file.Name(), make([]byte, 1024*200), 0666)
 	assert.Nil(t, err)
 
 	digest, size, err := PackTargzInfo(file.Name(), "test", true)

--- a/contrib/nydusify/pkg/viewer/viewer.go
+++ b/contrib/nydusify/pkg/viewer/viewer.go
@@ -3,7 +3,6 @@ package viewer
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -23,7 +22,7 @@ func prettyDump(obj interface{}, name string) error {
 	if err != nil {
 		return err
 	}
-	return ioutil.WriteFile(name, bytes, 0644)
+	return os.WriteFile(name, bytes, 0644)
 }
 
 // Opt defines fsViewer options, Target is the Nydus image reference

--- a/contrib/nydusify/tests/registry.go
+++ b/contrib/nydusify/tests/registry.go
@@ -7,7 +7,6 @@ package tests
 import (
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -51,7 +50,7 @@ func NewAuthRegistry(t *testing.T) *Registry {
 	assert.Nil(t, err)
 	authString := runWithOutput(t, "docker run --rm --entrypoint htpasswd httpd:2 -Bbn testuser testpassword")
 	authFile, _ := filepath.Abs(filepath.Join("auth", "htpasswd"))
-	err = ioutil.WriteFile(authFile, []byte(authString), 0644)
+	err = os.WriteFile(authFile, []byte(authString), 0644)
 	assert.Nil(t, err)
 
 	err = os.Mkdir(".docker", 0755)
@@ -62,7 +61,7 @@ func NewAuthRegistry(t *testing.T) *Registry {
 	configFile, _ := filepath.Abs(filepath.Join(".docker", "config.json"))
 	err = os.Setenv("DOCKER_CONFIG", path.Dir(configFile))
 	assert.Nil(t, err)
-	err = ioutil.WriteFile(configFile, []byte(configString), 0644)
+	err = os.WriteFile(configFile, []byte(configString), 0644)
 	assert.Nil(t, err)
 
 	containerID := runWithOutput(t, fmt.Sprintf("docker run -p %d:5000 --rm -d  -v %s:/auth "+


### PR DESCRIPTION
Interfaces in the io/ioutil package may not be available in future go versions, use new interfaces to avoid future build failures.

Signed-off-by: Qinqi Qu <quqinqi@linux.alibaba.com>