### PR TITLE
ci: fix converting top images

### DIFF
--- a/.github/workflows/convert.yml
+++ b/.github/workflows/convert.yml
@@ -50,6 +50,7 @@ jobs:
                  --source $I:latest \
                  --target ${{ env.REGISTRY }}/${{ env.ORGANIZATION }}/$I:nydus-nightly-v5 \
                  --build-cache ${{ env.REGISTRY }}/${{ env.ORGANIZATION }}/nydus-build-cache:$I-v5 \
+                 --build-cache-version v1 \
                  --fs-version 5
             # use local registry for speed
             sudo DOCKER_CONFIG=$HOME/.docker nydusify convert \
@@ -70,6 +71,7 @@ jobs:
                  --source $I:latest \
                  --target ${{ env.REGISTRY }}/${{ env.ORGANIZATION }}/$I:nydus-nightly-v6 \
                  --build-cache ${{ env.REGISTRY }}/${{ env.ORGANIZATION }}/nydus-build-cache:$I-v6 \
+                 --build-cache-version v1 \
                  --fs-version 6
             # use local registry for speed
             sudo DOCKER_CONFIG=$HOME/.docker nydusify convert \


### PR DESCRIPTION
Fix the panic when convert images in [CI](https://github.com/dragonflyoss/image-service/actions/runs/3727276947/jobs/6321277363):

```
Caused by:
    inconsistent compressor with the lower layer, current Zstd, lower: Lz4Block.
```

The previous build cache image uses Lz4Block compression, but the new version nydus-image uses Zstd by default, resulting in incompatibility.

Fix by using `--build-cache-version` option to invalidate the build cache image.

Signed-off-by: Yan Song <imeoer@linux.alibaba.com>