### PR TITLE
docs: update nydus path to /usr/bin for better compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ all-install: install contrib-install
 all-clean: clean contrib-clean
 
 TEST_WORKDIR_PREFIX ?= "/tmp"
-INSTALL_DIR_PREFIX ?= "/usr/local/bin"
+INSTALL_DIR_PREFIX ?= "/usr/bin"
 DOCKER ?= "true"
 
 CARGO ?= $(shell which cargo)

--- a/docs/containerd-env-setup.md
+++ b/docs/containerd-env-setup.md
@@ -7,13 +7,13 @@ This document will walk through how to setup a nydus image service to work with 
 1. Get `nydus-image`, `nydusd`, `nydusify`, `nydusctl` and `nydus-overlayfs` binaries from [release](https://github.com/dragonflyoss/image-service/releases/latest) page.
 
 ```bash
-sudo install -D -m 755 nydusd nydus-image nydusify nydusctl nydus-overlayfs /usr/local/bin
+sudo install -D -m 755 nydusd nydus-image nydusify nydusctl nydus-overlayfs /usr/bin
 ```
 
 2. Get `containerd-nydus-grpc` (nydus snapshotter) binary from nydus-snapshotter [release](https://github.com/containerd/nydus-snapshotter/releases/latest) page.
 
 ```bash
-sudo install -D -m 755 containerd-nydus-grpc /usr/local/bin
+sudo install -D -m 755 containerd-nydus-grpc /usr/bin
 ```
 
 ## Start Nydus Snapshotter
@@ -76,7 +76,7 @@ sudo rm -rf /var/lib/containerd-nydus
 3. Start `containerd-nydus-grpc` (nydus snapshotter):
 
 ```bash
-sudo /usr/local/bin/containerd-nydus-grpc \
+sudo /usr/bin/containerd-nydus-grpc \
     --config-path /etc/nydus/nydusd-config.fusedev.json \
     --log-to-stdout
 ```

--- a/docs/nydus-fscache.md
+++ b/docs/nydus-fscache.md
@@ -44,8 +44,8 @@ cd image-service
 make release
 ```
 
-4. Copy the "nydus-image" binary file compiled in Step 3 into _$PATH_ e.g. /usr/local/bin with \
-``cp target/release/nydus-image /usr/local/bin``
+4. Copy the "nydus-image" binary file compiled in Step 3 into _$PATH_ e.g. /usr/bin with \
+``cp target/release/nydus-image /usr/bin``
 
 5. Build ctr-remote with
 

--- a/docs/nydus-zran.md
+++ b/docs/nydus-zran.md
@@ -26,11 +26,11 @@ git clone https://github.com/dragonflyoss/image-service.git
 
 # Install nydusd
 cargo build --target x86_64-unknown-linux-musl --release --bin nydusd
-sudo install -D -m 755 ./target/x86_64-unknown-linux-musl/release/nydusd /usr/local/bin
+sudo install -D -m 755 ./target/x86_64-unknown-linux-musl/release/nydusd /usr/bin
 
 # Install nydus-image
 cargo build --target x86_64-unknown-linux-musl --release --bin nydus-image
-sudo install -D -m 755 ./target/x86_64-unknown-linux-musl/release/nydus-image /usr/local/bin
+sudo install -D -m 755 ./target/x86_64-unknown-linux-musl/release/nydus-image /usr/bin
 ```
 
 2. Get nydus zran artifact:


### PR DESCRIPTION
This PR fixes an issue where nydus snapshotter cannot find nydusd on some Linux versions, example:

![lQLPJxTVIAlqNzRSzQVPsJ7ZzP9sLOlPA7CXILGAnwA_1359_82](https://user-images.githubusercontent.com/29459113/210540700-b5600aa7-0730-4c01-a0b5-997ddd4b6338.png)

Signed-off-by: Qinqi Qu <quqinqi@linux.alibaba.com>