### PR TITLE
release: fix pipeline hang when compile for amd64

### DIFF
--- a/Cross.toml
+++ b/Cross.toml
@@ -1,2 +1,2 @@
 [build]
-pre-build = ["apt-get update && apt-get install -y cmake"]
+pre-build = ["apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y cmake"]


### PR DESCRIPTION
Add `DEBIAN_FRONTEND=noninteractive` to skip interaction when install
cmake, otherwise the command will stuck forever.

Ref: https://stackoverflow.com/questions/67452096/docker-build-hangs-based-on-order-of-install

A successful pipeline: https://github.com/imeoer/image-service/actions/runs/3950313612/jobs/6762680991

Signed-off-by: Yan Song <imeoer@linux.alibaba.com>