### PR TITLE
builder: fix inconsistent chunk size for merge

### DIFF
--- a/smoke/tests/native_layer_test.go
+++ b/smoke/tests/native_layer_test.go
@@ -114,8 +114,7 @@ func testNativeLayer(t *testing.T, ctx tool.Context) {
 	params.
 		Register(paramCompressor, []interface{}{"zstd", "none", "lz4_block"}).
 		Register(paramFSVersion, []interface{}{"5", "6"}).
-		// FIXME: specify chunk size `0x200000` case.
-		Register(paramChunkSize, []interface{}{"0x100000"}).
+		Register(paramChunkSize, []interface{}{"0x100000", "0x200000"}).
 		Register(paramCacheType, []interface{}{"blobcache", ""}).
 		Register(paramCacheCompressed, []interface{}{true, false}).
 		Register(paramRafsMode, []interface{}{"direct", "cached"}).


### PR DESCRIPTION
**builder: fix inconsistent chunk size for merge**

The chunk size should be set to rafs superblock when enable
chunk dict in `nydus-image merge` subcommand.

Otherwise merge will set default chunk size (0x100000) in final
bootstrap, causes that inconsistent chunk size between blob
entry and superblock, and with nydusd panic:

```
ERROR [/src/metadata/layout/v6.rs:1439] RafsV6Blob: idx 0 invalid chunk_size 0x200000, expect 0x100000
ERROR [/src/error.rs:22] Error:
        "invalid Rafs v6 blob entry"
        at rafs/src/metadata/layout/v6.rs:1648
        note: enable `RUST_BACKTRACE=1` env to display a backtrace
```

**smoke: enable chunk size 0x200000 test case**

We have fixed the chunk size related bug in `nydus-image merge`,
so just enable the test case in smoke.