### PR TITLE
rafs: avoid possible underflow in find_target_block()

### DIFF
--- a/rafs/src/metadata/direct_v6.rs
+++ b/rafs/src/metadata/direct_v6.rs
@@ -568,6 +568,9 @@ impl OndiskInodeWrapper {
             if h_name <= name && t_name >= name {
                 return Ok(Some(pivot as usize));
             } else if h_name > name {
+                if pivot == 0 {
+                    break;
+                }
                 last = pivot - 1;
             } else {
                 first = pivot + 1;


### PR DESCRIPTION
Avoid possible underflow in find_target_block().

Signed-off-by: Jiang Liu <gerry@linux.alibaba.com>