### PR TITLE
Fix anolis test

### DIFF
--- a/docs/nydus-fscache.md
+++ b/docs/nydus-fscache.md
@@ -89,13 +89,9 @@ make
 mkdir -p /var/lib/containerd-nydus
 
 ./bin/containerd-nydus-grpc \
- --config-path /etc/nydus/nydusd-config.fscache.json \
- --daemon-mode shared \
+ --nydusd-config /etc/nydus/nydusd-config.fscache.json \
  --fs-driver fscache \
- --log-level info \
- --root /var/lib/containerd-nydus \
- --cache-dir /var/lib/nydus/cache \
- --nydusd-path /path/to/nydusd \
+ --nydusd /path/to/nydusd \
  --log-to-stdout
 ```
 

--- a/misc/example/containerd-entrypoint.sh
+++ b/misc/example/containerd-entrypoint.sh
@@ -3,8 +3,8 @@
 set -eu
 
 if [ "$#" -eq 0 ]; then
-        /opt/bin/containerd -c /opt/etc/containerd/config.toml -l debug &
-	/opt/bin/containerd-nydus-grpc --nydusd-path /opt/bin/nydusd \
+	/opt/bin/containerd -c /opt/etc/containerd/config.toml -l debug &
+	/opt/bin/containerd-nydus-grpc --nydusd /opt/bin/nydusd \
 		--config-path /opt/etc/nydusd-config.json \
 		--log-level debug \
 		--root /var/lib/containerd-test/io.containerd.snapshotter.v1.nydus \

--- a/tests/bats/common_tests.sh
+++ b/tests/bats/common_tests.sh
@@ -4,9 +4,9 @@ compile_image="localhost/compile-image:${rust_toolchain}"
 nydus_snapshotter_repo="https://github.com/containerd/nydus-snapshotter.git"
 
 run_nydus_snapshotter() {
-        rm -rf /var/lib/containerd/io.containerd.snapshotter.v1.nydus
-        rm -rf /var/lib/nydus/cache
-        cat > /tmp/nydus-erofs-config.json <<EOF
+  rm -rf /var/lib/containerd/io.containerd.snapshotter.v1.nydus
+  rm -rf /var/lib/nydus/cache
+  cat >/tmp/nydus-erofs-config.json <<EOF
 {
   "type": "bootstrap",
   "config": {
@@ -18,15 +18,15 @@ run_nydus_snapshotter() {
   }
 }
 EOF
-        containerd-nydus-grpc --config-path /tmp/nydus-erofs-config.json --daemon-mode shared \
-                --fs-driver fscache --root /var/lib/containerd/io.containerd.snapshotter.v1.nydus \
-                --address /run/containerd/containerd-nydus-grpc.sock --nydusd-path /usr/local/bin/nydusd \
-                --log-to-stdout > ${BATS_TEST_DIRNAME}/nydus-snapshotter-${BATS_TEST_NAME}.log 2>&1 &
+  containerd-nydus-grpc --config-path /tmp/nydus-erofs-config.json --daemon-mode shared \
+    --fs-driver fscache --root /var/lib/containerd/io.containerd.snapshotter.v1.nydus \
+    --address /run/containerd/containerd-nydus-grpc.sock --nydusd /usr/local/bin/nydusd \
+    --log-to-stdout >${BATS_TEST_DIRNAME}/nydus-snapshotter-${BATS_TEST_NAME}.log 2>&1 &
 }
 
 config_containerd_for_nydus() {
-        [ -d "/etc/containerd" ] || mkdir -p /etc/containerd
-        cat > /etc/containerd/config.toml <<EOF
+  [ -d "/etc/containerd" ] || mkdir -p /etc/containerd
+  cat >/etc/containerd/config.toml <<EOF
 version = 2
 
 [plugins]
@@ -46,5 +46,5 @@ version = 2
    snapshotter = "nydus"
    disable_snapshot_annotations = false
 EOF
-        systemctl restart containerd
+  systemctl restart containerd
 }


### PR DESCRIPTION
Update smoke tests on anolis and docs about how to start nydus-snapshotter service.
In addition, simplify how to start nydus-snapshotter by removing cli flags with the same value as default value