### PR TITLE
[WIP]nydus-image: support chunk level deduplication between local images

### DIFF
--- a/rafs/src/metadata/chunk.rs
+++ b/rafs/src/metadata/chunk.rs
@@ -3,6 +3,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+use serde::{Deserialize, Serialize};
 use std::fmt::{self, Display, Formatter};
 
 use anyhow::{Context, Result};
@@ -18,7 +19,7 @@ use crate::metadata::{RafsStore, RafsVersion};
 use crate::RafsIoWrite;
 
 /// A ChunkInfo object wrapper for different RAFS versions.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum ChunkWrapper {
     /// Chunk info structure for RAFS v5.
     V5(RafsV5ChunkInfo),

--- a/rafs/src/metadata/layout/v5.rs
+++ b/rafs/src/metadata/layout/v5.rs
@@ -33,6 +33,7 @@
 //! On the other hand, Rafs v4 is compatible with Rafs v5, so Rafs v5 implementation supports
 //! both v4 and v5 metadata.
 
+use serde::{Deserialize, Serialize};
 use std::cmp;
 use std::convert::TryFrom;
 use std::ffi::{OsStr, OsString};
@@ -1054,7 +1055,7 @@ impl<'a> RafsStore for RafsV5InodeWrapper<'a> {
 
 /// Rafs v5 chunk on disk metadata.
 #[repr(C)]
-#[derive(Default, Clone, Copy, Debug)]
+#[derive(Default, Clone, Copy, Debug, Deserialize, Serialize)]
 pub struct RafsV5ChunkInfo {
     /// sha256(chunk), [char; RAFS_SHA256_LENGTH]
     pub block_id: RafsDigest, // 32
@@ -1339,7 +1340,7 @@ fn calculate_bio_chunk_index(
     (index_start, index_end)
 }
 
-pub(crate) fn rafsv5_align(size: usize) -> usize {
+pub fn rafsv5_align(size: usize) -> usize {
     if size & (RAFSV5_ALIGNMENT - 1) == 0 {
         size
     } else {

--- a/rafs/src/metadata/layout/v6.rs
+++ b/rafs/src/metadata/layout/v6.rs
@@ -119,7 +119,7 @@ pub struct RafsV6SuperBlock {
     /// # of devices besides the primary device.
     s_extra_devices: u16,
     /// Offset of the device table, `startoff = s_devt_slotoff * 128`.
-    s_devt_slotoff: u16,
+    pub s_devt_slotoff: u16,
     /// Padding.
     s_reserved: [u8; 38],
 }
@@ -271,6 +271,11 @@ impl RafsV6SuperBlock {
     /// Set number of extra devices.
     pub fn set_extra_devices(&mut self, count: u16) {
         self.s_extra_devices = count.to_le();
+    }
+
+    /// Set Offset of the device table.
+    pub fn set_devt_slotoff(&mut self, count: u64) {
+        self.s_devt_slotoff = ((count / size_of::<RafsV6Device>() as u64) as u16).to_le();
     }
 
     impl_pub_getter_setter!(magic, set_magic, s_magic, u32);
@@ -1534,7 +1539,7 @@ impl RafsV6Blob {
 #[derive(Clone, Debug, Default)]
 pub struct RafsV6BlobTable {
     /// Base blob information array.
-    entries: Vec<Arc<BlobInfo>>,
+    pub entries: Vec<Arc<BlobInfo>>,
 }
 
 impl RafsV6BlobTable {

--- a/src/bin/nydus-image/core/bootstrap_dedup.rs
+++ b/src/bin/nydus-image/core/bootstrap_dedup.rs
@@ -1,0 +1,223 @@
+// Copyright (C) 2022 Alibaba Cloud. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashMap;
+use std::convert::TryFrom;
+use std::fs;
+use std::io::SeekFrom;
+use std::mem::size_of;
+use std::path::{Path, PathBuf};
+
+use anyhow::Result;
+
+use nydus_rafs::metadata::chunk::ChunkWrapper;
+use nydus_rafs::metadata::layout::v5::{RafsV5ChunkInfo, RafsV5InodeTable, RafsV5XAttrsTable};
+use nydus_rafs::metadata::layout::v6::{
+    align_offset, RafsV6InodeChunkAddr, EROFS_BLOCK_SIZE, EROFS_INODE_SLOT_SIZE,
+};
+use nydus_rafs::metadata::{RafsMode, RafsSuper, RafsVersion};
+use nydus_rafs::{RafsIoReader, RafsIoWrite};
+use nydus_storage::device::BlobInfo;
+use nydus_utils::cas::CasMgr;
+use nydus_utils::digest::RafsDigest;
+
+use crate::anyhow::Context;
+use crate::core::bootstrap::Bootstrap;
+use crate::core::context::{
+    ArtifactFileWriter, ArtifactWriter, BlobContext, BlobManager, BuildContext, ConversionType,
+};
+use crate::core::feature::Features;
+use crate::node::{ChunkSource, Node, WhiteoutSpec};
+use crate::tree::Tree;
+use crate::ArtifactStorage;
+
+pub struct BootstrapDedup {
+    cas_mgr: CasMgr,
+    rs: RafsSuper,
+    cache_chunks: HashMap<RafsDigest, ChunkWrapper>,
+    insert_chunks: Vec<(String, String, String)>,
+    insert_blobs: Vec<(String, String)>,
+    reader: RafsIoReader,
+    writer: Box<dyn RafsIoWrite>,
+}
+
+impl BootstrapDedup {
+    pub fn new(
+        bootstrap_path: PathBuf,
+        output_path: PathBuf,
+        work_dir: impl AsRef<Path>,
+    ) -> Result<Self> {
+        let rs = RafsSuper::load_from_metadata(&bootstrap_path, RafsMode::Direct, true)?;
+        let cas_mgr = CasMgr::new(work_dir)?;
+        let cache_chunks = HashMap::new();
+        let insert_chunks = vec![];
+        let insert_blobs = vec![];
+
+        fs::copy(&bootstrap_path, &output_path)?;
+
+        let reader = Box::new(
+            fs::OpenOptions::new()
+                .read(true)
+                .write(false)
+                .open(&bootstrap_path)?,
+        ) as RafsIoReader;
+
+        let writer = Box::new(ArtifactFileWriter(ArtifactWriter::new(
+            ArtifactStorage::SingleFile(PathBuf::from(&output_path)),
+            true,
+        )?)) as Box<dyn RafsIoWrite>;
+
+        Ok(BootstrapDedup {
+            cas_mgr,
+            rs,
+            cache_chunks,
+            insert_chunks,
+            insert_blobs,
+            reader,
+            writer,
+        })
+    }
+
+    fn get_chunk_ofs(&mut self, node: &Node) -> Result<(u64, u64)> {
+        if self.rs.meta.is_v5() {
+            let unit = size_of::<RafsV5ChunkInfo>() as u64;
+
+            let mut inodes_table = RafsV5InodeTable::new(self.rs.meta.inode_table_entries as usize);
+            self.reader
+                .seek_to_offset(self.rs.meta.inode_table_offset)?;
+            inodes_table.load(&mut self.reader)?;
+
+            let chunk_idx_offset = inodes_table.get(node.src_ino)?;
+            let mut chunk_ofs = (chunk_idx_offset + node.inode.inode_size() as u32) as u64;
+            if node.inode.has_xattr() {
+                chunk_ofs +=
+                    (size_of::<RafsV5XAttrsTable>() + node.xattrs.aligned_size_v5()) as u64;
+            }
+
+            Ok((chunk_ofs, unit))
+        } else if self.rs.meta.is_v6() {
+            let unit = size_of::<RafsV6InodeChunkAddr>() as u64;
+
+            let chunk_idx_offset = self.rs.meta.meta_blkaddr as u64 * EROFS_BLOCK_SIZE
+                + node.src_ino * EROFS_INODE_SLOT_SIZE as u64;
+            let chunk_ofs = align_offset(chunk_idx_offset + node.v6_size_with_xattr() as u64, unit);
+
+            Ok((chunk_ofs, unit))
+        } else {
+            unimplemented!()
+        }
+    }
+
+    fn do_chunk_dedup(
+        &mut self,
+        nodes: Vec<Node>,
+        build_ctx: &BuildContext,
+        blob_mgr: &mut BlobManager,
+    ) -> Result<()> {
+        for node in nodes {
+            let (mut chunk_ofs, chunk_size) = self.get_chunk_ofs(&node)?;
+
+            for chunk in &node.chunks {
+                let chunk_id = chunk.inner.id();
+                let blob_id = blob_mgr
+                    .get_blob_id_by_idx(chunk.inner.blob_index() as usize)
+                    .unwrap();
+                self.writer
+                    .seek(SeekFrom::Start(chunk_ofs))
+                    .context("failed seek for chunk_ofs")
+                    .unwrap();
+
+                match self.cache_chunks.get(chunk_id) {
+                    //dedup chunk between layers
+                    Some(new_chunk) => node.dedup_bootstrap(new_chunk, self.writer.as_mut())?,
+                    None => match self.cas_mgr.get_chunk(chunk_id, &blob_id)? {
+                        Some((new_blob_id, chunk_info)) => {
+                            let blob_idx = match blob_mgr.get_blob_idx_by_id(&new_blob_id) {
+                                Some(blob_idx) => blob_idx,
+                                None => {
+                                    //Safe to use unwarp since we get blob_id from chunk table
+                                    let blob_info = self.cas_mgr.get_blob(&new_blob_id)?.unwrap();
+                                    let blob = serde_json::from_str::<BlobInfo>(&blob_info)?;
+                                    let blob_idx = blob_mgr.alloc_index()?;
+                                    blob_mgr.add(BlobContext::from(
+                                        build_ctx,
+                                        &blob,
+                                        ChunkSource::Parent,
+                                    ));
+                                    blob_idx
+                                }
+                            };
+                            let mut new_chunk = serde_json::from_str::<ChunkWrapper>(&chunk_info)?;
+                            new_chunk.set_blob_index(blob_idx);
+                            node.dedup_bootstrap(&new_chunk, self.writer.as_mut())?;
+                            self.cache_chunks.insert(*chunk_id, new_chunk);
+                        }
+                        None => {
+                            self.cache_chunks.insert(*chunk_id, chunk.inner.clone());
+                            //insert db
+                            let chunk_info = serde_json::to_string(&chunk.inner).unwrap();
+                            self.insert_chunks
+                                .push((String::from(*chunk_id), chunk_info, blob_id));
+                        }
+                    },
+                }
+
+                chunk_ofs += chunk_size;
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn do_dedup(&mut self) -> Result<()> {
+        let tree = Tree::from_bootstrap(&self.rs, &mut ())?;
+        let mut nodes = Vec::new();
+        tree.iterate(&mut |node| {
+            if node.is_reg() {
+                nodes.push(node.clone());
+            }
+            true
+        })?;
+
+        let mut build_ctx = BuildContext::new(
+            "".to_string(),
+            false,
+            0,
+            self.rs.meta.get_compressor(),
+            self.rs.meta.get_digester(),
+            self.rs.meta.explicit_uidgid(),
+            WhiteoutSpec::Oci,
+            ConversionType::DirectoryToRafs,
+            PathBuf::from(""),
+            Default::default(),
+            None,
+            false,
+            Features::new(),
+        );
+        build_ctx.set_fs_version(RafsVersion::try_from(self.rs.meta.version).unwrap());
+        let mut blob_mgr = BlobManager::new();
+        blob_mgr.from_blob_table(&build_ctx, self.rs.superblock.get_blob_infos());
+        self.do_chunk_dedup(nodes, &build_ctx, &mut blob_mgr)?;
+
+        let blob_table = blob_mgr.to_blob_table(&build_ctx)?;
+        let mut bootstrap = Bootstrap::new()?;
+        bootstrap.dedup(
+            &self.rs,
+            &mut self.reader,
+            self.writer.as_mut(),
+            &blob_table,
+            &self.cache_chunks,
+        )?;
+
+        let blobs = self.rs.superblock.get_blob_infos();
+        for blob in blobs {
+            self.insert_blobs
+                .push((String::from(blob.blob_id()), serde_json::to_string(&blob)?))
+        }
+        self.cas_mgr.add_blobs(&self.insert_blobs)?;
+        self.cas_mgr.add_chunks(&self.insert_chunks)?;
+
+        Ok(())
+    }
+}

--- a/src/bin/nydus-image/core/context.rs
+++ b/src/bin/nydus-image/core/context.rs
@@ -179,7 +179,7 @@ impl Write for ArtifactMemoryWriter {
     }
 }
 
-pub struct ArtifactFileWriter(ArtifactWriter);
+pub struct ArtifactFileWriter(pub ArtifactWriter);
 
 impl RafsIoWrite for ArtifactFileWriter {
     fn as_any(&self) -> &dyn Any {
@@ -694,6 +694,13 @@ impl BlobManager {
             }
         }
         None
+    }
+
+    pub fn get_blob_id_by_idx(&mut self, idx: usize) -> Option<String> {
+        if idx >= self.len() {
+            return None;
+        }
+        self.blobs[idx].blob_id()
     }
 
     pub fn get_blob_ids(&self) -> Vec<String> {

--- a/src/bin/nydus-image/core/mod.rs
+++ b/src/bin/nydus-image/core/mod.rs
@@ -5,6 +5,7 @@
 pub(crate) mod blob;
 pub(crate) mod blob_compact;
 pub(crate) mod bootstrap;
+pub(crate) mod bootstrap_dedup;
 pub(crate) mod chunk_dict;
 pub(crate) mod context;
 pub(crate) mod feature;

--- a/storage/src/device.rs
+++ b/storage/src/device.rs
@@ -19,6 +19,7 @@
 //! - [BlobIoVec](struct.BlobIoVec.html): a scatter/gather list for blob IO operation, containing
 //!   one or more blob IO descriptors
 //! - [BlobPrefetchRequest](struct.BlobPrefetchRequest.html): a blob data prefetching request.
+use serde::{Deserialize, Serialize};
 use std::any::Any;
 use std::collections::hash_map::Drain;
 use std::collections::HashMap;
@@ -45,6 +46,7 @@ pub(crate) const BLOB_FEATURE_INCOMPAT_MASK: u32 = 0x0000_ffff;
 pub(crate) const BLOB_FEATURE_INCOMPAT_VALUE: u32 = 0x0000_000f;
 
 bitflags! {
+    #[derive(Deserialize, Serialize)]
     /// Features bits for blob management.
     pub struct BlobFeatures: u32 {
         /// Uncompressed chunk data is 4K aligned.
@@ -85,7 +87,7 @@ impl TryFrom<u32> for BlobFeatures {
 ///
 /// The `BlobInfo` structure provides information for the storage subsystem to manage a blob file
 /// and serve blob IO requests for clients.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug, Default, Deserialize, Serialize)]
 pub struct BlobInfo {
     /// The index of blob in RAFS blob table.
     blob_index: u32,
@@ -134,6 +136,7 @@ pub struct BlobInfo {
     // Size of blob ToC content, it's zero for inlined bootstrap.
     rafs_blob_toc_size: u32,
 
+    #[serde(skip_deserializing, skip_serializing)]
     /// V6: support fs-cache mode
     fs_cache_file: Option<Arc<File>>,
 }
@@ -186,6 +189,10 @@ impl BlobInfo {
         self.blob_index
     }
 
+    /// Set the blob index.
+    pub fn set_blob_index(&mut self, index: u32) {
+        self.blob_index = index;
+    }
     /// Get the id of the blob.
     pub fn blob_id(&self) -> &str {
         &self.blob_id
@@ -386,6 +393,7 @@ impl BlobInfo {
 }
 
 bitflags! {
+    #[derive(Deserialize, Serialize)]
     /// Blob chunk flags.
     pub struct BlobChunkFlags: u32 {
         /// Chunk data is compressed.

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -17,6 +17,7 @@ libz-ng-sys = { version = "1.1.8", optional = true }
 log = "0.4"
 lz4-sys = "1.9.4"
 lz4 = "1.24.0"
+rusqlite = { version = "0.28.0", features = ["bundled"] }
 serde = { version = ">=1.0.27", features = ["serde_derive", "rc"] }
 serde_json = ">=1.0.9"
 sha2 = "0.10.0"

--- a/utils/src/cas.rs
+++ b/utils/src/cas.rs
@@ -1,0 +1,170 @@
+// Copyright (C) 2022 Alibaba Cloud. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fmt::{self, Display, Formatter};
+use std::path::{Path, PathBuf};
+
+use rusqlite::{Connection, OptionalExtension};
+
+use crate::digest::RafsDigest;
+
+/// Error codes related to local cas.
+#[derive(Debug)]
+pub enum CasError {
+    Io(std::io::Error),
+    Db(rusqlite::Error),
+}
+
+impl Display for CasError {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+impl std::error::Error for CasError {}
+
+impl From<rusqlite::Error> for CasError {
+    fn from(e: rusqlite::Error) -> Self {
+        CasError::Db(e)
+    }
+}
+
+/// Specialized `Result` for local cas.
+type Result<T> = std::result::Result<T, CasError>;
+
+pub struct CasMgr {
+    conn: Connection,
+}
+
+impl CasMgr {
+    pub fn new(path: impl AsRef<Path>) -> Result<CasMgr> {
+        let mut db_path = path.as_ref().to_owned();
+        db_path.push("cas.db");
+        let conn = Connection::open(db_path)?;
+
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS BlobInfos (
+            BlobId     TEXT NOT NULL PRIMARY KEY,
+            BlobInfo   TEXT NOT NULL
+        )",
+            (),
+        )?;
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS BlobIndex ON BlobInfos(BlobId)",
+            (),
+        )?;
+
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS ChunkInfos (
+            ChunkId           INTEGER PRIMARY KEY,
+            ChunkDigestValue  TEXT NOT NULL,
+            ChunkInfo         TEXT NOT NULL,
+            BlobId            TEXT NOT NULL,
+            UNIQUE(ChunkDigestValue, BlobId) ON CONFLICT IGNORE,
+            FOREIGN KEY(BlobId) REFERENCES BlobInfos(BlobId)
+        )",
+            (),
+        )?;
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS ChunkIndex ON ChunkInfos(ChunkDigestValue)",
+            (),
+        )?;
+
+        Ok(CasMgr { conn })
+    }
+
+    pub fn get_bootstrap(&mut self, _file: impl AsRef<Path>) -> Option<PathBuf> {
+        unimplemented!()
+    }
+
+    pub fn add_bootstrap(
+        &mut self,
+        _source: impl AsRef<Path>,
+        _target: impl AsRef<Path>,
+    ) -> Result<()> {
+        unimplemented!()
+    }
+
+    pub fn remove_bootstrap(&mut self, _file: impl AsRef<Path>) -> Result<()> {
+        unimplemented!()
+    }
+
+    pub fn get_blob(&self, blob_id: &str) -> Result<Option<String>> {
+        if let Some(blob_info) = self
+            .conn
+            .query_row(
+                "SELECT BlobInfo FROM BlobInfos WHERE BlobId = ?",
+                [blob_id],
+                |row| row.get::<usize, String>(0),
+            )
+            .optional()?
+        {
+            return Ok(Some(blob_info));
+        };
+
+        Ok(None)
+    }
+
+    pub fn add_blobs(&mut self, blobs: &Vec<(String, String)>) -> Result<()> {
+        let tran = self.conn.transaction()?;
+        for blob in blobs {
+            tran.execute(
+                "INSERT OR IGNORE INTO BlobInfos (BlobId, BlobInfo)
+                VALUES (?1, ?2)",
+                (&blob.0, &blob.1),
+            )
+            .unwrap();
+        }
+        tran.commit()?;
+
+        Ok(())
+    }
+
+    pub fn delete_blobs(&self, _chunks: &[String]) -> Result<()> {
+        unimplemented!()
+    }
+
+    pub fn get_chunk(
+        &self,
+        chunk_id: &RafsDigest,
+        blob_id: &str,
+    ) -> Result<Option<(String, String)>> {
+        if let Some((new_blob_id, chunk_info)) = self
+            .conn
+            .query_row(
+                "SELECT BlobId, ChunkInfo
+                FROM ChunkInfos INDEXED BY ChunkIndex
+                WHERE ChunkDigestValue = ?",
+                [String::from(chunk_id.to_owned()).as_str()],
+                |row| Ok((row.get(0)?, row.get(1)?)),
+            )
+            .optional()?
+        {
+            if new_blob_id != *blob_id {
+                return Ok(Some((new_blob_id, chunk_info)));
+            }
+        }
+
+        Ok(None)
+    }
+
+    pub fn add_chunks(&mut self, chunks: &Vec<(String, String, String)>) -> Result<()> {
+        let tran = self.conn.transaction()?;
+        for chunk in chunks {
+            tran.execute(
+                "INSERT OR IGNORE INTO ChunkInfos (ChunkDigestValue, ChunkInfo, BlobId)
+                    VALUES (?1, ?2, ?3)",
+                (&chunk.0, &chunk.1, &chunk.2),
+            )
+            .unwrap();
+        }
+        tran.commit()?;
+
+        Ok(())
+    }
+
+    pub fn delete_chunks(&self, _chunks: &[(String, String)]) -> Result<()> {
+        unimplemented!()
+    }
+}

--- a/utils/src/compress/mod.rs
+++ b/utils/src/compress/mod.rs
@@ -17,7 +17,7 @@ pub mod zlib_random;
 const COMPRESSION_MINIMUM_RATIO: usize = 100;
 
 /// Supported compression algorithms.
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Deserialize, Serialize)]
 pub enum Algorithm {
     None,
     Lz4Block,

--- a/utils/src/digest.rs
+++ b/utils/src/digest.rs
@@ -18,7 +18,7 @@ pub const RAFS_DIGEST_LENGTH: usize = 32;
 
 type DigestData = [u8; RAFS_DIGEST_LENGTH];
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Deserialize, Serialize)]
 pub enum Algorithm {
     Blake3,
     Sha256,
@@ -146,7 +146,9 @@ impl DigestHasher for Sha256 {
     }
 }
 
-#[derive(Clone, Copy, Hash, PartialEq, Eq, Debug, Default, Ord, PartialOrd)]
+#[derive(
+    Clone, Copy, Hash, PartialEq, Eq, Debug, Default, Ord, PartialOrd, Deserialize, Serialize,
+)]
 pub struct RafsDigest {
     pub data: DigestData,
 }

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -20,6 +20,7 @@ pub use self::reader::*;
 pub use self::types::*;
 
 pub mod async_helper;
+pub mod cas;
 pub mod compact;
 pub mod compress;
 pub mod digest;


### PR DESCRIPTION
Add the dedup option to nydus-image to support block level deduplication between local images. A local database cas.db was introduced, which records all chunks saved locally. Then We can redirect the chunks to those that already exist locally to avoid duplicate downloads.

There is still some work needs to be done, including:
1. Insert the on-demand downloaded chunk into the database to ensure that the database stores locally existing chunks.
2. Snapshotter's GC mechanism with the reference relationship of bootstrap after deduplication.

Signed-off-by: Huang Jianan <jnhuang@linux.alibaba.com>