### PR TITLE
nydusify & nydusd: give a briefer suggestion for insecure cert

### DIFF
--- a/contrib/nydusify/pkg/parser/parser.go
+++ b/contrib/nydusify/pkg/parser/parser.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/dragonflyoss/image-service/contrib/nydusify/pkg/remote"
 	"github.com/dragonflyoss/image-service/contrib/nydusify/pkg/utils"
@@ -188,6 +189,9 @@ func (parser *Parser) Parse(ctx context.Context) (*Parsed, error) {
 
 	imageDesc, err := parser.Remote.Resolve(ctx)
 	if err != nil {
+		if strings.Contains(err.Error(), "x509: certificate signed by unknown authority") {
+			logrus.Warningln("try to enable \"--source-insecure\" / \"--target-insecure\" option")
+		}
 		return nil, errors.Wrap(err, "resolve image")
 	}
 

--- a/storage/src/backend/registry.rs
+++ b/storage/src/backend/registry.rs
@@ -552,6 +552,12 @@ impl RegistryReader {
                         .map_err(RegistryError::Url)?;
                     self.request::<&[u8]>(Method::GET, url.as_str(), None, headers.clone(), false)?
                 }
+                Err(RegistryError::Request(ConnectionError::Common(e))) => {
+                    if e.to_string().contains("self signed certificate") {
+                        warn!("try to enable \"skip_verify: true\" option");
+                    }
+                    return Err(RegistryError::Request(ConnectionError::Common(e)));
+                }
                 Err(e) => {
                     return Err(e);
                 }


### PR DESCRIPTION
When the user encounters the error x509: certificate signed by unknown authority:
* try to enable "skip_verify: true" option for nydusd;
* try to enable "--source-insecure" / "--target-insecure" option for nydusify convert/check;

Signed-off-by: Wenyu Huang <huangwenyuu@outlook.com>