### PR TITLE
storage: return Ok(None) for check_range_ready_and_mark_pending () wh…

### DIFF
--- a/storage/src/cache/state/blob_state_map.rs
+++ b/storage/src/cache/state/blob_state_map.rs
@@ -206,7 +206,11 @@ impl RangeMap for BlobStateMap<IndexedChunkMap, u32> {
             }
         }
 
-        Ok(Some(res))
+        if res.is_empty() {
+            Ok(None)
+        } else {
+            Ok(Some(res))
+        }
     }
 
     fn set_range_ready_and_clear_pending(&self, start: Self::I, count: Self::I) -> Result<()> {


### PR DESCRIPTION
…en needed

Return Ok(None) for check_range_ready_and_mark_pending () when the result is empty, to follow the definition.

Signed-off-by: Jiang Liu <gerry@linux.alibaba.com>