### PR TITLE
rafs: support blobs with differrent compression/digest algorithm

### DIFF
--- a/src/bin/nydus-image/builder/stargz.rs
+++ b/src/bin/nydus-image/builder/stargz.rs
@@ -25,7 +25,7 @@ use nydus_storage::{RAFS_MAX_CHUNKS_PER_BLOB, RAFS_MAX_CHUNK_SIZE};
 use nydus_utils::compact::makedev;
 use nydus_utils::compress::compute_compressed_gzip_size;
 use nydus_utils::digest::{self, Algorithm, DigestHasher, RafsDigest};
-use nydus_utils::{try_round_up_4k, ByteSize};
+use nydus_utils::{compress, try_round_up_4k, ByteSize};
 
 use crate::builder::{build_bootstrap, Builder};
 use crate::core::blob::Blob;
@@ -825,7 +825,13 @@ impl Builder for StargzBuilder {
             build_bootstrap(ctx, bootstrap_mgr, &mut bootstrap_ctx, blob_mgr, tree)?;
 
         // Generate node chunks and digest
-        let mut blob_ctx = BlobContext::new(ctx.blob_id.clone(), 0, ctx.blob_features);
+        let mut blob_ctx = BlobContext::new(
+            ctx.blob_id.clone(),
+            0,
+            ctx.blob_features,
+            compress::Algorithm::GZip,
+            digest::Algorithm::Sha256,
+        );
         self.generate_nodes(ctx, &mut bootstrap_ctx, &mut blob_ctx, blob_mgr)?;
 
         // Dump blob meta

--- a/src/bin/nydus-image/core/blob_compact.rs
+++ b/src/bin/nydus-image/core/blob_compact.rs
@@ -514,8 +514,13 @@ impl BlobCompactor {
                 }
                 State::Rebuild(cs) => {
                     let blob_storage = ArtifactStorage::FileDir(PathBuf::from(dir));
-                    let mut blob_ctx =
-                        BlobContext::new(String::from(""), 0, build_ctx.blob_features);
+                    let mut blob_ctx = BlobContext::new(
+                        String::from(""),
+                        0,
+                        build_ctx.blob_features,
+                        build_ctx.compressor,
+                        build_ctx.digester,
+                    );
                     blob_ctx.set_meta_info_enabled(self.is_v6());
                     let blob_idx = self.new_blob_mgr.alloc_index()?;
                     let new_chunks = cs.dump(

--- a/src/bin/nydus-image/core/bootstrap.rs
+++ b/src/bin/nydus-image/core/bootstrap.rs
@@ -326,6 +326,7 @@ impl Bootstrap {
         let config = RafsSuperConfig {
             compressor: ctx.compressor,
             digester: ctx.digester,
+            chunk_size: ctx.chunk_size,
             explicit_uidgid: ctx.explicit_uidgid,
             version: ctx.fs_version,
         };

--- a/src/bin/nydus-image/main.rs
+++ b/src/bin/nydus-image/main.rs
@@ -704,6 +704,7 @@ impl Command {
                 version,
                 compressor,
                 digester,
+                chunk_size,
                 explicit_uidgid: !repeatable,
             };
             blob_mgr.set_chunk_dict(timing_tracer!(


### PR DESCRIPTION
Currently there's a constraint that all data blobs referenced by a RAFS filesystem must use the same compression and digest algorithms. The constraint is unnecessary, so relax it.

Signed-off-by: Jiang Liu <gerry@linux.alibaba.com>