### PR TITLE
rafs: add a configuration warmup to make window for prefetching

### DIFF
--- a/api/src/config.rs
+++ b/api/src/config.rs
@@ -586,6 +586,8 @@ pub struct RafsConfigV2 {
     /// Filesystem prefetching configuration.
     #[serde(default)]
     pub prefetch: PrefetchConfigV2,
+    #[serde(default)]
+    pub warmup: u64,
 }
 
 impl RafsConfigV2 {
@@ -908,9 +910,13 @@ struct RafsConfig {
     /// Record file name if file access trace log.
     #[serde(default)]
     pub latest_read_files: bool,
-    // ZERO value means, amplifying user io is not enabled.
+    /// ZERO value means, amplifying user io is not enabled.
     #[serde(default = "default_batch_size")]
     pub amplify_io: usize,
+    /// Let Rafs wait for a period before completing mount. So prefetch
+    /// can download data as much as possible. In millisecond.
+    #[serde(default)]
+    pub warmup: u64,
 }
 
 impl TryFrom<RafsConfig> for ConfigV2 {
@@ -928,6 +934,7 @@ impl TryFrom<RafsConfig> for ConfigV2 {
             access_pattern: v.access_pattern,
             latest_read_files: v.latest_read_files,
             prefetch: v.fs_prefetch.into(),
+            warmup: v.warmup,
         };
         if !cache.prefetch.enable && rafs.prefetch.enable {
             cache.prefetch = rafs.prefetch.clone();


### PR DESCRIPTION
Thus let rafs have a bigger chance to directly hit the local file cache to reduce the Registry request.

From the test results, the container startup has the same latency with much fewer requests to the registry

- with warmup enabled
```
{"repo": "golang", "bench": "golang:latestnydusv6", "pull_time": " 1.867576", "create_time": " 2.041314", "run_time": " 0.466915", "elapsed": " 4.375805"}

Backend Type:       "registry"
Read Amount:        355171173 Bytes (338.71762561798096 MB)
Read Count:         179
Read Errors:        0

Block Sizes:             <1K     1K~     4K~     16K~    64K~    128K~   512K~   1M~
Average Latency(millis): 0       156     52      32      57      65      32      56

Block Sizes:             <1K     1K~     4K~     16K~    64K~    128K~   512K~   1M~
Request Count:           0       1       1       2       2       3       2       168
```


- with warmup disabled
```
{"repo": "golang", "bench": "golang:latestnydusv6", "pull_time": " 1.464904", "create_time": " 0.608780", "run_time": " 2.441874", "elapsed": " 4.515558"}

Backend Type:       "registry"
Read Amount:        355171173 Bytes (338.71762561798096 MB)
Read Count:         747
Read Errors:        0

Block Sizes:             <1K     1K~     4K~     16K~    64K~    128K~   512K~   1M~
Average Latency(millis): 9       10      13      20      108     28      23      64

Block Sizes:             <1K     1K~     4K~     16K~    64K~    128K~   512K~   1M~
Request Count:           308     172     57      18      4       16      6       166
```