### PR TITLE
smoke: fix lost compatibility test case

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -102,12 +102,12 @@ jobs:
         done
     - name: Integration Test
       run: |
-        sudo install -D -m 755 contrib/nydusify/cmd/nydusify /usr/bin
-        sudo install -D -m 755 target/release/nydusd target/release/nydus-image /usr/bin
-        sudo mkdir -p /home/runner/work/workdir
+        sudo mkdir -p /usr/bin/nydus-latest /home/runner/work/workdir
+        sudo install -D -m 755 contrib/nydusify/cmd/nydusify /usr/bin/nydus-latest
+        sudo install -D -m 755 target/release/nydusd target/release/nydus-image /usr/bin/nydus-latest
 
-        versions=(v0.1.0 v2.1.2)
-        version_exports=(v0_1_0 v2_1_2)
+        versions=(v0.1.0 v2.1.2 latest)
+        version_exports=(v0_1_0 v2_1_2 latest)
         for i in ${!version_exports[@]}; do
           version=${versions[$i]}
           version_export=${version_exports[$i]}

--- a/smoke/Makefile
+++ b/smoke/Makefile
@@ -19,7 +19,7 @@ lint:
 # NYDUS_NYDUSIFY=/path/to/latest/nydusify \
 # make test
 test: build lint
-	sudo -E ./smoke.test -test.v -test.timeout 5m -test.parallel=8 -test.run=$(TESTS)
+	sudo -E ./smoke.test -test.v -test.timeout 10m -test.parallel=8 -test.run=$(TESTS)
 
 # WORK_DIR=/tmp \
 # NYDUS_BUILDER=/path/to/latest/nydus-image \

