### PR TITLE
builder: fix zran bootstrap merge

### DIFF
--- a/rafs/src/metadata/direct_v6.rs
+++ b/rafs/src/metadata/direct_v6.rs
@@ -1151,7 +1151,7 @@ impl RafsInodeExt for OndiskInodeWrapper {
             + OndiskInodeWrapper::inode_xattr_size(inode)
             + (idx as usize * size_of::<RafsV6InodeChunkAddr>());
         let chunk_addr = state.map.get_ref::<RafsV6InodeChunkAddr>(offset)?;
-        let has_device = self.mapping.device.lock().unwrap().is_empty();
+        let has_device = self.mapping.device.lock().unwrap().has_device();
 
         if state.meta.has_inlined_chunk_digest() && has_device {
             let blob_index = chunk_addr.blob_index();

--- a/storage/src/device.rs
+++ b/storage/src/device.rs
@@ -1022,8 +1022,8 @@ impl BlobDevice {
     }
 
     /// Check whether the `BlobDevice` has any blobs.
-    pub fn is_empty(&self) -> bool {
-        self.blob_count == 0
+    pub fn has_device(&self) -> bool {
+        self.blob_count > 0
     }
 
     /// Read a range of data from a data blob into the provided writer


### PR DESCRIPTION
Fix the panic when merge bootstraps for zran image:

```
level=info msg="no chunk information object for blob 0 chunk 0" module=builder
level=info msg="at rafs/src/metadata/direct_v6.rs:1163" module=builder
level=error msg="fail to run nydus-image merge..."
```

Signed-off-by: Yan Song <imeoer@linux.alibaba.com>