### PR TITLE
read prefetch list(runtime) from file

### DIFF
--- a/api/openapi/nydus-api-v1.yaml
+++ b/api/openapi/nydus-api-v1.yaml
@@ -348,10 +348,8 @@ components:
           description: usually to be the metadata source
           type: string
         prefetch_files:
-          description: files that need to be prefetched
-          type: array
-          items:
-            type: string
+          description: local file path which recorded a file list to be prefetched
+          type: string
         config:
           description: inline request, use to configure fs backend.
           type: string

--- a/api/openapi/nydus-api-v1.yaml
+++ b/api/openapi/nydus-api-v1.yaml
@@ -348,7 +348,7 @@ components:
           description: usually to be the metadata source
           type: string
         prefetch_files:
-          description: local file path which recorded a file list to be prefetched
+          description: local file path which recorded files/directories to be prefetched and separated by newlines
           type: string
         config:
           description: inline request, use to configure fs backend.

--- a/contrib/nydus-test/framework/rafs.py
+++ b/contrib/nydus-test/framework/rafs.py
@@ -619,8 +619,8 @@ class NydusDaemon(utils.ArtifactProcess):
         self.params.log_level(level)
         return self
 
-    def prefetch_files(self, dirs_list: str):
-        self.params.set_param("prefetch-files", dirs_list)
+    def prefetch_files(self, file_path: str):
+        self.params.set_param("prefetch-files", file_path)
         return self
 
     def shared_dir(self, shared_dir):

--- a/contrib/nydus-test/functional-test/test_nydus.py
+++ b/contrib/nydus-test/functional-test/test_nydus.py
@@ -582,7 +582,7 @@ def test_shared_blobcache(nydus_anchor: NydusAnchor, nydus_image, rafs_conf: Raf
             .apisock(tempfile.NamedTemporaryFile().name)
             .prefetch_files(os.path.abspath(tmp_file))
             .set_mountpoint(mountpoint)
-        )  
+        )
         return rafs
 
     cases = []
