### PR TITLE
Fully support RAFS blobs with inlined bootstrap

### DIFF
--- a/api/src/config.rs
+++ b/api/src/config.rs
@@ -53,6 +53,25 @@ impl ConfigV2 {
         }
     }
 
+    /// Create a new configuration object for `backend-localfs` and `filecache`.
+    pub fn new_localfs(id: &str, dir: &str) -> Result<Self> {
+        let content = format!(
+            r#"
+        version = 2
+        id = "{}"
+        backend.type = "localfs"
+        backend.localfs.dir = "{}"
+        cache.type = "filecache"
+        cache.compressed = false
+        cache.validate = false
+        cache.filecache.work_dir = "{}"
+        "#,
+            id, dir, dir
+        );
+
+        Self::from_str(&content)
+    }
+
     /// Read configuration information from a file.
     pub fn from_file<P: AsRef<Path>>(path: P) -> Result<Self> {
         let md = fs::metadata(path.as_ref())?;
@@ -1655,5 +1674,12 @@ mod tests {
         "#;
         let config = ConfigV2::from_str(content).unwrap();
         assert_eq!(&config.id, "");
+    }
+
+    #[test]
+    fn test_new_localfs() {
+        let config = ConfigV2::new_localfs("id1", "./").unwrap();
+        assert_eq!(&config.id, "id1");
+        assert_eq!(config.backend.as_ref().unwrap().backend_type, "localfs");
     }
 }

