### PR TITLE
utils: fix a compilation error for libz-ng-sys on ppc64le

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -788,6 +788,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "libz-sys"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9702761c3935f8cc2f101793272e202c72b99da8f4224a19ddcf1279a6450bbf"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1124,6 +1136,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "libz-ng-sys",
+ "libz-sys",
  "log",
  "lz4",
  "lz4-sys",

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -13,7 +13,6 @@ blake3 = "1.3"
 flate2 = { version = "1.0", features = ["zlib-ng"], default-features = false }
 lazy_static = "1.4"
 libc = "0.2"
-libz-ng-sys = { version = "1.1.8", optional = true }
 log = "0.4"
 lz4-sys = "1.9.4"
 lz4 = "1.24.0"
@@ -26,12 +25,17 @@ nix = "0.24"
 
 nydus-error = { version = "0.2", path = "../error" }
 
+[target.'cfg(target_arch = "ppc64le")'.dependencies]
+libz-sys = { version = "1.1.8", optional = true }
+[target.'cfg(not(target_arch = "ppc64le"))'.dependencies]
+libz-sys = { version = "1.1.8", package = "libz-ng-sys", optional = true }
+
 [dev-dependencies]
 vmm-sys-util = ">=0.9.0"
 tar = "0.4.38"
 
 [features]
-zran = ["libz-ng-sys"]
+zran = ["libz-sys"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/utils/src/compress/zlib_random.rs
+++ b/utils/src/compress/zlib_random.rs
@@ -12,7 +12,7 @@ use std::os::raw::{c_char, c_int, c_void};
 use std::sync::{Arc, Mutex};
 use std::{mem, ptr};
 
-use libz_ng_sys::{
+use libz_sys::{
     inflate, inflateEnd, inflateInit2_, inflatePrime, inflateReset, inflateSetDictionary, uInt,
     z_stream, Z_BLOCK, Z_BUF_ERROR, Z_OK, Z_STREAM_END,
 };


### PR DESCRIPTION
libz-ng-sys fails to compile on ppc64le, so fallback to libz-ng.

Signed-off-by: Jiang Liu <gerry@linux.alibaba.com>