### PR TITLE
storage: fix invalid hmac signature for oss backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -277,9 +277,9 @@ dependencies = [
 
 [[package]]
 name = "digest"
-version = "0.10.3"
+version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
+checksum = "8168378f4e5023e7218c89c891c0fd8ecdb5e5e4f18cb78f38cf245dd021e76f"
 dependencies = [
  "block-buffer",
  "crypto-common",
@@ -587,12 +587,6 @@ checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
  "digest",
 ]
-
-[[package]]
-name = "hmac-sha1-compact"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d103cfecf6edf3f7d1dc7c5ab64e99488c0f8d11786e43b40873e66e8489d014"
 
 [[package]]
 name = "http"
@@ -1094,7 +1088,6 @@ dependencies = [
  "fuse-backend-rs",
  "hex",
  "hmac",
- "hmac-sha1-compact",
  "http",
  "httpdate",
  "lazy_static",
@@ -1109,6 +1102,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "sha1",
  "sha2",
  "tar",
  "time",
@@ -1575,6 +1569,17 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
+]
+
+[[package]]
+name = "sha1"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f04293dc80c3993519f2d7f6f511707ee7094fe0c6d3406feb330cdb3540eba3"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -14,7 +14,6 @@ base64 = { version = "0.13.0", optional = true }
 bitflags = "1.2.1"
 hex = "0.4.3"
 hmac = { version = "0.12.1", optional = true }
-hmac-sha1-compact = { version = "1.1.1", optional = true }
 http = { version = "0.2.8", optional = true }
 httpdate = { version = "1.0", optional = true }
 lazy_static = "1.4.0"
@@ -36,6 +35,7 @@ fuse-backend-rs = "0.10"
 nydus-api = { version = "0.1", path = "../api" }
 nydus-utils = { version = "0.3", path = "../utils", features = ["zran"] }
 nydus-error = { version = "0.2", path = "../error" }
+sha1 = { version = "0.10.5", optional = true }
 
 [dev-dependencies]
 vmm-sys-util = "0.10"
@@ -44,7 +44,7 @@ regex = "1.7.0"
 
 [features]
 backend-localfs = []
-backend-oss = ["base64", "httpdate", "hmac-sha1-compact", "reqwest", "url"]
+backend-oss = ["base64", "httpdate", "hmac", "sha1", "reqwest", "url"]
 backend-registry = ["base64", "reqwest", "url"]
 backend-s3 = ["base64", "hmac", "http", "reqwest", "sha2", "time", "url"]
 


### PR DESCRIPTION
The crate `hmac-sha1-compact` is not work with oss signature calculation, causes that oss server throws the error:

```
SignatureDoesNotMatch: The request signature we calculated does
not match the signature you provided. Check your key and signing method.
```

Fix it by replacing with `hmac` and `sha1` crates.

Will add a smoke test case in https://github.com/dragonflyoss/image-service/pull/983 later.

Signed-off-by: Yan Song <imeoer@linux.alibaba.com>