--- a/api/src/config.rs
+++ b/api/src/config.rs
@@ -145,9 +145,12 @@ impl ConfigV2 {
 
     /// Get configuration information for RAFS filesystem.
     pub fn get_rafs_config(&self) -> Result<&RafsConfigV2> {
-        self.rafs
-            .as_ref()
-            .ok_or_else(|| einval!("no configuration information for rafs"))
+        self.rafs.as_ref().ok_or_else(|| {
+            Error::new(
+                ErrorKind::InvalidInput,
+                "no configuration information for rafs",
+            )
+        })
     }
 
     /// Clone the object with all secrets removed.

--- a/api/src/config.rs
+++ b/api/src/config.rs
@@ -6,7 +6,7 @@
 use std::collections::HashMap;
 use std::convert::{TryFrom, TryInto};
 use std::fs;
-use std::io::Result;
+use std::io::{Error, ErrorKind, Result};
 use std::path::Path;
 use std::str::FromStr;
 
@@ -118,6 +118,29 @@ impl ConfigV2 {
         self.cache
             .as_ref()
             .ok_or_else(|| einval!("no configuration information for cache"))
+    }
+
+    /// Get cache working directory.
+    pub fn get_cache_working_directory(&self) -> Result<String> {
+        let cache = self.get_cache_config()?;
+        match cache.cache_type.as_str() {
+            "filecache" => {
+                if let Some(c) = cache.file_cache.as_ref() {
+                    return Ok(c.work_dir.clone());
+                }
+            }
+            "fscache" => {
+                if let Some(c) = cache.fs_cache.as_ref() {
+                    return Ok(c.work_dir.clone());
+                }
+            }
+            _ => {}
+        }
+
+        Err(Error::new(
+            ErrorKind::NotFound,
+            "no working directory configured",
+        ))
     }
 
     /// Get configuration information for RAFS filesystem.

--- a/api/src/config.rs
+++ b/api/src/config.rs
@@ -124,7 +124,7 @@ impl ConfigV2 {
     pub fn get_cache_working_directory(&self) -> Result<String> {
         let cache = self.get_cache_config()?;
         match cache.cache_type.as_str() {
-            "filecache" => {
+            "blobcache" | "filecache" => {
                 if let Some(c) = cache.file_cache.as_ref() {
                     return Ok(c.work_dir.clone());
                 }

--- a/api/src/config.rs
+++ b/api/src/config.rs
@@ -144,6 +144,22 @@ impl ConfigV2 {
 
         cfg
     }
+
+    /// Check whether chunk digest validation is enabled or not.
+    pub fn is_chunk_validation_enabled(&self) -> bool {
+        let mut validation = if let Some(cache) = &self.cache {
+            cache.cache_validate
+        } else {
+            false
+        };
+        if let Some(rafs) = &self.rafs {
+            if rafs.validate {
+                validation = true;
+            }
+        }
+
+        validation
+    }
 }
 
 impl FromStr for ConfigV2 {

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -7,7 +7,7 @@
 //! The `nydus-api` crate defines API and related data structures for Nydus Image Service.
 //! All data structures used by the API are encoded in JSON format.
 
-#[macro_use]
+#[cfg_attr(feature = "handler", macro_use)]
 extern crate log;
 #[macro_use]
 extern crate serde;

--- a/rafs/src/fs.rs
+++ b/rafs/src/fs.rs
@@ -81,7 +81,7 @@ impl Rafs {
     pub fn new(cfg: &Arc<ConfigV2>, id: &str, path: &Path) -> RafsResult<(Self, RafsIoReader)> {
         let cache_cfg = cfg.get_cache_config().map_err(RafsError::LoadConfig)?;
         let rafs_cfg = cfg.get_rafs_config().map_err(RafsError::LoadConfig)?;
-        let (sb, reader) = RafsSuper::load_from_file(path, false, false, cfg.clone())
+        let (sb, reader) = RafsSuper::load_from_file(path, cfg.clone(), false, false, true)
             .map_err(RafsError::FillSuperblock)?;
         let blob_infos = sb.superblock.get_blob_infos();
         let device = BlobDevice::new(cfg, &blob_infos).map_err(RafsError::CreateDevice)?;

--- a/rafs/src/fs.rs
+++ b/rafs/src/fs.rs
@@ -86,6 +86,9 @@ impl Rafs {
 
         let blob_infos = sb.superblock.get_blob_infos();
         let device = BlobDevice::new(cfg, &blob_infos).map_err(RafsError::CreateDevice)?;
+        if cfg.is_chunk_validation_enabled() && sb.meta.has_inlined_chunk_digest() {
+            sb.superblock.set_blob_device(device.clone());
+        }
 
         let rafs = Rafs {
             id: id.to_string(),

--- a/rafs/src/metadata/cached_v5.rs
+++ b/rafs/src/metadata/cached_v5.rs
@@ -215,6 +215,14 @@ impl RafsSuperBlock for CachedSuperBlockV5 {
     fn root_ino(&self) -> u64 {
         RAFS_V5_ROOT_INODE
     }
+
+    fn get_chunk_info(&self, _idx: usize) -> Result<Arc<dyn BlobChunkInfo>> {
+        unimplemented!("used by RAFS v6 only")
+    }
+
+    fn set_blob_device(&self, _blob_device: BlobDevice) {
+        unimplemented!("used by RAFS v6 only")
+    }
 }
 
 /// Cached RAFS v5 inode object.

--- a/rafs/src/metadata/chunk.rs
+++ b/rafs/src/metadata/chunk.rs
@@ -8,6 +8,7 @@ use std::fmt::{self, Display, Formatter};
 use anyhow::{Context, Result};
 use nydus_storage::device::v5::BlobV5ChunkInfo;
 use nydus_storage::device::{BlobChunkFlags, BlobChunkInfo};
+use nydus_storage::meta::BlobMetaChunk;
 use nydus_utils::digest::RafsDigest;
 
 use crate::metadata::cached_v5::CachedChunkInfoV5;
@@ -37,7 +38,9 @@ impl ChunkWrapper {
 
     /// Create a `ChunkWrapper` object from a `BlobChunkInfo` trait object.
     pub fn from_chunk_info(cki: &dyn BlobChunkInfo) -> Self {
-        if let Some(cki_v5) = cki.as_any().downcast_ref::<CachedChunkInfoV5>() {
+        if let Some(cki) = cki.as_any().downcast_ref::<BlobMetaChunk>() {
+            ChunkWrapper::V6(to_rafsv5_chunk_info(cki))
+        } else if let Some(cki_v5) = cki.as_any().downcast_ref::<CachedChunkInfoV5>() {
             ChunkWrapper::V5(to_rafsv5_chunk_info(cki_v5))
         } else if let Some(cki_v5) = cki.as_any().downcast_ref::<DirectChunkInfoV5>() {
             ChunkWrapper::V5(to_rafsv5_chunk_info(cki_v5))

--- a/rafs/src/metadata/direct_v5.rs
+++ b/rafs/src/metadata/direct_v5.rs
@@ -326,6 +326,14 @@ impl RafsSuperBlock for DirectSuperBlockV5 {
     fn root_ino(&self) -> u64 {
         RAFS_V5_ROOT_INODE
     }
+
+    fn get_chunk_info(&self, _idx: usize) -> Result<Arc<dyn BlobChunkInfo>> {
+        unimplemented!("used by RAFS v6 only")
+    }
+
+    fn set_blob_device(&self, _blob_device: BlobDevice) {
+        unimplemented!("used by RAFS v6 only")
+    }
 }
 
 /// Direct-mapped RAFS v5 inode object.

--- a/rafs/src/metadata/direct_v6.rs
+++ b/rafs/src/metadata/direct_v6.rs
@@ -1170,7 +1170,12 @@ impl RafsInodeExt for OndiskInodeWrapper {
                 *chunk_map = Some(self.mapping.load_chunk_map()?);
             }
             match chunk_map.as_ref().unwrap().get(chunk_addr) {
-                None => Err(enoent!("failed to get chunk info")),
+                None => Err(enoent!(format!(
+                    "failed to get chunk info for chunk {}/{}/{}",
+                    chunk_addr.blob_index(),
+                    chunk_addr.blob_ci_index(),
+                    chunk_addr.block_addr()
+                ))),
                 Some(idx) => DirectChunkInfoV6::new(&state, self.mapping.clone(), *idx)
                     .map(|v| Arc::new(v) as Arc<dyn BlobChunkInfo>),
             }

--- a/rafs/src/metadata/direct_v6.rs
+++ b/rafs/src/metadata/direct_v6.rs
@@ -1151,8 +1151,9 @@ impl RafsInodeExt for OndiskInodeWrapper {
             + OndiskInodeWrapper::inode_xattr_size(inode)
             + (idx as usize * size_of::<RafsV6InodeChunkAddr>());
         let chunk_addr = state.map.get_ref::<RafsV6InodeChunkAddr>(offset)?;
+        let has_device = self.mapping.device.lock().unwrap().is_empty();
 
-        if state.meta.has_inlined_chunk_digest() {
+        if state.meta.has_inlined_chunk_digest() && has_device {
             let blob_index = chunk_addr.blob_index();
             let chunk_index = chunk_addr.blob_ci_index();
             let device = self.mapping.device.lock().unwrap();

--- a/rafs/src/metadata/direct_v6.rs
+++ b/rafs/src/metadata/direct_v6.rs
@@ -29,12 +29,12 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use arc_swap::{ArcSwap, Guard};
-use nydus_utils::filemap::{clone_file, FileMapState};
-use nydus_utils::{digest::RafsDigest, div_round_up, round_up};
-use storage::device::{
+use nydus_storage::device::{
     v5::BlobV5ChunkInfo, BlobChunkFlags, BlobChunkInfo, BlobDevice, BlobInfo, BlobIoDesc, BlobIoVec,
 };
-use storage::utils::readahead;
+use nydus_storage::utils::readahead;
+use nydus_utils::filemap::{clone_file, FileMapState};
+use nydus_utils::{digest::RafsDigest, div_round_up, round_up};
 
 use crate::metadata::layout::v5::RafsV5ChunkInfo;
 use crate::metadata::layout::v6::{
@@ -90,6 +90,7 @@ struct DirectCachedInfo {
 pub struct DirectSuperBlockV6 {
     info: Arc<DirectCachedInfo>,
     state: Arc<ArcSwap<DirectMappingState>>,
+    device: Arc<Mutex<BlobDevice>>,
 }
 
 impl DirectSuperBlockV6 {
@@ -109,6 +110,7 @@ impl DirectSuperBlockV6 {
         Self {
             info: Arc::new(info),
             state: Arc::new(ArcSwap::new(Arc::new(state))),
+            device: Arc::new(Mutex::new(BlobDevice::default())),
         }
     }
 
@@ -283,6 +285,10 @@ impl RafsSuperBlock for DirectSuperBlockV6 {
         let state = self.state.load();
         let chunk = DirectChunkInfoV6::new(&state, self.clone(), idx)?;
         Ok(Arc::new(chunk))
+    }
+
+    fn set_blob_device(&self, blob_device: BlobDevice) {
+        *self.device.lock().unwrap() = blob_device;
     }
 }
 
@@ -1145,14 +1151,29 @@ impl RafsInodeExt for OndiskInodeWrapper {
             + OndiskInodeWrapper::inode_xattr_size(inode)
             + (idx as usize * size_of::<RafsV6InodeChunkAddr>());
         let chunk_addr = state.map.get_ref::<RafsV6InodeChunkAddr>(offset)?;
-        let mut chunk_map = self.mapping.info.chunk_map.lock().unwrap();
-        if chunk_map.is_none() {
-            *chunk_map = Some(self.mapping.load_chunk_map()?);
-        }
-        match chunk_map.as_ref().unwrap().get(chunk_addr) {
-            None => Err(enoent!("failed to get chunk info")),
-            Some(idx) => DirectChunkInfoV6::new(&state, self.mapping.clone(), *idx)
-                .map(|v| Arc::new(v) as Arc<dyn BlobChunkInfo>),
+
+        if state.meta.has_inlined_chunk_digest() {
+            let blob_index = chunk_addr.blob_index();
+            let chunk_index = chunk_addr.blob_ci_index();
+            let device = self.mapping.device.lock().unwrap();
+            device
+                .get_chunk_info(blob_index, chunk_index)
+                .ok_or_else(|| {
+                    enoent!(format!(
+                        "no chunk information object for blob {} chunk {}",
+                        blob_index, chunk_index
+                    ))
+                })
+        } else {
+            let mut chunk_map = self.mapping.info.chunk_map.lock().unwrap();
+            if chunk_map.is_none() {
+                *chunk_map = Some(self.mapping.load_chunk_map()?);
+            }
+            match chunk_map.as_ref().unwrap().get(chunk_addr) {
+                None => Err(enoent!("failed to get chunk info")),
+                Some(idx) => DirectChunkInfoV6::new(&state, self.mapping.clone(), *idx)
+                    .map(|v| Arc::new(v) as Arc<dyn BlobChunkInfo>),
+            }
         }
     }
 }
@@ -1170,7 +1191,7 @@ macro_rules! impl_chunkinfo_getter {
 }
 
 /// RAFS v6 chunk information object.
-pub struct DirectChunkInfoV6 {
+pub(crate) struct DirectChunkInfoV6 {
     mapping: DirectSuperBlockV6,
     offset: usize,
     digest: RafsDigest,

--- a/rafs/src/metadata/layout/v6.rs
+++ b/rafs/src/metadata/layout/v6.rs
@@ -477,6 +477,11 @@ impl RafsV6SuperBlockExt {
         self.s_flags |= RafsSuperFlags::EXPLICIT_UID_GID.bits();
     }
 
+    /// Set flag indicating that chunk digest is inlined in the data blob.
+    pub fn set_inlined_chunk_digest(&mut self) {
+        self.s_flags |= RafsSuperFlags::INLINED_CHUNK_DIGEST.bits();
+    }
+
     /// Set message digest algorithm to handle chunk of the Rafs filesystem.
     pub fn set_digester(&mut self, digester: digest::Algorithm) {
         let c: RafsSuperFlags = digester.into();

--- a/rafs/src/metadata/layout/v6.rs
+++ b/rafs/src/metadata/layout/v6.rs
@@ -1269,7 +1269,7 @@ struct RafsV6Blob {
     // Size of the uncompressed blob, not including CI array and header.
     uncompressed_size: u64,
 
-    // Size of blob ToC content, it's zero for inlined bootstrap.
+    // Size of blob ToC content, it's zero for blobs with inlined-meta.
     rafs_blob_toc_size: u32,
     // Compression algorithm for the compression information array.
     ci_compressor: u32,
@@ -1281,12 +1281,13 @@ struct RafsV6Blob {
     ci_uncompressed_size: u64,
 
     // SHA256 digest of blob ToC content, including the toc tar header.
-    // It's all zero for inlined bootstrap.
+    // It's all zero for blobs with inlined-meta.
     rafs_blob_toc_digest: [u8; 32],
-    // SHA256 digest of RAFS blob containing `blob.meta`, `blob.digest` `blob.toc` and optionally
-    // 'image.boot`. Default to `self.blob_id` when it's all zero.
+    // SHA256 digest of RAFS blob for ZRAN, containing `blob.meta`, `blob.digest` `blob.toc` and
+    // optionally 'image.boot`. It's all zero for ZRAN blobs with inlined-meta, so need special
+    // handling.
     rafs_blob_digest: [u8; 32],
-    // Size of RAFS blob, zero for inlined bootstrap.
+    // Size of RAFS blob for ZRAN. It's zero ZRAN blobs with inlined-meta.
     rafs_blob_size: u64,
 
     reserved2: [u8; 48],
@@ -1366,7 +1367,8 @@ impl RafsV6Blob {
             return Err(einval!(msg));
         }
 
-        let id = blob_info.blob_id().as_bytes();
+        let blob_id = blob_info.blob_id();
+        let id = blob_id.as_bytes();
         let mut blob_id = [0u8; BLOB_SHA256_LEN];
         blob_id[..id.len()].copy_from_slice(id);
 

--- a/rafs/src/metadata/md_v6.rs
+++ b/rafs/src/metadata/md_v6.rs
@@ -45,8 +45,8 @@ impl RafsSuper {
         self.meta.inodes_count = sb.inodes_count();
 
         self.meta.flags = RafsSuperFlags::from_bits(ext_sb.flags())
-            .ok_or_else(|| einval!(format!("invalid super flags {:x}", ext_sb.flags())))?;
-        info!("rafs superblock features: {}", self.meta.flags);
+            .ok_or_else(|| einval!(format!("invalid RAFS flags {:x}", ext_sb.flags())))?;
+        info!("RAFS features: {}", self.meta.flags);
 
         self.meta.prefetch_table_entries = ext_sb.prefetch_table_size() / size_of::<u32>() as u32;
         self.meta.prefetch_table_offset = ext_sb.prefetch_table_offset();

--- a/rafs/src/metadata/mod.rs
+++ b/rafs/src/metadata/mod.rs
@@ -693,7 +693,7 @@ impl RafsSuper {
             let blobs = rs.superblock.get_blob_infos();
             for blob in blobs.iter() {
                 // Fix blob id for new images with old converters.
-                if blob.has_feature(BlobFeatures::INLINED_META) {
+                if blob.has_feature(BlobFeatures::INLINED_FS_META) {
                     blob.set_blob_id_from_meta_path(path.as_ref())?;
                     fixed = true;
                 }
@@ -702,7 +702,7 @@ impl RafsSuper {
                 // Fix blob id for old images with old converters.
                 let last = blobs.len() - 1;
                 let blob = &blobs[last];
-                if !blob.has_feature(BlobFeatures::CAP_INLINED_META) {
+                if !blob.has_feature(BlobFeatures::CAP_TAR_TOC) {
                     rs.set_blob_id_from_meta_path(path.as_ref())?;
                 }
             }
@@ -738,8 +738,8 @@ impl RafsSuper {
     pub fn set_blob_id_from_meta_path(&self, meta_path: &Path) -> Result<()> {
         let blobs = self.superblock.get_blob_infos();
         for blob in blobs.iter() {
-            if blob.has_feature(BlobFeatures::INLINED_META)
-                || !blob.has_feature(BlobFeatures::CAP_INLINED_META)
+            if blob.has_feature(BlobFeatures::INLINED_FS_META)
+                || !blob.has_feature(BlobFeatures::CAP_TAR_TOC)
             {
                 blob.set_blob_id_from_meta_path(meta_path)?;
             }

--- a/rafs/src/metadata/mod.rs
+++ b/rafs/src/metadata/mod.rs
@@ -681,7 +681,7 @@ impl RafsSuper {
             let path = match TocEntryList::extract_rafs_meta(id, config.clone()) {
                 Ok(v) => v,
                 Err(_e) => {
-                    debug!("failed to load inlined RAFS meta, {}", e);
+                    debug!("failed to load inlined RAFS meta, {}", _e);
                     return Err(e);
                 }
             };

--- a/rafs/src/metadata/mod.rs
+++ b/rafs/src/metadata/mod.rs
@@ -670,15 +670,8 @@ impl RafsSuper {
         let mut reader = Box::new(file) as RafsIoReader;
 
         if let Err(e) = rs.load(&mut reader) {
-            let id = match path.as_ref().file_stem() {
-                Some(v) => v,
-                None => return Err(e),
-            };
-            let id = match id.to_str() {
-                Some(v) => v,
-                None => return Err(e),
-            };
-            let path = match TocEntryList::extract_rafs_meta(id, config.clone()) {
+            let id = BlobInfo::get_blob_id_from_meta_path(path.as_ref())?;
+            let path = match TocEntryList::extract_rafs_meta(&id, config.clone()) {
                 Ok(v) => v,
                 Err(_e) => {
                     debug!("failed to load inlined RAFS meta, {}", _e);

--- a/rafs/src/metadata/noop.rs
+++ b/rafs/src/metadata/noop.rs
@@ -7,7 +7,7 @@
 use std::io::Result;
 use std::sync::Arc;
 
-use storage::device::BlobInfo;
+use storage::device::{BlobChunkInfo, BlobDevice, BlobInfo};
 
 use crate::metadata::{Inode, RafsInode, RafsSuperBlock, RafsSuperInodes};
 use crate::{RafsInodeExt, RafsIoReader, RafsResult};
@@ -56,5 +56,13 @@ impl RafsSuperBlock for NoopSuperBlock {
 
     fn root_ino(&self) -> u64 {
         unimplemented!()
+    }
+
+    fn get_chunk_info(&self, _idx: usize) -> Result<Arc<dyn BlobChunkInfo>> {
+        unimplemented!("used by RAFS v6 only")
+    }
+
+    fn set_blob_device(&self, _blob_device: BlobDevice) {
+        unimplemented!("used by RAFS v6 only")
     }
 }

--- a/rafs/src/mock/mock_super.rs
+++ b/rafs/src/mock/mock_super.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 use std::io::Result;
 use std::sync::Arc;
 
-use nydus_storage::device::BlobInfo;
+use nydus_storage::device::{BlobChunkInfo, BlobDevice, BlobInfo};
 
 use crate::metadata::{Inode, RafsInode, RafsSuperBlock, RafsSuperInodes};
 use crate::mock::MockInode;
@@ -63,6 +63,14 @@ impl RafsSuperBlock for MockSuperBlock {
     }
 
     fn root_ino(&self) -> u64 {
+        unimplemented!()
+    }
+
+    fn get_chunk_info(&self, _idx: usize) -> Result<Arc<dyn BlobChunkInfo>> {
+        unimplemented!()
+    }
+
+    fn set_blob_device(&self, _blob_device: BlobDevice) {
         unimplemented!()
     }
 }

--- a/src/bin/nydus-image/builder/mod.rs
+++ b/src/bin/nydus-image/builder/mod.rs
@@ -84,11 +84,7 @@ fn dump_bootstrap(
             }
         }
         if !ctx.conversion_type.is_to_ref() {
-            if ctx.blob_inline_meta {
-                blob_ctx.compressed_blob_size = 0;
-            } else {
-                blob_ctx.compressed_blob_size = blob_writer.pos()?;
-            }
+            blob_ctx.compressed_blob_size = blob_writer.pos()?;
         }
     }
 
@@ -174,11 +170,7 @@ fn finalize_blob(
         dump_toc(ctx, blob_ctx, blob_writer)?;
 
         if !ctx.conversion_type.is_to_ref() {
-            if ctx.blob_inline_meta {
-                blob_ctx.compressed_blob_size = 0;
-            } else {
-                blob_ctx.compressed_blob_size = blob_writer.pos()?;
-            }
+            blob_ctx.compressed_blob_size = blob_writer.pos()?;
         }
         if ctx.blob_inline_meta && blob_ctx.blob_id == "x".repeat(64) {
             blob_ctx.blob_id = String::new();

--- a/src/bin/nydus-image/core/blob.rs
+++ b/src/bin/nydus-image/core/blob.rs
@@ -55,6 +55,7 @@ impl Blob {
             ConversionType::TarToRef
             | ConversionType::TargzToRef
             | ConversionType::EStargzToRef => {
+                // Use `sha256(tarball)` as `blob_id` for ref-type conversions.
                 if let Some((_, blob_ctx)) = blob_mgr.get_current_blob() {
                     if let Some(zran) = &ctx.blob_zran_generator {
                         let reader = zran.lock().unwrap().reader();

--- a/src/bin/nydus-image/core/blob_compact.rs
+++ b/src/bin/nydus-image/core/blob_compact.rs
@@ -577,7 +577,7 @@ impl BlobCompactor {
             BootstrapManager::new(Some(ArtifactStorage::SingleFile(d_bootstrap)), None);
         let mut bootstrap_ctx = bootstrap_mgr.create_ctx(false)?;
         let mut ori_blob_mgr = BlobManager::new();
-        ori_blob_mgr.from_blob_table(&build_ctx, rs.superblock.get_blob_infos());
+        ori_blob_mgr.prepend_from_blob_table(&build_ctx, rs.superblock.get_blob_infos())?;
         if let Some(dict) = chunk_dict {
             ori_blob_mgr.set_chunk_dict(dict);
             ori_blob_mgr.extend_blob_table_from_chunk_dict(&build_ctx)?;

--- a/src/bin/nydus-image/core/bootstrap.rs
+++ b/src/bin/nydus-image/core/bootstrap.rs
@@ -328,7 +328,7 @@ impl Bootstrap {
 
         // Reuse lower layer blob table,
         // we need to append the blob entry of upper layer to the table
-        blob_mgr.prepend_from_blob_table(ctx, rs.superblock.get_blob_infos())?;
+        blob_mgr.extend_from_blob_table(ctx, rs.superblock.get_blob_infos())?;
 
         // Build node tree of lower layer from a bootstrap file, and add chunks
         // of lower node to layered_chunk_dict for chunk deduplication on next.

--- a/src/bin/nydus-image/core/bootstrap.rs
+++ b/src/bin/nydus-image/core/bootstrap.rs
@@ -311,8 +311,14 @@ impl Bootstrap {
         blob_mgr: &mut BlobManager,
     ) -> Result<Tree> {
         let rs = if let Some(path) = bootstrap_mgr.f_parent_path.as_ref() {
-            RafsSuper::load_from_file(path, true, false, ctx.configuration.clone())
-                .map(|(rs, _)| rs)?
+            RafsSuper::load_from_file(
+                path,
+                ctx.configuration.clone(),
+                true,
+                false,
+                ctx.can_access_data_blobs,
+            )
+            .map(|(rs, _)| rs)?
         } else {
             return Err(Error::msg("bootstrap context's parent bootstrap is null"));
         };

--- a/src/bin/nydus-image/core/chunk_dict.rs
+++ b/src/bin/nydus-image/core/chunk_dict.rs
@@ -98,7 +98,7 @@ impl HashChunkDict {
         config: Arc<ConfigV2>,
         target_rafs_config: Option<RafsSuperConfig>,
     ) -> Result<Self> {
-        let rs = RafsSuper::load_chunk_dict_from_metadata(path, config)
+        let (rs, _) = RafsSuper::load_from_file(path, true, true, config)
             .with_context(|| format!("failed to open bootstrap file {:?}", path))?;
         let mut d = HashChunkDict {
             m: HashMap::new(),

--- a/src/bin/nydus-image/core/context.rs
+++ b/src/bin/nydus-image/core/context.rs
@@ -442,6 +442,9 @@ impl BlobContext {
         if features.contains(BlobFeatures::ALIGNED) {
             blob_ctx.blob_meta_header.set_4k_aligned(true);
         }
+        if features.contains(BlobFeatures::INLINED_META) {
+            blob_ctx.blob_meta_header.set_inlined_meta(true);
+        }
         if features.contains(BlobFeatures::CHUNK_INFO_V2) {
             blob_ctx.blob_meta_header.set_chunk_info_v2(true);
         }
@@ -972,6 +975,11 @@ impl BuildContext {
         blob_inline_meta: bool,
         features: Features,
     ) -> Self {
+        let blob_features = if blob_inline_meta {
+            BlobFeatures::INLINED_META
+        } else {
+            BlobFeatures::empty()
+        };
         BuildContext {
             blob_id,
             aligned_chunk,
@@ -991,7 +999,7 @@ impl BuildContext {
             blob_storage,
             blob_zran_generator: None,
             blob_tar_reader: None,
-            blob_features: BlobFeatures::empty(),
+            blob_features,
             blob_inline_meta,
             has_xattr: false,
 

--- a/src/bin/nydus-image/core/context.rs
+++ b/src/bin/nydus-image/core/context.rs
@@ -449,7 +449,7 @@ impl BlobContext {
             .set_4k_aligned(features.contains(BlobFeatures::ALIGNED));
         blob_ctx
             .blob_meta_header
-            .set_inlined_meta(features.contains(BlobFeatures::INLINED_META));
+            .set_inlined_fs_meta(features.contains(BlobFeatures::INLINED_FS_META));
         blob_ctx
             .blob_meta_header
             .set_chunk_info_v2(features.contains(BlobFeatures::CHUNK_INFO_V2));
@@ -461,7 +461,7 @@ impl BlobContext {
             .set_inlined_chunk_digest(features.contains(BlobFeatures::INLINED_CHUNK_DIGEST));
         blob_ctx
             .blob_meta_header
-            .set_cap_inlined_meta(features.contains(BlobFeatures::CAP_INLINED_META));
+            .set_cap_tar_toc(features.contains(BlobFeatures::CAP_TAR_TOC));
 
         blob_ctx
     }
@@ -477,8 +477,8 @@ impl BlobContext {
 
         // Fixes up blob info objects from inlined-meta blobs.
         if chunk_source == ChunkSource::Dict || chunk_source == ChunkSource::Parent {
-            if features.contains(BlobFeatures::INLINED_META) {
-                features &= !BlobFeatures::INLINED_META;
+            if features.contains(BlobFeatures::INLINED_FS_META) {
+                features &= !BlobFeatures::INLINED_FS_META;
 
                 if !features.contains(BlobFeatures::ZRAN) {
                     blob_id = blob.blob_id();
@@ -538,9 +538,7 @@ impl BlobContext {
                         }
                     }
                 }
-            } else if !blob.has_feature(BlobFeatures::CAP_INLINED_META)
-                && !ctx.can_access_data_blobs
-            {
+            } else if !blob.has_feature(BlobFeatures::CAP_TAR_TOC) && !ctx.can_access_data_blobs {
                 blob_id = blob.blob_id();
             }
         }
@@ -1070,9 +1068,9 @@ impl BuildContext {
         features: Features,
     ) -> Self {
         let blob_features = if blob_inline_meta {
-            BlobFeatures::INLINED_META | BlobFeatures::CAP_INLINED_META
+            BlobFeatures::INLINED_FS_META | BlobFeatures::CAP_TAR_TOC
         } else {
-            BlobFeatures::CAP_INLINED_META
+            BlobFeatures::CAP_TAR_TOC
         };
         BuildContext {
             blob_id,

--- a/src/bin/nydus-image/core/node.rs
+++ b/src/bin/nydus-image/core/node.rs
@@ -667,7 +667,8 @@ impl Node {
                             .clone()
                             .get_blobs_by_inner_idx(chunk.blob_index())
                         {
-                            blob_mgr.add(BlobContext::from(ctx, blob, ChunkSource::Dict))
+                            let ctx = BlobContext::from(ctx, blob, ChunkSource::Dict)?;
+                            blob_mgr.add(ctx);
                         }
                         blob_idx
                     };

--- a/src/bin/nydus-image/core/tree.rs
+++ b/src/bin/nydus-image/core/tree.rs
@@ -266,6 +266,7 @@ impl<'a> MetadataTreeBuilder<'a> {
             PathBuf::from("/")
         };
 
+        let blobs = self.rs.superblock.get_blob_infos();
         let child_count = inode.get_child_count();
         let mut children = Vec::with_capacity(child_count as usize);
         event_tracer!("load_from_parent_bootstrap", +child_count);
@@ -279,7 +280,10 @@ impl<'a> MetadataTreeBuilder<'a> {
 
             if child.is_reg() {
                 for chunk in &child.chunks {
-                    chunk_dict.add_chunk(chunk.inner.clone());
+                    let blob_idx = chunk.inner.blob_index();
+                    if let Some(blob) = blobs.get(blob_idx as usize) {
+                        chunk_dict.add_chunk(chunk.inner.clone(), blob.digester());
+                    }
                 }
             }
 

--- a/src/bin/nydus-image/inspect.rs
+++ b/src/bin/nydus-image/inspect.rs
@@ -13,6 +13,8 @@ use std::{
     sync::{Arc, Mutex},
 };
 
+use anyhow::Context;
+use nydus_api::ConfigV2;
 use nydus_rafs::metadata::{RafsInode, RafsInodeExt, RafsInodeWalkAction, RafsSuper};
 use nydus_rafs::{RafsIoRead, RafsIoReader};
 use nydus_storage::device::BlobChunkInfo;
@@ -34,18 +36,28 @@ pub(crate) struct RafsInspector {
 
 impl RafsInspector {
     // create the RafsInspector
-    pub fn new(bootstrap_path: &Path, request_mode: bool) -> Result<Self, anyhow::Error> {
-        // Load Bootstrap
-        let mut f = <dyn RafsIoRead>::from_file(bootstrap_path)
-            .map_err(|e| anyhow!("Can't find bootstrap, path={:?}, {:?}", bootstrap_path, e))?;
-
-        // Load rafs_meta(RafsSuper) from bootstrap
+    pub fn new(
+        bootstrap_path: &Path,
+        request_mode: bool,
+        config: Arc<ConfigV2>,
+    ) -> Result<Self, anyhow::Error> {
+        let mut f = <dyn RafsIoRead>::from_file(bootstrap_path).map_err(|e| {
+            anyhow!(
+                "failed to open RAFS meta file, path={:?}, {:?}",
+                bootstrap_path,
+                e
+            )
+        })?;
         let mut rafs_meta = RafsSuper::default();
         rafs_meta
             .load(&mut f)
-            .map_err(|e| anyhow!("Can't load bootstrap, error {:?}", e))?;
+            .map_err(|e| anyhow!("failed to load RAFS meta, error {:?}", e))?;
+        if rafs_meta.meta.has_inlined_chunk_digest() {
+            rafs_meta.create_blob_device(config).context(
+                "failed to open RAFS data blob, wrong working directory or configuration?",
+            )?;
+        }
 
-        // Get ino of root directory.
         let root_ino = rafs_meta.superblock.root_ino();
 
         Ok(RafsInspector {
@@ -89,16 +101,29 @@ impl RafsInspector {
         } else {
             println!(
                 r#"
-    Version:            {version}
-    Inodes Count:       {inodes_count}
-    Chunk Size:         {chunk_size}KB
-    Root Inode:         {root_inode}
-    Flags:              {flags}"#,
+    Version:                {version}
+    Inodes Count:           {inodes_count}
+    Chunk Size:             {chunk_size}KB
+    Root Inode:             {root_inode}
+    Flags:                  {flags}
+    Blob table offset:      0x{blob_tbl_offset:x}
+    Blob table size:        0x{blob_tbl_size:x}
+    Prefetch table offset:  0x{prefetch_tbl_offset:x}
+    Prefetch table entries: 0x{prefetch_tbl_entries:x}
+    Chunk table offset:     0x{chunk_tbl_offset:x}
+    Chunk table size:       0x{chunk_tbl_size:x}
+    "#,
                 version = self.rafs_meta.meta.version >> 8,
                 inodes_count = self.rafs_meta.meta.inodes_count,
                 chunk_size = self.rafs_meta.meta.chunk_size / 1024,
                 flags = self.rafs_meta.meta.flags,
                 root_inode = self.rafs_meta.superblock.root_ino(),
+                blob_tbl_offset = self.rafs_meta.meta.blob_table_offset,
+                blob_tbl_size = self.rafs_meta.meta.blob_table_size,
+                prefetch_tbl_offset = self.rafs_meta.meta.prefetch_table_offset,
+                prefetch_tbl_entries = self.rafs_meta.meta.prefetch_table_entries,
+                chunk_tbl_offset = self.rafs_meta.meta.chunk_table_offset,
+                chunk_tbl_size = self.rafs_meta.meta.chunk_table_size,
             );
             None
         };
@@ -208,55 +233,53 @@ impl RafsInspector {
                     return Err(Error::new(ErrorKind::Other, e));
                 }
 
-                if self.rafs_meta.meta.is_v5() {
-                    let child_inode = self.rafs_meta.get_extended_inode(child_ino, false)?;
-                    let mut chunks = Vec::<Arc<dyn BlobChunkInfo>>::new();
+                let child_inode = dir_inode.get_child_by_name(&child_name)?;
+                let mut chunks = Vec::<Arc<dyn BlobChunkInfo>>::new();
 
-                    // only reg_file can get and print chunk info
-                    if !child_inode.is_reg() {
+                // only reg_file can get and print chunk info
+                if !child_inode.is_reg() {
+                    return Ok(RafsInodeWalkAction::Break);
+                }
+
+                let chunk_count = child_inode.get_chunk_count();
+                for idx in 0..chunk_count {
+                    let cur_chunk = child_inode.get_chunk_info(idx)?;
+                    chunks.push(cur_chunk);
+                }
+
+                println!("  Chunk list:");
+                for (i, c) in chunks.iter().enumerate() {
+                    let blob_id = if let Ok(id) = self.get_blob_id_by_index(c.blob_index()) {
+                        id.to_owned()
+                    } else {
+                        error!(
+                            "Blob index is {}. But no blob entry associate with it",
+                            c.blob_index()
+                        );
                         return Ok(RafsInodeWalkAction::Break);
-                    }
+                    };
 
-                    let chunk_count = child_inode.get_chunk_count();
-                    for idx in 0..chunk_count {
-                        let cur_chunk = child_inode.get_chunk_info(idx)?;
-                        chunks.push(cur_chunk);
-                    }
+                    // file_offset = chunk_index * chunk_size
+                    let file_offset = i * self.rafs_meta.meta.chunk_size as usize;
 
-                    println!("  Chunk list:");
-                    for (i, c) in chunks.iter().enumerate() {
-                        let blob_id = if let Ok(id) = self.get_blob_id_by_index(c.blob_index()) {
-                            id.to_owned()
-                        } else {
-                            error!(
-                                "Blob index is {}. But no blob entry associate with it",
-                                c.blob_index()
-                            );
-                            return Ok(RafsInodeWalkAction::Break);
-                        };
-
-                        // file_offset = chunk_index * chunk_size
-                        let file_offset = c.id() * self.rafs_meta.meta.chunk_size;
-
-                        println!(
-                            r#"        {} ->
+                    println!(
+                        r#"        {} ->
         file offset: {file_offset}, chunk index: {chunk_index}
         compressed size: {compressed_size}, decompressed size: {decompressed_size}
         compressed offset: {compressed_offset}, decompressed offset: {decompressed_offset}
-        blob id: {blob_id} 
+        blob id: {blob_id}
         chunk id: {chunk_id}
     "#,
-                            i,
-                            chunk_index = c.id(),
-                            file_offset = file_offset,
-                            compressed_size = c.compressed_size(),
-                            decompressed_size = c.uncompressed_size(),
-                            decompressed_offset = c.uncompressed_offset(),
-                            compressed_offset = c.compressed_offset(),
-                            blob_id = blob_id,
-                            chunk_id = c.chunk_id()
-                        );
-                    }
+                        i,
+                        chunk_index = c.id(),
+                        file_offset = file_offset,
+                        compressed_size = c.compressed_size(),
+                        decompressed_size = c.uncompressed_size(),
+                        decompressed_offset = c.uncompressed_offset(),
+                        compressed_offset = c.compressed_offset(),
+                        blob_id = blob_id,
+                        chunk_id = c.chunk_id()
+                    );
                 }
                 Ok(RafsInodeWalkAction::Break)
             } else {
@@ -272,9 +295,9 @@ impl RafsInspector {
         let blob_infos = self.rafs_meta.superblock.get_blob_infos();
 
         let mut value = json!([]);
-        for (_i, blob_info) in blob_infos.iter().enumerate() {
+        for blob_info in blob_infos.iter() {
             if self.request_mode {
-                let v = json!({"blob_id": blob_info.blob_id(), 
+                let v = json!({"blob_id": blob_info.blob_id(),
                                     "readahead_offset": blob_info.prefetch_offset(),
                                     "readahead_size": blob_info.prefetch_size(),
                                     "decompressed_size": blob_info.uncompressed_size(),
@@ -283,17 +306,45 @@ impl RafsInspector {
             } else {
                 print!(
                     r#"
-Blob ID:            {blob_id}
-Readahead Offset:   {readahead_offset}
-Readahead Size:     {readahead_size}
-Cache Size:         {cache_size}
-Compressed Size:    {compressed_size}
+Blob Index:             {blob_index}
+Blob ID:                {blob_id}
+Features:               {features:?}
+Compressor:             {compressor}
+Digester:               {digester}
+Cache Size:             {cache_size}
+Compressed Size:        {compressed_size}
+Chunk Size:             {chunk_size}
+Chunk Count:            {chunk_count}
+Prefetch Table Offset:  {prefetch_tbl_offset}
+Prefetch Table Size:    {prefetch_tbl_size}
+Meta Compressor:        {meta_compressor}
+Meta Offset:            {meta_offset}
+Meta Compressed Size:   {meta_comp_size}
+Meta Uncompressed Size: {meta_uncomp_size}
+ToC Digest:             {toc_digest}
+ToC Size:               {toc_size}
+RAFS Blob Digest:       {rafs_digest}
+RAFS Blob Size:         {rafs_size}
 "#,
+                    blob_index = blob_info.blob_index(),
                     blob_id = blob_info.blob_id(),
-                    readahead_offset = blob_info.prefetch_offset(),
-                    readahead_size = blob_info.prefetch_size(),
+                    features = blob_info.features(),
                     cache_size = blob_info.uncompressed_size(),
                     compressed_size = blob_info.compressed_size(),
+                    chunk_size = blob_info.chunk_size(),
+                    chunk_count = blob_info.chunk_count(),
+                    compressor = blob_info.compressor(),
+                    digester = blob_info.digester(),
+                    prefetch_tbl_offset = blob_info.prefetch_offset(),
+                    prefetch_tbl_size = blob_info.prefetch_size(),
+                    meta_compressor = blob_info.meta_ci_compressor(),
+                    meta_offset = blob_info.meta_ci_offset(),
+                    meta_comp_size = blob_info.meta_ci_compressed_size(),
+                    meta_uncomp_size = blob_info.meta_ci_uncompressed_size(),
+                    toc_digest = hex::encode(blob_info.rafs_blob_toc_digest()),
+                    toc_size = blob_info.rafs_blob_toc_size(),
+                    rafs_digest = hex::encode(blob_info.rafs_blob_digest()),
+                    rafs_size = blob_info.rafs_blob_size(),
                 );
             }
         }
@@ -604,12 +655,12 @@ Blocks:             {blocks}"#,
     // Match blobinfo by using blob index
     fn get_blob_id_by_index(&self, blob_index: u32) -> Result<String, anyhow::Error> {
         let blob_infos = self.rafs_meta.superblock.get_blob_infos();
-        for (_i, b) in blob_infos.iter().enumerate() {
+        for b in blob_infos.iter() {
             if b.blob_index() == blob_index {
                 return Ok(b.blob_id().to_owned());
             }
         }
-        Err(anyhow!("can not find blob info by index: {}", blob_index))
+        Err(anyhow!("can not find blob by index: {}", blob_index))
     }
 }
 
@@ -628,7 +679,7 @@ impl Executor {
     pub fn execute(
         inspector: &mut RafsInspector,
         input: String,
-    ) -> std::result::Result<Option<Value>, ExecuteError> {
+    ) -> Result<Option<Value>, ExecuteError> {
         let mut raw = input
             .strip_suffix('\n')
             .unwrap_or(&input)
@@ -638,7 +689,6 @@ impl Executor {
             None => return Ok(None),
         };
         let args = raw.next().map(|a| a.trim());
-
         debug!("execute {:?} {:?}", cmd, args);
 
         let output = match (cmd, args) {
@@ -664,8 +714,8 @@ impl Executor {
                 })?;
                 inspector.cmd_check_inode(ino)
             }
-            _ => {
-                println!("Unsupported command!");
+            (cmd, _) => {
+                println!("Unsupported command: {}", cmd);
                 {
                     Self::usage();
                     return Err(ExecuteError::IllegalCommand);
@@ -680,14 +730,15 @@ impl Executor {
     pub(crate) fn usage() {
         println!(
             r#"
-    stats:              Display global rafs metadata
+    stats:              Display RAFS filesystesm metadata
     ls:                 Show files in current directory
     cd DIR:             Change current directory
-    stat FILE_NAME:     Show particular information of rafs inode
-    blobs:              Show blobs table
+    stat FILE_NAME:     Show particular information of RAFS file
+    blobs:              Show blob table
     prefetch:           Show prefetch table
     chunk OFFSET:       List basic info of a single chunk together with a list of files that share it
     icheck INODE:       Show path of the inode and basic information
+    exit:               Exit
         "#
         );
     }
@@ -698,7 +749,7 @@ pub(crate) struct Prompt {}
 impl Prompt {
     pub(crate) fn run(mut inspector: RafsInspector) {
         loop {
-            print!("Inspecting Rafs :> ");
+            print!("Inspecting RAFS :> ");
             std::io::stdout().flush().unwrap();
 
             let mut input = String::new();
@@ -709,12 +760,12 @@ impl Prompt {
                 Err(ExecuteError::IllegalCommand) => continue,
                 Err(ExecuteError::HelpCommand) => continue,
                 Err(ExecuteError::ExecError(e)) => {
-                    println!("Failed in executing command, {:?}", e);
+                    println!("Failed to execute command, {:?}", e);
                     continue;
                 }
                 Ok(Some(o)) => {
                     serde_json::to_writer(std::io::stdout(), &o)
-                        .unwrap_or_else(|e| error!("Failed to serialize, {:?}", e));
+                        .unwrap_or_else(|e| error!("Failed to serialize message, {:?}", e));
                 }
                 _ => continue,
             }

--- a/src/bin/nydus-image/inspect.rs
+++ b/src/bin/nydus-image/inspect.rs
@@ -40,7 +40,7 @@ impl RafsInspector {
         request_mode: bool,
         config: Arc<ConfigV2>,
     ) -> Result<Self, anyhow::Error> {
-        let (rafs_meta, f) = RafsSuper::load_from_file(bootstrap_path, false, false, config)?;
+        let (rafs_meta, f) = RafsSuper::load_from_file(bootstrap_path, config, false, false, true)?;
         let root_ino = rafs_meta.superblock.root_ino();
 
         Ok(RafsInspector {

--- a/src/bin/nydus-image/merge.rs
+++ b/src/bin/nydus-image/merge.rs
@@ -6,10 +6,11 @@ use std::collections::HashSet;
 use std::convert::TryFrom;
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
+use std::sync::Arc;
 
 use anyhow::{Context, Result};
 use hex::FromHex;
-
+use nydus_api::ConfigV2;
 use nydus_rafs::metadata::{RafsInodeExt, RafsSuper, RafsVersion};
 
 use crate::core::bootstrap::Bootstrap;
@@ -29,6 +30,7 @@ use crate::core::tree::{MetadataTreeBuilder, Tree};
 pub struct Merger {}
 
 impl Merger {
+    /*
     /// Merge assumes the bootstrap name is in `$blob_digest` format.
     fn get_raw_blob_digest(bootstrap_path: &Path) -> Result<String> {
         let file_name = bootstrap_path
@@ -38,6 +40,7 @@ impl Merger {
             .ok_or_else(|| anyhow!("convert to string"))?;
         Ok(file_name.to_string())
     }
+     */
 
     fn get_digest_from_list(digests: &Option<Vec<String>>, idx: usize) -> Result<Option<[u8; 32]>> {
         Ok(if let Some(digests) = &digests {
@@ -66,45 +69,50 @@ impl Merger {
     /// # Arguments
     /// - sources: contains one or more per layer bootstraps in order of lower to higher.
     /// - chunk_dict: contain the chunk dictionary used to build per layer boostrap, or None.
+    #[allow(clippy::too_many_arguments)]
     pub fn merge(
         ctx: &mut BuildContext,
         sources: Vec<PathBuf>,
         blob_digests: Option<Vec<String>>,
-        blob_toc_digests: Option<Vec<String>>,
         blob_sizes: Option<Vec<u64>>,
+        blob_toc_digests: Option<Vec<String>>,
+        blob_toc_sizes: Option<Vec<u64>>,
         target: ArtifactStorage,
         chunk_dict: Option<PathBuf>,
+        config_v2: Arc<ConfigV2>,
     ) -> Result<BuildOutput> {
         if sources.is_empty() {
             bail!("source bootstrap list is empty , at least one bootstrap is required");
         }
-
-        if blob_digests.is_some() || blob_toc_digests.is_some() || blob_sizes.is_some() {
+        if let Some(digests) = blob_digests.as_ref() {
             ensure!(
-                blob_digests
-                    .as_ref()
-                    .map(|items| items.len())
-                    .unwrap_or_default()
-                    == sources.len(),
-                "blob digests count is not enough, expected {}",
+                digests.len() == sources.len(),
+                "number of blob digest entries {} doesn't match number of sources {}",
+                digests.len(),
                 sources.len(),
             );
+        }
+        if let Some(toc_digests) = blob_toc_digests.as_ref() {
             ensure!(
-                blob_toc_digests
-                    .as_ref()
-                    .map(|items| items.len())
-                    .unwrap_or_default()
-                    == sources.len(),
-                "blob toc digests count is not enough, expected {}",
+                toc_digests.len() == sources.len(),
+                "number of toc digest entries {} doesn't match number of sources {}",
+                toc_digests.len(),
                 sources.len(),
             );
+        }
+        if let Some(sizes) = blob_sizes.as_ref() {
             ensure!(
-                blob_sizes
-                    .as_ref()
-                    .map(|items| items.len())
-                    .unwrap_or_default()
-                    == sources.len(),
-                "blob sizes count is not enough, expected {}",
+                sizes.len() == sources.len(),
+                "number of blob size entries {} doesn't match number of sources {}",
+                sizes.len(),
+                sources.len(),
+            );
+        }
+        if let Some(sizes) = blob_toc_sizes.as_ref() {
+            ensure!(
+                sizes.len() == sources.len(),
+                "number of toc size entries {} doesn't match number of sources {}",
+                sizes.len(),
                 sources.len(),
             );
         }
@@ -114,7 +122,7 @@ impl Merger {
         let mut config = None;
         if let Some(chunk_dict_path) = &chunk_dict {
             let (rs, _) =
-                RafsSuper::load_from_file(chunk_dict_path, true, false, ctx.configuration.clone())
+                RafsSuper::load_from_file(chunk_dict_path, true, false, config_v2.clone())
                     .context(format!("load chunk dict bootstrap {:?}", chunk_dict_path))?;
             config = Some(rs.meta.get_config());
             for blob in rs.superblock.get_blob_infos() {
@@ -122,28 +130,22 @@ impl Merger {
             }
         }
 
-        let mut fs_version = None;
+        let mut fs_version = RafsVersion::V6;
         let mut chunk_size = None;
         let mut tree: Option<Tree> = None;
         let mut blob_mgr = BlobManager::new();
-        for (layer_idx, bootstrap_path) in sources.iter().enumerate() {
-            let (rs, _) =
-                RafsSuper::load_from_file(bootstrap_path, true, false, ctx.configuration.clone())
-                    .context(format!("load bootstrap {:?}", bootstrap_path))?;
 
+        for (layer_idx, bootstrap_path) in sources.iter().enumerate() {
+            let (rs, _) = RafsSuper::load_from_file(bootstrap_path, true, false, config_v2.clone())
+                .context(format!("load bootstrap {:?}", bootstrap_path))?;
             config
                 .get_or_insert_with(|| rs.meta.get_config())
                 .check_compatibility(&rs.meta)?;
-
-            fs_version = Some(rs.meta.version);
+            fs_version = RafsVersion::try_from(rs.meta.version)
+                .context("failed to get RAFS version number")?;
             ctx.compressor = rs.meta.get_compressor();
             ctx.digester = rs.meta.get_digester();
             ctx.explicit_uidgid = rs.meta.explicit_uidgid();
-
-            let raw_blob_digest = Self::get_raw_blob_digest(bootstrap_path)?;
-            let rafs_blob_digest = Self::get_digest_from_list(&blob_digests, layer_idx)?;
-            let rafs_blob_toc_digest = Self::get_digest_from_list(&blob_toc_digests, layer_idx)?;
-            let rafs_blob_size = Self::get_size_from_list(&blob_sizes, layer_idx)?;
 
             let mut blob_idx_map = Vec::new();
             let mut parent_blob_added = false;
@@ -156,18 +158,25 @@ impl Merger {
                     if parent_blob_added {
                         bail!("invalid per layer bootstrap, having multiple associated data blobs");
                     }
+                    parent_blob_added = true;
+
                     // The blob id (blob sha256 hash) in parent bootstrap is invalid for nydusd
                     // runtime, should change it to the hash of whole tar blob.
-                    blob_ctx.blob_id = raw_blob_digest.clone();
-                    if let Some(digest) = rafs_blob_digest {
+                    blob_ctx.blob_id = blob.blob_id().to_owned();
+                    if let Some(digest) = Self::get_digest_from_list(&blob_digests, layer_idx)? {
                         blob_ctx.rafs_blob_digest = digest;
                     }
-                    if let Some(digest) = rafs_blob_toc_digest {
-                        blob_ctx.rafs_blob_toc_digest = digest;
-                    }
-                    if let Some(size) = rafs_blob_size {
+                    if let Some(size) = Self::get_size_from_list(&blob_sizes, layer_idx)? {
                         blob_ctx.rafs_blob_size = size;
                     }
+                    if let Some(digest) = Self::get_digest_from_list(&blob_toc_digests, layer_idx)?
+                    {
+                        blob_ctx.rafs_blob_toc_digest = digest;
+                    }
+                    if let Some(size) = Self::get_size_from_list(&blob_toc_sizes, layer_idx)? {
+                        blob_ctx.rafs_blob_toc_size = size as u32;
+                    }
+
                     if chunk_size.is_none() {
                         chunk_size = Some(blob_ctx.chunk_size);
                     }
@@ -179,7 +188,6 @@ impl Merger {
                             chunk_size.unwrap(),
                         );
                     }
-                    parent_blob_added = true;
                 }
 
                 let mut found = false;
@@ -238,10 +246,9 @@ impl Merger {
             }
         }
 
-        // Safe to unwrap because a valid version must exist
-        ctx.fs_version = RafsVersion::try_from(fs_version.unwrap())?;
         // Safe to unwrap because there is at least one source bootstrap.
         let mut tree = tree.unwrap();
+        ctx.fs_version = fs_version;
         if let Some(chunk_size) = chunk_size {
             ctx.chunk_size = chunk_size;
         }

--- a/src/bin/nydus-image/merge.rs
+++ b/src/bin/nydus-image/merge.rs
@@ -134,7 +134,7 @@ impl Merger {
         let mut fs_version = RafsVersion::V6;
         let mut chunk_size = None;
         let mut tree: Option<Tree> = None;
-        let mut blob_mgr = BlobManager::new();
+        let mut blob_mgr = BlobManager::new(ctx.digester);
 
         for (layer_idx, bootstrap_path) in sources.iter().enumerate() {
             let (rs, _) = RafsSuper::load_from_file(bootstrap_path, true, false, config_v2.clone())
@@ -250,7 +250,7 @@ impl Merger {
                     tree.apply(node, true, WhiteoutSpec::Oci)?;
                 }
             } else {
-                let mut dict = HashChunkDict::default();
+                let mut dict = HashChunkDict::new(rs.meta.get_digester());
                 tree = Some(Tree::from_bootstrap(&rs, &mut dict)?);
             }
         }

--- a/src/bin/nydus-image/stat.rs
+++ b/src/bin/nydus-image/stat.rs
@@ -6,9 +6,11 @@ use std::collections::HashSet;
 use std::fs::OpenOptions;
 use std::path::Path;
 use std::sync::atomic::Ordering;
+use std::sync::Arc;
 
 use anyhow::{Context, Result};
-use nydus_rafs::metadata::{RafsMode, RafsSuper};
+use nydus_api::ConfigV2;
+use nydus_rafs::metadata::RafsSuper;
 use serde::Serialize;
 
 use crate::core::chunk_dict::{ChunkDict, HashChunkDict};
@@ -157,8 +159,8 @@ impl ImageStat {
         }
     }
 
-    pub fn stat(&mut self, path: &Path, is_base: bool) -> Result<()> {
-        let rs = RafsSuper::load_from_metadata(path, RafsMode::Direct, false)?;
+    pub fn stat(&mut self, path: &Path, is_base: bool, config: Arc<ConfigV2>) -> Result<()> {
+        let (rs, _) = RafsSuper::load_from_file(path, false, false, config)?;
         let mut dict = HashChunkDict::default();
         let mut hardlinks = HashSet::new();
         let tree =

--- a/src/bin/nydus-image/stat.rs
+++ b/src/bin/nydus-image/stat.rs
@@ -161,7 +161,7 @@ impl ImageStat {
     }
 
     pub fn stat(&mut self, path: &Path, is_base: bool, config: Arc<ConfigV2>) -> Result<()> {
-        let (rs, _) = RafsSuper::load_from_file(path, false, false, config)?;
+        let (rs, _) = RafsSuper::load_from_file(path, config, false, false, true)?;
         let mut dict = HashChunkDict::new(rs.meta.get_digester());
         let mut hardlinks = HashSet::new();
         let tree =

--- a/src/bin/nydus-image/stat.rs
+++ b/src/bin/nydus-image/stat.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 use anyhow::{Context, Result};
 use nydus_api::ConfigV2;
 use nydus_rafs::metadata::RafsSuper;
+use nydus_utils::digest;
 use serde::Serialize;
 
 use crate::core::chunk_dict::{ChunkDict, HashChunkDict};
@@ -147,21 +148,21 @@ pub(crate) struct ImageStat {
 }
 
 impl ImageStat {
-    pub fn new() -> Self {
+    pub fn new(digester: digest::Algorithm) -> Self {
         ImageStat {
             dedup_enabled: false,
             target_enabled: false,
 
             base_image: ImageInfo::new(),
             target_image: ImageInfo::new(),
-            dedup_dict: Default::default(),
+            dedup_dict: HashChunkDict::new(digester),
             dedup_info: [Default::default(); 20],
         }
     }
 
     pub fn stat(&mut self, path: &Path, is_base: bool, config: Arc<ConfigV2>) -> Result<()> {
         let (rs, _) = RafsSuper::load_from_file(path, false, false, config)?;
-        let mut dict = HashChunkDict::default();
+        let mut dict = HashChunkDict::new(rs.meta.get_digester());
         let mut hardlinks = HashSet::new();
         let tree =
             Tree::from_bootstrap(&rs, &mut dict).context("failed to load bootstrap for stats")?;
@@ -208,11 +209,16 @@ impl ImageStat {
                 image.own_chunks += 1;
                 image.own_comp_size += entry.0.compressed_size() as u64;
                 image.own_uncomp_size += entry.0.uncompressed_size() as u64;
-                self.dedup_dict.add_chunk(entry.0.clone());
+                self.dedup_dict
+                    .add_chunk(entry.0.clone(), rs.meta.get_digester());
             }
         } else {
             for entry in dict.m.values() {
-                if self.dedup_dict.get_chunk(entry.0.id()).is_some() {
+                if self
+                    .dedup_dict
+                    .get_chunk(entry.0.id(), entry.0.uncompressed_size())
+                    .is_some()
+                {
                     image.ref_chunks += 1;
                     image.ref_comp_size += entry.0.compressed_size() as u64;
                     image.ref_uncomp_size += entry.0.uncompressed_size() as u64;

--- a/src/bin/nydus-image/unpack/mod.rs
+++ b/src/bin/nydus-image/unpack/mod.rs
@@ -61,9 +61,10 @@ impl OCIUnpacker {
     fn load_rafs(&self, config: Arc<ConfigV2>) -> Result<RafsSuper> {
         let (rs, _) = RafsSuper::load_from_file(
             self.bootstrap.as_path(),
+            config.clone(),
             config.is_chunk_validation_enabled(),
             false,
-            config.clone(),
+            true,
         )?;
         Ok(rs)
     }

--- a/src/bin/nydus-image/validator.rs
+++ b/src/bin/nydus-image/validator.rs
@@ -20,7 +20,7 @@ pub struct Validator {
 
 impl Validator {
     pub fn new(bootstrap_path: &Path, config: Arc<ConfigV2>) -> Result<Self> {
-        let (sb, _) = RafsSuper::load_from_file(bootstrap_path, true, false, config)?;
+        let (sb, _) = RafsSuper::load_from_file(bootstrap_path, config, true, false, true)?;
 
         Ok(Self { sb })
     }

--- a/src/bin/nydus-image/validator.rs
+++ b/src/bin/nydus-image/validator.rs
@@ -8,7 +8,8 @@ use std::path::Path;
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
-use nydus_rafs::metadata::{RafsMode, RafsSuper};
+use nydus_api::ConfigV2;
+use nydus_rafs::metadata::RafsSuper;
 use nydus_storage::device::BlobInfo;
 
 use crate::tree::Tree;
@@ -18,8 +19,8 @@ pub struct Validator {
 }
 
 impl Validator {
-    pub fn new(bootstrap_path: &Path) -> Result<Self> {
-        let sb = RafsSuper::load_from_metadata(bootstrap_path, RafsMode::Direct, true)?;
+    pub fn new(bootstrap_path: &Path, config: Arc<ConfigV2>) -> Result<Self> {
+        let (sb, _) = RafsSuper::load_from_file(bootstrap_path, true, false, config)?;
 
         Ok(Self { sb })
     }

--- a/src/blob_cache.rs
+++ b/src/blob_cache.rs
@@ -14,7 +14,7 @@ use nydus_api::{
     BlobCacheEntry, BlobCacheList, BlobCacheObjectId, ConfigV2, BLOB_CACHE_TYPE_DATA_BLOB,
     BLOB_CACHE_TYPE_META_BLOB,
 };
-use nydus_rafs::metadata::{RafsMode, RafsSuper};
+use nydus_rafs::metadata::RafsSuper;
 use nydus_storage::device::BlobInfo;
 
 const ID_SPLITTER: &str = "/";
@@ -92,7 +92,7 @@ impl BlobCacheObjectConfig {
     }
 
     fn new_data_blob(domain_id: String, blob_info: Arc<BlobInfo>, config: Arc<ConfigV2>) -> Self {
-        let scoped_blob_id = generate_blob_key(&domain_id, blob_info.blob_id());
+        let scoped_blob_id = generate_blob_key(&domain_id, &blob_info.blob_id());
 
         BlobCacheObjectConfig::DataBlob(Arc::new(BlobCacheConfigDataBlob {
             blob_info,
@@ -343,7 +343,7 @@ impl BlobCacheMgr {
         path: PathBuf,
         factory_config: Arc<ConfigV2>,
     ) -> Result<()> {
-        let rs = RafsSuper::load_from_metadata(&path, RafsMode::Direct, true)?;
+        let (rs, _) = RafsSuper::load_from_file(&path, true, false, factory_config.clone())?;
         let meta = BlobCacheObjectConfig::new_meta_blob(
             domain_id.to_string(),
             id.to_string(),

--- a/src/blob_cache.rs
+++ b/src/blob_cache.rs
@@ -343,7 +343,7 @@ impl BlobCacheMgr {
         path: PathBuf,
         factory_config: Arc<ConfigV2>,
     ) -> Result<()> {
-        let (rs, _) = RafsSuper::load_from_file(&path, true, false, factory_config.clone())?;
+        let (rs, _) = RafsSuper::load_from_file(&path, factory_config.clone(), true, false, true)?;
         let meta = BlobCacheObjectConfig::new_meta_blob(
             domain_id.to_string(),
             id.to_string(),

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -12,6 +12,7 @@ edition = "2018"
 arc-swap = "1.5"
 base64 = { version = "0.13.0", optional = true }
 bitflags = "1.2.1"
+hex = "0.4.3"
 hmac = { version = "0.12.1", optional = true }
 hmac-sha1-compact = { version = "1.1.1", optional = true }
 http = { version = "0.2.8", optional = true }
@@ -29,7 +30,6 @@ tar = "0.4.38"
 time = { version = "0.3.14", features = ["formatting"], optional = true }
 tokio = { version = "1.19.0", features = ["rt", "rt-multi-thread", "sync", "time"] }
 url = { version = "2.1.1", optional = true }
-hex = "0.4.3"
 vm-memory = "0.9"
 fuse-backend-rs = "0.10"
 

--- a/storage/src/backend/mod.rs
+++ b/storage/src/backend/mod.rs
@@ -117,6 +117,23 @@ pub trait BlobReader: Send + Sync {
         }
     }
 
+    /// Read as much as possible data into buffer.
+    fn read_all(&self, buf: &mut [u8], offset: u64) -> BackendResult<usize> {
+        let mut off = 0usize;
+        let mut left = buf.len();
+
+        while left > 0 {
+            let cnt = self.read(&mut buf[off..], offset + off as u64)?;
+            if cnt == 0 {
+                break;
+            }
+            off += cnt;
+            left -= cnt;
+        }
+
+        Ok(off as usize)
+    }
+
     /// Read a range of data from the blob file into the provided buffers.
     ///
     /// Read data of range [offset, offset + max_size) from the blob file, and returns:

--- a/storage/src/backend/mod.rs
+++ b/storage/src/backend/mod.rs
@@ -13,6 +13,7 @@
 //!   The [LocalFs](localfs/struct.LocalFs.html) storage backend supports backend level data
 //!   prefetching, which is to load data into page cache.
 
+use std::fmt;
 use std::io::Read;
 use std::{sync::Arc, time::Duration};
 
@@ -58,6 +59,21 @@ pub enum BackendError {
     #[cfg(any(feature = "backend-oss", feature = "backend-s3"))]
     /// Error from object storage backend.
     ObjectStorage(self::object_storage::ObjectStorageError),
+}
+
+impl fmt::Display for BackendError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            BackendError::Unsupported(s) => write!(f, "{}", s),
+            BackendError::CopyData(e) => write!(f, "failed to copy data, {}", e),
+            #[cfg(feature = "backend-registry")]
+            BackendError::Registry(e) => write!(f, "{:?}", e),
+            #[cfg(feature = "backend-localfs")]
+            BackendError::LocalFs(e) => write!(f, "{}", e),
+            #[cfg(any(feature = "backend-oss", feature = "backend-s3"))]
+            BackendError::ObjectStorage(e) => write!(f, "{}", e),
+        }
+    }
 }
 
 /// Specialized `Result` for storage backends.

--- a/storage/src/backend/object_storage.rs
+++ b/storage/src/backend/object_storage.rs
@@ -5,6 +5,7 @@
 
 //! Base module used to implement object storage backend drivers (such as oss, s3, etc.).
 
+use std::fmt;
 use std::fmt::Debug;
 use std::io::{Error, Result};
 use std::marker::Send;
@@ -22,11 +23,24 @@ use super::{BackendError, BackendResult, BlobBackend, BlobReader};
 #[derive(Debug)]
 pub enum ObjectStorageError {
     Auth(Error),
-    Url(String),
     Request(ConnectionError),
     ConstructHeader(String),
     Transport(reqwest::Error),
     Response(String),
+}
+
+impl fmt::Display for ObjectStorageError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            ObjectStorageError::Auth(e) => write!(f, "failed to generate auth info, {}", e),
+            ObjectStorageError::Request(e) => write!(f, "network communication error, {}", e),
+            ObjectStorageError::ConstructHeader(e) => {
+                write!(f, "failed to generate HTTP header, {}", e)
+            }
+            ObjectStorageError::Transport(e) => write!(f, "network communication error, {}", e),
+            ObjectStorageError::Response(s) => write!(f, "network communication error, {}", s),
+        }
+    }
 }
 
 impl From<ObjectStorageError> for BackendError {

--- a/storage/src/cache/cachedfile.rs
+++ b/storage/src/cache/cachedfile.rs
@@ -118,6 +118,7 @@ impl FileCacheMeta {
 }
 
 pub(crate) struct FileCacheEntry {
+    pub(crate) blob_id: String,
     pub(crate) blob_info: Arc<BlobInfo>,
     pub(crate) chunk_map: Arc<dyn ChunkMap>,
     pub(crate) file: Arc<File>,
@@ -371,7 +372,7 @@ impl AsRawFd for FileCacheEntry {
 
 impl BlobCache for FileCacheEntry {
     fn blob_id(&self) -> &str {
-        self.blob_info.blob_id()
+        &self.blob_id
     }
 
     fn blob_uncompressed_size(&self) -> Result<u64> {
@@ -446,8 +447,7 @@ impl BlobCache for FileCacheEntry {
                 warn!("storage: inaccurate prefetch status");
             }
             if val == 0 || val == 1 {
-                self.workers
-                    .flush_pending_prefetch_requests(self.blob_info.blob_id());
+                self.workers.flush_pending_prefetch_requests(&self.blob_id);
                 return Ok(());
             }
         }

--- a/storage/src/cache/cachedfile.rs
+++ b/storage/src/cache/cachedfile.rs
@@ -53,9 +53,10 @@ impl FileCacheMeta {
         reader: Option<Arc<dyn BlobReader>>,
         runtime: Option<Arc<Runtime>>,
         sync: bool,
+        validation: bool,
     ) -> Result<Self> {
         if sync {
-            match BlobMetaInfo::new(&blob_file, &blob_info, reader.as_ref()) {
+            match BlobMetaInfo::new(&blob_file, &blob_info, reader.as_ref(), validation) {
                 Ok(m) => Ok(FileCacheMeta {
                     has_error: Arc::new(AtomicBool::new(false)),
                     meta: Arc::new(Mutex::new(Some(Arc::new(m)))),
@@ -77,7 +78,8 @@ impl FileCacheMeta {
                         Duration::from_millis(DOWNLOAD_META_RETRY_DELAY),
                     );
                     while retry < DOWNLOAD_META_RETRY_COUNT {
-                        match BlobMetaInfo::new(&blob_file, &blob_info, reader.as_ref()) {
+                        match BlobMetaInfo::new(&blob_file, &blob_info, reader.as_ref(), validation)
+                        {
                             Ok(m) => {
                                 *meta1.meta.lock().unwrap() = Some(Arc::new(m));
                                 return;

--- a/storage/src/cache/dummycache.rs
+++ b/storage/src/cache/dummycache.rs
@@ -36,6 +36,7 @@ use crate::utils::{alloc_buf, copyv};
 use crate::{StorageError, StorageResult};
 
 struct DummyCache {
+    blob_id: String,
     blob_info: Arc<BlobInfo>,
     chunk_map: Arc<dyn ChunkMap>,
     reader: Arc<dyn BlobReader>,
@@ -47,7 +48,7 @@ struct DummyCache {
 
 impl BlobCache for DummyCache {
     fn blob_id(&self) -> &str {
-        self.blob_info.blob_id()
+        &self.blob_id
     }
 
     fn blob_uncompressed_size(&self) -> Result<u64> {
@@ -208,10 +209,11 @@ impl BlobCacheMgr for DummyCacheMgr {
             ));
         }
 
-        let blob_id = blob_info.blob_id().to_owned();
+        let blob_id = blob_info.blob_id();
         let reader = self.backend.get_reader(&blob_id).map_err(|e| eother!(e))?;
 
         Ok(Arc::new(DummyCache {
+            blob_id,
             blob_info: blob_info.clone(),
             chunk_map: Arc::new(NoopChunkMap::new(self.cached)),
             reader,

--- a/storage/src/cache/filecache/mod.rs
+++ b/storage/src/cache/filecache/mod.rs
@@ -190,12 +190,10 @@ impl FileCacheEntry {
             .open(blob_file_path.clone() + suffix)?;
         let (chunk_map, is_direct_chunkmap) =
             Self::create_chunk_map(mgr, &blob_info, &blob_file_path)?;
-        let reader = mgr.backend.get_reader(&blob_id).map_err(|e| {
-            eio!(format!(
-                "failed to get reader for blob {}, {:?}",
-                blob_id, e
-            ))
-        })?;
+        let reader = mgr
+            .backend
+            .get_reader(&blob_id)
+            .map_err(|e| eio!(format!("failed to get reader for blob {}, {}", blob_id, e)))?;
         let rafs_blob_reader = if is_zran {
             mgr.backend
                 .get_reader(&rafs_blob_id)

--- a/storage/src/cache/fscache/mod.rs
+++ b/storage/src/cache/fscache/mod.rs
@@ -76,7 +76,7 @@ impl FsCacheMgr {
 
     // Get the file cache entry for the specified blob object.
     fn get(&self, blob: &Arc<BlobInfo>) -> Option<Arc<FileCacheEntry>> {
-        self.blobs.read().unwrap().get(blob.blob_id()).cloned()
+        self.blobs.read().unwrap().get(&blob.blob_id()).cloned()
     }
 
     // Create a file cache entry for the specified blob object if not present, otherwise
@@ -95,15 +95,16 @@ impl FsCacheMgr {
         )?;
         let entry = Arc::new(entry);
         let mut guard = self.blobs.write().unwrap();
-        if let Some(entry) = guard.get(blob.blob_id()) {
+        if let Some(entry) = guard.get(&blob.blob_id()) {
             Ok(entry.clone())
         } else {
-            guard.insert(blob.blob_id().to_owned(), entry.clone());
+            let blob_id = blob.blob_id();
+            guard.insert(blob_id.clone(), entry.clone());
             self.metrics
                 .underlying_files
                 .lock()
                 .unwrap()
-                .insert(blob.blob_id().to_string());
+                .insert(blob_id);
             Ok(entry)
         }
     }
@@ -204,7 +205,14 @@ impl FileCacheEntry {
         let file = blob_info
             .get_fscache_file()
             .ok_or_else(|| einval!("No fscache file associated with the blob_info"))?;
-        let blob_file_path = format!("{}/{}", mgr.work_dir, blob_info.blob_id());
+        let is_zran = blob_info.has_feature(BlobFeatures::ZRAN);
+        let blob_id = blob_info.blob_id();
+        let rafs_blob_id = if is_zran {
+            blob_info.get_rafs_blob_id()?
+        } else {
+            blob_id.clone()
+        };
+        let blob_file_path = format!("{}/{}", mgr.work_dir, rafs_blob_id);
         let chunk_map = Arc::new(BlobStateMap::from(IndexedChunkMap::new(
             &blob_file_path,
             blob_info.chunk_count(),
@@ -212,20 +220,19 @@ impl FileCacheEntry {
         )?));
         let reader = mgr
             .backend
-            .get_reader(blob_info.blob_id())
-            .map_err(|_e| eio!("failed to get blob reader"))?;
+            .get_reader(&blob_id)
+            .map_err(|_e| eio!("failed to get reader for data blob"))?;
+        let rafs_blob_reader = if is_zran {
+            mgr.backend
+                .get_reader(&rafs_blob_id)
+                .map_err(|_e| eio!("failed to get reader for rafs blob"))?
+        } else {
+            reader.clone()
+        };
         let blob_compressed_size = Self::get_blob_size(&reader, &blob_info)?;
         let need_validation = mgr.need_validation
             && !blob_info.is_legacy_stargz()
             && blob_info.has_feature(BlobFeatures::INLINED_CHUNK_DIGEST);
-        let rafs_blob_reader = if blob_info.rafs_blob_digest() != &[0u8; 32] {
-            let ref_blob_id = hex::encode(blob_info.rafs_blob_digest());
-            mgr.backend
-                .get_reader(&ref_blob_id)
-                .map_err(|_e| eio!("failed to get rafs blob reader"))?
-        } else {
-            reader.clone()
-        };
         let meta = if blob_info.meta_ci_is_valid() {
             FileCacheMeta::new(
                 blob_file_path,
@@ -240,11 +247,11 @@ impl FileCacheEntry {
                 "fscache doesn't support blobs without blob meta information"
             ));
         };
-        let is_zran = blob_info.has_feature(BlobFeatures::ZRAN);
 
         Self::restore_chunk_map(blob_info.clone(), file.clone(), &meta, &chunk_map);
 
         Ok(FileCacheEntry {
+            blob_id,
             blob_info: blob_info.clone(),
             chunk_map,
             file,

--- a/storage/src/device.rs
+++ b/storage/src/device.rs
@@ -1069,6 +1069,21 @@ impl BlobDevice {
         }
     }
 
+    /// RAFS V6: get chunk information object for chunks.
+    pub fn get_chunk_info(
+        &self,
+        blob_index: u32,
+        chunk_index: u32,
+    ) -> Option<Arc<dyn BlobChunkInfo>> {
+        if (blob_index as usize) < self.blob_count {
+            let state = self.blobs.load();
+            let blob = &state[blob_index as usize];
+            blob.get_chunk_info(chunk_index)
+        } else {
+            None
+        }
+    }
+
     fn get_blob_by_iovec(&self, iovec: &BlobIoVec) -> Option<Arc<dyn BlobCache>> {
         let blob_index = iovec.blob_index();
         if (blob_index as usize) < self.blob_count {

--- a/storage/src/device.rs
+++ b/storage/src/device.rs
@@ -42,7 +42,7 @@ use crate::cache::BlobCache;
 use crate::factory::BLOB_FACTORY;
 
 pub(crate) const BLOB_FEATURE_INCOMPAT_MASK: u32 = 0x0000_ffff;
-pub(crate) const BLOB_FEATURE_INCOMPAT_VALUE: u32 = 0x0000_000f;
+pub(crate) const BLOB_FEATURE_INCOMPAT_VALUE: u32 = 0x0000_001f;
 
 bitflags! {
     /// Features bits for blob management.
@@ -55,6 +55,8 @@ bitflags! {
         const CHUNK_INFO_V2 = 0x0000_0004;
         /// Blob compression information data include context data for zlib random access.
         const ZRAN = 0x0000_0008;
+        /// Chunk digest array is inlined in the data blob.
+        const INLINED_CHUNK_DIGEST = 0x0000_0010;
         /// Rafs V5 image without extended blob table, this is an internal flag.
         const _V5_NO_EXT_BLOB_TABLE = 0x1000_0000;
     }

--- a/storage/src/factory.rs
+++ b/storage/src/factory.rs
@@ -121,7 +121,7 @@ impl BlobFactory {
         if let Some(mgr) = guard.get(&key) {
             return mgr.get_blob_cache(blob_info);
         }
-        let backend = Self::new_backend(backend_cfg, blob_info.blob_id())?;
+        let backend = Self::new_backend(backend_cfg, &blob_info.blob_id())?;
         let mgr = match cache_cfg.cache_type.as_str() {
             "blobcache" | "filecache" => {
                 let mgr = FileCacheMgr::new(cache_cfg, backend, ASYNC_RUNTIME.clone(), &config.id)?;

--- a/storage/src/meta/chunk_info_v1.rs
+++ b/storage/src/meta/chunk_info_v1.rs
@@ -132,6 +132,7 @@ mod tests {
     use std::sync::Arc;
 
     use nydus_utils::compress;
+    use nydus_utils::digest::RafsDigest;
     use nydus_utils::filemap::FileMapState;
     use nydus_utils::metrics::BackendMetrics;
     use vmm_sys_util::tempfile::TempFile;
@@ -205,9 +206,12 @@ mod tests {
                     comp_info: u64::to_le(0x00ff_f000_0010_0000),
                 },
             ])),
+            chunk_digest_array: Default::default(),
             zran_info_array: Default::default(),
             zran_dict_table: Default::default(),
-            filemap: FileMapState::default(),
+            blob_meta_file_map: FileMapState::default(),
+            chunk_digest_file_map: FileMapState::default(),
+            chunk_digest_default: RafsDigest::default(),
         };
 
         assert_eq!(
@@ -281,9 +285,12 @@ mod tests {
                     comp_info: u64::to_le(0x00ff_f000_0000_5000),
                 },
             ])),
+            chunk_digest_array: Default::default(),
             zran_info_array: Default::default(),
             zran_dict_table: Default::default(),
-            filemap: FileMapState::default(),
+            blob_meta_file_map: FileMapState::default(),
+            chunk_digest_file_map: FileMapState::default(),
+            chunk_digest_default: RafsDigest::default(),
         };
         let info = BlobMetaInfo {
             state: Arc::new(state),

--- a/storage/src/meta/chunk_info_v2.rs
+++ b/storage/src/meta/chunk_info_v2.rs
@@ -212,6 +212,7 @@ impl Display for BlobChunkInfoV2Ondisk {
 mod tests {
     use super::*;
     use crate::meta::BlobMetaChunkArray;
+    use nydus_utils::digest::RafsDigest;
     use nydus_utils::filemap::FileMapState;
     use std::mem::ManuallyDrop;
 
@@ -286,9 +287,12 @@ mod tests {
                     data: 0,
                 },
             ])),
+            chunk_digest_array: Default::default(),
             zran_info_array: Default::default(),
             zran_dict_table: Default::default(),
-            filemap: FileMapState::default(),
+            blob_meta_file_map: FileMapState::default(),
+            chunk_digest_file_map: FileMapState::default(),
+            chunk_digest_default: RafsDigest::default(),
         };
 
         assert_eq!(

--- a/storage/src/meta/mod.rs
+++ b/storage/src/meta/mod.rs
@@ -246,6 +246,15 @@ impl BlobMetaHeaderOndisk {
         }
     }
 
+    /// Set flag indicating whether RAFS meta is inlined in the data blob.
+    pub fn set_inlined_meta(&mut self, inlined: bool) {
+        if inlined {
+            self.s_features |= BlobFeatures::INLINED_META.bits();
+        } else {
+            self.s_features &= !BlobFeatures::INLINED_META.bits();
+        }
+    }
+
     /// Set flag indicating whether to chunk information format v2 is used or not.
     pub fn set_chunk_info_v2(&mut self, enable: bool) {
         if enable {

--- a/storage/src/meta/mod.rs
+++ b/storage/src/meta/mod.rs
@@ -247,11 +247,11 @@ impl BlobMetaHeaderOndisk {
     }
 
     /// Set flag indicating whether RAFS meta is inlined in the data blob.
-    pub fn set_inlined_meta(&mut self, inlined: bool) {
+    pub fn set_inlined_fs_meta(&mut self, inlined: bool) {
         if inlined {
-            self.s_features |= BlobFeatures::INLINED_META.bits();
+            self.s_features |= BlobFeatures::INLINED_FS_META.bits();
         } else {
-            self.s_features &= !BlobFeatures::INLINED_META.bits();
+            self.s_features &= !BlobFeatures::INLINED_FS_META.bits();
         }
     }
 
@@ -283,11 +283,11 @@ impl BlobMetaHeaderOndisk {
     }
 
     /// Set flag indicating having inlined-meta capability.
-    pub fn set_cap_inlined_meta(&mut self, enable: bool) {
+    pub fn set_cap_tar_toc(&mut self, enable: bool) {
         if enable {
-            self.s_features |= BlobFeatures::CAP_INLINED_META.bits();
+            self.s_features |= BlobFeatures::CAP_TAR_TOC.bits();
         } else {
-            self.s_features &= !BlobFeatures::CAP_INLINED_META.bits();
+            self.s_features &= !BlobFeatures::CAP_TAR_TOC.bits();
         }
     }
 
@@ -1660,7 +1660,7 @@ pub(crate) mod tests {
         let path = PathBuf::from(root_dir).join("../tests/texture/zran/233c72f2b6b698c07021c4da367cfe2dff4f049efbaa885ca0ff760ea297865a");
 
         let features = BlobFeatures::ALIGNED
-            | BlobFeatures::INLINED_META
+            | BlobFeatures::INLINED_FS_META
             | BlobFeatures::CHUNK_INFO_V2
             | BlobFeatures::ZRAN;
         let mut blob_info = BlobInfo::new(
@@ -1713,7 +1713,7 @@ pub(crate) mod tests {
         let path = PathBuf::from(root_dir).join("../tests/texture/zran/233c72f2b6b698c07021c4da367cfe2dff4f049efbaa885ca0ff760ea297865a");
 
         let features = BlobFeatures::ALIGNED
-            | BlobFeatures::INLINED_META
+            | BlobFeatures::INLINED_FS_META
             | BlobFeatures::CHUNK_INFO_V2
             | BlobFeatures::ZRAN;
         let mut blob_info = BlobInfo::new(
@@ -1770,7 +1770,7 @@ pub(crate) mod tests {
         let path = PathBuf::from(root_dir).join("../tests/texture/zran/233c72f2b6b698c07021c4da367cfe2dff4f049efbaa885ca0ff760ea297865a");
 
         let features = BlobFeatures::ALIGNED
-            | BlobFeatures::INLINED_META
+            | BlobFeatures::INLINED_FS_META
             | BlobFeatures::CHUNK_INFO_V2
             | BlobFeatures::ZRAN;
         let mut blob_info = BlobInfo::new(

--- a/storage/src/meta/mod.rs
+++ b/storage/src/meta/mod.rs
@@ -43,15 +43,17 @@ use std::fs::OpenOptions;
 use std::io::Result;
 use std::mem::{size_of, ManuallyDrop};
 use std::ops::{Add, BitAnd, Not};
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use nydus_utils::compress;
 use nydus_utils::compress::zlib_random::ZranContext;
-use nydus_utils::digest::RafsDigest;
+use nydus_utils::digest::{DigestData, RafsDigest};
 use nydus_utils::filemap::FileMapState;
 
 use crate::backend::BlobReader;
 use crate::device::{BlobChunkInfo, BlobFeatures, BlobInfo};
+use crate::meta::toc::{TocEntryList, TocLocation};
 use crate::utils::alloc_buf;
 use crate::{RAFS_MAX_CHUNKS_PER_BLOB, RAFS_MAX_CHUNK_SIZE};
 
@@ -76,7 +78,9 @@ const BLOB_METADATA_V2_MAX_SIZE: u64 = RAFS_MAX_CHUNK_SIZE * 24;
 const BLOB_METADATA_V2_RESERVED_SIZE: u64 = BLOB_METADATA_HEADER_SIZE - 64;
 
 /// File suffix for blob meta file.
-pub const FILE_SUFFIX: &str = "blob.meta";
+const META_FILE_SUFFIX: &str = "blob.meta";
+const DIGEST_FILE_SUFFIX: &str = "blob.digest";
+const TOC_FILE_SUFFIX: &str = "blob.toc";
 
 /// On disk format for blob meta data header, containing meta information for a data blob.
 #[repr(C)]
@@ -259,6 +263,15 @@ impl BlobMetaHeaderOndisk {
         }
     }
 
+    /// Set flag indicating that chunk digest is inlined in the data blob.
+    pub fn set_inlined_chunk_digest(&mut self, enable: bool) {
+        if enable {
+            self.s_features |= BlobFeatures::INLINED_CHUNK_DIGEST.bits();
+        } else {
+            self.s_features &= !BlobFeatures::INLINED_CHUNK_DIGEST.bits();
+        }
+    }
+
     /// Get blob meta feature flags.
     pub fn features(&self) -> u32 {
         self.s_features
@@ -298,6 +311,7 @@ impl BlobMetaInfo {
         blob_path: &str,
         blob_info: &BlobInfo,
         reader: Option<&Arc<dyn BlobReader>>,
+        load_chunk_digest: bool,
     ) -> Result<Self> {
         assert_eq!(
             size_of::<BlobMetaHeaderOndisk>() as u64,
@@ -313,7 +327,7 @@ impl BlobMetaInfo {
         }
 
         let uncompressed_size = blob_info.meta_ci_uncompressed_size() as usize;
-        let meta_path = format!("{}.{}", blob_path, FILE_SUFFIX);
+        let meta_path = format!("{}.{}", blob_path, META_FILE_SUFFIX);
         trace!(
             "try to open blob meta file: path {:?} uncompressed_size {} chunk_count {}",
             meta_path,
@@ -351,19 +365,19 @@ impl BlobMetaInfo {
         let base = filemap.validate_range(0, expected_size)?;
         let header = filemap.get_mut::<BlobMetaHeaderOndisk>(aligned_uncompressed_size as usize)?;
         if !Self::validate_header(blob_info, header)? {
-            if !enable_write {
+            if let Some(reader) = reader {
+                let buffer =
+                    unsafe { std::slice::from_raw_parts_mut(base as *mut u8, expected_size) };
+                buffer[0..].fill(0);
+                Self::read_metadata(blob_info, reader, buffer)?;
+                assert!(Self::validate_header(blob_info, header).is_ok());
+                filemap.sync_data()?;
+            } else {
                 return Err(enoent!(format!(
                     "blob metadata file '{}' header is invalid",
                     meta_path
                 )));
             }
-
-            let buffer = unsafe { std::slice::from_raw_parts_mut(base as *mut u8, expected_size) };
-            buffer[0..].fill(0);
-            Self::read_metadata(blob_info, reader.as_ref().unwrap(), buffer)?;
-
-            assert!(Self::validate_header(blob_info, header).is_ok());
-            filemap.sync_data()?;
         }
 
         let chunk_infos = BlobMetaChunkArray::from_file_map(&filemap, blob_info)?;
@@ -374,20 +388,25 @@ impl BlobMetaInfo {
             compressed_size: blob_info.compressed_size(),
             uncompressed_size: round_up_4k(blob_info.uncompressed_size()),
             chunk_info_array: chunk_infos,
+            chunk_digest_array: Default::default(),
             zran_info_array: Default::default(),
             zran_dict_table: Default::default(),
-            filemap,
+            blob_meta_file_map: filemap,
+            chunk_digest_file_map: FileMapState::default(),
+            chunk_digest_default: RafsDigest::default(),
         };
 
         if blob_info.has_feature(BlobFeatures::ZRAN) {
             let header = state
-                .filemap
+                .blob_meta_file_map
                 .get_mut::<BlobMetaHeaderOndisk>(aligned_uncompressed_size as usize)?;
             let zran_offset = header.s_ci_zran_offset as usize;
             let zran_count = header.s_ci_zran_count as usize;
             let ci_zran_size = header.s_ci_zran_size as usize;
             let zran_size = header.s_ci_zran_count as usize * size_of::<ZranInflateContext>();
-            let ptr = state.filemap.validate_range(zran_offset, zran_size)?;
+            let ptr = state
+                .blob_meta_file_map
+                .validate_range(zran_offset, zran_size)?;
             let array = unsafe {
                 Vec::from_raw_parts(
                     ptr as *mut u8 as *mut ZranInflateContext,
@@ -399,11 +418,64 @@ impl BlobMetaInfo {
 
             let zran_dict_size = ci_zran_size - zran_size;
             let ptr = state
-                .filemap
+                .blob_meta_file_map
                 .validate_range(zran_offset + zran_size, zran_dict_size)?;
             let array =
                 unsafe { Vec::from_raw_parts(ptr as *mut u8, zran_dict_size, zran_dict_size) };
             state.zran_dict_table = ManuallyDrop::new(array);
+        }
+
+        if load_chunk_digest && blob_info.has_feature(BlobFeatures::INLINED_CHUNK_DIGEST) {
+            let digest_path = PathBuf::from(format!("{}.{}", blob_path, DIGEST_FILE_SUFFIX));
+            if let Some(reader) = reader {
+                let toc_path = format!("{}.{}", blob_path, TOC_FILE_SUFFIX);
+                let location = if blob_info.rafs_blob_toc_size() != 0 {
+                    let offset =
+                        blob_info.compressed_size() - blob_info.rafs_blob_toc_size() as u64;
+                    let mut location =
+                        TocLocation::new(offset, blob_info.rafs_blob_toc_size() as u64);
+                    let digest = blob_info.rafs_blob_toc_digest();
+                    for c in digest {
+                        if *c != 0 {
+                            location.validate_digest = true;
+                            location.digest.data = *digest;
+                            break;
+                        }
+                    }
+                    location
+                } else {
+                    TocLocation::default()
+                };
+                let toc_list =
+                    TocEntryList::read_from_cache_file(&toc_path, reader.as_ref(), &location)?;
+                toc_list.extract_from_blob(reader.clone(), None, Some(&digest_path))?;
+            }
+            if !digest_path.exists() {
+                return Err(eother!("failed to download chunk digest file from blob"));
+            }
+
+            let file = OpenOptions::new().read(true).open(&digest_path)?;
+            let md = file.metadata()?;
+            let size = 32 * blob_info.chunk_count() as usize;
+            if md.len() != size as u64 {
+                return Err(eother!(format!(
+                    "size of chunk digest file doesn't match, expect {}, got {}",
+                    size,
+                    md.len()
+                )));
+            }
+
+            let file_map = FileMapState::new(file, 0, size, false)?;
+            let ptr = file_map.validate_range(0, size)?;
+            let array = unsafe {
+                Vec::from_raw_parts(
+                    ptr as *mut u8 as *mut _,
+                    chunk_count as usize,
+                    chunk_count as usize,
+                )
+            };
+            state.chunk_digest_file_map = file_map;
+            state.chunk_digest_array = ManuallyDrop::new(array);
         }
 
         Ok(BlobMetaInfo {
@@ -498,10 +570,27 @@ impl BlobMetaInfo {
         self.state.add_more_chunks(chunks, max_size)
     }
 
+    /// Get uncompressed offset of chunks.
     pub fn get_uncompressed_offset(&self, chunk_index: usize) -> u64 {
         self.state.get_uncompressed_offset(chunk_index)
     }
 
+    /// Get number of chunks in the data blob.
+    pub fn get_chunk_count(&self) -> usize {
+        self.state.chunk_info_array.len()
+    }
+
+    /// Get content digest for chunks.
+    pub fn get_chunk_digest(&self, chunk_index: usize) -> Option<&[u8]> {
+        self.state.get_chunk_digest(chunk_index)
+    }
+
+    /// Get `BlobChunkInfo` object for chunks.
+    pub fn get_chunk_info(&self, chunk_index: usize) -> Arc<dyn BlobChunkInfo> {
+        BlobMetaChunk::new(chunk_index, &self.state)
+    }
+
+    /// Get chunk index for an uncompressed offset.
     pub fn get_chunk_index(&self, addr: u64) -> Result<usize> {
         self.state.get_chunk_index(addr)
     }
@@ -678,9 +767,12 @@ pub struct BlobMetaState {
     pub(crate) compressed_size: u64,
     pub(crate) uncompressed_size: u64,
     pub(crate) chunk_info_array: ManuallyDrop<BlobMetaChunkArray>,
+    pub(crate) chunk_digest_array: ManuallyDrop<Vec<DigestData>>,
     pub(crate) zran_info_array: ManuallyDrop<Vec<ZranInflateContext>>,
     pub(crate) zran_dict_table: ManuallyDrop<Vec<u8>>,
-    filemap: FileMapState,
+    blob_meta_file_map: FileMapState,
+    chunk_digest_file_map: FileMapState,
+    chunk_digest_default: RafsDigest,
 }
 
 impl BlobMetaState {
@@ -717,6 +809,14 @@ impl BlobMetaState {
 
     fn get_uncompressed_offset(&self, chunk_index: usize) -> u64 {
         self.chunk_info_array.uncompressed_offset(chunk_index)
+    }
+
+    fn get_chunk_digest(&self, chunk_index: usize) -> Option<&[u8]> {
+        if chunk_index < self.chunk_digest_array.len() {
+            Some(&self.chunk_digest_array[chunk_index])
+        } else {
+            None
+        }
     }
 
     fn get_chunk_index(&self, addr: u64) -> Result<usize> {
@@ -1328,7 +1428,12 @@ impl BlobMetaChunk {
 
 impl BlobChunkInfo for BlobMetaChunk {
     fn chunk_id(&self) -> &RafsDigest {
-        panic!("BlobMetaChunk doesn't support `chunk_id()`");
+        if self.chunk_index < self.meta.chunk_digest_array.len() {
+            let digest = &self.meta.chunk_digest_array[self.chunk_index];
+            digest.into()
+        } else {
+            &self.meta.chunk_digest_default
+        }
     }
 
     fn id(&self) -> u32 {
@@ -1512,7 +1617,7 @@ pub(crate) mod tests {
             features,
         );
         blob_info.set_blob_meta_info(0, 0xa1290, 0xa1290, compress::Algorithm::None as u32);
-        let meta = BlobMetaInfo::new(&path.display().to_string(), &blob_info, None).unwrap();
+        let meta = BlobMetaInfo::new(&path.display().to_string(), &blob_info, None, false).unwrap();
         assert_eq!(meta.state.chunk_info_array.len(), 0xa3);
         assert_eq!(meta.state.zran_info_array.len(), 0x15);
         assert_eq!(meta.state.zran_dict_table.len(), 0xa0348 - 0x15 * 40);
@@ -1565,7 +1670,7 @@ pub(crate) mod tests {
             features,
         );
         blob_info.set_blob_meta_info(0, 0xa1290, 0xa1290, compress::Algorithm::None as u32);
-        let meta = BlobMetaInfo::new(&path.display().to_string(), &blob_info, None).unwrap();
+        let meta = BlobMetaInfo::new(&path.display().to_string(), &blob_info, None, false).unwrap();
         assert_eq!(meta.state.chunk_info_array.len(), 0xa3);
         assert_eq!(meta.state.zran_info_array.len(), 0x15);
         assert_eq!(meta.state.zran_dict_table.len(), 0xa0348 - 0x15 * 40);
@@ -1622,7 +1727,7 @@ pub(crate) mod tests {
             features,
         );
         blob_info.set_blob_meta_info(0, 0xa1290, 0xa1290, compress::Algorithm::None as u32);
-        let meta = BlobMetaInfo::new(&path.display().to_string(), &blob_info, None).unwrap();
+        let meta = BlobMetaInfo::new(&path.display().to_string(), &blob_info, None, false).unwrap();
         assert_eq!(meta.state.chunk_info_array.len(), 0xa3);
         assert_eq!(meta.state.zran_info_array.len(), 0x15);
         assert_eq!(meta.state.zran_dict_table.len(), 0xa0348 - 0x15 * 40);

--- a/storage/src/meta/mod.rs
+++ b/storage/src/meta/mod.rs
@@ -1575,6 +1575,9 @@ pub fn format_blob_features(features: BlobFeatures) -> String {
     if features.contains(BlobFeatures::ZRAN) {
         output += "zran ";
     }
+    if features.contains(BlobFeatures::INLINED_CHUNK_DIGEST) {
+        output += "chunk-digest ";
+    }
     output.trim_end().to_string()
 }
 

--- a/storage/src/meta/mod.rs
+++ b/storage/src/meta/mod.rs
@@ -282,6 +282,15 @@ impl BlobMetaHeaderOndisk {
         }
     }
 
+    /// Set flag indicating having inlined-meta capability.
+    pub fn set_cap_inlined_meta(&mut self, enable: bool) {
+        if enable {
+            self.s_features |= BlobFeatures::CAP_INLINED_META.bits();
+        } else {
+            self.s_features &= !BlobFeatures::CAP_INLINED_META.bits();
+        }
+    }
+
     /// Get blob meta feature flags.
     pub fn features(&self) -> u32 {
         self.s_features

--- a/storage/src/meta/toc.rs
+++ b/storage/src/meta/toc.rs
@@ -425,7 +425,7 @@ impl TocEntryList {
 
     fn parse(buf: &[u8], size: usize, location: &TocLocation) -> Result<Self> {
         if location.validate_digest {
-            let dv = digest::RafsDigest::from_buf(&buf, digest::Algorithm::Sha256);
+            let dv = digest::RafsDigest::from_buf(buf, digest::Algorithm::Sha256);
             if dv != location.digest {
                 return Err(eother!("toc content digest value doesn't match"));
             }
@@ -603,10 +603,8 @@ impl TocLocation {
     }
 
     fn validate(&self) -> Result<()> {
-        if !self.auto_detect {
-            if !(512..=0x10000).contains(&self.size) || self.size % 128 != 0 {
-                return Err(eother!(format!("invalid size {} of blob ToC", self.size)));
-            }
+        if !self.auto_detect && (!(512..=0x10000).contains(&self.size) || self.size % 128 != 0) {
+            return Err(eother!(format!("invalid size {} of blob ToC", self.size)));
         }
 
         Ok(())

--- a/storage/src/meta/toc.rs
+++ b/storage/src/meta/toc.rs
@@ -363,7 +363,7 @@ impl TocEntryList {
         let (offset, size) = if location.auto_detect {
             let blob_size = reader
                 .blob_size()
-                .map_err(|e| eio!(format!("failed to get blob size, {:?}", e)))?;
+                .map_err(|e| eio!(format!("failed to get blob size, {}", e)))?;
             let size = if blob_size > 0x1000 {
                 0x1000
             } else {
@@ -378,7 +378,7 @@ impl TocEntryList {
         let mut buf = alloc_buf(size);
         let sz = reader
             .read(&mut buf, offset)
-            .map_err(|e| eother!(format!("failed to read ToC from backend, {:?}", e)))?;
+            .map_err(|e| eother!(format!("failed to read ToC from backend, {}", e)))?;
         if sz != size {
             return Err(eother!(format!(
                 "failed to read ToC from backend, expect {}, got {} bytes",
@@ -390,7 +390,7 @@ impl TocEntryList {
             writer.write_all(&buf)?;
         }
 
-        Self::parse(&buf, size, location)
+        Self::parse_toc_header(&buf, size, location)
     }
 
     /// Read a `TocEntryList` from a cache file or the storage backend.
@@ -407,8 +407,8 @@ impl TocEntryList {
             if size > 512 && size % 128 == 0 && md.len() <= 0x1000 {
                 let mut buf = alloc_buf(size as usize);
                 file.read_exact(&mut buf)
-                    .map_err(|e| eother!(format!("failed to read ToC from cache, {:?}", e)))?;
-                if let Ok(toc) = Self::parse(&buf, size as usize, location) {
+                    .map_err(|e| eother!(format!("failed to read ToC from cache, {}", e)))?;
+                if let Ok(toc) = Self::parse_toc_header(&buf, size as usize, location) {
                     return Ok(toc);
                 }
             }
@@ -439,7 +439,7 @@ impl TocEntryList {
         }
     }
 
-    fn parse(buf: &[u8], size: usize, location: &TocLocation) -> Result<Self> {
+    fn parse_toc_header(buf: &[u8], size: usize, location: &TocLocation) -> Result<Self> {
         if size < 512 {
             return Err(einval!(format!("blob ToC size {} is too small", size)));
         }
@@ -602,7 +602,7 @@ impl TocEntryList {
         let blob_mgr = BlobFactory::new_backend(backend_config, "extract_rafs_meta")?;
         let reader = blob_mgr
             .get_reader(id)
-            .map_err(|e| eother!(format!("failed to get reader for blob {}, {:?}", id, e)))?;
+            .map_err(|e| eother!(format!("failed to get reader for blob {}, {}", id, e)))?;
         let location = TocLocation::default();
         let toc = TocEntryList::read_from_blob::<File>(reader.as_ref(), None, &location)?;
         toc.extract_from_blob(reader, Some(path.clone()), None)?;

--- a/storage/src/meta/toc.rs
+++ b/storage/src/meta/toc.rs
@@ -4,18 +4,16 @@
 
 //! Rafs filesystem TOC entry layout and data structures.
 
-use std::convert::TryFrom;
-use std::convert::TryInto;
-use std::fs::OpenOptions;
+use std::convert::{TryFrom, TryInto};
+use std::fs::{self, OpenOptions};
 use std::io::{Error, Read, Result, Write};
 use std::mem::size_of;
 use std::path::Path;
+use std::slice;
 use std::sync::Arc;
-use std::{fs, slice};
 
-use nydus_utils::compress::Decoder;
-use nydus_utils::digest::{DigestHasher, RafsDigest};
-use nydus_utils::{compress, digest};
+use nydus_utils::compress::{self, Decoder};
+use nydus_utils::digest::{self, DigestHasher, RafsDigest};
 use serde::Serialize;
 use tar::{EntryType, Header};
 
@@ -30,6 +28,8 @@ pub const ENTRY_BOOTSTRAP: &str = "image.boot";
 pub const ENTRY_BLOB_META: &str = "blob.meta";
 /// File name for RAFS blob compression information.
 pub const ENTRY_BLOB_META_HEADER: &str = "blob.meta.header";
+/// File name for RAFS chunk digest array.
+pub const ENTRY_BLOB_DIGEST: &str = "blob.digest";
 /// File name for RAFS blob ToC table.
 pub const ENTRY_TOC: &str = "rafs.blob.toc";
 
@@ -338,32 +338,97 @@ impl TocEntryList {
     }
 
     /// Read a `TocEntryList` from a reader.
-    pub fn read_from_blob(
+    pub fn read_from_blob<W: Write>(
         reader: &dyn BlobReader,
-        offset: u64,
-        size: u64,
-        digest: &RafsDigest,
+        cache_file: Option<&mut W>,
+        location: &TocLocation,
     ) -> Result<Self> {
-        if !(512..=0x10000).contains(&size) || size % 128 != 0 {
-            return Err(eother!(format!("invalid size {} of blob ToC", size)));
-        }
+        location.validate()?;
+        let (offset, size) = if location.auto_detect {
+            let blob_size = reader
+                .blob_size()
+                .map_err(|e| eio!(format!("failed to get blob size, {:?}", e)))?;
+            let size = if blob_size > 0x1000 {
+                0x1000
+            } else {
+                blob_size >> 7 << 7
+            };
+            (blob_size - size, size)
+        } else {
+            (location.offset, location.size)
+        };
 
         let size = size as usize;
         let mut buf = alloc_buf(size);
         let sz = reader
             .read(&mut buf, offset)
-            .map_err(|e| eother!(format!("failed to read data from backend, {:?}", e)))?;
-
+            .map_err(|e| eother!(format!("failed to read ToC from backend, {:?}", e)))?;
         if sz != size {
             return Err(eother!(format!(
-                "failed to read data from backend, expect {}, got {} bytes",
+                "failed to read ToC from backend, expect {}, got {} bytes",
                 size, sz
             )));
         }
 
-        let dv = digest::RafsDigest::from_buf(&buf, digest::Algorithm::Sha256);
-        if &dv != digest {
-            return Err(eother!("toc content digest value doesn't match"));
+        if let Some(writer) = cache_file {
+            writer.write_all(&buf)?;
+        }
+
+        Self::parse(&buf, size, location)
+    }
+
+    /// Read a `TocEntryList` from a cache file or the storage backend.
+    pub fn read_from_cache_file<P: AsRef<Path>>(
+        path: P,
+        reader: &dyn BlobReader,
+        location: &TocLocation,
+    ) -> Result<Self> {
+        location.validate()?;
+
+        if let Ok(mut file) = OpenOptions::new().read(true).open(path.as_ref()) {
+            let md = file.metadata()?;
+            if md.len() <= 0x1000 {
+                let size = md.len() as usize;
+                let mut buf = alloc_buf(size);
+                file.read_exact(&mut buf)
+                    .map_err(|e| eother!(format!("failed to read ToC from cache, {:?}", e)))?;
+                if let Ok(toc) = Self::parse(&buf, size as usize, location) {
+                    return Ok(toc);
+                }
+            }
+        }
+
+        let p = path
+            .as_ref()
+            .to_path_buf()
+            .with_extension("toc_downloading");
+        if let Ok(mut file) = OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(true)
+            .open(p.as_path())
+        {
+            match Self::read_from_blob(reader, Some(&mut file), location) {
+                Ok(v) => {
+                    let _ = fs::rename(p, path.as_ref());
+                    Ok(v)
+                }
+                Err(e) => {
+                    let _ = fs::remove_file(p);
+                    Err(e)
+                }
+            }
+        } else {
+            Self::read_from_blob::<fs::File>(reader, None, location)
+        }
+    }
+
+    fn parse(buf: &[u8], size: usize, location: &TocLocation) -> Result<Self> {
+        if location.validate_digest {
+            let dv = digest::RafsDigest::from_buf(&buf, digest::Algorithm::Sha256);
+            if dv != location.digest {
+                return Err(eother!("toc content digest value doesn't match"));
+            }
         }
 
         let size = size - 512;
@@ -375,7 +440,9 @@ impl TocEntryList {
         let entry_size = header
             .entry_size()
             .map_err(|_| eother!("failed to get entry size from tar header"))?;
-        if entry_size != size as u64 {
+        if (location.auto_detect && entry_size > size as u64)
+            || (!location.auto_detect && entry_size != size as u64)
+        {
             return Err(eother!(format!(
                 "invalid toc entry size in tar header, expect {}, got {}",
                 size, entry_size
@@ -395,7 +462,7 @@ impl TocEntryList {
             .ok_or_else(|| eother!("invalid GNU tar header for ToC"))?;
 
         let mut list = TocEntryList::new();
-        let mut pos = 0;
+        let mut pos = size - entry_size as usize;
         while pos < size {
             let mut entry = TocEntry::default();
             let s = unsafe {
@@ -414,6 +481,7 @@ impl TocEntryList {
         &self,
         reader: Arc<dyn BlobReader>,
         bootstrap: Option<P>,
+        digest: Option<P>,
     ) -> Result<()> {
         if let Some(path) = bootstrap {
             let bootstrap = self
@@ -443,8 +511,101 @@ impl TocEntryList {
                     .write(true)
                     .truncate(true)
                     .open(p.as_path())?;
-                bootstrap.extract_from_reader(reader, &mut file)?;
+                bootstrap.extract_from_reader(reader.clone(), &mut file)?;
                 fs::rename(p, path)?;
+            }
+        }
+
+        if let Some(path) = digest {
+            let cda = self
+                .get_entry(ENTRY_BLOB_DIGEST)
+                .ok_or_else(|| enoent!("`blob.digest` doesn't exist in the ToC list"))?;
+            if cda.compressor() == compress::Algorithm::None
+                && cda.compressed_size() != cda.uncompressed_size()
+            {
+                return Err(einval!("invalid ToC entry for `image.boot`"));
+            }
+
+            let mut ready = false;
+            if path.as_ref().exists() {
+                let mut file = OpenOptions::new().read(true).open(path.as_ref())?;
+                let digest = RafsDigest::from_reader(&mut file, digest::Algorithm::Sha256)?;
+                if digest.data == cda.uncompressed_digest {
+                    ready = true;
+                }
+            }
+            if !ready {
+                let p = path
+                    .as_ref()
+                    .to_path_buf()
+                    .with_extension("toc_downloading");
+                let mut file = OpenOptions::new()
+                    .create(true)
+                    .write(true)
+                    .truncate(true)
+                    .open(p.as_path())?;
+                cda.extract_from_reader(reader.clone(), &mut file)?;
+                fs::rename(p, path)?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Information to locate ToC in data blobs.
+pub struct TocLocation {
+    /// Enable validating digest of the ToC content.
+    pub validate_digest: bool,
+    /// Auto detect location of ToC content.
+    pub auto_detect: bool,
+    /// Offset of the ToC content in the data blob.
+    pub offset: u64,
+    /// Size of the ToC content.
+    pub size: u64,
+    /// SHA256 digest of ToC content.
+    pub digest: RafsDigest,
+}
+
+impl Default for TocLocation {
+    fn default() -> Self {
+        TocLocation {
+            validate_digest: false,
+            auto_detect: true,
+            offset: 0,
+            size: 0,
+            digest: RafsDigest::default(),
+        }
+    }
+}
+
+impl TocLocation {
+    /// Create a `TocLocation` object with offset and size.
+    pub fn new(offset: u64, size: u64) -> Self {
+        TocLocation {
+            validate_digest: false,
+            auto_detect: false,
+            offset,
+            size,
+            digest: RafsDigest::default(),
+        }
+    }
+
+    /// Create a `TocLocation` object with offset, size and digest.
+    pub fn with_digest(offset: u64, size: u64, digest: RafsDigest) -> Self {
+        TocLocation {
+            validate_digest: true,
+            auto_detect: false,
+            offset,
+            size,
+            digest,
+        }
+    }
+
+    fn validate(&self) -> Result<()> {
+        if !self.auto_detect {
+            if !(512..=0x10000).contains(&self.size) || self.size % 128 != 0 {
+                return Err(eother!(format!("invalid size {} of blob ToC", self.size)));
             }
         }
 
@@ -457,6 +618,7 @@ mod tests {
     use super::*;
     use crate::factory::BlobFactory;
     use nydus_api::{BackendConfigV2, LocalFsConfig};
+    use vmm_sys_util::tempfile::TempFile;
 
     #[test]
     fn test_read_toc_list() {
@@ -482,7 +644,9 @@ mod tests {
         };
         let blob_mgr = BlobFactory::new_backend(&config, id).unwrap();
         let blob = blob_mgr.get_reader(id).unwrap();
-        let list = TocEntryList::read_from_blob(blob.as_ref(), 9010, 1024, &digest).unwrap();
+        let location = TocLocation::with_digest(9010, 1024, digest);
+        let list =
+            TocEntryList::read_from_blob::<fs::File>(blob.as_ref(), None, &location).unwrap();
         assert_eq!(list.entries.len(), 4);
 
         assert!(list.get_entry(ENTRY_BLOB_RAW).is_some());
@@ -501,5 +665,83 @@ mod tests {
         assert_eq!(entry.uncompressed_size, 0x1000);
         entry.extract_from_reader(blob.clone(), &mut buf).unwrap();
         assert!(!buf.is_empty());
+    }
+
+    #[test]
+    fn test_parse_toc_list() {
+        let root_dir = &std::env::var("CARGO_MANIFEST_DIR").expect("$CARGO_MANIFEST_DIR");
+        let path = Path::new(root_dir).join("../tests/texture/toc");
+        let id = "2fa78cad554b75ac91a4a125ed148d0ddeb25efa4aaa8bd80e5dc292690a4dca";
+        let mut digest = RafsDigest {
+            data: [
+                79u8, 223, 187, 54, 239, 116, 163, 198, 58, 40, 226, 171, 175, 165, 64, 68, 199,
+                89, 65, 85, 190, 182, 221, 173, 159, 54, 130, 92, 254, 88, 40, 108,
+            ],
+        };
+        let config = BackendConfigV2 {
+            backend_type: "localfs".to_string(),
+            localfs: Some(LocalFsConfig {
+                blob_file: "".to_string(),
+                dir: path.to_str().unwrap().to_string(),
+                alt_dirs: vec![],
+            }),
+            oss: None,
+            registry: None,
+            s3: None,
+        };
+        let blob_mgr = BlobFactory::new_backend(&config, id).unwrap();
+        let blob = blob_mgr.get_reader(id).unwrap();
+
+        digest.data[0] = 0;
+        let location = TocLocation::with_digest(9010, 1024, digest);
+        assert!(TocEntryList::read_from_blob::<fs::File>(blob.as_ref(), None, &location).is_err());
+        digest.data[0] = 79u8;
+
+        let location = TocLocation::new(9000, 1024);
+        assert!(TocEntryList::read_from_blob::<fs::File>(blob.as_ref(), None, &location).is_err());
+
+        let location = Default::default();
+        let list =
+            TocEntryList::read_from_blob::<fs::File>(blob.as_ref(), None, &location).unwrap();
+        assert_eq!(list.entries.len(), 4);
+    }
+
+    #[test]
+    fn test_read_from_cache_file() {
+        let root_dir = &std::env::var("CARGO_MANIFEST_DIR").expect("$CARGO_MANIFEST_DIR");
+        let path = Path::new(root_dir).join("../tests/texture/toc");
+        let id = "2fa78cad554b75ac91a4a125ed148d0ddeb25efa4aaa8bd80e5dc292690a4dca";
+        let config = BackendConfigV2 {
+            backend_type: "localfs".to_string(),
+            localfs: Some(LocalFsConfig {
+                blob_file: "".to_string(),
+                dir: path.to_str().unwrap().to_string(),
+                alt_dirs: vec![],
+            }),
+            oss: None,
+            registry: None,
+            s3: None,
+        };
+        let blob_mgr = BlobFactory::new_backend(&config, id).unwrap();
+        let blob = blob_mgr.get_reader(id).unwrap();
+
+        let tempfile = TempFile::new().unwrap();
+        let path = tempfile.as_path().to_path_buf();
+        let mut file = tempfile.into_file();
+        file.write_all(&[0u8; 32]).unwrap();
+
+        let location = Default::default();
+        let list = TocEntryList::read_from_cache_file(&path, blob.as_ref(), &location).unwrap();
+        assert_eq!(list.entries.len(), 4);
+        assert_eq!(path.metadata().unwrap().len(), 0x1000);
+        let list = TocEntryList::read_from_cache_file(&path, blob.as_ref(), &location).unwrap();
+        assert_eq!(list.entries.len(), 4);
+
+        list.extract_from_blob(blob.clone(), Some(path.as_path()), None)
+            .unwrap();
+        assert_eq!(path.metadata().unwrap().len(), 20480);
+        list.extract_from_blob(blob.clone(), Some(path.as_path()), None)
+            .unwrap();
+        assert_eq!(path.metadata().unwrap().len(), 20480);
     }
 }

--- a/utils/src/digest.rs
+++ b/utils/src/digest.rs
@@ -16,7 +16,8 @@ use sha2::Sha256;
 /// Size in bytes of chunk digest value.
 pub const RAFS_DIGEST_LENGTH: usize = 32;
 
-type DigestData = [u8; RAFS_DIGEST_LENGTH];
+/// Type alias for digest data.
+pub type DigestData = [u8; RAFS_DIGEST_LENGTH];
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub enum Algorithm {
@@ -146,6 +147,7 @@ impl DigestHasher for Sha256 {
     }
 }
 
+#[repr(C)]
 #[derive(Clone, Copy, Hash, PartialEq, Eq, Debug, Default, Ord, PartialOrd)]
 pub struct RafsDigest {
     pub data: DigestData,
@@ -189,6 +191,12 @@ impl RafsDigest {
 impl From<DigestData> for RafsDigest {
     fn from(data: DigestData) -> Self {
         Self { data }
+    }
+}
+
+impl From<&DigestData> for &RafsDigest {
+    fn from(data: &DigestData) -> Self {
+        unsafe { &*(data as *const DigestData as *const u8 as *const RafsDigest) }
     }
 }
 


### PR DESCRIPTION
RAFS metadata/bootstrap can be inlined into RAFS data blobs with `nydus-image create --blob-inline-meta`.
So we need update `nydus-image` and `nydusd` to fully support inlined metadata.
This PR enhances following components to support inlined metadata:
- nydus-image create --blob-inline-meta --features blob-toc
- nydus-image create --parent-bootstrap
- nydus-image create --chunk-dict
- nydus-image check
- nydus-image inspect
- nydus-image stat
- nydus-image merge
- nydusd

There are still several TODOs:
- support images generated by `nydus-image create --blob-inline-meta` without `--features blob-toc`. Currently it only supports images generated by `nydus-image create --blob-inline-meta --features blob-toc`
- --chunk-dict doesn't work with ZRan images
- --blob-id conflicts with ZRan and `--blob-inlined-meta`