### PR TITLE
smoke: support async test cases

### DIFF
--- a/smoke/tests/api_test.go
+++ b/smoke/tests/api_test.go
@@ -19,25 +19,10 @@ import (
 
 	"github.com/dragonflyoss/image-service/smoke/tests/texture"
 	"github.com/dragonflyoss/image-service/smoke/tests/tool"
+	"github.com/dragonflyoss/image-service/smoke/tests/tool/test"
 )
 
-type APIV1TestSuite struct {
-}
-
-func (a *APIV1TestSuite) start(pt *testing.T) {
-	pt.Run("TestDaemonStatus", func(t *testing.T) {
-		t.Parallel()
-		a.TestDaemonStatus(t)
-	})
-	pt.Run("TestMetrics", func(t *testing.T) {
-		t.Parallel()
-		a.TestMetrics(t)
-	})
-	pt.Run("TestPrefetch", func(t *testing.T) {
-		t.Parallel()
-		a.TestPrefetch(t)
-	})
-}
+type APIV1TestSuite struct{}
 
 func (a *APIV1TestSuite) TestDaemonStatus(t *testing.T) {
 
@@ -249,6 +234,5 @@ func (a *APIV1TestSuite) visit(path string) error {
 }
 
 func TestAPI(t *testing.T) {
-	apiV1Tests := APIV1TestSuite{}
-	apiV1Tests.start(t)
+	test.Run(t, &APIV1TestSuite{})
 }

--- a/smoke/tests/native_layer_test.go
+++ b/smoke/tests/native_layer_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/containerd/nydus-snapshotter/pkg/converter"
 	"github.com/dragonflyoss/image-service/smoke/tests/texture"
 	"github.com/dragonflyoss/image-service/smoke/tests/tool"
+	"github.com/dragonflyoss/image-service/smoke/tests/tool/test"
 	"github.com/opencontainers/go-digest"
 	"github.com/stretchr/testify/require"
 )
@@ -25,100 +26,21 @@ const (
 	paramEnablePrefetch  = "enable_prefetch"
 )
 
