### PR TITLE
storage: trim `\0` at the tail of blob id

### DIFF
--- a/storage/src/device.rs
+++ b/storage/src/device.rs
@@ -165,6 +165,7 @@ impl BlobInfo {
         chunk_count: u32,
         blob_features: BlobFeatures,
     ) -> Self {
+        let blob_id = blob_id.trim_end_matches('\0').to_string();
         let mut blob_info = BlobInfo {
             blob_index,
             blob_id,


### PR DESCRIPTION
With user specified blob id, there may be padding `\0` at the end, which must be trimmed when building blob file path from blob id.

Signed-off-by: Jiang Liu <gerry@linux.alibaba.com>