### PR TITLE
add e2e testcases for ci

### DIFF
--- a/tests/bats/Makefile
+++ b/tests/bats/Makefile
@@ -1,0 +1,14 @@
+ifneq (,$(wildcard /usr/lib/os-release))
+include /usr/lib/os-release
+else
+include /etc/os-release
+endif
+
+ci:
+	bash -f ./install_bats.sh
+	bats --show-output-of-passing-tests --formatter tap build_docker_image.bats
+	bats --show-output-of-passing-tests --formatter tap compile_nydusd.bats
+	bats --show-output-of-passing-tests --formatter tap compile_ctr_remote.bats
+	bats --show-output-of-passing-tests --formatter tap compile_nydus_snapshotter.bats
+	bats --show-output-of-passing-tests --formatter tap run_container_with_rafs.bats
+	bats --show-output-of-passing-tests --formatter tap run_container_with_zran.bats

--- a/tests/bats/build_docker_image.bats
+++ b/tests/bats/build_docker_image.bats
@@ -1,0 +1,34 @@
+#!/usr/bin/bats
+
+load "${BATS_TEST_DIRNAME}/common_tests.sh"
+
+setup() {
+	dockerfile="/tmp/rust_golang_dockerfile"
+	cat > $dockerfile <<EOF
+FROM rust:${rust_toolchain}
+
+RUN apt-get update -y \
+    && apt-get install -y cmake g++ pkg-config jq libcurl4-openssl-dev libelf-dev libdw-dev binutils-dev libiberty-dev musl-tools \
+    && rustup component add rustfmt clippy \
+    && rm -rf /var/lib/apt/lists/*
+
+# install golang env
+Run wget https://go.dev/dl/go1.19.linux-amd64.tar.gz \
+    && tar -C /usr/local -xzf go1.19.linux-amd64.tar.gz \
+    && rm -rf go1.19.linux-amd64.tar.gz
+
+ENV PATH \$PATH:/usr/local/go/bin
+RUN go env -w GO111MODULE=on
+RUN go env -w GOPROXY=https://goproxy.io,direct
+EOF
+}
+
+@test "build rust golang image" {
+	yum install -y docker
+        docker build -f $dockerfile -t $compile_image .
+}
+
+teardown() {
+	rm -f $dockerfile
+}
+

--- a/tests/bats/common_tests.sh
+++ b/tests/bats/common_tests.sh
@@ -1,0 +1,50 @@
+repo_base_dir="${BATS_TEST_DIRNAME}/../.."
+rust_toolchain=$(cat ${repo_base_dir}/rust-toolchain)
+compile_image="localhost/compile-image:${rust_toolchain}"
+nydus_snapshotter_repo="https://github.com/containerd/nydus-snapshotter.git"
+
+run_nydus_snapshotter() {
+        rm -rf /var/lib/containerd/io.containerd.snapshotter.v1.nydus
+        rm -rf /var/lib/nydus/cache
+        cat > /tmp/nydus-erofs-config.json <<EOF
+{
+  "type": "bootstrap",
+  "config": {
+    "backend_type": "registry",
+    "backend_config": {
+      "scheme": "https"
+    },
+    "cache_type": "fscache"
+  }
+}
+EOF
+        containerd-nydus-grpc --config-path /tmp/nydus-erofs-config.json --daemon-mode shared \
+                --fs-driver fscache --root /var/lib/containerd/io.containerd.snapshotter.v1.nydus \
+                --address /run/containerd/containerd-nydus-grpc.sock --nydusd-path /usr/local/bin/nydusd \
+                --log-to-stdout > ${BATS_TEST_DIRNAME}/nydus-snapshotter-${BATS_TEST_NAME}.log 2>&1 &
+}
+
+config_containerd_for_nydus() {
+        [ -d "/etc/containerd" ] || mkdir -p /etc/containerd
+        cat > /etc/containerd/config.toml <<EOF
+version = 2
+
+[plugins]
+  [plugins."io.containerd.grpc.v1.cri"]
+    [plugins."io.containerd.grpc.v1.cri".cni]
+      bin_dir = "/usr/lib/cni"
+      conf_dir = "/etc/cni/net.d"
+  [plugins."io.containerd.internal.v1.opt"]
+    path = "/var/lib/containerd/opt"
+
+[proxy_plugins]
+  [proxy_plugins.nydus]
+    type = "snapshot"
+    address = "/run/containerd/containerd-nydus-grpc.sock"
+
+[plugins."io.containerd.grpc.v1.cri".containerd]
+   snapshotter = "nydus"
+   disable_snapshot_annotations = false
+EOF
+        systemctl restart containerd
+}

--- a/tests/bats/compile_ctr_remote.bats
+++ b/tests/bats/compile_ctr_remote.bats
@@ -1,0 +1,14 @@
+#!/usr/bin/bats
+
+load "${BATS_TEST_DIRNAME}/common_tests.sh"
+
+@test "compile ctr remote" {
+        docker run --rm -v $repo_base_dir:/image-service $compile_image bash -c 'cd /image-service/contrib/ctr-remote && make clean && make'
+        if [ -f "${repo_base_dir}/contrib/ctr-remote/bin/ctr-remote" ]; then
+                /usr/bin/cp -f ${repo_base_dir}/contrib/ctr-remote/bin/ctr-remote /usr/local/bin/
+        else
+                echo "cannot find ctr-remote binary"
+                exit 1
+        fi
+}
+

--- a/tests/bats/compile_nydus_snapshotter.bats
+++ b/tests/bats/compile_nydus_snapshotter.bats
@@ -1,0 +1,25 @@
+#!/usr/bin/bats
+
+load "${BATS_TEST_DIRNAME}/common_tests.sh"
+
+setup() {
+	rm -rf /tmp/nydus-snapshotter
+        mkdir /tmp/nydus-snapshotter
+        git clone "${nydus_snapshotter_repo}" /tmp/nydus-snapshotter
+}
+
+@test "compile nydus snapshotter" {
+        docker run --rm -v /tmp/nydus-snapshotter:/nydus-snapshotter $compile_image bash -c 'cd /nydus-snapshotter && make clear && make'
+        if [ -f "/tmp/nydus-snapshotter/bin/containerd-nydus-grpc" ]; then
+                /usr/bin/cp -f /tmp/nydus-snapshotter/bin/containerd-nydus-grpc /usr/local/bin/
+                echo "nydus-snapshotter version"
+                containerd-nydus-grpc --version
+        else
+                echo "cannot find containerd-nydus-grpc binary"
+                exit 1
+        fi
+}
+
+teardown() {
+	rm -rf /tmp/nydus-snapshotter
+}

--- a/tests/bats/compile_nydusd.bats
+++ b/tests/bats/compile_nydusd.bats
@@ -1,0 +1,14 @@
+#!/usr/bin/bats
+
+load "${BATS_TEST_DIRNAME}/common_tests.sh"
+
+@test "compile nydusd" {
+        docker run --rm -v $repo_base_dir:/image-service $compile_image bash -c 'cd /image-service && make clean && make release'
+        if [ -f "${repo_base_dir}/target/release/nydusd" ] && [ -f "${repo_base_dir}/target/release/nydus-image" ]; then
+                /usr/bin/cp -f ${repo_base_dir}/target/release/nydusd /usr/local/bin/
+                /usr/bin/cp -f ${repo_base_dir}/target/release/nydus-image /usr/local/bin/
+        else
+                echo "cannot find nydusd binary or nydus-image binary"
+                exit 1
+        fi
+}

--- a/tests/bats/install_bats.sh
+++ b/tests/bats/install_bats.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+
+which bats && exit
+
+BATS_REPO="https://github.com/bats-core/bats-core.git"
+LOCAL_DIR="/tmp/bats"
+echo "Install BATS from sources"
+rm -rf $LOCAL_DIR
+mkdir -p $LOCAL_DIR
+pushd "${LOCAL_DIR}"
+git clone "${BATS_REPO}" || true
+cd bats-core
+sh -c "./install.sh /usr"
+popd
+rm -rf $LOCAL_DIR

--- a/tests/bats/run_container_with_rafs.bats
+++ b/tests/bats/run_container_with_rafs.bats
@@ -1,0 +1,29 @@
+#!/usr/bin/bats
+
+load "${BATS_TEST_DIRNAME}/common_tests.sh"
+
+setup() {
+	nydus_rafs_image="docker.io/hsiangkao/ubuntu:20.04-rafs-v6"
+	run_nydus_snapshotter
+	config_containerd_for_nydus
+	ctr images ls | grep -q "${nydus_rafs_image}" && ctr images rm $nydus_rafs_image
+	ctr-remote images rpull $nydus_rafs_image
+}
+
+@test "run container with rafs" {
+	ctr run --rm --snapshotter=nydus $nydus_rafs_image test_container tar cvf /tmp/foo.tar --exclude=/sys --exclude=/proc --exclude=/dev /
+}
+
+teardown() {
+	dmesg -T | tail -300 > ${BATS_TEST_DIRNAME}/dmesg-${BATS_TEST_NAME}.log
+	ctr images ls | grep -q "${nydus_rafs_image}" && ctr images rm $nydus_rafs_image
+	if ps -ef | grep containerd-nydus-grpc | grep -v grep; then
+		ps -ef | grep containerd-nydus-grpc | grep -v grep | awk '{print $2}' | xargs kill -9
+	fi
+	if ps -ef | grep nydusd | grep fscache; then
+		ps -ef | grep nydusd | grep fscache | awk '{print $2}' | xargs kill -9
+	fi
+	if mount | grep 'erofs on'; then
+		mount | grep 'erofs on' | awk '{print $3}' | xargs umount
+	fi
+}

--- a/tests/bats/run_container_with_zran.bats
+++ b/tests/bats/run_container_with_zran.bats
@@ -1,0 +1,29 @@
+#!/usr/bin/bats
+
+load "${BATS_TEST_DIRNAME}/common_tests.sh"
+
+setup() {
+	nydus_zran_image="docker.io/hsiangkao/node:18-nydus-oci-ref"
+	run_nydus_snapshotter
+	config_containerd_for_nydus
+	ctr images ls | grep -q "${nydus_zran_image}" && ctr images rm $nydus_zran_image
+	ctr-remote images rpull $nydus_zran_image
+}
+
+@test "run container with zran" {
+	ctr run --rm --snapshotter=nydus $nydus_zran_image test_container tar cvf /tmp/foo.tar --exclude=/sys --exclude=/proc --exclude=/dev /
+}
+
+teardown() {
+	dmesg -T | tail -300 > ${BATS_TEST_DIRNAME}/dmesg-${BATS_TEST_NAME}.log
+	ctr images ls | grep -q "${nydus_zran_image}" && ctr images rm $nydus_zran_image
+	if ps -ef | grep containerd-nydus-grpc | grep -v grep; then
+		ps -ef | grep containerd-nydus-grpc | grep -v grep | awk '{print $2}' | xargs kill -9
+	fi
+	if ps -ef | grep nydusd | grep fscache; then
+		ps -ef | grep nydusd | grep fscache | awk '{print $2}' | xargs kill -9
+	fi
+	if mount | grep 'erofs on'; then
+		mount | grep 'erofs on' | awk '{print $3}' | xargs umount
+	fi
+}


### PR DESCRIPTION
These test cases are developed with bats test framework, which covers compile related components, run container with rafs image and zran image.

Signed-off-by: Yiqun Leng <yqleng@linux.alibaba.com>