-func makeNativeLayerTest(ctx tool.Context) func(t *testing.T) {
-	return func(t *testing.T) {
-		t.Parallel()
-
-		packOption := converter.PackOption{
-			BuilderPath: ctx.Binary.Builder,
-			Compressor:  ctx.Build.Compressor,
-			FsVersion:   ctx.Build.FSVersion,
-			ChunkSize:   ctx.Build.ChunkSize,
-		}
-
-		// Prepare work directory
-		ctx.PrepareWorkDir(t)
-		defer ctx.Destroy(t)
-
-		// Make chunk dict layer
-		chunkDictLayer := texture.MakeChunkDictLayer(t, filepath.Join(ctx.Env.WorkDir, "source-chunk-dict"))
-		chunkDictBlobDigest := chunkDictLayer.Pack(t, packOption, ctx.Env.BlobDir)
-		mergeOption := converter.MergeOption{
-			ChunkDictPath: "",
-			BuilderPath:   ctx.Binary.Builder,
-		}
-		actualDigests, chunkDictBootstrap := tool.MergeLayers(t, ctx, mergeOption, []converter.Layer{
-			{
-				Digest: chunkDictBlobDigest,
-			},
-		})
-		require.Equal(t, actualDigests, []digest.Digest{chunkDictBlobDigest})
-
-		// Make lower layer (with chunk dict)
-		packOption.ChunkDictPath = chunkDictBootstrap
-		lowerLayer := texture.MakeLowerLayer(t, filepath.Join(ctx.Env.WorkDir, "source-lower"))
-		lowerBlobDigest := lowerLayer.Pack(t, packOption, ctx.Env.BlobDir)
-
-		// Check repeatable build
-		lowerBlobDigestNew := lowerLayer.Pack(t, packOption, ctx.Env.BlobDir)
-		require.Equal(t, lowerBlobDigest, lowerBlobDigestNew)
-
-		mergeOption = converter.MergeOption{
-			ChunkDictPath: chunkDictBootstrap,
-			BuilderPath:   ctx.Binary.Builder,
-		}
-		actualDigests, lowerBootstrap := tool.MergeLayers(t, ctx, mergeOption, []converter.Layer{
-			{
-				Digest: lowerBlobDigest,
-			},
-		})
-		require.Equal(t, actualDigests, []digest.Digest{chunkDictBlobDigest})
-
-		// Verify lower layer mounted by nydusd
-		ctx.Env.BootstrapPath = lowerBootstrap
-		tool.Verify(t, ctx, lowerLayer.FileTree)
-
-		// Make upper layer (with chunk dict)
-		upperLayer := texture.MakeUpperLayer(t, filepath.Join(ctx.Env.WorkDir, "source-upper"))
-		upperBlobDigest := upperLayer.Pack(t, packOption, ctx.Env.BlobDir)
-
-		// Check repeatable build
-		upperBlobDigestNew := upperLayer.Pack(t, packOption, ctx.Env.BlobDir)
-		require.Equal(t, upperBlobDigest, upperBlobDigestNew)
-
-		mergeOption = converter.MergeOption{
-			ChunkDictPath: chunkDictBootstrap,
-			BuilderPath:   ctx.Binary.Builder,
-		}
-		actualDigests, overlayBootstrap := tool.MergeLayers(t, ctx, mergeOption, []converter.Layer{
-			{
-				Digest: lowerBlobDigest,
-			},
-			{
-				Digest: upperBlobDigest,
-			},
-		})
-		require.Equal(t, actualDigests, []digest.Digest{chunkDictBlobDigest, upperBlobDigest})
-
-		// Verify overlay (lower+upper) layer mounted by nydusd
-		lowerLayer.Overlay(t, upperLayer)
-		ctx.Env.BootstrapPath = overlayBootstrap
-		tool.Verify(t, ctx, lowerLayer.FileTree)
-	}
+type NativeLayerTestSuite struct {
+	t *testing.T
 }
 
-func testNativeLayer(t *testing.T, ctx tool.Context) {
-	t.Parallel()
+func (n *NativeLayerTestSuite) TestMakeLayers() test.Generator {
 
-	params := tool.DescartesIterator{}
-	params.
-		Register(paramCompressor, []interface{}{"zstd", "none", "lz4_block"}).
-		Register(paramFSVersion, []interface{}{"5", "6"}).
-		Register(paramChunkSize, []interface{}{"0x100000", "0x200000"}).
-		Register(paramCacheType, []interface{}{"blobcache", ""}).
-		Register(paramCacheCompressed, []interface{}{true, false}).
-		Register(paramRafsMode, []interface{}{"direct", "cached"}).
-		Register(paramEnablePrefetch, []interface{}{false, true}).
+	scenarios := tool.DescartesIterator{}
+	scenarios.
+		Dimension(paramCompressor, []interface{}{"zstd", "none", "lz4_block"}).
+		Dimension(paramFSVersion, []interface{}{"5", "6"}).
+		Dimension(paramChunkSize, []interface{}{"0x100000", "0x200000"}).
+		Dimension(paramCacheType, []interface{}{"blobcache", ""}).
+		Dimension(paramCacheCompressed, []interface{}{true, false}).
+		Dimension(paramRafsMode, []interface{}{"direct", "cached"}).
+		Dimension(paramEnablePrefetch, []interface{}{false, true}).
 		Skip(func(param *tool.DescartesItem) bool {
 
 			// rafs v6 not support cached mode nor dummy cache
@@ -134,21 +56,106 @@ func testNativeLayer(t *testing.T, ctx tool.Context) {
 			return false
 		})
 
-	for params.HasNext() {
-		param := params.Next()
+	return func() (name string, testCase test.Case) {
+		if !scenarios.HasNext() {
+			return
+		}
+		scenario := scenarios.Next()
 
-		ctx.Build.Compressor = param.GetString(paramCompressor)
-		ctx.Build.FSVersion = param.GetString(paramFSVersion)
-		ctx.Build.ChunkSize = param.GetString(paramChunkSize)
-		ctx.Runtime.CacheType = param.GetString(paramCacheType)
-		ctx.Runtime.CacheCompressed = param.GetBool(paramCacheCompressed)
-		ctx.Runtime.RafsMode = param.GetString(paramRafsMode)
-		ctx.Runtime.EnablePrefetch = param.GetBool(paramEnablePrefetch)
+		ctx := tool.DefaultContext(n.t)
+		ctx.Build.Compressor = scenario.GetString(paramCompressor)
+		ctx.Build.FSVersion = scenario.GetString(paramFSVersion)
+		ctx.Build.ChunkSize = scenario.GetString(paramChunkSize)
+		ctx.Runtime.CacheType = scenario.GetString(paramCacheType)
+		ctx.Runtime.CacheCompressed = scenario.GetBool(paramCacheCompressed)
+		ctx.Runtime.RafsMode = scenario.GetString(paramRafsMode)
+		ctx.Runtime.EnablePrefetch = scenario.GetBool(paramEnablePrefetch)
 
-		t.Run(param.Str(), makeNativeLayerTest(ctx))
+		return scenario.Str(), func(t *testing.T) {
+			n.testMakeLayers(*ctx, t)
+		}
 	}
 }
 
+func (n *NativeLayerTestSuite) testMakeLayers(ctx tool.Context, t *testing.T) {
+
+	packOption := converter.PackOption{
+		BuilderPath: ctx.Binary.Builder,
+		Compressor:  ctx.Build.Compressor,
+		FsVersion:   ctx.Build.FSVersion,
+		ChunkSize:   ctx.Build.ChunkSize,
+	}
+
+	// Prepare work directory
+	ctx.PrepareWorkDir(t)
+	defer ctx.Destroy(t)
+
+	// Make chunk dict layer
+	chunkDictLayer := texture.MakeChunkDictLayer(t, filepath.Join(ctx.Env.WorkDir, "source-chunk-dict"))
+	chunkDictBlobDigest := chunkDictLayer.Pack(t, packOption, ctx.Env.BlobDir)
+	mergeOption := converter.MergeOption{
+		ChunkDictPath: "",
+		BuilderPath:   ctx.Binary.Builder,
+	}
+	actualDigests, chunkDictBootstrap := tool.MergeLayers(t, ctx, mergeOption, []converter.Layer{
+		{
+			Digest: chunkDictBlobDigest,
+		},
+	})
+	require.Equal(t, actualDigests, []digest.Digest{chunkDictBlobDigest})
+
+	// Make lower layer (with chunk dict)
+	packOption.ChunkDictPath = chunkDictBootstrap
+	lowerLayer := texture.MakeLowerLayer(t, filepath.Join(ctx.Env.WorkDir, "source-lower"))
+	lowerBlobDigest := lowerLayer.Pack(t, packOption, ctx.Env.BlobDir)
+
+	// Check repeatable build
+	lowerBlobDigestNew := lowerLayer.Pack(t, packOption, ctx.Env.BlobDir)
+	require.Equal(t, lowerBlobDigest, lowerBlobDigestNew)
+
+	mergeOption = converter.MergeOption{
+		ChunkDictPath: chunkDictBootstrap,
+		BuilderPath:   ctx.Binary.Builder,
+	}
+	actualDigests, lowerBootstrap := tool.MergeLayers(t, ctx, mergeOption, []converter.Layer{
+		{
+			Digest: lowerBlobDigest,
+		},
+	})
+	require.Equal(t, actualDigests, []digest.Digest{chunkDictBlobDigest})
+
+	// Verify lower layer mounted by nydusd
+	ctx.Env.BootstrapPath = lowerBootstrap
+	tool.Verify(t, ctx, lowerLayer.FileTree)
+
+	// Make upper layer (with chunk dict)
+	upperLayer := texture.MakeUpperLayer(t, filepath.Join(ctx.Env.WorkDir, "source-upper"))
+	upperBlobDigest := upperLayer.Pack(t, packOption, ctx.Env.BlobDir)
+
+	// Check repeatable build
+	upperBlobDigestNew := upperLayer.Pack(t, packOption, ctx.Env.BlobDir)
+	require.Equal(t, upperBlobDigest, upperBlobDigestNew)
+
+	mergeOption = converter.MergeOption{
+		ChunkDictPath: chunkDictBootstrap,
+		BuilderPath:   ctx.Binary.Builder,
+	}
+	actualDigests, overlayBootstrap := tool.MergeLayers(t, ctx, mergeOption, []converter.Layer{
+		{
+			Digest: lowerBlobDigest,
+		},
+		{
+			Digest: upperBlobDigest,
+		},
+	})
+	require.Equal(t, actualDigests, []digest.Digest{chunkDictBlobDigest, upperBlobDigest})
+
+	// Verify overlay (lower+upper) layer mounted by nydusd
+	lowerLayer.Overlay(t, upperLayer)
+	ctx.Env.BootstrapPath = overlayBootstrap
+	tool.Verify(t, ctx, lowerLayer.FileTree)
+}
+
 func TestNativeLayer(t *testing.T) {
-	testNativeLayer(t, *tool.DefaultContext(t))
+	test.Run(t, &NativeLayerTestSuite{t: t})
 }

--- a/smoke/tests/tool/iterator.go
+++ b/smoke/tests/tool/iterator.go
@@ -58,8 +58,8 @@ func (d *DescartesItem) Str() string {
 //
 //	products := tool.DescartesIterator{}
 //	products.
-//		Register("name", []interface{}{"foo", "imoer", "morgan"}).
-//		Register("age", []interface{}{"20", "30"}).
+//		Dimension("name", []interface{}{"foo", "imoer", "morgan"}).
+//		Dimension("age", []interface{}{"20", "30"}).
 //		Skip(func(item *tool.DescartesItem) bool {
 //    		// skip ("morgan", "30")
 //    		return item.GetString("name") == "morgan" && param.GetString("age") == "30"
@@ -164,7 +164,7 @@ func (c *DescartesIterator) clearNext() {
 	c.nextItem = nil
 }
 
-func (c *DescartesIterator) Register(name string, vals []interface{}) *DescartesIterator {
+func (c *DescartesIterator) Dimension(name string, vals []interface{}) *DescartesIterator {
 	if c.cursorMap == nil {
 		c.cursorMap = make(map[string]int)
 	}

--- a/smoke/tests/tool/test/suite.go
+++ b/smoke/tests/tool/test/suite.go
@@ -1,0 +1,246 @@
+package test
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+const (
+	prefix = "Test"
+
+	flagSync = uint8(1)
+)
+
+func Sync(opts *options) {
+	opts.flag |= flagSync
+}
+
+type Option func(opts *options)
+
+type options struct {
+	flag uint8
+}
+
+type Case func(*testing.T)
+
+type Generator func() (name string, testCase Case)
+
+// This is a testing framework that helps coders organize test cases into test suite.
+//
+// It provides both dynamic and static/common way to define test cases. The dynamic
+// way generates test cases by customized generator in runtime. The static way executes
+// cases which are defined in compiling.
+//
+// It also provides both synchronized and asynchronous way to run test cases. The
+// asynchronous/synchronized control is suite-leveled.
+//
+// Compared with github.com/onsi/ginkgo, this framework provides simpler way to organize
+// cases into suite, which requires less learing of terms and less nested definitions.
+// Moreover, the asynchronous run is more golang-natived, which requires no other binary.
+//
+// Compared with github.com/stretchr/testify, this framework provides asynchronous mode
+// and dynamic way to generate cases.
+//
+// Example1: synchronized way
+//
+//        import (
+//            "fmt"
+//            "testing"
+//
+//            "github.com/stretchr/testify/require"
+//        )
+//
+//        type TestSuite struct{}
+//
+//        func (s *TestSuite) TestOk(t *testing.T) {
+//            require.Equal(t, 1, 1)
+//        }
+//
+//        func (s *TestSuite) TestFail(t *testing.T) {
+//            require.Equal(t, 1, 2)
+//        }
+//
+//        func (s *TestSuite) TestDynamicTest() TestGenerator {
+//            caseNum := 0
+//            return func() (name string, testCase TestCase) {
+//                if caseNum <= 5 {
+//                    testCase = func(t *testing.T) {
+//                        require.Equal(t, 1, 2)
+//                    }
+//                }
+//                caseNum++
+//                return fmt.Sprintf("dynamic_test_%v", caseNum), testCase
+//            }
+//        }
+//
+//        func Test1(t *testing.T) {
+//            Run(t, &TestSuite{}, Sync)
+//        }
+//
+// Output:
+//        `go test -v --parallel 4`
+//            1. The cases are serialized executed.
+//            2. The dynamic tests are generated and executed.
+//
+//        === RUN   Test1
+//        === RUN   Test1/dynamic_test_1
+//        === RUN   Test1/dynamic_test_2
+//        === RUN   Test1/dynamic_test_3
+//        === RUN   Test1/dynamic_test_4
+//        === RUN   Test1/dynamic_test_5
+//        === RUN   Test1/dynamic_test_6
+//        === RUN   Test1/TestFail
+//            suite_test.go:18:
+//                        Error Trace:    suite_test.go:18
+//                        Error:          Not equal:
+//                                        expected: 1
+//                                        actual  : 2
+//                        Test:           Test1/TestFail
+//        === RUN   Test1/TestOk
+//        --- FAIL: Test1 (0.00s)
+//            --- PASS: Test1/dynamic_test_1 (0.00s)
+//            --- PASS: Test1/dynamic_test_2 (0.00s)
+//            --- PASS: Test1/dynamic_test_3 (0.00s)
+//            --- PASS: Test1/dynamic_test_4 (0.00s)
+//            --- PASS: Test1/dynamic_test_5 (0.00s)
+//            --- PASS: Test1/dynamic_test_6 (0.00s)
+//            --- FAIL: Test1/TestFail (0.00s)
+//            --- PASS: Test1/TestOk (0.00s)
+//
+// Example2: asynchronized way
+//
+//        import (
+//            "fmt"
+//            "testing"
+//            "time"
+//        )
+//
+//        type AsyncTestSuite struct{}
+//
+//        func (s *AsyncTestSuite) Test1(t *testing.T) {
+//            for i := 0; i < 5; i++ {
+//                time.Sleep(time.Second)
+//            }
+//        }
+//
+//        func (s *AsyncTestSuite) Test2(t *testing.T) {
+//            for i := 0; i < 5; i++ {
+//                time.Sleep(time.Second)
+//            }
+//        }
+//
+//        func (s *AsyncTestSuite) Test3(t *testing.T) {
+//            for i := 0; i < 5; i++ {
+//                time.Sleep(time.Second)
+//            }
+//        }
+//
+//        func (s *AsyncTestSuite) TestDynamicTest() TestGenerator {
+//            caseNum := 0
+//            return func() (name string, testCase TestCase) {
+//                if caseNum <= 5 {
+//                    testCase = func(t *testing.T) {
+//                        for i := 0; i < 5; i++ {
+//                            time.Sleep(time.Second)
+//                        }
+//                    }
+//                }
+//                caseNum++
+//                return "", testCase
+//            }
+//        }
+//
+//        func Test1(t *testing.T) {
+//            Run(t, &AsyncTestSuite{})
+//        }
+//
+// Output:
+//        `go test -v --parallel 4`
+//            1. The cases are parallel executed, which leads to random completion.
+//            2. The dynamic tests are named automicly in lack of customized name.
+//
+//            --- PASS: Test1 (0.00s)
+//                --- PASS: Test1/TestDynamicTest_4 (5.00s)
+//                --- PASS: Test1/Test1 (5.00s)
+//                --- PASS: Test1/TestDynamicTest_6 (5.00s)
+//                --- PASS: Test1/TestDynamicTest_5 (5.00s)
+//                --- PASS: Test1/TestDynamicTest_2 (5.00s)
+//                --- PASS: Test1/TestDynamicTest_3 (5.00s)
+//                --- PASS: Test1/TestDynamicTest_1 (5.00s)
+//                --- PASS: Test1/Test3 (5.00s)
+//                --- PASS: Test1/Test2 (5.00s)
+//
+//
+func Run(t *testing.T, suite interface{}, opts ...Option) {
+
+	cases := reflect.ValueOf(suite)
+	if cases.Type().Kind() != reflect.Pointer || !reflect.Indirect(cases).IsValid() {
+		panic("test suite should be &struct{}")
+	}
+
+	var option options
+	for _, opt := range opts {
+		opt(&option)
+	}
+
+	ifTests := func(method *reflect.Method) bool {
+		return strings.HasPrefix(method.Name, prefix) &&
+			method.Type.NumIn() == 1 &&
+			method.Type.NumOut() == 1 &&
+			method.Type.Out(0).
+				AssignableTo(
+					reflect.TypeOf(func() (n string, t Case) { return "", nil }))
+	}
+	ifTest := func(method *reflect.Method) bool {
+		return strings.HasPrefix(method.Name, prefix) &&
+			method.Type.NumIn() == 2 &&
+			method.Type.NumOut() == 0 &&
+			method.Type.In(1).AssignableTo(reflect.TypeOf(&testing.T{}))
+	}
+
+	casesMeta := reflect.TypeOf(suite)
+	for idx := 0; idx < casesMeta.NumMethod(); idx++ {
+		testCase := cases.Method(idx)
+		meta := casesMeta.Method(idx)
+
+		if ifTests(&meta) {
+			factory, ok := testCase.Interface().(func() Generator)
+			if !ok || factory == nil {
+				continue
+			}
+			runDynamicTest(t, meta.Name, factory(), option.flag)
+			continue
+		}
+
+		if ifTest(&meta) {
+			testCase, ok := testCase.Interface().(func(*testing.T))
+			if !ok {
+				continue
+			}
+			runTest(t, meta.Name, testCase, option.flag)
+		}
+	}
+}
+
+func runTest(t *testing.T, name string, testCase Case, flags uint8) {
+	t.Run(name, func(t *testing.T) {
+		if flags&flagSync == 0 {
+			t.Parallel()
+		}
+		testCase(t)
+	})
+}
+
+func runDynamicTest(t *testing.T, name string, generator Generator, flags uint8) {
+	count := 0
+	for caseName, testCase := generator(); testCase != nil; caseName, testCase = generator() {
+		count++
+		if len(caseName) == 0 {
+			caseName = fmt.Sprintf("%s_%v", name, count)
+		}
+
+		runTest(t, caseName, testCase, flags)
+	}
+}


### PR DESCRIPTION
It provides both dynamic and static/common way to define test cases. The dynamic way generates test cases by customized generator in runtime. The static way executes cases which are defined in compiling.

It also provides both synchronized and asynchronous way to run test cases. The asynchronous/synchronized control is suite-leveled.

Compared with github.com/onsi/ginkgo, this framework provides simpler way to organize cases into suite, which requires less learing of terms and less nested definitions. Moreover, the asynchronous run is more golang-natived, which requires no other binary.

Compared with github.com/stretchr/testify, this framework provides asynchronous mode and dynamic way to generate cases.

Signed-off-by: 泰友 <cuichengxu.ccx@antgroup.com>