### PR TITLE
Enable generating ZRan image from tar files

### DIFF
--- a/rafs/src/metadata/layout/v6.rs
+++ b/rafs/src/metadata/layout/v6.rs
@@ -1245,7 +1245,7 @@ pub fn calculate_nid(offset: u64, meta_size: u64) -> u64 {
 #[repr(C)]
 #[derive(Clone, Copy, Debug)]
 struct RafsV6Blob {
-    // SHA256 of raw data blob in string form.
+    // SHA256 digest of the blob containing chunk data.
     blob_id: [u8; BLOB_SHA256_LEN],
     // Index in the blob table.
     blob_index: u32,
@@ -1264,6 +1264,7 @@ struct RafsV6Blob {
     // Size of the uncompressed blob, not including CI array and header.
     uncompressed_size: u64,
 
+    // Size of blob ToC content, it's zero for inlined bootstrap.
     rafs_blob_toc_size: u32,
     // Compression algorithm for the compression information array.
     ci_compressor: u32,
@@ -1274,11 +1275,13 @@ struct RafsV6Blob {
     // Size of the uncompressed compression information array.
     ci_uncompressed_size: u64,
 
-    // SHA256 digest of the TOC list digest (including toc list tar header, only valid in merged bootstrap).
+    // SHA256 digest of blob ToC content, including the toc tar header.
+    // It's all zero for inlined bootstrap.
     rafs_blob_toc_digest: [u8; 32],
-    // SHA256 digest of the rafs blob (only valid in merged bootstrap).
+    // SHA256 digest of RAFS blob containing `blob.meta`, `blob.digest` `blob.toc` and optionally
+    // 'image.boot`. Default to `self.blob_id` when it's all zero.
     rafs_blob_digest: [u8; 32],
-    // Size of the rafs blob (only valid in merged bootstrap).
+    // Size of RAFS blob, zero for inlined bootstrap.
     rafs_blob_size: u64,
 
     reserved2: [u8; 48],

--- a/src/bin/nydus-image/core/blob.rs
+++ b/src/bin/nydus-image/core/blob.rs
@@ -51,13 +51,21 @@ impl Blob {
             | ConversionType::EStargzToRafs => {
                 Self::finalize_blob_data(ctx, blob_mgr, blob_writer)?;
             }
-            ConversionType::TargzToRef | ConversionType::EStargzToRef => {
+            ConversionType::TarToRef
+            | ConversionType::TargzToRef
+            | ConversionType::EStargzToRef => {
                 if let Some((_, blob_ctx)) = blob_mgr.get_current_blob() {
                     if let Some(zran) = &ctx.blob_zran_generator {
                         let reader = zran.lock().unwrap().reader();
                         blob_ctx.compressed_blob_size = reader.get_data_size();
                         if blob_ctx.blob_id.is_empty() {
                             let hash = reader.get_data_digest();
+                            blob_ctx.blob_id = format!("{:x}", hash.finalize());
+                        }
+                    } else if let Some(tar_reader) = &ctx.blob_tar_reader {
+                        blob_ctx.compressed_blob_size = tar_reader.position();
+                        if blob_ctx.blob_id.is_empty() {
+                            let hash = tar_reader.get_hash_object();
                             blob_ctx.blob_id = format!("{:x}", hash.finalize());
                         }
                     }
@@ -126,8 +134,7 @@ impl Blob {
         let mut ci_data = blob_meta_info.as_byte_slice();
         let mut zran_buf = Vec::new();
         let mut header = blob_ctx.blob_meta_header;
-        if ctx.blob_features.contains(BlobFeatures::ZRAN) {
-            let zran = ctx.blob_zran_generator.as_ref().unwrap();
+        if let Some(ref zran) = ctx.blob_zran_generator {
             let (zran_data, zran_count) = zran.lock().unwrap().to_vec()?;
             header.set_ci_zran_count(zran_count);
             header.set_ci_zran_offset(ci_data.len() as u64);

--- a/src/bin/nydus-image/core/blob.rs
+++ b/src/bin/nydus-image/core/blob.rs
@@ -55,11 +55,11 @@ impl Blob {
                 if let Some((_, blob_ctx)) = blob_mgr.get_current_blob() {
                     if let Some(zran) = &ctx.blob_zran_generator {
                         let reader = zran.lock().unwrap().reader();
-                        blob_ctx.blob_hash = reader.get_data_digest();
                         blob_ctx.compressed_blob_size = reader.get_data_size();
-                    }
-                    if blob_ctx.blob_id.is_empty() {
-                        blob_ctx.blob_id = format!("{:x}", blob_ctx.blob_hash.clone().finalize());
+                        if blob_ctx.blob_id.is_empty() {
+                            let hash = reader.get_data_digest();
+                            blob_ctx.blob_id = format!("{:x}", hash.finalize());
+                        }
                     }
                 }
                 Self::finalize_blob_data(ctx, blob_mgr, blob_writer)?;

--- a/src/bin/nydus-image/core/context.rs
+++ b/src/bin/nydus-image/core/context.rs
@@ -33,7 +33,7 @@ use nydus_storage::meta::{
     BlobChunkInfoV2Ondisk, BlobMetaChunkArray, BlobMetaChunkInfo, BlobMetaHeaderOndisk,
     ZranContextGenerator,
 };
-use nydus_utils::{compress, digest, div_round_up, round_down_4k, BufReaderPos};
+use nydus_utils::{compress, digest, div_round_up, round_down_4k, BufReaderInfo};
 
 use super::chunk_dict::{ChunkDict, HashChunkDict};
 use super::feature::Features;
@@ -916,7 +916,7 @@ pub struct BuildContext {
     /// Storage writing blob to single file or a directory.
     pub blob_storage: Option<ArtifactStorage>,
     pub blob_zran_generator: Option<Mutex<ZranContextGenerator<File>>>,
-    pub blob_tar_reader: Option<BufReaderPos<File>>,
+    pub blob_tar_reader: Option<BufReaderInfo<File>>,
     pub blob_features: BlobFeatures,
     pub blob_inline_meta: bool,
     pub has_xattr: bool,

--- a/src/bin/nydus-image/core/context.rs
+++ b/src/bin/nydus-image/core/context.rs
@@ -33,7 +33,7 @@ use nydus_storage::meta::{
     BlobChunkInfoV2Ondisk, BlobMetaChunkArray, BlobMetaChunkInfo, BlobMetaHeaderOndisk,
     ZranContextGenerator,
 };
-use nydus_utils::{compress, digest, div_round_up, round_down_4k};
+use nydus_utils::{compress, digest, div_round_up, round_down_4k, BufReaderPos};
 
 use super::chunk_dict::{ChunkDict, HashChunkDict};
 use super::feature::Features;
@@ -56,6 +56,7 @@ pub enum ConversionType {
     TargzToRef,
     TarToStargz,
     TarToRafs,
+    TarToRef,
 }
 
 impl Default for ConversionType {
@@ -101,6 +102,7 @@ impl fmt::Display for ConversionType {
             ConversionType::TargzToRef => write!(f, "targz-ref"),
             ConversionType::TarToRafs => write!(f, "tar-rafs"),
             ConversionType::TarToStargz => write!(f, "tar-stargz"),
+            ConversionType::TarToRef => write!(f, "tar-ref"),
         }
     }
 }
@@ -112,6 +114,7 @@ impl ConversionType {
             ConversionType::EStargzToRef
                 | ConversionType::EStargzIndexToRef
                 | ConversionType::TargzToRef
+                | ConversionType::TarToRef
         )
     }
 }
@@ -913,6 +916,7 @@ pub struct BuildContext {
     /// Storage writing blob to single file or a directory.
     pub blob_storage: Option<ArtifactStorage>,
     pub blob_zran_generator: Option<Mutex<ZranContextGenerator<File>>>,
+    pub blob_tar_reader: Option<BufReaderPos<File>>,
     pub blob_features: BlobFeatures,
     pub blob_inline_meta: bool,
     pub has_xattr: bool,
@@ -955,6 +959,7 @@ impl BuildContext {
             prefetch,
             blob_storage,
             blob_zran_generator: None,
+            blob_tar_reader: None,
             blob_features: BlobFeatures::empty(),
             blob_inline_meta,
             has_xattr: false,
@@ -992,6 +997,7 @@ impl Default for BuildContext {
             prefetch: Prefetch::default(),
             blob_storage: None,
             blob_zran_generator: None,
+            blob_tar_reader: None,
             blob_features: BlobFeatures::empty(),
             has_xattr: true,
             blob_inline_meta: false,

--- a/src/bin/nydus-image/main.rs
+++ b/src/bin/nydus-image/main.rs
@@ -617,7 +617,9 @@ impl Command {
                     );
                 }
             }
-            ConversionType::TargzToRef | ConversionType::EStargzToRef => {
+            ConversionType::TarToRef
+            | ConversionType::TargzToRef
+            | ConversionType::EStargzToRef => {
                 Self::ensure_file(&source_path)?;
                 if blob_stor.is_none() {
                     bail!("both --blob and --blob-dir are not provided");
@@ -719,21 +721,24 @@ impl Command {
 
         let mut builder: Box<dyn Builder> = match conversion_type {
             ConversionType::DirectoryToRafs => Box::new(DirectoryBuilder::new()),
-            ConversionType::DirectoryToStargz => unimplemented!(),
-            ConversionType::DirectoryToTargz => unimplemented!(),
-            ConversionType::EStargzToRafs => Box::new(TarballBuilder::new(conversion_type)),
-            ConversionType::EStargzToRef => Box::new(TarballBuilder::new(conversion_type)),
             ConversionType::EStargzIndexToRef => Box::new(StargzBuilder::new(blob_data_size)),
-            ConversionType::TargzToRafs => Box::new(TarballBuilder::new(conversion_type)),
-            ConversionType::TargzToRef => {
-                if version.is_v6() {
-                    build_ctx.blob_features.insert(BlobFeatures::CHUNK_INFO_V2);
-                    build_ctx.blob_features.insert(BlobFeatures::ZRAN);
+            ConversionType::EStargzToRafs
+            | ConversionType::TargzToRafs
+            | ConversionType::TarToRafs => Box::new(TarballBuilder::new(conversion_type)),
+            ConversionType::EStargzToRef
+            | ConversionType::TargzToRef
+            | ConversionType::TarToRef => {
+                if version.is_v5() {
+                    bail!("conversion type {} conflicts with RAFS v5", conversion_type);
                 }
+                build_ctx.blob_features.insert(BlobFeatures::CHUNK_INFO_V2);
+                build_ctx.blob_features.insert(BlobFeatures::ZRAN);
                 Box::new(TarballBuilder::new(conversion_type))
             }
-            ConversionType::TarToRafs => Box::new(TarballBuilder::new(conversion_type)),
-            ConversionType::TarToStargz | ConversionType::TargzToStargz => unimplemented!(),
+            ConversionType::DirectoryToStargz
+            | ConversionType::DirectoryToTargz
+            | ConversionType::TarToStargz
+            | ConversionType::TargzToStargz => unimplemented!(),
         };
         let build_output = timing_tracer!(
             {

--- a/src/bin/nydus-image/main.rs
+++ b/src/bin/nydus-image/main.rs
@@ -606,15 +606,30 @@ impl Command {
             }
             ConversionType::EStargzToRafs
             | ConversionType::TargzToRafs
-            | ConversionType::TarToRafs
-            | ConversionType::TargzToRef
-            | ConversionType::EStargzToRef => {
+            | ConversionType::TarToRafs => {
                 Self::ensure_file(&source_path)?;
                 if blob_stor.is_none() {
                     bail!("both --blob and --blob-dir are not provided");
                 } else if !prefetch.disabled && prefetch.policy == PrefetchPolicy::Blob {
                     bail!(
                         "conversion type {} conflicts with '--prefetch-policy blob'",
+                        conversion_type
+                    );
+                }
+            }
+            ConversionType::TargzToRef | ConversionType::EStargzToRef => {
+                Self::ensure_file(&source_path)?;
+                if blob_stor.is_none() {
+                    bail!("both --blob and --blob-dir are not provided");
+                } else if !prefetch.disabled && prefetch.policy == PrefetchPolicy::Blob {
+                    bail!(
+                        "conversion type {} conflicts with '--prefetch-policy blob'",
+                        conversion_type
+                    );
+                }
+                if blob_id.trim() != "" {
+                    bail!(
+                        "conversion type '{}' conflicts with '--blob-id'",
                         conversion_type
                     );
                 }

--- a/storage/src/device.rs
+++ b/storage/src/device.rs
@@ -123,12 +123,15 @@ pub struct BlobInfo {
     /// V6: Size of the uncompressed chunk information array.
     meta_ci_uncompressed_size: u64,
 
-    // SHA256 digest of the TOC list digest (including toc list tar header, only valid in merged bootstrap).
+    // SHA256 digest of blob ToC content, including the toc tar header.
+    // It's all zero for inlined bootstrap.
     rafs_blob_toc_digest: [u8; 32],
-    // SHA256 digest of the rafs blob (only valid in merged bootstrap).
+    // SHA256 digest of RAFS blob containing `blob.meta`, `blob.digest` `blob.toc` and optionally
+    // 'image.boot`. Default to `self.blob_id` when it's all zero.
     rafs_blob_digest: [u8; 32],
-    // Size of the rafs blob (only valid in merged bootstrap).
+    // Size of RAFS blob, zero for inlined bootstrap.
     rafs_blob_size: u64,
+    // Size of blob ToC content, it's zero for inlined bootstrap.
     rafs_blob_toc_size: u32,
 
     /// V6: support fs-cache mode
@@ -335,36 +338,48 @@ impl BlobInfo {
         }
     }
 
+    /// Get SHA256 digest of the ToC content, including the toc tar header.
+    ///
+    /// It's all zero for inlined bootstrap.
     pub fn rafs_blob_toc_digest(&self) -> &[u8; 32] {
         &self.rafs_blob_toc_digest
     }
 
+    /// Set SHA256 digest of the ToC content, including the toc tar header.
     pub fn set_rafs_blob_toc_digest(&mut self, digest: [u8; 32]) {
         self.rafs_blob_toc_digest = digest;
     }
 
-    /// Get size of blob `Table of Content`.
+    /// Get size of the ToC content. It's all zero for inlined bootstrap.
     pub fn rafs_blob_toc_size(&self) -> u32 {
         self.rafs_blob_toc_size
     }
 
-    /// Get size of blob `Table of Content`.
+    /// Set size of the ToC content.
     pub fn set_rafs_blob_toc_size(&mut self, sz: u32) {
         self.rafs_blob_toc_size = sz;
     }
 
+    /// The RAFS blob contains `blob.meta`, `blob.digest`, `image.boot`, `ToC` etc.
+    /// Get SHA256 digest of RAFS blob containing `blob.meta`, `blob.digest` `blob.toc` and
+    /// optionally 'image.boot`.
+    ///
+    /// Default to `self.blob_id` when it's all zero.
     pub fn rafs_blob_digest(&self) -> &[u8; 32] {
         &self.rafs_blob_digest
     }
 
+    /// Set SHA256 digest of the RAFS blob.
     pub fn set_rafs_blob_digest(&mut self, digest: [u8; 32]) {
         self.rafs_blob_digest = digest;
     }
 
+    /// Get size of the RAFS blob.
     pub fn rafs_blob_size(&self) -> u64 {
         self.rafs_blob_size
     }
 
+    /// Set size of the RAFS blob.
     pub fn set_rafs_blob_size(&mut self, size: u64) {
         self.rafs_blob_size = size;
     }

--- a/utils/src/compress/zlib_random.rs
+++ b/utils/src/compress/zlib_random.rs
@@ -311,7 +311,7 @@ impl<R> ZranReader<R> {
     pub fn set_initial_data(&self, buf: &[u8]) {
         let mut state = self.inner.lock().unwrap();
         assert_eq!(state.stream.avail_in(), 0);
-        assert!(buf.len() < state.input.len());
+        assert!(buf.len() <= state.input.len());
         let ptr = state.input.as_mut_ptr();
         assert_eq!(state.stream.stream.next_in, ptr);
 

--- a/utils/src/compress/zlib_random.rs
+++ b/utils/src/compress/zlib_random.rs
@@ -307,6 +307,20 @@ impl<R> ZranReader<R> {
         })
     }
 
+    /// Copy data from the buffer into the internal input buffer.
+    pub fn set_initial_data(&self, buf: &[u8]) {
+        let mut state = self.inner.lock().unwrap();
+        assert_eq!(state.stream.avail_in(), 0);
+        assert!(buf.len() < state.input.len());
+        let ptr = state.input.as_mut_ptr();
+        assert_eq!(state.stream.stream.next_in, ptr);
+
+        state.input[..buf.len()].copy_from_slice(buf);
+        state.reader_hash.update(buf);
+        state.reader_size += buf.len() as u64;
+        state.stream.set_avail_in(buf.len() as u32);
+    }
+
     /// Get size of data read from the reader.
     pub fn get_data_size(&self) -> u64 {
         self.inner.lock().unwrap().reader_size

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -11,18 +11,12 @@ extern crate serde;
 #[macro_use]
 extern crate lazy_static;
 
-use crate::digest::DigestHasher;
-use sha2::Sha256;
 use std::convert::{Into, TryFrom, TryInto};
-use std::fs::File;
-use std::io::{BufReader, Read};
-use std::marker::PhantomData;
-use std::os::unix::io::{AsRawFd, RawFd};
-use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 pub use self::exec::*;
 pub use self::inode_bitmap::InodeBitmap;
+pub use self::reader::*;
 pub use self::types::*;
 
 pub mod async_helper;
@@ -34,6 +28,7 @@ pub mod filemap;
 pub mod inode_bitmap;
 pub mod metrics;
 pub mod mpmc;
+pub mod reader;
 pub mod types;
 
 /// Round up and divide the value `n` by `d`.
@@ -63,93 +58,6 @@ pub fn try_round_up_4k<U: TryFrom<u64>, T: Into<u64>>(x: T) -> Option<U> {
 
 pub fn round_down_4k(x: u64) -> u64 {
     x & (!4095u64)
-}
-
-/// A wrapper reader to read a range of data from a file.
-pub struct FileRangeReader<'a> {
-    fd: RawFd,
-    offset: u64,
-    size: u64,
-    r: PhantomData<&'a u8>,
-}
-
-impl<'a> FileRangeReader<'a> {
-    /// Create a wrapper reader to read a range of data from the file.
-    pub fn new(f: &File, offset: u64, size: u64) -> Self {
-        Self {
-            fd: f.as_raw_fd(),
-            offset,
-            size,
-            r: PhantomData,
-        }
-    }
-}
-
-impl<'a> Read for FileRangeReader<'a> {
-    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        let size = std::cmp::min(self.size as usize, buf.len());
-        let nr_read = nix::sys::uio::pread(self.fd, &mut buf[0..size], self.offset as i64)
-            .map_err(|_| last_error!())?;
-        self.offset += nr_read as u64;
-        self.size -= nr_read as u64;
-        Ok(nr_read)
-    }
-}
-
-struct BufReaderState<R: Read> {
-    reader: BufReader<R>,
-    pos: u64,
-    hash: Sha256,
-}
-
-/// A wrapper over `BufReader` to track current position.
-pub struct BufReaderPos<R: Read> {
-    state: Arc<Mutex<BufReaderState<R>>>,
-}
-
-impl<R: Read> BufReaderPos<R> {
-    /// Create a new instance of `BufReaderPos` from a `BufReader`.
-    pub fn from_buf_reader(buf_reader: BufReader<R>) -> Self {
-        let state = BufReaderState {
-            reader: buf_reader,
-            pos: 0,
-            hash: Sha256::default(),
-        };
-        Self {
-            state: Arc::new(Mutex::new(state)),
-        }
-    }
-
-    /// Get current position of the reader.
-    pub fn position(&self) -> u64 {
-        self.state.lock().unwrap().pos
-    }
-
-    /// Get the hash object.
-    pub fn get_hash_object(&self) -> Sha256 {
-        self.state.lock().unwrap().hash.clone()
-    }
-}
-
-impl<R: Read> Read for BufReaderPos<R> {
-    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        let mut state = self.state.lock().unwrap();
-        state.reader.read(buf).map(|v| {
-            state.pos += v as u64;
-            if v > 0 {
-                state.hash.digest_update(&buf[..v]);
-            }
-            v
-        })
-    }
-}
-
-impl<R: Read> Clone for BufReaderPos<R> {
-    fn clone(&self) -> Self {
-        Self {
-            state: self.state.clone(),
-        }
-    }
 }
 
 pub enum DelayType {
@@ -187,7 +95,6 @@ impl Delayer {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use vmm_sys_util::tempfile::TempFile;
 
     #[test]
     fn test_rounders() {
@@ -222,18 +129,5 @@ mod tests {
         assert_eq!(try_round_up_4k::<u64, _>(u64::MAX - 1), None);
         // fail to convert u64 to u32
         assert_eq!(try_round_up_4k::<u32, _>(u64::MAX - 4096), None);
-    }
-
-    #[test]
-    fn test_file_range_reader() {
-        let file = TempFile::new().unwrap();
-        std::fs::write(file.as_path(), b"This is a test").unwrap();
-        let mut reader = FileRangeReader::new(file.as_file(), 4, 6);
-        let mut buf = vec![0u8; 128];
-        let res = reader.read(&mut buf).unwrap();
-        assert_eq!(res, 6);
-        assert_eq!(&buf[..6], b" is a ".as_slice());
-        let res = reader.read(&mut buf).unwrap();
-        assert_eq!(res, 0);
     }
 }

--- a/utils/src/reader.rs
+++ b/utils/src/reader.rs
@@ -1,0 +1,119 @@
+// Copyright (C) 2022 Alibaba Cloud. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fs::File;
+use std::io::{BufReader, Read};
+use std::marker::PhantomData;
+use std::os::unix::io::{AsRawFd, RawFd};
+use std::sync::{Arc, Mutex};
+
+use sha2::Sha256;
+
+use crate::digest::DigestHasher;
+
+/// A wrapper reader to read a range of data from a file.
+pub struct FileRangeReader<'a> {
+    fd: RawFd,
+    offset: u64,
+    size: u64,
+    r: PhantomData<&'a u8>,
+}
+
+impl<'a> FileRangeReader<'a> {
+    /// Create a wrapper reader to read a range of data from the file.
+    pub fn new(f: &File, offset: u64, size: u64) -> Self {
+        Self {
+            fd: f.as_raw_fd(),
+            offset,
+            size,
+            r: PhantomData,
+        }
+    }
+}
+
+impl<'a> Read for FileRangeReader<'a> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let size = std::cmp::min(self.size as usize, buf.len());
+        let nr_read = nix::sys::uio::pread(self.fd, &mut buf[0..size], self.offset as i64)
+            .map_err(|_| last_error!())?;
+        self.offset += nr_read as u64;
+        self.size -= nr_read as u64;
+        Ok(nr_read)
+    }
+}
+
+struct BufReaderState<R: Read> {
+    reader: BufReader<R>,
+    pos: u64,
+    hash: Sha256,
+}
+
+/// A wrapper over `BufReader` to track current position.
+pub struct BufReaderInfo<R: Read> {
+    state: Arc<Mutex<BufReaderState<R>>>,
+}
+
+impl<R: Read> BufReaderInfo<R> {
+    /// Create a new instance of `BufReaderPos` from a `BufReader`.
+    pub fn from_buf_reader(buf_reader: BufReader<R>) -> Self {
+        let state = BufReaderState {
+            reader: buf_reader,
+            pos: 0,
+            hash: Sha256::default(),
+        };
+        Self {
+            state: Arc::new(Mutex::new(state)),
+        }
+    }
+
+    /// Get current position of the reader.
+    pub fn position(&self) -> u64 {
+        self.state.lock().unwrap().pos
+    }
+
+    /// Get the hash object.
+    pub fn get_hash_object(&self) -> Sha256 {
+        self.state.lock().unwrap().hash.clone()
+    }
+}
+
+impl<R: Read> Read for BufReaderInfo<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let mut state = self.state.lock().unwrap();
+        state.reader.read(buf).map(|v| {
+            state.pos += v as u64;
+            if v > 0 {
+                state.hash.digest_update(&buf[..v]);
+            }
+            v
+        })
+    }
+}
+
+impl<R: Read> Clone for BufReaderInfo<R> {
+    fn clone(&self) -> Self {
+        Self {
+            state: self.state.clone(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use vmm_sys_util::tempfile::TempFile;
+
+    #[test]
+    fn test_file_range_reader() {
+        let file = TempFile::new().unwrap();
+        std::fs::write(file.as_path(), b"This is a test").unwrap();
+        let mut reader = FileRangeReader::new(file.as_file(), 4, 6);
+        let mut buf = vec![0u8; 128];
+        let res = reader.read(&mut buf).unwrap();
+        assert_eq!(res, 6);
+        assert_eq!(&buf[..6], b" is a ".as_slice());
+        let res = reader.read(&mut buf).unwrap();
+        assert_eq!(res, 0);
+    }
+}


### PR DESCRIPTION
Enable generating ZRan image from tar files and also fix several bugs related to `rafs_blob_digest`.