### PR TITLE
storage: avoid file leakage in error handling path

### DIFF
--- a/src/bin/nydus-image/main.rs
+++ b/src/bin/nydus-image/main.rs
@@ -237,6 +237,7 @@ fn prepare_cmd_args(bti_string: &'static str) -> App {
                     Arg::new("blob-offset")
                         .long("blob-offset")
                         .help("File offset to store RAFS data, to support storing data blobs into tar files")
+                        .hide(true)
                         .default_value("0"),
                 )
                 .arg(

--- a/storage/src/device.rs
+++ b/storage/src/device.rs
@@ -165,6 +165,7 @@ impl BlobInfo {
         chunk_count: u32,
         blob_features: BlobFeatures,
     ) -> Self {
+        let blob_id = blob_id.trim_end_matches('\0').to_string();
         let mut blob_info = BlobInfo {
             blob_index,
             blob_id,


### PR DESCRIPTION
If error happens during preparing chunkmap and blob.meta files for data blobs, some files may be left over. So change code to avoid file leakages.

Signed-off-by: Jiang Liu <gerry@linux.alibaba.com>