--- a/smoke/tests/compatibility_test.go
+++ b/smoke/tests/compatibility_test.go
@@ -5,9 +5,6 @@
 package tests
 
 import (
-	"fmt"
-	"os"
-	"strings"
 	"testing"
 
 	"github.com/dragonflyoss/image-service/smoke/tests/tool"
@@ -19,19 +16,6 @@ const (
 	paramNydusdVersion     = "nydusd_version"
 	paramNydusifyVersion   = "nydusify_version"
 )
-
-func getFromEnv(t *testing.T, env, version string) string {
-	version = strings.ReplaceAll(version, ".", "_")
-	key := fmt.Sprintf("%s_%s", env, version)
-	if version == "latest" {
-		key = env
-	}
-	binary := os.Getenv(key)
-	if binary == "" {
-		t.Skipf("skip compatibility test because no env `%s` specified", key)
-	}
-	return binary
-}
 
 func TestCompatibility(t *testing.T) {
 
@@ -72,12 +56,12 @@ func TestCompatibility(t *testing.T) {
 		nydusifyNotSupportCompressor := param.GetString(paramNydusifyVersion) == "v0.1.0"
 		nydusifyOnlySupportV5 := param.GetString(paramNydusifyVersion) == "v0.1.0"
 
-		builderPath := getFromEnv(t, "NYDUS_BUILDER", param.GetString(paramNydusImageVersion))
-		nydusdPath := getFromEnv(t, "NYDUS_NYDUSD", param.GetString(paramNydusdVersion))
-		nydusifyPath := getFromEnv(t, "NYDUS_NYDUSIFY", param.GetString(paramNydusifyVersion))
-		nydusifyCheckerPath := getFromEnv(t, "NYDUS_NYDUSIFY", "latest")
+		builderPath := tool.GetBinary(t, "NYDUS_BUILDER", param.GetString(paramNydusImageVersion))
+		nydusdPath := tool.GetBinary(t, "NYDUS_NYDUSD", param.GetString(paramNydusdVersion))
+		nydusifyPath := tool.GetBinary(t, "NYDUS_NYDUSIFY", param.GetString(paramNydusifyVersion))
+		nydusifyCheckerPath := tool.GetBinary(t, "NYDUS_NYDUSIFY", "latest")
 
-		ctx := tool.DefaultContext()
+		ctx := tool.DefaultContext(t)
 		ctx.Binary = tool.BinaryContext{
 			Builder:                      builderPath,
 			Nydusd:                       nydusdPath,

--- a/smoke/tests/image_test.go
+++ b/smoke/tests/image_test.go
@@ -81,7 +81,7 @@ func TestImage(t *testing.T) {
 			preparedImages[image] = tool.PrepareImage(t, image)
 		}
 
-		ctx := tool.DefaultContext()
+		ctx := tool.DefaultContext(t)
 		ctx.Build.FSVersion = param.GetString(paramFSVersion)
 		ctx.Build.OCIRef = param.GetBool(paramZran)
 

--- a/smoke/tests/native_layer_test.go
+++ b/smoke/tests/native_layer_test.go
@@ -150,5 +150,5 @@ func testNativeLayer(t *testing.T, ctx tool.Context) {
 }
 
 func TestNativeLayer(t *testing.T) {
-	testNativeLayer(t, *tool.DefaultContext())
+	testNativeLayer(t, *tool.DefaultContext(t))
 }

--- a/smoke/tests/tool/context.go
+++ b/smoke/tests/tool/context.go
@@ -54,13 +54,13 @@ type Context struct {
 	Env     EnvContext
 }
 
-func DefaultContext() *Context {
+func DefaultContext(t *testing.T) *Context {
 	return &Context{
 		Binary: BinaryContext{
-			Builder:               "nydus-image",
-			Nydusd:                "nydusd",
-			Nydusify:              "nydusify",
-			NydusifyChecker:       "nydusify",
+			Builder:               GetBinary(t, "NYDUS_BUILDER", "latest"),
+			Nydusd:                GetBinary(t, "NYDUS_NYDUSD", "latest"),
+			Nydusify:              GetBinary(t, "NYDUS_NYDUSIFY", "latest"),
+			NydusifyChecker:       GetBinary(t, "NYDUS_NYDUSIFY", "latest"),
 			NydusifyOnlySupportV5: false,
 		},
 		Build: BuildContext{

--- a/smoke/tests/tool/util.go
+++ b/smoke/tests/tool/util.go
@@ -5,12 +5,20 @@
 package tool
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+var defaultBinary = map[string]string{
+	"NYDUS_BUILDER":  "nydus-image",
+	"NYDUS_NYDUSD":   "nydusd",
+	"NYDUS_NYDUSIFY": "nydusify",
+}
 
 func Run(t *testing.T, cmd string) {
 	_cmd := exec.Command("sh", "-c", cmd)
@@ -32,21 +40,18 @@ func RunWithOutput(cmd string) string {
 	return string(output)
 }
 
-func GetBinaries(t *testing.T) (string, string, string) {
-	builderPath := os.Getenv("NYDUS_BUILDER")
-	if builderPath == "" {
-		builderPath = "nydus-image"
+func GetBinary(t *testing.T, env, version string) string {
+	version = strings.ReplaceAll(version, ".", "_")
+	key := fmt.Sprintf("%s_%s", env, version)
+	if version == "latest" && os.Getenv(key) == "" {
+		key = env
 	}
-
-	nydusdPath := os.Getenv("NYDUS_NYDUSD")
-	if nydusdPath == "" {
-		nydusdPath = "nydusd"
+	binary := os.Getenv(key)
+	if binary == "" {
+		if version == "latest" && defaultBinary[env] != "" {
+			return defaultBinary[env]
+		}
+		t.Fatalf("not found binary from env `%s`, version %s", env, version)
 	}
-
-	nydusifyPath := os.Getenv("NYDUS_NYDUSIFY")
-	if nydusifyPath == "" {
-		nydusifyPath = "nydusify"
-	}
-
-	return builderPath, nydusdPath, nydusifyPath
+	return binary
 }

--- a/smoke/tests/zran_layer_test.go
+++ b/smoke/tests/zran_layer_test.go
@@ -21,6 +21,8 @@ const (
 
 func makeZranLayerTest(ctx tool.Context) func(t *testing.T) {
 	return func(t *testing.T) {
+		t.Parallel()
+
 		// Prepare work directory
 		ctx.PrepareWorkDir(t)
 		defer ctx.Destroy(t)
@@ -47,15 +49,13 @@ func makeZranLayerTest(ctx tool.Context) func(t *testing.T) {
 }
 
 func TestZranLayer(t *testing.T) {
-	t.Parallel()
-
 	params := tool.DescartesIterator{}
 	params.
 		Register(paramGzip, []interface{}{false, true}).
 		Register(paramCacheCompressed, []interface{}{true, false}).
 		Register(paramEnablePrefetch, []interface{}{false, true})
 
-	ctx := tool.DefaultContext()
+	ctx := tool.DefaultContext(t)
 	for params.HasNext() {
 		param := params.Next()
 


### PR DESCRIPTION
We skipped compatibility test cases because of incorrect env configuration, this patch fixes it.

See previous action: https://github.com/dragonflyoss/image-service/actions/runs/4042014250/jobs/6949286202#step:7:70

Signed-off-by: Yan Song <imeoer@linux.alibaba.com>