### PR TITLE
nydusify: recover more options

### DIFF
--- a/contrib/nydusify/cmd/nydusify.go
+++ b/contrib/nydusify/cmd/nydusify.go
@@ -313,21 +313,34 @@ func main() {
 				},
 
 				&cli.BoolFlag{
-					Name:    "multi-platform",
+					Name:    "merge-platform",
 					Value:   false,
 					Usage:   "Generate an OCI image index with both OCI and Nydus manifests for the image, please ensure that the OCI image exists in the target repository",
-					EnvVars: []string{"MULTI_PLATFORM"},
+					EnvVars: []string{"MERGE_PLATFORM"},
+					Aliases: []string{"multi-platform"},
+				},
+				&cli.BoolFlag{
+					Name:  "all-platforms",
+					Value: false,
+					Usage: "Convert images for all platforms, conflicts with --platform",
 				},
 				&cli.StringFlag{
 					Name:  "platform",
 					Value: "linux/" + runtime.GOARCH,
-					Usage: "Specify platform identifier to choose image manifest, possible values: 'linux/amd64' and 'linux/arm64'",
+					Usage: "Convert images for specific platforms, for example: 'linux/amd64,linux/arm64'",
 				},
 				&cli.BoolFlag{
-					Name:    "docker-v2-format",
+					Name:    "oci-ref",
 					Value:   false,
-					Usage:   "Enable support of docker image manifest v2, schema 2 format",
-					EnvVars: []string{"DOCKER_V2_FORMAT"},
+					Usage:   "Convert to OCI-referenced nydus zran image",
+					EnvVars: []string{"OCI_REF"},
+				},
+				&cli.BoolFlag{
+					Name:    "oci",
+					Value:   false,
+					Usage:   "Convert Docker media types to OCI media types",
+					EnvVars: []string{"OCI"},
+					Aliases: []string{"docker-v2-format"},
 				},
 				&cli.StringFlag{
 					Name:        "fs-version",
@@ -368,10 +381,11 @@ func main() {
 					EnvVars: []string{"COMPRESSOR"},
 				},
 				&cli.StringFlag{
-					Name:    "chunk-size",
+					Name:    "fs-chunk-size",
 					Value:   "0x100000",
 					Usage:   "size of nydus image data chunk, must be power of two and between 0x1000-0x100000, [default: 0x100000]",
-					EnvVars: []string{"CHUNK_SIZE"},
+					EnvVars: []string{"FS_CHUNK_SIZE"},
+					Aliases: []string{"chunk-size"},
 				},
 				&cli.StringFlag{
 					Name:    "work-dir",
@@ -418,8 +432,6 @@ func main() {
 					return fmt.Errorf("--fs-version should be one of %v", possibleFsVersions)
 				}
 
-				targetPlatform := c.String("platform")
-
 				prefetchPatterns, err := getPrefetchPatterns(c)
 				if err != nil {
 					return err
@@ -456,13 +468,16 @@ func main() {
 					ChunkDictInsecure: c.Bool("chunk-dict-insecure"),
 
 					PrefetchPatterns: prefetchPatterns,
-					MultiPlatform:    c.Bool("multi-platform"),
-					DockerV2Format:   c.Bool("docker-v2-format"),
-					TargetPlatform:   targetPlatform,
+					MergePlatform:    c.Bool("merge-platform"),
+					Docker2OCI:       c.Bool("oci"),
 					FsVersion:        fsVersion,
 					FsAlignChunk:     c.Bool("backend-aligned-chunk") || c.Bool("fs-align-chunk"),
 					Compressor:       c.String("compressor"),
 					ChunkSize:        c.String("chunk-size"),
+
+					OCIRef:       c.Bool("oci-ref"),
+					AllPlatforms: c.Bool("all-platforms"),
+					Platforms:    c.String("platform"),
 				}
 
 				return converter.Convert(context.Background(), opt)

--- a/contrib/nydusify/examples/converter/main.go
+++ b/contrib/nydusify/examples/converter/main.go
@@ -14,7 +14,7 @@ func main() {
 	target := "localhost:5000/ubuntu:latest-nydus"
 
 	opt := converter.Opt{
-		TargetPlatform: "linux/amd64",
+		Platforms:      "linux/amd64",
 		Source:         source,
 		Target:         target,
 		SourceInsecure: true,
@@ -23,8 +23,8 @@ func main() {
 		WorkDir:          workDir,
 		PrefetchPatterns: "/",
 		NydusImagePath:   nydusImagePath,
-		MultiPlatform:    false,
-		DockerV2Format:   true,
+		MergePlatform:    false,
+		Docker2OCI:       true,
 	}
 
 	if err := converter.Convert(context.Background(), opt); err != nil {

--- a/contrib/nydusify/go.mod
+++ b/contrib/nydusify/go.mod
@@ -127,7 +127,7 @@ require (
 replace github.com/opencontainers/runc => github.com/opencontainers/runc v1.1.2
 
 // It will be updated to official repo once acceleration-service release.
-replace github.com/goharbor/acceleration-service => github.com/imeoer/acceleration-service v0.0.29
+replace github.com/goharbor/acceleration-service => github.com/imeoer/acceleration-service v0.0.30
 
 // It will be updated to official repo once nydus-snapshotter release.
-replace github.com/containerd/nydus-snapshotter => github.com/imeoer/nydus-snapshotter v0.3.22
+replace github.com/containerd/nydus-snapshotter => github.com/imeoer/nydus-snapshotter v0.3.28

--- a/contrib/nydusify/go.sum
+++ b/contrib/nydusify/go.sum
@@ -886,10 +886,10 @@ github.com/imdario/mergo v0.3.8/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/imdario/mergo v0.3.10/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
-github.com/imeoer/acceleration-service v0.0.29 h1:w+rCegCdSpSvaTbyLzGFGkBR7Ffv6Rh7WwtdmN9NvDw=
-github.com/imeoer/acceleration-service v0.0.29/go.mod h1:5kgqf0924xPu2+Qs4Ys5UiO4MyxuV7e4yT2mB/fnZqk=
-github.com/imeoer/nydus-snapshotter v0.3.22 h1:Vg+dKVTmmiNGWCJ/4KMCYHIgAx3demSPXvxnBLv2UJ0=
-github.com/imeoer/nydus-snapshotter v0.3.22/go.mod h1:xRVCi0yITol7k6yzjGY1tdlYZZVy5Qn+7YVLDjZ+0AE=
+github.com/imeoer/acceleration-service v0.0.30 h1:ysz0YyJ5DGLg3bZ49p7lFia2CLJW4qvYdFAq3nhLxs4=
+github.com/imeoer/acceleration-service v0.0.30/go.mod h1:xaf4RDjR7wjGgQ7io16LAYTNzqXlTzFcS4OtwwJghC8=
+github.com/imeoer/nydus-snapshotter v0.3.28 h1:KYFEZoukvm7G70Jb+KaJoO6vS/D/ViHoLgmEH5d2f18=
+github.com/imeoer/nydus-snapshotter v0.3.28/go.mod h1:xRVCi0yITol7k6yzjGY1tdlYZZVy5Qn+7YVLDjZ+0AE=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
 github.com/intel/goresctrl v0.2.0/go.mod h1:+CZdzouYFn5EsxgqAQTEzMfwKwuc0fVdMrT9FCCAVRQ=

--- a/contrib/nydusify/pkg/converter/config.go
+++ b/contrib/nydusify/pkg/converter/config.go
@@ -9,23 +9,25 @@ import "strconv"
 func getConfig(opt Opt) map[string]string {
 	cfg := map[string]string{}
 
-	cfg["backend_type"] = opt.BackendType
-	cfg["backend_config"] = opt.BackendConfig
-	cfg["fs_version"] = opt.FsVersion
-	cfg["compressor"] = opt.Compressor
-	cfg["merge_manifest"] = strconv.FormatBool(opt.MultiPlatform)
 	cfg["work_dir"] = opt.WorkDir
 	cfg["builder"] = opt.NydusImagePath
+
+	cfg["backend_type"] = opt.BackendType
+	cfg["backend_config"] = opt.BackendConfig
+	cfg["backend_force_push"] = strconv.FormatBool(opt.BackendForcePush)
+
 	cfg["chunk_dict_ref"] = opt.ChunkDictRef
+	cfg["docker2oci"] = strconv.FormatBool(!opt.Docker2OCI)
+	cfg["merge_manifest"] = strconv.FormatBool(opt.MergePlatform)
+	cfg["oci_ref"] = strconv.FormatBool(opt.OCIRef)
+
+	cfg["prefetch_patterns"] = opt.PrefetchPatterns
+	cfg["compressor"] = opt.Compressor
+	cfg["fs_version"] = opt.FsVersion
+	cfg["fs_align_chunk"] = strconv.FormatBool(opt.FsAlignChunk)
+	cfg["fs_chunk_size"] = opt.ChunkSize
 
 	// FIXME: still needs to be supported by acceld converter package.
-	cfg["backend_force_push"] = strconv.FormatBool(opt.BackendForcePush)
-	cfg["docker2oci"] = strconv.FormatBool(!opt.DockerV2Format)
-	cfg["platform"] = opt.TargetPlatform
-	cfg["fs_align_chunk"] = strconv.FormatBool(opt.FsAlignChunk)
-	cfg["prefetch_patterns"] = opt.PrefetchPatterns
-	cfg["chunk_size"] = opt.ChunkSize
-
 	cfg["cache_ref"] = opt.CacheRef
 	cfg["cache_version"] = opt.CacheVersion
 	cfg["cache_max_records"] = strconv.FormatUint(uint64(opt.CacheMaxRecords), 10)

--- a/contrib/nydusify/pkg/converter/converter.go
+++ b/contrib/nydusify/pkg/converter/converter.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/dragonflyoss/image-service/contrib/nydusify/pkg/converter/provider"
 	"github.com/goharbor/acceleration-service/pkg/converter"
+	"github.com/goharbor/acceleration-service/pkg/platformutil"
 )
 
 type Opt struct {
@@ -33,14 +34,17 @@ type Opt struct {
 	BackendConfig    string
 	BackendForcePush bool
 
-	TargetPlatform   string
-	MultiPlatform    bool
-	DockerV2Format   bool
+	MergePlatform    bool
+	Docker2OCI       bool
 	FsVersion        string
 	FsAlignChunk     bool
 	Compressor       string
 	ChunkSize        string
 	PrefetchPatterns string
+	OCIRef           bool
+
+	AllPlatforms bool
+	Platforms    string
 }
 
 func Convert(ctx context.Context, opt Opt) error {
@@ -49,9 +53,15 @@ func Convert(ctx context.Context, opt Opt) error {
 		return err
 	}
 
-	cvt, err := converter.NewLocalConverter(
+	platformMC, err := platformutil.ParsePlatforms(opt.AllPlatforms, opt.Platforms)
+	if err != nil {
+		return err
+	}
+
+	cvt, err := converter.New(
 		converter.WithProvider(pvd),
 		converter.WithDriver("nydus", getConfig(opt)),
+		converter.WithPlatform(platformMC),
 	)
 	if err != nil {
 		return err

--- a/contrib/nydusify/tests/nydusify.go
+++ b/contrib/nydusify/tests/nydusify.go
@@ -86,9 +86,9 @@ func (nydusify *Nydusify) Convert(t *testing.T) {
 	}
 
 	opt := converter.Opt{
-		TargetPlatform: "linux/amd64",
-		Source:         host + "/" + nydusify.Source,
-		Target:         host + "/" + nydusify.Target,
+		Platforms: "linux/amd64",
+		Source:    host + "/" + nydusify.Source,
+		Target:    host + "/" + nydusify.Target,
 
 		CacheRef:        buildCache,
 		CacheMaxRecords: 10,
@@ -97,8 +97,8 @@ func (nydusify *Nydusify) Convert(t *testing.T) {
 		WorkDir:          nydusify.workDir,
 		PrefetchPatterns: "/",
 		NydusImagePath:   nydusImagePath,
-		MultiPlatform:    false,
-		DockerV2Format:   true,
+		MergePlatform:    false,
+		Docker2OCI:       true,
 
 		BackendType:   nydusify.backendType,
 		BackendConfig: nydusify.backendConfig,


### PR DESCRIPTION
After nydusify was refactored, some options functionality was lost, since
the acceld converter package is currently supported, we now add them back.

- Recover `--backend-force-push` option;
- Recover `--oci` (alias `--docker-v2-format`) option;
- Recover `--platform` option, and support multiple platforms;
- Recover `--fs-align-chunk` option;
- Recover `--fs-chunk-size` (alias `--chunk-size`) option;
- Recover `--prefetch-patterns` option;
- Add `--oci-ref` option;
- Add `--all-platforms` option;

Signed-off-by: Yan Song <imeoer@linux.alibaba.com>