@@ -613,7 +613,7 @@ def test_shared_blobcache(nydus_anchor: NydusAnchor, nydus_image, rafs_conf: Raf
 
     for case in cases:
         case[0].umount()
-    
+
 
 # @pytest.mark.skip(reason="ECS can't pass this case!")
 @pytest.mark.parametrize("sig", [signal.SIGTERM, signal.SIGINT])
@@ -753,8 +753,7 @@ def test_specified_prefetch(
 
     tmp_file = tmp_path / "prefetch.txt"
     with open(tmp_file, "w") as f:
-        for d in prefetching_files:
-            f.write(os.path.join("/", d) + "\n") 
+        f.writelines(os.path.join("/", d) + '\n' for d in prefetching_files)
 
     print(os.path.abspath(tmp_file))
     rafs = NydusDaemon(nydus_anchor, nydus_scratch_image, rafs_conf)

--- a/contrib/nydus-test/functional-test/test_nydus.py
+++ b/contrib/nydus-test/functional-test/test_nydus.py
@@ -564,7 +564,7 @@ def test_pseudo_fs(nydus_anchor, nydus_image: RafsImage, rafs_conf: RafsConf):
     nc.umount_rafs("/pseudo3")
 
 
-def test_shared_blobcache(nydus_anchor: NydusAnchor, nydus_image, rafs_conf: RafsConf):
+def test_shared_blobcache(nydus_anchor: NydusAnchor, nydus_image, rafs_conf: RafsConf, tmp_path):
     """
     description:
         Start more than one nydusd, let them share the same blobcache.
@@ -573,13 +573,16 @@ def test_shared_blobcache(nydus_anchor: NydusAnchor, nydus_image, rafs_conf: Raf
     rafs_conf.enable_rafs_blobcache().set_rafs_backend(Backend.LOCALFS)
     rafs_conf.dump_rafs_conf()
 
+    tmp_file = tmp_path / "prefetch.txt"
+    tmp_file.write_text("/")
+
     def make_rafs(mountpoint):
         rafs = (
             NydusDaemon(nydus_anchor, nydus_image, rafs_conf)
             .apisock(tempfile.NamedTemporaryFile().name)
-            .prefetch_files("/")
+            .prefetch_files(os.path.abspath(tmp_file))
             .set_mountpoint(mountpoint)
-        )
+        )  
         return rafs
 
     cases = []
@@ -610,7 +613,7 @@ def test_shared_blobcache(nydus_anchor: NydusAnchor, nydus_image, rafs_conf: Raf
 
     for case in cases:
         case[0].umount()
-
+    
 
 # @pytest.mark.skip(reason="ECS can't pass this case!")
 @pytest.mark.parametrize("sig", [signal.SIGTERM, signal.SIGINT])
@@ -716,6 +719,7 @@ def test_specified_prefetch(
     rafs_conf: RafsConf,
     nydus_scratch_image: RafsImage,
     backend,
+    tmp_path
 ):
     """
     description:
@@ -747,10 +751,14 @@ def test_specified_prefetch(
     prefetching_files.append("/a/b/c/d")
     prefetching_files.append(os.path.join("/", "f/g/h/"))
 
-    specified_files = " ".join([os.path.join("/", d) for d in prefetching_files])
+    tmp_file = tmp_path / "prefetch.txt"
+    with open(tmp_file, "w") as f:
+        for d in prefetching_files:
+            f.write(os.path.join("/", d) + "\n") 
 
+    print(os.path.abspath(tmp_file))
     rafs = NydusDaemon(nydus_anchor, nydus_scratch_image, rafs_conf)
-    rafs.prefetch_files(specified_files).mount()
+    rafs.prefetch_files(os.path.abspath(tmp_file)).mount()
 
     nc = NydusAPIClient(rafs.get_apisock())
 
@@ -850,6 +858,7 @@ def test_blobcache_recovery(
     nydus_anchor: NydusAnchor,
     rafs_conf: RafsConf,
     nydus_scratch_image: RafsImage,
+    tmp_path
 ):
     rafs_conf.set_rafs_backend(Backend.BACKEND_PROXY)
     rafs_conf.enable_fs_prefetch()
@@ -868,7 +877,9 @@ def test_blobcache_recovery(
     nydus_scratch_image.set_backend(Backend.BACKEND_PROXY).create_image()
 
     rafs = NydusDaemon(nydus_anchor, nydus_scratch_image, rafs_conf)
-    rafs.prefetch_files("/").mount()
+    tmp_file = tmp_path / "prefetch.txt"
+    tmp_file.write_text("/")
+    rafs.prefetch_files(os.path.abspath(tmp_file)).mount()
     wg = WorkloadGen(nydus_anchor.mountpoint, nydus_scratch_image.rootfs())
 
     wg.setup_workload_generator()

--- a/contrib/nydus-test/functional-test/test_nydusify.py
+++ b/contrib/nydus-test/functional-test/test_nydusify.py
@@ -2,6 +2,7 @@ import pytest
 import posixpath
 import time
 import platform
+import os
 
 from nydus_anchor import NydusAnchor
 from oss import OssHelper
@@ -32,6 +33,7 @@ def test_basic_conversion(
     fs_version,
     local_registry,
     nydusify_converter,
+    tmp_path
 ):
     """
     No need to locate where bootstrap is as we can directly pull it from registry
@@ -73,7 +75,9 @@ def test_basic_conversion(
 
     workload_gen = WorkloadGen(nydus_anchor.mountpoint, nydus_anchor.overlayfs)
     # No need to locate where bootstrap is as we can directly pull it from registry
-    rafs.thread_num(6).bootstrap(pulled_bootstrap).prefetch_files("/").mount()
+    tmp_file = tmp_path / "prefetch.txt"
+    tmp_file.write_text("/")
+    rafs.thread_num(6).bootstrap(pulled_bootstrap).prefetch_files(os.path.abspath(tmp_file)).mount()
 
     assert workload_gen.verify_entire_fs()
     workload_gen.setup_workload_generator()
@@ -96,6 +100,7 @@ def test_build_cache(
     enable_multiplatform,
     local_registry,
     nydusify_converter,
+    tmp_path
 ):
     """
     No need to locate where bootstrap is as we can directly pull it from registry
@@ -153,7 +158,9 @@ def test_build_cache(
 
     workload_gen = WorkloadGen(nydus_anchor.mountpoint, nydus_anchor.overlayfs)
     # No need to locate where bootstrap is as we can directly pull it from registry
-    rafs.thread_num(6).bootstrap(pulled_bootstrap).prefetch_files("/").mount()
+    tmp_file = tmp_path / "prefetch.txt"
+    tmp_file.write_text("/")
+    rafs.thread_num(6).bootstrap(pulled_bootstrap).prefetch_files(os.path.abspath(tmp_file)).mount()
 
     assert workload_gen.verify_entire_fs()
     workload_gen.setup_workload_generator()
@@ -173,6 +180,7 @@ def test_upload_oss(
     source,
     local_registry,
     nydusify_converter,
+    tmp_path
 ):
     """
     docker python client manual: https://docker-py.readthedocs.io/en/stable/
@@ -230,7 +238,10 @@ def test_upload_oss(
     rafs = NydusDaemon(nydus_anchor, None, rafs_conf)
 
     workload_gen = WorkloadGen(nydus_anchor.mountpoint, nydus_anchor.overlayfs)
-    rafs.thread_num(6).bootstrap(pulled_bootstrap).prefetch_files("/").mount()
+    
+    tmp_file = tmp_path / "prefetch.txt"
+    tmp_file.write_text("/")
+    rafs.thread_num(6).bootstrap(pulled_bootstrap).prefetch_files(os.path.abspath(tmp_file)).mount()
 
     assert workload_gen.verify_entire_fs()
     workload_gen.setup_workload_generator()
@@ -273,6 +284,7 @@ def test_chunk_dict(
     chunk_dict_arg,
     local_registry,
     nydusify_converter,
+    tmp_path
 ):
     '''
     only support oss backend now
@@ -327,7 +339,10 @@ def test_chunk_dict(
     rafs = RafsMount(nydus_anchor, None, rafs_conf)
 
     workload_gen = WorkloadGen(nydus_anchor.mount_point, nydus_anchor.overlayfs)
-    rafs.thread_num(6).bootstrap(pulled_bootstrap).prefetch_files("/").mount()
+
+    tmp_file = tmp_path / "prefetch.txt"
+    tmp_file.write_text("/")
+    rafs.thread_num(6).bootstrap(pulled_bootstrap).prefetch_files(os.path.abspath(tmp_file)).mount()
 
     assert workload_gen.verify_entire_fs()
     workload_gen.setup_workload_generator()
@@ -351,6 +366,7 @@ def test_cross_platform_multiplatform(
     enable_multiplatform,
     local_registry,
     nydusify_converter,
+    tmp_path
 ):
     """
     - copy the entire repo from source registry to target registry
@@ -434,7 +450,9 @@ def test_cross_platform_multiplatform(
     workload_gen = WorkloadGen(nydus_anchor.mountpoint, nydus_anchor.overlayfs)
     # No need to locate where bootstrap is as we can directly pull it from registry
     rafs = NydusDaemon(nydus_anchor, None, rafs_conf)
-    rafs.thread_num(6).bootstrap(pulled_bootstrap).prefetch_files("/").mount()
+    tmp_file = tmp_path / "prefetch.txt"
+    tmp_file.write_text("/")
+    rafs.thread_num(6).bootstrap(pulled_bootstrap).prefetch_files(os.path.abspath(tmp_file)).mount()
 
     assert workload_gen.verify_entire_fs()
     workload_gen.setup_workload_generator()

--- a/src/bin/nydusd/main.rs
+++ b/src/bin/nydusd/main.rs
@@ -220,7 +220,7 @@ fn append_fs_options(app: Command) -> Command {
     .arg(
         Arg::new("prefetch-files")
             .long("prefetch-files")
-            .help("A file include the list of files/directories to prefetch")
+            .help("A file including the list of files/directories to be prefetched")
             .required(false)
             .requires("bootstrap")
             .num_args(1),

--- a/src/bin/nydusd/main.rs
+++ b/src/bin/nydusd/main.rs
@@ -220,7 +220,7 @@ fn append_fs_options(app: Command) -> Command {
     .arg(
         Arg::new("prefetch-files")
             .long("prefetch-files")
-            .help("A file including the list of files/directories to be prefetched")
+            .help("local file path which recorded files/directories to be prefetched and separated by newlines")
             .required(false)
             .requires("bootstrap")
             .num_args(1),


### PR DESCRIPTION
change the nydusd  arg --prefetch as a file path, we can read the prefetch list from the file. For example:
we can use `--prefetch-files /tmp/test` and the `/tmp/test` is like 
```
/etc
/bin
/src/test.py
```
When nydusd is mounted, this file is read by line to form a prefetch list 