### PR TITLE
nydus-test: enable test_upload_oss test

### DIFF
--- a/contrib/nydus-test/functional-test/test_nydusify.py
+++ b/contrib/nydus-test/functional-test/test_nydusify.py
@@ -161,7 +161,6 @@ def test_build_cache(
     workload_gen.finish_torture_read()
 
 
-@pytest.mark.skip(reason="Get rid of OSS dependency!")
 @pytest.mark.parametrize(
     "source",
     [


### PR DESCRIPTION
We don't have any blocker to testing it.