### PR TITLE
nydusd: refine commandline help messages

### DIFF
--- a/src/bin/nydusd/daemon.rs
+++ b/src/bin/nydusd/daemon.rs
@@ -23,10 +23,10 @@ use rust_fsm::*;
 use serde::{self, Serialize};
 use serde_json::Error as SerdeError;
 
-use crate::fs_service::{FsBackendCollection, FsService};
 use nydus_app::BuildTimeInfo;
-use rafs::RafsError;
+use nydus_rafs::RafsError;
 
+use crate::fs_service::{FsBackendCollection, FsService};
 use crate::upgrade::UpgradeMgrError;
 
 #[allow(dead_code)]

--- a/src/bin/nydusd/fs_service.rs
+++ b/src/bin/nydusd/fs_service.rs
@@ -16,10 +16,10 @@ use fuse_backend_rs::api::{BackFileSystem, Vfs};
 use fuse_backend_rs::passthrough::{Config, PassthroughFs};
 use nydus::{FsBackendDescriptor, FsBackendType};
 use nydus_api::ConfigV2;
-use rafs::fs::Rafs;
-use rafs::{RafsError, RafsIoRead};
+use nydus_rafs::fs::Rafs;
+use nydus_rafs::{RafsError, RafsIoRead};
+use nydus_storage::factory::BLOB_FACTORY;
 use serde::{self, Deserialize, Serialize};
-use storage::factory::BLOB_FACTORY;
 
 use crate::daemon::DaemonResult;
 use crate::upgrade::{self, UpgradeManager};

--- a/src/bin/nydusd/fusedev.rs
+++ b/src/bin/nydusd/fusedev.rs
@@ -277,6 +277,7 @@ impl FusedevDaemon {
         Ok(())
     }
 
+    /*
     pub fn get_fusedev_fsservice(&self) -> &FusedevFsService {
         self.service
             .as_ref()
@@ -284,6 +285,7 @@ impl FusedevDaemon {
             .downcast_ref::<FusedevFsService>()
             .unwrap()
     }
+     */
 }
 
 impl DaemonStateMachineSubscriber for FusedevDaemon {


### PR DESCRIPTION
Refine commandline help messages, and restrict the way to provide command line options for subcommands.

Signed-off-by: Jiang Liu <gerry@linux.alibaba.com>