### PR TITLE
treewide: tidy up several paths

### DIFF
--- a/docs/containerd-env-setup.md
+++ b/docs/containerd-env-setup.md
@@ -20,10 +20,10 @@ sudo install -D -m 755 containerd-nydus-grpc /usr/local/bin
 
 Nydus provides a containerd remote snapshotter `containerd-nydus-grpc` (nydus snapshotter) to prepare container rootfs with nydus formatted images.
 
-1. Prepare a `nydusd` configuration to `/etc/nydusd-config.json`:
+1. Prepare a `nydusd` configuration to `/etc/nydus/nydusd-config.fusedev.json`:
 
 ```bash
-$ sudo tee /etc/nydusd-config.json > /dev/null << EOF
+$ sudo tee /etc/nydus/nydusd-config.fusedev.json > /dev/null << EOF
 {
   "device": {
     "backend": {
@@ -77,7 +77,7 @@ sudo rm -rf /var/lib/containerd-nydus
 
 ```bash
 sudo /usr/local/bin/containerd-nydus-grpc \
-    --config-path /etc/nydusd-config.json \
+    --config-path /etc/nydus/nydusd-config.fusedev.json \
     --log-to-stdout
 ```
 

--- a/docs/nydus-fscache.md
+++ b/docs/nydus-fscache.md
@@ -67,7 +67,7 @@ make
   make
   ```
 
-3. Prepare a configuration json like below, named as `/path/nydus-erofs-config.json`:
+3. Prepare a configuration json like below, named as `/etc/nydus/nydusd-config.fscache.json`:
 
 ```json
 {
@@ -86,16 +86,15 @@ make
 
 ```
 # make sure the directory exists.
-mkdir -p /var/lib/containerd/io.containerd.snapshotter.v1.nydus
+mkdir -p /var/lib/containerd-nydus
 
 ./bin/containerd-nydus-grpc \
- --config-path /path/nydus-erofs-config.json \
+ --config-path /etc/nydus/nydusd-config.fscache.json \
  --daemon-mode shared \
  --fs-driver fscache \
  --log-level info \
- --root /var/lib/containerd/io.containerd.snapshotter.v1.nydus \
+ --root /var/lib/containerd-nydus \
  --cache-dir /var/lib/nydus/cache \
- --address /run/containerd/containerd-nydus-grpc.sock \
  --nydusd-path /path/to/nydusd \
  --log-to-stdout
 ```
@@ -117,7 +116,7 @@ version = 2
 [proxy_plugins]
   [proxy_plugins.nydus]
     type = "snapshot"
-    address = "/run/containerd/containerd-nydus-grpc.sock"
+    address = "/run/containerd-nydus/containerd-nydus-grpc.sock"
 
 [plugins."io.containerd.grpc.v1.cri".containerd]
    snapshotter = "nydus"


### PR DESCRIPTION
1. --config-path "/etc/nydus/nydusd-config.fusedev.json" or "/etc/nydus/nydusd-config.fscache.json"
2. --root "/var/lib/containerd-nydus"
3. --address "/run/containerd-nydus/containerd-nydus-grpc.sock"

Signed-off-by: Gao Xiang \<hsiangkao@linux.alibaba.com\>