### PR TITLE
storage: fix bugs in prefetch data for ZRan images

### DIFF
--- a/storage/src/cache/worker.rs
+++ b/storage/src/cache/worker.rs
@@ -352,15 +352,7 @@ impl AsyncWorkerMgr {
         metrics.prefetch_data_amount.add(size);
 
         if let Some(obj) = cache.get_blob_object() {
-            if let Err(e) = obj.fetch_range_compressed(offset, size) {
-                warn!(
-                    "storage: failed to prefetch data from blob {}, offset {}, size {}, {}, will try resend",
-                    cache.blob_id(),
-                    offset,
-                    size,
-                    e
-                );
-
+            if let Err(_e) = obj.fetch_range_compressed(offset, size, true) {
                 if mgr.retry_times.load(Ordering::Relaxed) > 0 {
                     mgr.retry_times.fetch_sub(1, Ordering::Relaxed);
                     ASYNC_RUNTIME.spawn(async move {

--- a/storage/src/device.rs
+++ b/storage/src/device.rs
@@ -978,7 +978,7 @@ pub trait BlobObject: AsRawFd {
     /// Fetch data from storage backend covering compressed blob range [offset, offset + size).
     ///
     /// Used by asynchronous prefetch worker to implement blob prefetch.
-    fn fetch_range_compressed(&self, offset: u64, size: u64) -> io::Result<()>;
+    fn fetch_range_compressed(&self, offset: u64, size: u64, prefetch: bool) -> io::Result<()>;
 
     /// Fetch data from storage backend and make sure data range [offset, offset + size) is ready
     /// for use.


### PR DESCRIPTION
ZRan images may have holes between compressed chunk data, which breaks the prefetch algorithm. So fix the bug by special handling of prefetch for ZRan images.

Signed-off-by: Jiang Liu <gerry@linux.alibaba.com>