### PR TITLE
utils: replace libz-sys with libz-ng-sys

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,6 +207,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmake"
+version = "0.1.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db34956e100b30725f2eb215f90d4871051239535632f84fea3bc92722c66b7c"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "constant_time_eq"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -327,7 +336,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
 dependencies = [
  "crc32fast",
- "libz-sys",
+ "libz-ng-sys",
  "miniz_oxide",
 ]
 
@@ -769,15 +778,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
 
 [[package]]
-name = "libz-sys"
+name = "libz-ng-sys"
 version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9702761c3935f8cc2f101793272e202c72b99da8f4224a19ddcf1279a6450bbf"
+checksum = "4399ae96a9966bf581e726de86969f803a81b7ce795fcd5480e640589457e0f2"
 dependencies = [
- "cc",
+ "cmake",
  "libc",
- "pkg-config",
- "vcpkg",
 ]
 
 [[package]]
@@ -1117,7 +1124,7 @@ dependencies = [
  "flate2",
  "lazy_static",
  "libc",
- "libz-sys",
+ "libz-ng-sys",
  "log",
  "lz4",
  "lz4-sys",

--- a/misc/musl-static/Dockerfile
+++ b/misc/musl-static/Dockerfile
@@ -2,6 +2,8 @@ FROM clux/muslrust:1.61.0
 
 ARG RUST_TARGET=x86_64-unknown-linux-musl
 
+RUN apt update && apt install -y cmake
+
 WORKDIR /nydus-rs
 
 CMD rustup component add clippy && \

--- a/misc/nydus-smoke/Dockerfile
+++ b/misc/nydus-smoke/Dockerfile
@@ -5,7 +5,7 @@ RUN mkdir /root/.cargo/
 RUN rustup component add rustfmt && rustup component add clippy
 
 ENV CARGO_HOME=/root/.cargo
-RUN apt update && apt install -y tree
+RUN apt update && apt install -y cmake tree
 
 WORKDIR /nydus-rs
 

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -10,10 +10,10 @@ edition = "2018"
 
 [dependencies]
 blake3 = "1.3"
-flate2 = { version = "1.0", features = ["zlib"], default-features = false }
+flate2 = { version = "1.0", features = ["zlib-ng"], default-features = false }
 lazy_static = "1.4"
 libc = "0.2"
-libz-sys = { version = "1.1.8", optional = true }
+libz-ng-sys = { version = "1.1.8", optional = true }
 log = "0.4"
 lz4-sys = "1.9.4"
 lz4 = "1.24.0"
@@ -31,7 +31,7 @@ vmm-sys-util = ">=0.9.0"
 tar = "0.4.38"
 
 [features]
-zran = ["libz-sys"]
+zran = ["libz-ng-sys"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/utils/src/compress/zlib_random.rs
+++ b/utils/src/compress/zlib_random.rs
@@ -12,7 +12,7 @@ use std::os::raw::{c_char, c_int, c_void};
 use std::sync::{Arc, Mutex};
 use std::{mem, ptr};
 
-use libz_sys::{
+use libz_ng_sys::{
     inflate, inflateEnd, inflateInit2_, inflatePrime, inflateReset, inflateSetDictionary, uInt,
     z_stream, Z_BLOCK, Z_BUF_ERROR, Z_OK, Z_STREAM_END,
 };
@@ -28,7 +28,10 @@ const ZRAN_MIN_COMP_SIZE: u64 = 768 * 1024;
 const ZRAN_MAX_COMP_SIZE: u64 = 2048 * 1024;
 const ZRAN_MAX_UNCOMP_SIZE: u64 = 2048 * 1024;
 const ZLIB_ALIGN: usize = std::mem::align_of::<usize>();
-const ZLIB_VERSION: &str = "1.2.8\0";
+// For libz-sys
+//const ZLIB_VERSION: &str = "1.2.8\0";
+// For libz-ng-sys
+const ZLIB_VERSION: &str = "2.1.0\0";
 
 /// Information to retrieve a data chunk from an associated random access slice.
 #[derive(Debug, Eq, PartialEq)]
@@ -547,7 +550,7 @@ impl ZranStream {
         let mut len: uInt = 0;
         assert_eq!(buf.len(), ZRAN_DICT_WIN_SIZE);
         let ret = unsafe {
-            inflateGetDictionary(
+            zng_inflateGetDictionary(
                 self.stream.deref_mut() as *mut z_stream,
                 buf.as_mut_ptr(),
                 &mut len as *mut uInt,
@@ -668,7 +671,7 @@ extern "C" fn zfree(_ptr: *mut c_void, address: *mut c_void) {
 }
 
 extern "system" {
-    pub fn inflateGetDictionary(
+    pub fn zng_inflateGetDictionary(
         strm: *mut z_stream,
         dictionary: *mut u8,
         dictLength: *mut uInt,


### PR DESCRIPTION
zlib-ng may have better performance than zlib, and it's api compatible with zlib.

Signed-off-by: Jiang Liu <gerry@linux.alibaba.com>