### PR TITLE
nydus-test: fix debug panic

### DIFF
--- a/contrib/nydus-test/framework/workload_gen.py
+++ b/contrib/nydus-test/framework/workload_gen.py
@@ -402,7 +402,7 @@ class WorkloadGen:
 
                     io_size = WorkloadGen.pick_io_size()
                     logging.debug(
-                        "File %s" % target_file, "Pos %u" % pos, "IO Size %u" % io_size
+                        "File %s , Pos %u, IO Size %u", target_file, pos, io_size
                     )
                     op_cnt += 1
                     total_size += io_size


### PR DESCRIPTION
Reproduction: add `NYDUS_TEST_VERBOSE=YES` to booting envs of pytest. 
For example:

```shell
    sudo NYDUS_TEST_VERBOSE=YES pytest functional-test/test_layered_image.py::test_basic_read
```

Output:
```
    ERROR    root:workload_gen.py:459 Stress read failure, not all arguments converted during string formatting
    Traceback (most recent call last):
      File "/home/morgan/workspace/rust/image-service/contrib/nydus-test/framework/workload_gen.py", line 456, in io_read
        cnt, size, duration = self.read_collected_files(io_duration)
      File "/home/morgan/workspace/rust/image-service/contrib/nydus-test/framework/workload_gen.py", line 404, in read_collected_files
        logging.debug(
      File "/usr/lib/python3.10/logging/__init__.py", line 2148, in debug
        root.debug(msg, *args, **kwargs)
      File "/usr/lib/python3.10/logging/__init__.py", line 1465, in debug
        self._log(DEBUG, msg, args, **kwargs)
      File "/usr/lib/python3.10/logging/__init__.py", line 1624, in _log
        self.handle(record)
      File "/usr/lib/python3.10/logging/__init__.py", line 1634, in handle
        self.callHandlers(record)
      File "/usr/lib/python3.10/logging/__init__.py", line 1696, in callHandlers
        hdlr.handle(record)
      File "/usr/lib/python3.10/logging/__init__.py", line 968, in handle
        self.emit(record)
      File "/usr/local/lib/python3.10/dist-packages/_pytest/logging.py", line 343, in emit
        super().emit(record)
      File "/usr/lib/python3.10/logging/__init__.py", line 1108, in emit
        self.handleError(record)
      File "/usr/lib/python3.10/logging/__init__.py", line 1100, in emit
        msg = self.format(record)
      File "/usr/lib/python3.10/logging/__init__.py", line 943, in format
        return fmt.format(record)
      File "/usr/local/lib/python3.10/dist-packages/_pytest/logging.py", line 114, in format
        return super().format(record)
      File "/usr/lib/python3.10/logging/__init__.py", line 678, in format
        record.message = record.getMessage()
      File "/usr/lib/python3.10/logging/__init__.py", line 368, in getMessage
        msg = msg % self.args
    TypeError: not all arguments converted during string formatting
```

Signed-off-by: 泰友 <cuichengxu.ccx@antgroup.com>