### PR TITLE
makefile: revert a change on default `install` prefix dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ all-install: install contrib-install
 all-clean: clean contrib-clean
 
 TEST_WORKDIR_PREFIX ?= "/tmp"
-INSTALL_DIR_PREFIX ?= "/usr/bin"
+INSTALL_DIR_PREFIX ?= "/usr/local/bin"
 DOCKER ?= "true"
 
 CARGO ?= $(shell which cargo)


### PR DESCRIPTION
For user-self-compiled binaries, we'd better install them into `/usr/local/bin` rather than `/usr/bin` which software packages manager usually put binaries. If the default $PATH does not have `/usr/local/bin`, we should append it to the $PATH or change the install prefix by assigning it with `/usr/bin` when performing `make install`

Signed-off-by: Changwei Ge <gechangwei@bytedance.com>