### PR TITLE
simplify backend storage registry HTTP client

### DIFF
--- a/storage/src/backend/connection.rs
+++ b/storage/src/backend/connection.rs
@@ -418,6 +418,9 @@ impl Connection {
         self.shutdown.store(true, Ordering::Release);
     }
 
+    /// A low-level transport layer to backend storage via HTTP
+    /// Deal with HTTP proxy and mirror registries.
+    ///
     /// If the auth_through is enable, all requests are send to the mirror server.
     /// If the auth_through disabled, e.g. P2P/Dragonfly, we try to avoid sending
     /// non-authorization request to the mirror server, which causes performance loss.
@@ -433,7 +436,6 @@ impl Connection {
         query: Option<&[(&str, &str)]>,
         data: Option<ReqBody<R>>,
         headers: &mut HeaderMap,
-        catch_status: bool,
         // This means the request is dedicated to authorization.
         requesting_auth: bool,
     ) -> ConnectionResult<Response> {
@@ -462,8 +464,6 @@ impl Connection {
                     &query,
                     data_cloned,
                     headers,
-                    catch_status,
-                    true,
                 );
 
                 match result {
@@ -535,8 +535,6 @@ impl Connection {
                         &query,
                         data_cloned,
                         headers,
-                        catch_status,
-                        false,
                     );
 
                     match result {
@@ -573,16 +571,7 @@ impl Connection {
             }
         }
 
-        self.call_inner(
-            &self.client,
-            method,
-            url,
-            &query,
-            data,
-            headers,
-            catch_status,
-            false,
-        )
+        self.call_inner(&self.client, method, url, &query, data, headers)
     }
 
     fn build_connection(proxy: &str, config: &ConnectionConfig) -> Result<Client> {
@@ -622,8 +611,6 @@ impl Connection {
         query: &Option<&[(&str, &str)]>,
         data: Option<ReqBody<R>>,
         headers: &HeaderMap,
-        catch_status: bool,
-        proxy: bool,
     ) -> ConnectionResult<Response> {
         // Only clone header when debugging to reduce potential overhead.
         let display_headers = if max_level() >= Level::Debug {
@@ -660,20 +647,16 @@ impl Connection {
         }
 
         debug!(
-            "{} Request: {} {} headers: {:?}, proxy: {}, data: {}, duration: {}ms",
+            "{} Request: {} {} headers: {:?}, data: {}, duration: {}ms",
             std::thread::current().name().unwrap_or_default(),
             method,
             url,
             display_headers,
-            proxy,
             has_data,
             Instant::now().duration_since(start).as_millis(),
         );
 
-        match ret {
-            Err(err) => Err(ConnectionError::Common(err)),
-            Ok(resp) => respond(resp, catch_status),
-        }
+        ret.map_err(ConnectionError::Common)
     }
 }
 

--- a/storage/src/backend/connection.rs
+++ b/storage/src/backend/connection.rs
@@ -220,16 +220,6 @@ pub(crate) fn is_success_status(status: StatusCode) -> bool {
     status >= StatusCode::OK && status < StatusCode::BAD_REQUEST
 }
 
-/// Convert a HTTP `Response` into an `Result<Response>`.
-pub(crate) fn respond(resp: Response, catch_status: bool) -> ConnectionResult<Response> {
-    if !catch_status || is_success_status(resp.status()) {
-        Ok(resp)
-    } else {
-        let msg = resp.text().map_err(ConnectionError::Format)?;
-        Err(ConnectionError::ErrorWithMsg(msg))
-    }
-}
-
 /// A network connection to communicate with remote server.
 #[derive(Debug)]
 pub(crate) struct Connection {

--- a/storage/src/backend/object_storage.rs
+++ b/storage/src/backend/object_storage.rs
@@ -78,6 +78,13 @@ where
             .connection
             .call::<&[u8]>(Method::HEAD, url.as_str(), None, None, &mut headers, false)
             .map_err(ObjectStorageError::Request)?;
+
+        if resp.status() != StatusCode::OK && resp.status() != StatusCode::NO_CONTENT {
+            return Err(BackendError::ObjectStorage(ObjectStorageError::Response(
+                format!("head blob size, status {}", resp.status()),
+            )));
+        }
+
         let content_length = resp
             .headers()
             .get(CONTENT_LENGTH)

--- a/storage/src/backend/object_storage.rs
+++ b/storage/src/backend/object_storage.rs
@@ -75,15 +75,7 @@ where
 
         let resp = self
             .connection
-            .call::<&[u8]>(
-                Method::HEAD,
-                url.as_str(),
-                None,
-                None,
-                &mut headers,
-                true,
-                false,
-            )
+            .call::<&[u8]>(Method::HEAD, url.as_str(), None, None, &mut headers, false)
             .map_err(ObjectStorageError::Request)?;
         let content_length = resp
             .headers()
@@ -122,15 +114,7 @@ where
         // Safe because the the call() is a synchronous operation.
         let mut resp = self
             .connection
-            .call::<&[u8]>(
-                Method::GET,
-                url.as_str(),
-                None,
-                None,
-                &mut headers,
-                true,
-                false,
-            )
+            .call::<&[u8]>(Method::GET, url.as_str(), None, None, &mut headers, false)
             .map_err(ObjectStorageError::Request)?;
         Ok(resp
             .copy_to(&mut buf)

--- a/storage/src/backend/registry.rs
+++ b/storage/src/backend/registry.rs
@@ -22,9 +22,7 @@ use url::{ParseError, Url};
 use nydus_api::RegistryConfig;
 use nydus_utils::metrics::BackendMetrics;
 
-use crate::backend::connection::{
-    is_success_status, respond, Connection, ConnectionConfig, ConnectionError, ReqBody,
-};
+use crate::backend::connection::{Connection, ConnectionConfig, ConnectionError, ReqBody};
 use crate::backend::{BackendError, BackendResult, BlobBackend, BlobReader};
 
 const REGISTRY_CLIENT_ID: &str = "nydus-registry-client";
@@ -45,7 +43,7 @@ pub enum RegistryError {
     Scheme(String),
     Auth(String),
     ResponseHead(String),
-    Response(std::io::Error),
+    Response(String),
     Transport(reqwest::Error),
 }
 
@@ -73,10 +71,11 @@ impl Cache {
         String::new()
     }
 
-    fn set(&self, last: &str, current: String) {
-        if last != current {
+    fn set(&self, new: &str) {
+        let current = self.get();
+        if new != current {
             let mut cached_guard = self.0.write().unwrap();
-            *cached_guard = current;
+            *cached_guard = new.to_string();
         }
     }
 }
@@ -187,17 +186,16 @@ struct RegistryState {
 }
 
 impl RegistryState {
-    fn url(&self, path: &str, query: &[&str]) -> std::result::Result<String, ParseError> {
-        let path = if query.is_empty() {
-            format!("/v2/{}{}", self.repo, path)
-        } else {
-            format!("/v2/{}{}?{}", self.repo, path, query.join("&"))
-        };
-        let url = format!("{}://{}", self.scheme, self.host.as_str());
-        let url = Url::parse(url.as_str())?;
-        let url = url.join(path.as_str())?;
+    fn blob_url(&self, blob_id: &str) -> String {
+        let url = format!(
+            "{}://{}/v2/{}/blobs/sha256:{}",
+            self.scheme,
+            self.host.as_str(),
+            self.repo,
+            blob_id
+        );
 
-        Ok(url.to_string())
+        url
     }
 
     fn needs_fallback_http(&self, e: &dyn Error) -> bool {
@@ -392,11 +390,8 @@ impl RegistryReader {
         url: &str,
         mut headers: HeaderMap,
     ) -> RegistryResult<Response> {
-        // Try get authorization header from cache for this request
-        let mut last_cached_auth = String::new();
         let cached_auth = self.state.cached_auth.get();
         if !cached_auth.is_empty() {
-            last_cached_auth = cached_auth.clone();
             headers.insert(
                 HEADER_AUTHORIZATION,
                 HeaderValue::from_str(cached_auth.as_str()).unwrap(),
@@ -438,17 +433,16 @@ impl RegistryReader {
                         HeaderValue::from_str(auth_header.as_str()).unwrap(),
                     );
 
-                    // Try to request registry server with `authorization` header again
-                    let resp = self
+                    // Cache authorization header for next request
+                    // Cache the auth earlier, so other threads have bigger chance to reuse the auth.
+                    self.state.cached_auth.set(auth_header.as_str());
+
+                    // Try to request registry server with `authorization` header again,
+                    // It's exactly a resend of the original request!
+                    resp = self
                         .connection
                         .call::<&[u8]>(method, url, None, None, &mut headers, false)
                         .map_err(RegistryError::Request)?;
-
-                    let status = resp.status();
-                    if is_success_status(status) {
-                        // Cache authorization header for next request
-                        self.state.cached_auth.set(&last_cached_auth, auth_header)
-                    }
                 }
             }
         }
@@ -473,136 +467,128 @@ impl RegistryReader {
         offset: u64,
         allow_retry: bool,
     ) -> RegistryResult<usize> {
-        let url = format!("/blobs/sha256:{}", self.blob_id);
-        let url = self
-            .state
-            .url(url.as_str(), &[])
-            .map_err(RegistryError::Url)?;
         let mut headers = HeaderMap::new();
         let end_at = offset + buf.len() as u64 - 1;
         let range = format!("bytes={}-{}", offset, end_at);
         headers.insert("Range", range.parse().unwrap());
 
-        let mut resp;
-        let cached_redirect = self.state.cached_redirect.get(&self.blob_id);
+        let url = if let Some(redirect_url) = self.state.cached_redirect.get(&self.blob_id) {
+            redirect_url
+        } else {
+            self.state.blob_url(self.blob_id.as_str())
+        };
 
-        if let Some(cached_redirect) = cached_redirect {
-            resp = self
-                .connection
-                .call::<&[u8]>(
-                    Method::GET,
-                    cached_redirect.as_str(),
-                    None,
-                    None,
-                    &mut headers,
-                    false,
-                )
-                .map_err(RegistryError::Request)?;
-
-            // The request has expired or has been denied, need to re-request
-            if allow_retry
-                && vec![StatusCode::UNAUTHORIZED, StatusCode::FORBIDDEN].contains(&resp.status())
+        let mut resp = match self.request::<&[u8]>(Method::GET, url.as_str(), headers.clone()) {
+            Ok(res) => res,
+            Err(RegistryError::Request(ConnectionError::Common(e)))
+                if self.state.needs_fallback_http(&e) =>
             {
-                warn!(
-                    "The redirected link has expired: {}, will retry read",
-                    cached_redirect.as_str()
-                );
-                self.state.cached_redirect.remove(&self.blob_id);
-                // Try read again only once
-                return self._try_read(buf, offset, false);
+                self.state.fallback_http();
+                let url = self.state.blob_url(self.blob_id.as_str());
+                self.request::<&[u8]>(Method::GET, url.as_str(), headers.clone())?
+            }
+            Err(e) => {
+                return Err(e);
+            }
+        };
+        let status = resp.status();
+
+        if status == StatusCode::PARTIAL_CONTENT || status == StatusCode::OK {
+            resp.copy_to(&mut buf)
+                .map_err(RegistryError::Transport)
+                .map(|size| size as usize)
+        } else if REDIRECTED_STATUS_CODE.contains(&status) {
+            // Handle redirect request and cache redirect url
+            let l = self.redirect(&resp)?;
+            self.state.cached_redirect.set(self.blob_id.clone(), l);
+            if allow_retry {
+                // Only allow retrying for once.
+                self._try_read(buf, offset, false)
+            } else {
+                Err(RegistryError::Common(format!(
+                    "no more retry, status {}",
+                    status
+                )))
+            }
+        } else if status == StatusCode::UNAUTHORIZED || status == StatusCode::FORBIDDEN {
+            warn!(
+                "The redirected link has expired: {}, status {}, will retry read",
+                url.as_str(),
+                status
+            );
+            self.state.cached_redirect.remove(&self.blob_id);
+            if allow_retry {
+                // Only allow retrying for once.
+                self._try_read(buf, offset, false)
+            } else {
+                Err(RegistryError::Common(format!(
+                    "no more retry, status {}, response {:?}",
+                    status, resp
+                )))
             }
         } else {
-            resp = match self.request::<&[u8]>(Method::GET, url.as_str(), headers.clone()) {
-                Ok(res) => res,
-                Err(RegistryError::Request(ConnectionError::Common(e)))
-                    if self.state.needs_fallback_http(&e) =>
-                {
-                    self.state.fallback_http();
-                    let url = self
-                        .state
-                        .url(format!("/blobs/sha256:{}", self.blob_id).as_str(), &[])
-                        .map_err(RegistryError::Url)?;
-                    self.request::<&[u8]>(Method::GET, url.as_str(), headers.clone())?
-                }
-                Err(RegistryError::Request(ConnectionError::Common(e))) => {
-                    if e.to_string().contains("self signed certificate") {
-                        warn!("try to enable \"skip_verify: true\" option");
-                    }
-                    return Err(RegistryError::Request(ConnectionError::Common(e)));
-                }
-                Err(e) => {
-                    return Err(e);
-                }
-            };
-            let status = resp.status();
-
-            // Handle redirect request and cache redirect url
-            if REDIRECTED_STATUS_CODE.contains(&status) {
-                if let Some(location) = resp.headers().get("location") {
-                    let location = location.to_str().unwrap();
-                    let mut location = Url::parse(location).map_err(RegistryError::Url)?;
-                    // Note: Some P2P proxy server supports only scheme specified origin blob server,
-                    // so we need change scheme to `blob_url_scheme` here
-                    if !self.state.blob_url_scheme.is_empty() {
-                        location
-                            .set_scheme(&self.state.blob_url_scheme)
-                            .map_err(|_| {
-                                RegistryError::Scheme(self.state.blob_url_scheme.clone())
-                            })?;
-                    }
-                    if !self.state.blob_redirected_host.is_empty() {
-                        location
-                            .set_host(Some(self.state.blob_redirected_host.as_str()))
-                            .map_err(|e| {
-                                error!(
-                                    "Failed to set blob redirected host to {}: {:?}",
-                                    self.state.blob_redirected_host.as_str(),
-                                    e
-                                );
-                                RegistryError::Url(e)
-                            })?;
-                        debug!("New redirected location {:?}", location.host_str());
-                    }
-                    let resp_ret = self
-                        .connection
-                        .call::<&[u8]>(
-                            Method::GET,
-                            location.as_str(),
-                            None,
-                            None,
-                            &mut headers,
-                            true,
-                        )
-                        .map_err(RegistryError::Request);
-                    match resp_ret {
-                        Ok(_resp) => {
-                            resp = _resp;
-                            self.state
-                                .cached_redirect
-                                .set(self.blob_id.clone(), location.as_str().to_string())
-                        }
-                        Err(err) => {
-                            return Err(err);
-                        }
-                    }
-                };
-            } else {
-                resp = respond(resp, true).map_err(RegistryError::Request)?;
-            }
+            self.state.cached_redirect.remove(&self.blob_id);
+            Err(RegistryError::Common(format!(
+                "Unrecognized status code {}, response {:?}",
+                status, resp
+            )))
         }
+    }
 
-        resp.copy_to(&mut buf)
-            .map_err(RegistryError::Transport)
-            .map(|size| size as usize)
+    /// Handle URL redirection, it may tweak the redirected location as per
+    /// Rafs configuration.
+    fn redirect(&self, resp: &Response) -> RegistryResult<String> {
+        if let Some(location) = resp.headers().get("location") {
+            let location = location
+                .to_str()
+                .map_err(|e| RegistryError::Response(format!("invalidate location, {:?}", e)))?;
+
+            let mut url = if !self.state.blob_redirected_host.is_empty()
+                || !self.state.blob_url_scheme.is_empty()
+            {
+                Some(Url::parse(location).map_err(RegistryError::Url)?)
+            } else {
+                None
+            };
+
+            if let Some(r) = url.as_mut() {
+                // Note: Some P2P proxy server supports only scheme specified origin blob server,
+                // so we need change scheme to `blob_url_scheme` here
+                if !self.state.blob_url_scheme.is_empty() {
+                    r.set_scheme(&self.state.blob_url_scheme)
+                        .map_err(|_| RegistryError::Scheme(self.state.blob_url_scheme.clone()))?;
+                }
+                if !self.state.blob_redirected_host.is_empty() {
+                    r.set_host(Some(self.state.blob_redirected_host.as_str()))
+                        .map_err(|e| {
+                            error!(
+                                "Failed to set blob redirected host to {}: {:?}",
+                                self.state.blob_redirected_host.as_str(),
+                                e
+                            );
+                            RegistryError::Url(e)
+                        })?;
+                    debug!("New redirected location {:?}", r.host_str());
+                }
+            }
+
+            if let Some(ref r) = url {
+                Ok(r.to_string())
+            } else {
+                Ok(location.to_string())
+            }
+        } else {
+            Err(RegistryError::Response(format!(
+                "no location when handling redirect, response {:?}",
+                resp
+            )))
+        }
     }
 }
 
 impl BlobReader for RegistryReader {
     fn blob_size(&self) -> BackendResult<u64> {
-        let url = self
-            .state
-            .url(&format!("/blobs/sha256:{}", self.blob_id), &[])
-            .map_err(RegistryError::Url)?;
+        let url = self.state.blob_url(self.blob_id.as_str());
 
         let resp = match self.request::<&[u8]>(Method::HEAD, url.as_str(), HeaderMap::new()) {
             Ok(res) => res,
@@ -610,10 +596,7 @@ impl BlobReader for RegistryReader {
                 if self.state.needs_fallback_http(&e) =>
             {
                 self.state.fallback_http();
-                let url = self
-                    .state
-                    .url(format!("/blobs/sha256:{}", self.blob_id).as_str(), &[])
-                    .map_err(RegistryError::Url)?;
+                let url = self.state.blob_url(self.blob_id.as_str());
                 self.request::<&[u8]>(Method::HEAD, url.as_str(), HeaderMap::new())?
             }
             Err(e) => {
@@ -768,9 +751,7 @@ impl Registry {
                                     let new_cached_auth = format!("Bearer {}", token);
                                     info!("Authorization token for registry has been refreshed.");
                                     // Refresh authorization token
-                                    state
-                                        .cached_auth
-                                        .set(&state.cached_auth.get(), new_cached_auth);
+                                    state.cached_auth.set(new_cached_auth.as_str());
                                 }
                             }
                         }
@@ -839,9 +820,9 @@ mod tests {
 
         assert_eq!(cache.get(), "test");
 
-        cache.set("test", "test1".to_owned());
+        cache.set("test1".to_owned().as_str());
         assert_eq!(cache.get(), "test1");
-        cache.set("test1", "test1".to_owned());
+        cache.set("test1".to_owned().as_str());
         assert_eq!(cache.get(), "test1");
     }
 
@@ -877,12 +858,8 @@ mod tests {
         };
 
         assert_eq!(
-            state.url("image", &["blabla"]).unwrap(),
-            "http://alibaba-inc.com/v2/nydusimage?blabla".to_owned()
-        );
-        assert_eq!(
-            state.url("image", &[]).unwrap(),
-            "http://alibaba-inc.com/v2/nydusimage".to_owned()
+            state.blob_url("abcde"),
+            "http://alibaba-inc.com/v2/nydus/blobs/sha256:abcde".to_owned()
         );
     }
 


### PR DESCRIPTION
1. No more conversion and judgment on registry response status code in the underlying connection layer. Just let the upper layer process the status code.
2. Let the registry client only use the helper function `request` rather than calling the underlying `call` method.
3. Simplify how to construct the URL to access blobs

`Connection` layer is a low-level transparent layer used by many modules, it is hard to say what status code should be treated as Success in such a lower layer. Let the upper layer handle the status code itself. Connection Ok(()) only means the request is successfully sent and processed by the registry server side.

The current registry client wrongly treats some responses as success and copies the response body to upper layer as image data chunks.

```
[2022-12-12 17:59:24.056751 +08:00] ERROR [/home/gechangwei/.cargo/git/checkouts/fuse-backend-rs-891780d38d588b3b/f717974/src/api/server/sync_io.rs:1180] fuse: reply error header OutHeader { len: 16, error: -5, unique: 700 }, error Os { code: 5, kind: Uncategorized, message: "Input/output error" }
[2022-12-12 17:59:26.057091 +08:00] WARN [storage/src/cache/state/blob_state_map.rs:120] Waiting for backend IO expires. chunk index 217, compressed offset 4329908
[2022-12-12 17:59:26.059065 +08:00] ERROR [error/src/error.rs:21] Error:
	"request for 416877 bytes but got 346 bytes"
	at storage/src/cache/mod.rs:209
	note: enable `RUST_BACKTRACE=1` env to display a backtrace
[2022-12-12 17:59:26.059094 +08:00] ERROR [/home/gechangwei/.cargo/git/checkouts/fuse-backend-rs-891780d38d588b3b/f717974/src/api/server/sync_io.rs:1180] fuse: reply error header OutHeader { len: 16, error: -5, unique: 702 }, error Os { code: 5, kind: Uncategorized, message: "Input/output error" }
[2022-12-12 17:59:28.059243 +08:00] WARN [storage/src/cache/state/blob_state_map.rs:120] Waiting for backend IO expires. chunk index 217, compressed offset 4329908
[2022-12-12 17:59:28.061074 +08:00] ERROR [error/src/error.rs:21] Error:
	"request for 416877 bytes but got 346 bytes"
	at storage/src/cache/mod.rs:209


	"request for 1208223 bytes but got 346 bytes"
	"request for 2028282 bytes but got 346 bytes"
	"request for 2176 bytes but got 346 bytes"
	"request for 1456899 bytes but got 346 bytes"
	"request for 2914838 bytes but got 346 bytes"
	"request for 2487163 bytes but got 346 bytes"
	"request for 2989585 bytes but got 346 bytes"
	"request for 1875970 bytes but got 346 bytes"
	"request for 3051237 bytes but got 346 bytes"
	"request for 2301065 bytes but got 346 bytes"
	"request for 2103970 bytes but got 346 bytes"
	"request for 2986356 bytes but got 346 bytes"
	"request for 1813040 bytes but got 346 bytes"
	"request for 2179829 bytes but got 346 bytes"
	"request for 2192490 bytes but got 346 bytes"
	"request for 2579762 bytes but got 346 bytes"
	"request for 2457311 bytes but got 346 bytes"
	"request for 2220056 bytes but got 346 bytes"
	"request for 290185 bytes but got 346 bytes"
	"request for 2372729 bytes but got 346 bytes"
	"request for 692 bytes but got 346 bytes"

```

In addition, nydusd storage backend only serves read-only requests, so remove unnecessary request body to reduce number of function
parameters.


