### PR TITLE
storage: add BlobFeature::HAS_TAR_HEADER to calcalute

### DIFF
--- a/src/bin/nydus-image/core/context.rs
+++ b/src/bin/nydus-image/core/context.rs
@@ -464,6 +464,9 @@ impl BlobContext {
             .set_inlined_chunk_digest(features.contains(BlobFeatures::INLINED_CHUNK_DIGEST));
         blob_ctx
             .blob_meta_header
+            .set_has_tar_header(features.contains(BlobFeatures::HAS_TAR_HEADER));
+        blob_ctx
+            .blob_meta_header
             .set_has_toc(features.contains(BlobFeatures::HAS_TOC));
         blob_ctx
             .blob_meta_header
@@ -1080,9 +1083,11 @@ impl BuildContext {
         let mut blob_features = BlobFeatures::CAP_TAR_TOC;
         if blob_inline_meta {
             blob_features |= BlobFeatures::INLINED_FS_META;
+            blob_features |= BlobFeatures::HAS_TAR_HEADER;
         };
         if features.is_enabled(Feature::BlobToc) {
             blob_features |= BlobFeatures::HAS_TOC;
+            blob_features |= BlobFeatures::HAS_TAR_HEADER;
         }
 
         BuildContext {

--- a/storage/src/device.rs
+++ b/storage/src/device.rs
@@ -61,6 +61,8 @@ bitflags! {
         const SEPARATE = 0x0000_0010;
         /// Chunk digest array is inlined in the data blob.
         const INLINED_CHUNK_DIGEST = 0x0000_0020;
+        /// Blob has TAR headers to separate contents.
+        const HAS_TAR_HEADER = 0x1000_0000;
         /// Blob has Table of Content (ToC) at the tail.
         const HAS_TOC = 0x2000_0000;
         /// Data blob are encoded with Tar header and optionally ToC.
@@ -229,9 +231,7 @@ impl BlobInfo {
             // Image built with nydus 2.2 and newer versions.
             if self.meta_ci_is_valid() {
                 // For RAFS v6
-                if self.has_feature(BlobFeatures::HAS_TOC)
-                    || self.has_feature(BlobFeatures::INLINED_FS_META)
-                {
+                if self.has_feature(BlobFeatures::HAS_TAR_HEADER) {
                     // There's a tar header between chunk data and compression information.
                     self.meta_ci_offset - 0x200
                 } else {
@@ -239,8 +239,8 @@ impl BlobInfo {
                 }
             } else {
                 // For RAFS v5
-                if self.has_feature(BlobFeatures::INLINED_FS_META) {
-                    // There's a tar header between chunk data and compression information.
+                if self.has_feature(BlobFeatures::HAS_TAR_HEADER) {
+                    // There's a tar header between chunk data and fs meta data.
                     self.compressed_size - 0x200
                 } else {
                     self.compressed_size

--- a/storage/src/meta/mod.rs
+++ b/storage/src/meta/mod.rs
@@ -282,7 +282,16 @@ impl BlobCompressionContextHeader {
         }
     }
 
-    /// Set flag indicating new blob format with tar/toc headers.
+    /// Set flag indicating new blob format with tar headers.
+    pub fn set_has_tar_header(&mut self, enable: bool) {
+        if enable {
+            self.s_features |= BlobFeatures::HAS_TAR_HEADER.bits();
+        } else {
+            self.s_features &= !BlobFeatures::HAS_TAR_HEADER.bits();
+        }
+    }
+
+    /// Set flag indicating new blob format with toc headers.
     pub fn set_has_toc(&mut self, enable: bool) {
         if enable {
             self.s_features |= BlobFeatures::HAS_TOC.bits();
@@ -1646,7 +1655,10 @@ pub trait BlobMetaChunkInfo {
 pub fn format_blob_features(features: BlobFeatures) -> String {
     let mut output = String::new();
     if features.contains(BlobFeatures::ALIGNED) {
-        output += "4K-align ";
+        output += "aligned ";
+    }
+    if features.contains(BlobFeatures::CAP_TAR_TOC) {
+        output += "cap_toc ";
     }
     if features.contains(BlobFeatures::INLINED_CHUNK_DIGEST) {
         output += "chunk-digest ";
@@ -1659,6 +1671,9 @@ pub fn format_blob_features(features: BlobFeatures) -> String {
     }
     if features.contains(BlobFeatures::SEPARATE) {
         output += "separate ";
+    }
+    if features.contains(BlobFeatures::HAS_TAR_HEADER) {
+        output += "tar-header ";
     }
     if features.contains(BlobFeatures::HAS_TOC) {
         output += "toc ";


### PR DESCRIPTION
Add BlobFeature::HAS_TAR_HEADER to calcalute compressed blob size for merged bootstrap. When merging data blobs with inlined bootstrap, the BlobFeature::INLINED_FS_META flag will get lost, so we need a new flag to indicate there's tar header in these data blobs.

Signed-off-by: Jiang Liu <gerry@linux.alibaba.com>