### PR TITLE
storage: remove incorrect assert

### DIFF
--- a/storage/src/cache/cachedfile.rs
+++ b/storage/src/cache/cachedfile.rs
@@ -670,11 +670,6 @@ impl FileCacheEntry {
     fn do_fetch_chunks(&self, chunks: &[Arc<dyn BlobChunkInfo>], prefetch: bool) -> Result<()> {
         // Validate input parameters.
         assert!(!chunks.is_empty());
-        if chunks.len() > 1 {
-            for idx in 0..chunks.len() - 1 {
-                assert_eq!(chunks[idx].id() + 1, chunks[idx + 1].id());
-            }
-        }
 
         // Get chunks not ready yet, also marking them as in-flight.
         let bitmap = self

--- a/utils/src/compress/zlib_random.rs
+++ b/utils/src/compress/zlib_random.rs
@@ -450,8 +450,11 @@ impl<R: Read> Read for ZranReaderState<R> {
                         return Err(eio!("failed to decode data from compressed data stream"));
                     }
                 }
-                _ => {
-                    return Err(eio!("failed to decode data from compressed data stream"));
+                e => {
+                    return Err(eio!(format!(
+                        "failed to decode data from compressed data stream, error code {}",
+                        e
+                    )));
                 }
             }
         }


### PR DESCRIPTION
Now the storage already supports fetching discrete chunks, so remove the incorrect assert.

Signed-off-by: Jiang Liu <gerry@linux.alibaba.com>