### PR TITLE
storage: introduce BlobFeatures::SEPARATE to support tar-ref

### DIFF
--- a/rafs/src/metadata/layout/v6.rs
+++ b/rafs/src/metadata/layout/v6.rs
@@ -1272,7 +1272,7 @@ struct RafsV6Blob {
     uncompressed_size: u64,
 
     // Size of blob ToC content, it's zero for blobs with inlined-meta.
-    rafs_blob_toc_size: u32,
+    blob_toc_size: u32,
     // Compression algorithm for the compression information array.
     ci_compressor: u32,
     // Offset into the compressed blob for the compression information array.
@@ -1284,13 +1284,13 @@ struct RafsV6Blob {
 
     // SHA256 digest of blob ToC content, including the toc tar header.
     // It's all zero for blobs with inlined-meta.
-    rafs_blob_toc_digest: [u8; 32],
+    blob_toc_digest: [u8; 32],
     // SHA256 digest of RAFS blob for ZRAN, containing `blob.meta`, `blob.digest` `blob.toc` and
     // optionally 'image.boot`. It's all zero for ZRAN blobs with inlined-meta, so need special
     // handling.
-    rafs_blob_digest: [u8; 32],
+    blob_meta_digest: [u8; 32],
     // Size of RAFS blob for ZRAN. It's zero ZRAN blobs with inlined-meta.
-    rafs_blob_size: u64,
+    blob_meta_size: u64,
 
     reserved2: [u8; 48],
 }
@@ -1312,10 +1312,10 @@ impl Default for RafsV6Blob {
             ci_compressed_size: 0u64,
             ci_uncompressed_size: 0u64,
 
-            rafs_blob_toc_digest: [0u8; 32],
-            rafs_blob_digest: [0u8; 32],
-            rafs_blob_size: 0,
-            rafs_blob_toc_size: 0u32,
+            blob_toc_digest: [0u8; 32],
+            blob_meta_digest: [0u8; 32],
+            blob_meta_size: 0,
+            blob_toc_size: 0u32,
 
             reserved2: [0u8; 48],
         }
@@ -1355,10 +1355,10 @@ impl RafsV6Blob {
             u64::from_le(self.ci_uncompressed_size),
             u32::from_le(self.ci_compressor),
         );
-        blob_info.set_rafs_blob_toc_digest(self.rafs_blob_toc_digest);
-        blob_info.set_rafs_blob_digest(self.rafs_blob_digest);
-        blob_info.set_rafs_blob_size(self.rafs_blob_size);
-        blob_info.set_rafs_blob_toc_size(self.rafs_blob_toc_size);
+        blob_info.set_blob_toc_digest(self.blob_toc_digest);
+        blob_info.set_blob_meta_digest(self.blob_meta_digest);
+        blob_info.set_blob_meta_size(self.blob_meta_size);
+        blob_info.set_blob_toc_size(self.blob_toc_size);
 
         Ok(blob_info)
     }
@@ -1389,10 +1389,10 @@ impl RafsV6Blob {
             ci_compressed_size: blob_info.meta_ci_compressed_size().to_le(),
             ci_uncompressed_size: blob_info.meta_ci_uncompressed_size().to_le(),
 
-            rafs_blob_toc_digest: *blob_info.rafs_blob_toc_digest(),
-            rafs_blob_digest: *blob_info.rafs_blob_digest(),
-            rafs_blob_size: blob_info.rafs_blob_size(),
-            rafs_blob_toc_size: blob_info.rafs_blob_toc_size(),
+            blob_toc_digest: *blob_info.blob_toc_digest(),
+            blob_meta_digest: *blob_info.blob_meta_digest(),
+            blob_meta_size: blob_info.blob_meta_size(),
+            blob_toc_size: blob_info.blob_toc_size(),
 
             reserved2: [0u8; 48],
         })
