### PR TITLE
rafs: fix overflow panic of rafs v6 lookup

### DIFF
--- a/rafs/src/metadata/direct_v6.rs
+++ b/rafs/src/metadata/direct_v6.rs
@@ -538,24 +538,30 @@ impl OndiskInodeWrapper {
         }
 
         let blocks_count = div_round_up(inode.size(), EROFS_BLOCK_SIZE);
-        let mut first = 0usize;
-        let mut last = (blocks_count - 1) as usize;
+        let mut first = 0;
+        let mut last = (blocks_count - 1) as i64;
         let mut target_block = 0usize;
         while first <= last {
             let pivot = first + ((last - first) >> 1);
             let head_entry = self
-                .get_entry(state, inode, pivot, 0)
+                .get_entry(state, inode, pivot as usize, 0)
                 .map_err(err_invalidate_data)?;
             let head_name_offset = head_entry.e_nameoff as usize;
             let entries_count = head_name_offset / size_of::<RafsV6Dirent>();
             let h_name = self
-                .entry_name(state, inode, pivot, 0, entries_count)
+                .entry_name(state, inode, pivot as usize, 0, entries_count)
                 .map_err(err_invalidate_data)?;
             let t_name = self
-                .entry_name(state, inode, pivot, entries_count - 1, entries_count)
+                .entry_name(
+                    state,
+                    inode,
+                    pivot as usize,
+                    entries_count - 1,
+                    entries_count,
+                )
                 .map_err(err_invalidate_data)?;
             if h_name <= name && t_name >= name {
-                target_block = pivot;
+                target_block = pivot as usize;
                 break;
             } else if h_name > name {
                 last = pivot - 1;
@@ -968,14 +974,14 @@ impl RafsInode for OndiskInodeWrapper {
             let entries_count = head_name_offset / size_of::<RafsV6Dirent>();
 
             let mut first = 0;
-            let mut last = entries_count - 1;
+            let mut last = (entries_count - 1) as i64;
             while first <= last {
                 let pivot = first + ((last - first) >> 1);
                 let de = self
-                    .get_entry(&state, inode, target_block, pivot)
+                    .get_entry(&state, inode, target_block, pivot as usize)
                     .map_err(err_invalidate_data)?;
                 let d_name = self
-                    .entry_name(&state, inode, target_block, pivot, entries_count)
+                    .entry_name(&state, inode, target_block, pivot as usize, entries_count)
                     .map_err(err_invalidate_data)?;
                 match d_name.cmp(name) {
                     Ordering::Equal => {


### PR DESCRIPTION
The directory for v6 is stored in the following way： ...name1name2
The first subdirectory has always been ".".

When looking for some file whose ascii value is less than "." like "*", we need to move forward to the block index -1. This caused uszie's index "pirvot" to attempt to subtract with overflow and then panic.

Signed-off-by: Huang Jianan <jnhuang@linux.alibaba.com>