### PR TITLE
cross: install cmake

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,2 @@
+[build]
+pre-build = ["apt-get update && apt-get install -y cmake"]


### PR DESCRIPTION
Building nydusd failed on linux-riscv64 with:

  thread 'main' panicked at '
  failed to execute command: No such file or directory (os error 2)
  is `cmake` not installed?

We need to install cmake to allow cross-rs to build.