@@ -1435,8 +1435,8 @@ impl RafsV6Blob {
             || c_size != chunk_size as u64
         {
             error!(
-                "RafsV6Blob: idx {} invalid chunk_size {:x}",
-                blob_index, c_size,
+                "RafsV6Blob: idx {} invalid chunk_size 0x{:x}, expect 0x{:x}",
+                blob_index, c_size, chunk_size
             );
             return false;
         }
@@ -1586,10 +1586,10 @@ impl RafsV6BlobTable {
         uncompressed_size: u64,
         compressed_size: u64,
         flags: RafsSuperFlags,
-        rafs_blob_digest: [u8; 32],
-        rafs_blob_toc_digest: [u8; 32],
-        rafs_blob_size: u64,
-        rafs_blob_toc_size: u32,
+        blob_meta_digest: [u8; 32],
+        blob_toc_digest: [u8; 32],
+        blob_meta_size: u64,
+        blob_toc_size: u32,
         header: BlobCompressionContextHeader,
     ) -> u32 {
         let blob_index = self.entries.len() as u32;
@@ -1613,10 +1613,10 @@ impl RafsV6BlobTable {
             header.ci_uncompressed_size(),
             header.ci_compressor() as u32,
         );
-        blob_info.set_rafs_blob_digest(rafs_blob_digest);
-        blob_info.set_rafs_blob_toc_digest(rafs_blob_toc_digest);
-        blob_info.set_rafs_blob_size(rafs_blob_size);
-        blob_info.set_rafs_blob_toc_size(rafs_blob_toc_size);
+        blob_info.set_blob_meta_digest(blob_meta_digest);
+        blob_info.set_blob_toc_digest(blob_toc_digest);
+        blob_info.set_blob_meta_size(blob_meta_size);
+        blob_info.set_blob_toc_size(blob_toc_size);
 
         self.entries.push(Arc::new(blob_info));
 

--- a/src/bin/nydus-image/builder/mod.rs
+++ b/src/bin/nydus-image/builder/mod.rs
@@ -159,8 +159,8 @@ fn dump_toc(
         hasher.digest_update(&data);
         let header = blob_ctx.write_tar_header(blob_writer, toc::TOC_ENTRY_BLOB_TOC, toc_size)?;
         hasher.digest_update(header.as_bytes());
-        blob_ctx.rafs_blob_toc_digest = hasher.digest_finalize().data;
-        blob_ctx.rafs_blob_toc_size = toc_size as u32 + header.as_bytes().len() as u32;
+        blob_ctx.blob_toc_digest = hasher.digest_finalize().data;
+        blob_ctx.blob_toc_size = toc_size as u32 + header.as_bytes().len() as u32;
     }
     Ok(())
 }
@@ -181,7 +181,7 @@ fn finalize_blob(
         }
 
         let hash = blob_ctx.blob_hash.clone().finalize();
-        let rafs_blob_id = if ctx.blob_id.is_empty() {
+        let blob_meta_id = if ctx.blob_id.is_empty() {
             format!("{:x}", hash)
         } else {
             assert!(!ctx.conversion_type.is_to_ref());
@@ -208,15 +208,15 @@ fn finalize_blob(
                 }
             }
             if !ctx.blob_inline_meta {
-                blob_ctx.rafs_blob_digest = hash.into();
-                blob_ctx.rafs_blob_size = blob_writer.pos()?;
+                blob_ctx.blob_meta_digest = hash.into();
+                blob_ctx.blob_meta_size = blob_writer.pos()?;
             }
         } else if blob_ctx.blob_id.is_empty() {
             // `blob_ctx.blob_id` should be RAFS blob id.
-            blob_ctx.blob_id = rafs_blob_id.clone();
+            blob_ctx.blob_id = blob_meta_id.clone();
         }
 
-        blob_writer.finalize(Some(rafs_blob_id))?;
+        blob_writer.finalize(Some(blob_meta_id))?;
     }
 
     Ok(())

--- a/src/bin/nydus-image/builder/tarball.rs
+++ b/src/bin/nydus-image/builder/tarball.rs
@@ -30,6 +30,7 @@ use nydus_rafs::metadata::inode::InodeWrapper;
 use nydus_rafs::metadata::layout::v5::{RafsV5Inode, RafsV5InodeFlags};
 use nydus_rafs::metadata::layout::RafsXAttrs;
 use nydus_rafs::metadata::{Inode, RafsVersion};
+use nydus_storage::device::BlobFeatures;
 use nydus_storage::meta::ZranContextGenerator;
 use nydus_storage::RAFS_MAX_CHUNKS_PER_BLOB;
 use nydus_utils::compact::makedev;
