### PR TITLE
Fix warning message related to data prefetch

### DIFF
--- a/rafs/src/fs.rs
+++ b/rafs/src/fs.rs
@@ -438,7 +438,7 @@ impl Rafs {
                 let batch_size = 1024 * 1024 * 2;
 
                 for blob in &blob_infos {
-                    let blob_size = blob.compressed_size();
+                    let blob_size = blob.compressed_data_size();
                     let count = div_round_up(blob_size, batch_size);
 
                     let mut pre_offset = 0u64;

--- a/src/bin/nydus-image/core/context.rs
+++ b/src/bin/nydus-image/core/context.rs
@@ -588,7 +588,7 @@ impl BlobContext {
 
     // TODO: check the logic to reset prefetch size
     pub fn set_blob_prefetch_size(&mut self, ctx: &BuildContext) {
-        if (self.compressed_blob_size > 0
+        if (self.uncompressed_blob_size > 0
             || (ctx.conversion_type == ConversionType::EStargzIndexToRef
                 && !self.blob_id.is_empty()))
             && ctx.prefetch.policy != PrefetchPolicy::Blob
@@ -657,7 +657,7 @@ impl BlobContext {
 
     /// Get blob id if the blob has some chunks.
     pub fn blob_id(&mut self) -> Option<String> {
-        if self.compressed_blob_size > 0 {
+        if self.uncompressed_blob_size > 0 {
             Some(self.blob_id.to_string())
         } else {
             None

--- a/src/bin/nydus-image/inspect.rs
+++ b/src/bin/nydus-image/inspect.rs
@@ -292,11 +292,12 @@ impl RafsInspector {
 Blob Index:             {blob_index}
 Blob ID:                {blob_id}
 Raw Blob ID:            {raw_blob_id}
+Blob Size:              {blob_size}
+Compressed Data Size:   {compressed_size}
+Uncompressed Data Size: {uncompressed_size}
 Features:               {features:?}
 Compressor:             {compressor}
 Digester:               {digester}
-Cache Size:             {cache_size}
-Compressed Size:        {compressed_size}
 Chunk Size:             {chunk_size}
 Chunk Count:            {chunk_count}
 Prefetch Table Offset:  {prefetch_tbl_offset}
@@ -314,8 +315,9 @@ RAFS Blob Size:         {rafs_size}
                     blob_id = blob_info.blob_id(),
                     raw_blob_id = blob_info.raw_blob_id(),
                     features = blob_info.features(),
-                    cache_size = blob_info.uncompressed_size(),
-                    compressed_size = blob_info.compressed_size(),
+                    uncompressed_size = blob_info.uncompressed_size(),
+                    blob_size = blob_info.compressed_size(),
+                    compressed_size = blob_info.compressed_data_size(),
                     chunk_size = blob_info.chunk_size(),
                     chunk_count = blob_info.chunk_count(),
                     compressor = blob_info.compressor(),

--- a/src/bin/nydus-image/main.rs
+++ b/src/bin/nydus-image/main.rs
@@ -995,9 +995,10 @@ impl Command {
         let mut blob_ids = Vec::new();
         for (idx, blob) in blobs.iter().enumerate() {
             println!(
-                "\t {}: {}, compressed size 0x{:x}, uncompressed size 0x{:x}, chunks: 0x{:x}, features: {}",
+                "\t {}: {}, compressed data size 0x{:x}, compressed file size 0x{:x}, uncompressed file size 0x{:x}, chunks: 0x{:x}, features: {}",
                 idx,
                 blob.blob_id(),
+                blob.compressed_data_size(),
                 blob.compressed_size(),
                 blob.uncompressed_size(),
                 blob.chunk_count(),

--- a/src/bin/nydusd/fs_cache.rs
+++ b/src/bin/nydusd/fs_cache.rs
@@ -510,7 +510,7 @@ impl FsCacheHandler {
             Some(1) => nydus_api::default_batch_size() as u64,
             Some(s) => s as u64,
         };
-        let blob_size = blob_info.compressed_size();
+        let blob_size = blob_info.compressed_data_size();
         let count = (blob_size + size - 1) / size;
         let mut blob_req = Vec::with_capacity(count as usize);
         let mut pre_offset = 0u64;

--- a/storage/src/cache/filecache/mod.rs
+++ b/storage/src/cache/filecache/mod.rs
@@ -221,7 +221,7 @@ impl FileCacheEntry {
         // Set cache file to its expected size.
         let file_size = file.metadata()?.len();
         let cached_file_size = if mgr.cache_raw_data {
-            blob_info.compressed_size()
+            blob_info.compressed_data_size()
         } else {
             blob_info.uncompressed_size()
         };

--- a/storage/src/device.rs
+++ b/storage/src/device.rs
@@ -59,6 +59,8 @@ bitflags! {
         const ZRAN = 0x0000_0008;
         /// Chunk digest array is inlined in the data blob.
         const INLINED_CHUNK_DIGEST = 0x0000_0010;
+        /// Blob has Table of Content (ToC) at the tail.
+        const HAS_TOC = 0x2000_0000;
         /// Data blob are encoded with Tar header and optionally ToC.
         /// It's also a flag indicating that images are generated with `nydus-image` v2.2 or newer.
         const CAP_TAR_TOC = 0x4000_0000;

--- a/storage/src/meta/mod.rs
+++ b/storage/src/meta/mod.rs
@@ -274,6 +274,15 @@ impl BlobCompressionContextHeader {
     }
 
     /// Set flag indicating new blob format with tar/toc headers.
+    pub fn set_has_toc(&mut self, enable: bool) {
+        if enable {
+            self.s_features |= BlobFeatures::HAS_TOC.bits();
+        } else {
+            self.s_features &= !BlobFeatures::HAS_TOC.bits();
+        }
+    }
+
+    /// Set flag indicating having inlined-meta capability.
     pub fn set_cap_tar_toc(&mut self, enable: bool) {
         if enable {
             self.s_features |= BlobFeatures::CAP_TAR_TOC.bits();
@@ -1603,6 +1612,9 @@ pub fn format_blob_features(features: BlobFeatures) -> String {
     }
     if features.contains(BlobFeatures::INLINED_FS_META) {
         output += "fs-meta ";
+    }
+    if features.contains(BlobFeatures::HAS_TOC) {
+        output += "toc ";
     }
     if features.contains(BlobFeatures::ZRAN) {
         output += "zran ";


### PR DESCRIPTION
There are different definitions about blob.compressed_size():
- size of all data chunks
- size of the data blob, including data chunks, digests, fs meta, toc
    
So introduce blob.compressed_data_size() to get size of all data chunks, and blob.compressed_size() to get blob size.
