### PR TITLE
nydusctl: print fs read errors and total read data

### DIFF
--- a/src/bin/nydusctl/commands.rs
+++ b/src/bin/nydusctl/commands.rs
@@ -296,6 +296,7 @@ impl CommandFsStats {
         let metrics = client.get("v1/metrics").await?;
         let m = metrics.as_object().unwrap();
         let fop_counter = m["fop_hits"].as_array().unwrap();
+        let fop_errors = m["fop_errors"].as_array().unwrap();
         if raw {
             println!("{}", metrics);
         } else {
@@ -322,7 +323,15 @@ impl CommandFsStats {
                 print!("{:<8}", d.as_u64().unwrap());
             }
 
-            println!();
+            println!("\n");
+
+            println!("Read Errors: {}", fop_errors[4]);
+            let data_read = m["data_read"].as_u64().unwrap();
+            println!(
+                "Read Data: {}Bytes ({}MB)",
+                data_read,
+                data_read / 1024 / 1024
+            );
 
             print!(
                 r#"


### PR DESCRIPTION
Also print rafs layer total read data amount and read errors. It helps to analyze system performance.

example:
```
Read Latency:   <1ms    ~20ms   ~50ms   ~100ms  ~500ms  ~1s     ~2s     2s~
Reads Count:    2244    2       440     10      3       0       0       0
Read Errors: 0
Cumulative Read Data: 66708312Bytes (63MB)

FOP Counters:
Getattr(490) Readlink(5) Open(0) Release(0) Read(2699) Statfs(0) Getxattr(1931) Listxattr(3)
Opendir(0) Lookup(159) Readdir(0) Readdirplus(140) Access(0) Forget(0) BatchForget(0)
```

Signed-off-by: Changwei Ge <gechangwei@bytedance.com>