### PR TITLE
nydusd: fix a bug in parsing `fscache-tag` commandline option

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -220,7 +220,7 @@ impl<'a> SubCmdArgs<'a> {
         if let Some(v) = self.subargs.get_one::<String>(key) {
             Some(v)
         } else {
-            self.args.get_one::<String>(key)
+            self.args.try_get_one::<String>(key).unwrap_or_default()
         }
     }
 


### PR DESCRIPTION
When `--fscache` is present but `--fscache-tag` is missing, nydusd will panic.

Signed-off-by: Jiang Liu <gerry@linux.alibaba.com>