### PR TITLE
Fix 2.1 broken compressed cache

### DIFF
--- a/contrib/nydus-test/functional-test/test_nydus.py
+++ b/contrib/nydus-test/functional-test/test_nydus.py
@@ -156,8 +156,10 @@ def test_prefetch_without_cache(
 
 
 @pytest.mark.parametrize("thread_cnt", [3])
-@pytest.mark.parametrize("compressor", [Compressor.LZ4_BLOCK, Compressor.NONE])
-@pytest.mark.parametrize("is_cache_compressed", [False])
+@pytest.mark.parametrize(
+    "compressor", [Compressor.LZ4_BLOCK, Compressor.ZSTD, Compressor.NONE]
+)
+@pytest.mark.parametrize("is_cache_compressed", [True, False])
 def test_prefetch_with_cache(
     nydus_anchor: NydusAnchor,
     nydus_scratch_image: RafsImage,
@@ -175,7 +177,7 @@ def test_prefetch_with_cache(
       - Rafs can be unmounted.
     """
     rafs_conf.enable_rafs_blobcache(is_compressed=is_cache_compressed)
-    rafs_conf.set_rafs_backend(Backend.BACKEND_PROXY, prefix="object_prefix/")
+    rafs_conf.set_rafs_backend(Backend.BACKEND_PROXY)
     rafs_conf.enable_fs_prefetch(threads_count=4, bandwidth_rate=Size(40, Unit.MB).B)
     rafs_conf.dump_rafs_conf()
 
@@ -186,9 +188,7 @@ def test_prefetch_with_cache(
     dist.put_hardlinks(6)
     dist.put_multiple_chinese_files(random.randint(20, 28), Size(20, Unit.KB))
 
-    nydus_scratch_image.set_backend(
-        Backend.BACKEND_PROXY, prefix="object_prefix/"
-    ).create_image(
+    nydus_scratch_image.set_backend(Backend.BACKEND_PROXY).create_image(
         compressor=compressor,
         readahead_policy="fs",
         readahead_files="/".encode(),

--- a/storage/src/cache/filecache/mod.rs
+++ b/storage/src/cache/filecache/mod.rs
@@ -194,7 +194,7 @@ impl FileCacheEntry {
         let is_stargz = blob_info.is_stargz();
         let is_compressed = mgr.is_compressed || is_stargz;
         let need_validate = (mgr.validate || !is_direct_chunkmap) && !is_stargz;
-        let is_get_blob_object_supported = !mgr.is_compressed && is_direct_chunkmap;
+        let is_get_blob_object_supported = is_direct_chunkmap;
 
         trace!(
             "comp {} direct {} stargz {}",
@@ -202,7 +202,7 @@ impl FileCacheEntry {
             is_direct_chunkmap,
             is_stargz
         );
-        let meta = if is_get_blob_object_supported && blob_info.meta_ci_is_valid() {
+        let meta = if blob_info.meta_ci_is_valid() {
             // Set cache file to its expected size.
             let file_size = file.metadata()?.len();
             if file_size == 0 {

--- a/storage/src/cache/mod.rs
+++ b/storage/src/cache/mod.rs
@@ -229,7 +229,6 @@ pub trait BlobCache: Send + Sync {
             let size = chunk.compressed_size();
             let d_size = chunk.uncompressed_size() as usize;
             if offset != last
-                || offset - blob_offset > usize::MAX as u64
                 || offset.checked_add(size as u64).is_none()
                 || ((!self.is_stargz() && d_size as u64 > RAFS_MAX_CHUNK_SIZE)
                     || (self.is_stargz() && d_size > 4 << 20))

--- a/storage/src/cache/mod.rs
+++ b/storage/src/cache/mod.rs
@@ -49,6 +49,8 @@ pub use fscache::FsCacheMgr;
 /// Timeout in milli-seconds to retrieve blob data from backend storage.
 pub const SINGLE_INFLIGHT_WAIT_TIMEOUT: u64 = 2000;
 
+type ChunkHook<'a> = &'a dyn Fn(Arc<dyn BlobChunkInfo>, &[u8], Option<&[u8]>) -> Result<()>;
+
 struct BlobIoMergeState<'a, F: FnMut(BlobIoRange)> {
     cb: F,
     size: u32,
@@ -188,7 +190,9 @@ pub trait BlobCache: Send + Sync {
     /// chunks into one backend request. Callers must ensure that chunks in `chunks` covers a
     /// continuous range, and the range exactly matches [`blob_offset`..`blob_offset` + `blob_size`].
     /// Function `read_chunks()` returns one buffer containing decompressed chunk data for each
-    /// entry in the `chunks` array in corresponding order.
+    /// entry in the `chunks` array in corresponding order. `chunk_hook` provides caller a hook point to receive
+    /// and process raw chunks data. `output` indicates that raw chunks read from backend should be decompressed
+    /// and passed to caller
     ///
     /// This method returns success only if all requested data are successfully fetched.
     fn read_chunks(
@@ -197,6 +201,8 @@ pub trait BlobCache: Send + Sync {
         blob_size: usize,
         chunks: &[Arc<dyn BlobChunkInfo>],
         prefetch: bool,
+        output: bool,
+        chunk_hook: Option<ChunkHook>,
     ) -> Result<Vec<Vec<u8>>> {
         // Read requested data from the backend by altogether.
         let mut c_buf = alloc_buf(blob_size);
@@ -222,7 +228,13 @@ pub trait BlobCache: Send + Sync {
         );
 
         let mut last = blob_offset;
-        let mut buffers: Vec<Vec<u8>> = Vec::with_capacity(chunks.len());
+
+        let mut buffers = if output {
+            Vec::with_capacity(chunks.len())
+        } else {
+            Default::default()
+        };
+
         for chunk in chunks {
             // Ensure BlobIoChunk is valid and continuous.
             let offset = chunk.compressed_offset();
@@ -242,16 +254,31 @@ pub trait BlobCache: Send + Sync {
             let buf = &c_buf[offset_merged..end_merged];
             let mut buffer = alloc_buf(d_size);
 
-            self.process_raw_chunk(
-                chunk.as_ref(),
-                buf,
-                None,
-                &mut buffer,
-                chunk.is_compressed(),
-                false,
-            )?;
-            buffers.push(buffer);
+            if output {
+                self.process_raw_chunk(
+                    chunk.as_ref(),
+                    buf,
+                    None,
+                    &mut buffer,
+                    chunk.is_compressed(),
+                    false,
+                )?;
+                buffers.push(buffer);
+            }
+
             last = offset + size as u64;
+
+            if let Some(f) = chunk_hook {
+                f(
+                    chunk.clone(),
+                    buf,
+                    if output {
+                        Some(buffers.last().unwrap().as_slice())
+                    } else {
+                        None
+                    },
+                )?;
+            }
         }
 
         Ok(buffers)


### PR DESCRIPTION
From my test, the compressed local blob cache can no longer work on branch v2.1. This PR fixes the feature and tries to improve runtime efficiency a bit.