### PR TITLE
avoid too much information log

### DIFF
--- a/api/src/http_handler.rs
+++ b/api/src/http_handler.rs
@@ -184,12 +184,12 @@ fn kick_api_server(
 // --> GET / 200 835ms 746b
 
 fn trace_api_begin(request: &dbs_uhttp::Request) {
-    info!("<--- {:?} {:?}", request.method(), request.uri());
+    debug!("<--- {:?} {:?}", request.method(), request.uri());
 }
 
 fn trace_api_end(response: &dbs_uhttp::Response, method: dbs_uhttp::Method, recv_time: SystemTime) {
     let elapse = SystemTime::now().duration_since(recv_time);
-    info!(
+    debug!(
         "---> {:?} Status Code: {:?}, Elapse: {:?}, Body Size: {:?}",
         method,
         response.status(),

--- a/storage/src/backend/registry.rs
+++ b/storage/src/backend/registry.rs
@@ -276,7 +276,7 @@ impl RegistryState {
         if let Ok(now_timestamp) = SystemTime::now().duration_since(UNIX_EPOCH) {
             self.refresh_token_time
                 .store(Some(Arc::new(now_timestamp.as_secs() + ret.expires_in)));
-            info!(
+            debug!(
                 "cached bearer auth, next time: {}",
                 now_timestamp.as_secs() + ret.expires_in
             );


### PR DESCRIPTION
There are too many information logs about `nydus API` when enabling metrics in `nydus-snapshotter`.
Moreover, too much information about `cached bearer auth` will be displayed when there are many layers.

Maybe we should change these levels to `debug`?

Signed-off-by: Bin Tang <tangbin.bin@bytedance.com>