### PR TITLE
nydus-image: fix a bug in handle xattr for tarballs

### DIFF
--- a/storage/src/cache/filecache/mod.rs
+++ b/storage/src/cache/filecache/mod.rs
@@ -196,9 +196,12 @@ impl FileCacheEntry {
             .get_reader(&blob_id)
             .map_err(|e| eio!(format!("failed to get reader for blob {}, {}", blob_id, e)))?;
         let blob_meta_reader = if is_separate_meta {
-            mgr.backend
-                .get_reader(&blob_meta_id)
-                .map_err(|_e| eio!("failed to get reader for rafs blob"))?
+            mgr.backend.get_reader(&blob_meta_id).map_err(|e| {
+                eio!(format!(
+                    "failed to get reader for blob.meta {}, {}",
+                    blob_id, e
+                ))
+            })?
         } else {
             reader.clone()
         };

--- a/storage/src/cache/fscache/mod.rs
+++ b/storage/src/cache/fscache/mod.rs
@@ -224,9 +224,12 @@ impl FileCacheEntry {
             .get_reader(&blob_id)
             .map_err(|_e| eio!("failed to get reader for data blob"))?;
         let blob_meta_reader = if is_separate_meta {
-            mgr.backend
-                .get_reader(&blob_meta_id)
-                .map_err(|_e| eio!("failed to get reader for rafs blob"))?
+            mgr.backend.get_reader(&blob_meta_id).map_err(|e| {
+                eio!(format!(
+                    "failed to get reader for blob.meta {}, {}",
+                    blob_id, e
+                ))
+            })?
         } else {
             reader.clone()
         };


### PR DESCRIPTION
There's a bug in xattr handling for tarball which causing losing of xattrs.

Fixes: https://github.com/dragonflyoss/image-service/issues/990

Signed-off-by: Jiang Liu <gerry@linux.alibaba.com>