### PR TITLE
storage: minor fixups for zran in fscache

### DIFF
--- a/storage/src/cache/cachedfile.rs
+++ b/storage/src/cache/cachedfile.rs
@@ -688,7 +688,7 @@ impl FileCacheEntry {
             for chunk_id in pending.iter() {
                 status[(*chunk_id - chunk_index) as usize] = true;
             }
-            (0, pending.len())
+            (0, pending.len() - 1)
         } else {
             let mut start = u32::MAX;
             let mut end = 0;

--- a/storage/src/cache/mod.rs
+++ b/storage/src/cache/mod.rs
@@ -441,7 +441,11 @@ impl<'a, 'b> ChunkDecompressState<'a, 'b> {
         if end > self.d_buf.len() {
             return Err(einval!("invalid ZRan decompression status"));
         }
-        Ok(self.d_buf[offset as usize..end].to_vec())
+        // Use alloc_buf here to ensure 4k alignment for later use
+        // in adjust_buffer_for_dio.
+        let mut buffer = alloc_buf(chunk.uncompressed_size() as usize);
+        buffer.copy_from_slice(&self.d_buf[offset as usize..end]);
+        Ok(buffer)
     }
 
     fn next_buf(&mut self, chunk: &dyn BlobChunkInfo) -> Result<Vec<u8>> {

--- a/storage/src/meta/mod.rs
+++ b/storage/src/meta/mod.rs
@@ -1089,6 +1089,7 @@ impl BlobMetaChunkArray {
                     zran_last = entry.get_zran_index();
                 }
                 vec.push(BlobMetaChunk::new(index, state));
+                index += 1;
             }
             return Ok(vec);
         }
@@ -1179,6 +1180,7 @@ impl BlobMetaChunkArray {
                     zran_last = entry.get_zran_index();
                 }
                 vec.push(BlobMetaChunk::new(index, state));
+                index += 1;
             }
             return Ok(vec);
         }


### PR DESCRIPTION
Fix the panic when run a zran image in fscache driver:

```
thread '<unnamed>' panicked at 'index out of bounds: the len
   is 14 but the index is 14': storage/src/cache/cachedfile.rs:707
```

Signed-off-by: Yan Song <imeoer@linux.alibaba.com>