### PR TITLE
dep: remove unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -296,19 +296,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "env_logger"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
-dependencies = [
- "atty",
- "humantime",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
 name = "fastrand"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -511,17 +498,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "getrandom"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eb1a864a501629691edf6c15a593b7a51eebaa1e8468e9ddc623de7c9b58ec6"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi",
-]
-
-[[package]]
 name = "gimli"
 version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -621,12 +597,6 @@ name = "httpdate"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
-
-[[package]]
-name = "humantime"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
@@ -1038,7 +1008,6 @@ dependencies = [
  "anyhow",
  "base64",
  "clap",
- "env_logger",
  "fuse-backend-rs",
  "hex",
  "hyper",
@@ -1057,12 +1026,8 @@ dependencies = [
  "nydus-storage",
  "nydus-utils",
  "openssl",
- "openssl-src",
- "rand",
- "rand_core",
  "rlimit",
  "rust-fsm",
- "sendfd",
  "serde",
  "serde_json",
  "sha2",
@@ -1152,9 +1117,9 @@ checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
 
 [[package]]
 name = "openssl"
-version = "0.10.41"
+version = "0.10.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "618febf65336490dfcf20b73f885f5651a0c89c64c2d4a8c3662585a70bf5bd0"
+checksum = "b102428fd03bc5edf97f62620f7298614c45cedf287c271e7ed450bbaf83f2e1"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1184,18 +1149,18 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-src"
-version = "111.22.0+1.1.1q"
+version = "111.24.0+1.1.1s"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f31f0d509d1c1ae9cada2f9539ff8f37933831fd5098879e482aa687d659853"
+checksum = "3498f259dab01178c6228c6b00dcef0ed2a2d5e20d648c017861227773ea4abd"
 dependencies = [
  "cc",
 ]
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.75"
+version = "0.9.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5f9bd0c2710541a3cda73d6f9ac4f1b240de4ae261065d309dbe73d9dceb42f"
+checksum = "23bbbf7854cd45b83958ebe919f0e8e516793727652e27fda10a8384cfc790b7"
 dependencies = [
  "autocfg",
  "cc",
@@ -1242,18 +1207,18 @@ checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
 
 [[package]]
 name = "pin-project"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78203e83c48cffbe01e4a2d35d566ca4de445d79a85372fc64e378bfc812a260"
+checksum = "ad29a609b6bcd67fee905812e544992d216af9d755757c05ed2d0e15a74c6ecc"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.0.11"
+version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "710faf75e1b33345361201d36d04e98ac1ed8909151a017ed384700836104c74"
+checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1277,12 +1242,6 @@ name = "pkg-config"
 version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1df8c4ec4b0627e53bdf214615ad287367e482558cf84b109250b37464dc03ae"
-
-[[package]]
-name = "ppv-lite86"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb9f9e6e233e5c4a35559a617bf40a4ec447db2e84c20b55a6f83167b7e57872"
 
 [[package]]
 name = "proc-macro-error"
@@ -1324,36 +1283,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bcdf212e9776fbcb2d23ab029360416bb1706b1aea2d1a5ba002727cbcab804"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d34f1408f55294453790c48b2f1ebbb1c5b4b7563eb1f418bcfcfdbb06ebb4e7"
-dependencies = [
- "getrandom",
 ]
 
 [[package]]
@@ -1430,9 +1359,9 @@ dependencies = [
 
 [[package]]
 name = "rlimit"
-version = "0.8.3"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7278a1ec8bfd4a4e07515c589f5ff7b309a373f987393aef44813d9dcf87aa3"
+checksum = "ea5c77e0e5e2bfeb5fcf2c084eb20a9ed9d95cab167d88784956c29419342925"
 dependencies = [
  "libc",
 ]
@@ -1516,15 +1445,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
 dependencies = [
  "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "sendfd"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "150f119d9abefb9138b9923127ab2bb7e4a74851dea4404c496e1188455867f1"
-dependencies = [
  "libc",
 ]
 
@@ -1755,9 +1675,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "1.8.0"
+version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9724f9a975fb987ef7a3cd9be0350edcbe130698af5b8f7a631e23d42d052484"
+checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,49 +14,50 @@ resolver = "2"
 panic = "abort"
 
 [[bin]]
+name = "nydusctl"
+path = "src/bin/nydusctl/main.rs"
+
+[[bin]]
 name = "nydusd"
 path = "src/bin/nydusd/main.rs"
+
+[[bin]]
+name = "nydus-image"
+path = "src/bin/nydus-image/main.rs"
 
 [lib]
 name = "nydus"
 path = "src/lib.rs"
 
 [dependencies]
-rlimit = "0.8.3"
-log = "0.4.8"
-libc = "0.2"
-vmm-sys-util = "0.10.0"
+anyhow = "1"
+base64 = "0.13.0"
 clap = { version = "4.0.18", features = ["derive", "cargo"] }
+fuse-backend-rs = "0.10.1"
+hex = "0.4.3"
+hyper = "0.14.11"
+hyperlocal = "0.8.0"
+indexmap = "1"
+lazy_static = "1"
+libc = "0.2"
+log = "0.4.8"
+mio = { version = "0.8", features = ["os-poll", "os-ext"] }
+nix = "0.24.0"
+rlimit = "0.9.0"
+rust-fsm = "0.6.0"
 serde = { version = "1.0.110", features = ["serde_derive", "rc"] }
 serde_json = "1.0.51"
 sha2 = "0.10.2"
-time = { version = "0.3.14", features = ["serde-human-readable"] }
-lazy_static = "1.4.0"
-xattr = "0.2.2"
-nix = "0.24.0"
-anyhow = "1.0.35"
-base64 = "0.13.0"
-rust-fsm = "0.6.0"
-vm-memory = { version = "0.9.0", features = ["backend-mmap"], optional = true }
-openssl = { version = "0.10.40", features = ["vendored"] }
-# pin openssl-src to bring in fix for https://rustsec.org/advisories/RUSTSEC-2022-0032
-openssl-src = { version = "111.22" }
-hyperlocal = "0.8.0"
-tokio = { version = "1.24", features = ["macros"] }
-hyper = "0.14.11"
-# pin rand_core to bring in fix for https://rustsec.org/advisories/RUSTSEC-2021-0023
-rand_core = "0.6.2"
 tar = "0.4.38"
-mio = { version = "0.8", features = ["os-poll", "os-ext"] }
-hex = "0.4.3"
+time = { version = "0.3.14", features = ["serde-human-readable"] }
+tokio = { version = "1.24", features = ["macros"] }
+vmm-sys-util = "0.10.0"
+xattr = "0.2.3"
 
-fuse-backend-rs = "0.10.1"
-vhost = { version = "0.5.0", features = ["vhost-user-slave"], optional = true }
-vhost-user-backend = { version = "0.7.0", optional = true }
-virtio-bindings = { version = "0.1", features = [
-    "virtio-v5_0_0",
-], optional = true }
-virtio-queue = { version = "0.6.0", optional = true }
+# Build static linked openssl library
+openssl = { version = "0.10.45", features = ["vendored"] }
+# pin openssl-src to bring in fix for https://rustsec.org/advisories/RUSTSEC-2022-0032
+#openssl-src = { version = "111.22" }
 
 nydus-api = { version = "0.1.0", path = "api", features = ["handler"] }
 nydus-app = { version = "0.3.0", path = "app" }
@@ -68,15 +69,14 @@ nydus-rafs = { version = "0.1.0", path = "rafs", features = [
 ] }
 nydus-storage = { version = "0.5.0", path = "storage" }
 nydus-utils = { version = "0.3.0", path = "utils" }
-nydus-blobfs = { version = "0.1.0", path = "blobfs", features = [
-    "virtiofs",
-], optional = true }
-indexmap = "1.9.1"
 
-[dev-dependencies]
-sendfd = "0.3.3"
-env_logger = "0.8.2"
-rand = "0.8.5"
+nydus-blobfs = { version = "0.1.0", path = "blobfs", features = ["virtiofs"], optional = true }
+
+vhost = { version = "0.5.0", features = ["vhost-user-slave"], optional = true }
+vhost-user-backend = { version = "0.7.0", optional = true }
+virtio-bindings = { version = "0.1", features = ["virtio-v5_0_0"], optional = true }
+virtio-queue = { version = "0.6.0", optional = true }
+vm-memory = { version = "0.9.0", features = ["backend-mmap"], optional = true }
 
 [features]
 default = ["fuse-backend-rs/fusedev"]

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -33,7 +33,7 @@ libz-sys = { version = "1.1.8", features = ["zlib-ng"], default-features = false
 flate2 = { version = "1.0.17", features = ["zlib-ng-compat"], default-features = false }
 
 [dev-dependencies]
-vmm-sys-util = ">=0.9.0"
+vmm-sys-util = "0.10.0"
 tar = "0.4.38"
 
 [features]


### PR DESCRIPTION
Remove unused dependencies, and upgrade fuse-backend-rs to fix a bug in `lookup()`.

Signed-off-by: Jiang Liu <gerry@linux.alibaba.com>