### PR TITLE
utils: let flate2 use libz instead of libz-ng for ppc64le

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -336,7 +336,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
 dependencies = [
  "crc32fast",
- "libz-ng-sys",
+ "libz-sys",
  "miniz_oxide",
 ]
 
@@ -778,22 +778,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
 
 [[package]]
-name = "libz-ng-sys"
-version = "1.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4399ae96a9966bf581e726de86969f803a81b7ce795fcd5480e640589457e0f2"
-dependencies = [
- "cmake",
- "libc",
-]
-
-[[package]]
 name = "libz-sys"
 version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9702761c3935f8cc2f101793272e202c72b99da8f4224a19ddcf1279a6450bbf"
 dependencies = [
  "cc",
+ "cmake",
  "libc",
  "pkg-config",
  "vcpkg",
@@ -1135,7 +1126,6 @@ dependencies = [
  "flate2",
  "lazy_static",
  "libc",
- "libz-ng-sys",
  "libz-sys",
  "log",
  "lz4",

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -10,7 +10,6 @@ edition = "2018"
 
 [dependencies]
 blake3 = "1.3"
-flate2 = { version = "1.0", features = ["zlib-ng"], default-features = false }
 lazy_static = "1.4"
 libc = "0.2"
 log = "0.4"
@@ -25,10 +24,13 @@ nix = "0.24"
 
 nydus-error = { version = "0.2", path = "../error" }
 
-[target.'cfg(target_arch = "powerpc64le")'.dependencies]
-libz-sys = { version = "1.1.8", optional = true }
-[target.'cfg(not(target_arch = "powerpc64le"))'.dependencies]
-libz-sys = { version = "1.1.8", package = "libz-ng-sys", optional = true }
+# libz-ng-sys doesn't compile on ppc64. Have to fallback to stock zlib-sys
+[target.'cfg(target_arch = "powerpc64")'.dependencies]
+libz-sys = { version = "1.1.8", features = ["stock-zlib"], default-features = false, optional = true }
+flate2 = { version = "1.0.17", features = ["zlib"], default-features = false }
+[target.'cfg(not(target_arch = "powerpc64"))'.dependencies]
+libz-sys = { version = "1.1.8", features = ["zlib-ng"], default-features = false, optional = true }
+flate2 = { version = "1.0.17", features = ["zlib-ng-compat"], default-features = false }
 
 [dev-dependencies]
 vmm-sys-util = ">=0.9.0"


### PR DESCRIPTION
Let flate2 use libz instead of libz-ng for ppc64le, libz-ng fails to compile on ppc64le platforms.