@@ -118,6 +119,7 @@ impl<'a> TarballTreeBuilder<'a> {
                     let generator = ZranContextGenerator::from_buf_reader(buf_reader)?;
                     let reader = generator.reader();
                     self.ctx.blob_zran_generator = Some(Mutex::new(generator));
+                    self.ctx.blob_features.insert(BlobFeatures::ZRAN);
                     TarReader::Zran(reader)
                 } else {
                     buf_reader.seek_relative(-3).unwrap();

--- a/src/bin/nydus-image/core/blob.rs
+++ b/src/bin/nydus-image/core/blob.rs
@@ -142,9 +142,14 @@ impl Blob {
             header.set_ci_zran_offset(ci_data.len() as u64);
             header.set_ci_zran_size(zran_data.len() as u64);
             header.set_ci_zran(true);
+            header.set_separate_blob(true);
             zran_buf = [ci_data, &zran_data].concat();
             ci_data = &zran_buf;
+        } else if ctx.blob_tar_reader.is_some() {
+            header.set_separate_blob(true);
+            header.set_ci_zran(false);
         } else {
+            header.set_separate_blob(false);
             header.set_ci_zran(false);
         };
 

--- a/src/bin/nydus-image/core/node.rs
+++ b/src/bin/nydus-image/core/node.rs
@@ -587,7 +587,7 @@ impl Node {
         chunk.set_uncompressed_offset(pre_uncompressed_offset);
         chunk.set_uncompressed_size(uncompressed_size);
 
-        let compressed_size = if ctx.blob_features.contains(BlobFeatures::ZRAN) {
+        let compressed_size = if ctx.blob_features.contains(BlobFeatures::SEPARATE) {
             // For `tar-ref`, `targz-ref`, `estargz-ref` and `estargzindex-ref`.
             chunk.compressed_size()
         } else {

--- a/src/bin/nydus-image/inspect.rs
+++ b/src/bin/nydus-image/inspect.rs
@@ -298,7 +298,7 @@ Uncompressed Data Size: {uncompressed_size}
 Features:               {features:?}
 Compressor:             {compressor}
 Digester:               {digester}
-Chunk Size:             {chunk_size}
+Chunk Size:             0x{chunk_size:x}
 Chunk Count:            {chunk_count}
 Prefetch Table Offset:  {prefetch_tbl_offset}
 Prefetch Table Size:    {prefetch_tbl_size}
@@ -328,10 +328,10 @@ RAFS Blob Size:         {rafs_size}
                     meta_offset = blob_info.meta_ci_offset(),
                     meta_comp_size = blob_info.meta_ci_compressed_size(),
                     meta_uncomp_size = blob_info.meta_ci_uncompressed_size(),
-                    toc_digest = hex::encode(blob_info.rafs_blob_toc_digest()),
-                    toc_size = blob_info.rafs_blob_toc_size(),
-                    rafs_digest = hex::encode(blob_info.rafs_blob_digest()),
-                    rafs_size = blob_info.rafs_blob_size(),
+                    toc_digest = hex::encode(blob_info.blob_toc_digest()),
+                    toc_size = blob_info.blob_toc_size(),
+                    rafs_digest = hex::encode(blob_info.blob_meta_digest()),
+                    rafs_size = blob_info.blob_meta_size(),
                 );
             }
         }

--- a/src/bin/nydus-image/main.rs
+++ b/src/bin/nydus-image/main.rs
@@ -816,7 +816,7 @@ impl Command {
                     bail!("conversion type {} conflicts with RAFS v5", conversion_type);
                 }
                 build_ctx.blob_features.insert(BlobFeatures::CHUNK_INFO_V2);
-                build_ctx.blob_features.insert(BlobFeatures::ZRAN);
+                build_ctx.blob_features.insert(BlobFeatures::SEPARATE);
                 Box::new(TarballBuilder::new(conversion_type))
             }
             ConversionType::DirectoryToStargz

--- a/src/bin/nydus-image/merge.rs
+++ b/src/bin/nydus-image/merge.rs
@@ -169,25 +169,25 @@ impl Merger {
                         blob_ctx.blob_id = BlobInfo::get_blob_id_from_meta_path(bootstrap_path)?;
                     }
                     if let Some(digest) = Self::get_digest_from_list(&blob_digests, layer_idx)? {
-                        if blob.has_feature(BlobFeatures::ZRAN) {
-                            blob_ctx.rafs_blob_digest = digest;
+                        if blob.has_feature(BlobFeatures::SEPARATE) {
+                            blob_ctx.blob_meta_digest = digest;
                         } else {
                             blob_ctx.blob_id = hex::encode(digest);
                         }
                     }
                     if let Some(size) = Self::get_size_from_list(&blob_sizes, layer_idx)? {
-                        if blob.has_feature(BlobFeatures::ZRAN) {
-                            blob_ctx.rafs_blob_size = size;
+                        if blob.has_feature(BlobFeatures::SEPARATE) {
+                            blob_ctx.blob_meta_size = size;
                         } else {
                             blob_ctx.compressed_blob_size = size;
                         }
                     }
                     if let Some(digest) = Self::get_digest_from_list(&blob_toc_digests, layer_idx)?
                     {
-                        blob_ctx.rafs_blob_toc_digest = digest;
+                        blob_ctx.blob_toc_digest = digest;
                     }
                     if let Some(size) = Self::get_size_from_list(&blob_toc_sizes, layer_idx)? {
-                        blob_ctx.rafs_blob_toc_size = size as u32;
+                        blob_ctx.blob_toc_size = size as u32;
                     }
 
                     if chunk_size.is_none() {

--- a/storage/src/meta/chunk_info_v2.rs
+++ b/storage/src/meta/chunk_info_v2.rs
@@ -144,7 +144,7 @@ impl BlobMetaChunkInfo for BlobChunkInfoV2Ondisk {
         if self.compressed_end() > state.compressed_size
             || self.uncompressed_end() > state.uncompressed_size
             || self.uncompressed_size() == 0
-            || (!self.is_zran() && self.compressed_size() == 0)
+            || (!state.is_separate() && self.compressed_size() == 0)
             || (!self.is_compressed() && self.uncompressed_size() != self.compressed_size())
         {
             return Err(einval!(format!(


### PR DESCRIPTION
Introduce BlobFeatures::SEPARATE to support tar-ref, in addition to BlobFeatures::ZRAN.
SEPARATE means that blob.data is separated from blob.meta. ZRAN means that it contains ZRAN context information and should be decoded by ZRAN.

Fixes: https://github.com/dragonflyoss/image-service/issues/990

Signed-off-by: Jiang Liu <gerry@linux.alibaba.com>