### PR TITLE
nydusify: fix overlayfs mount options for check

### DIFF
--- a/contrib/nydusify/pkg/checker/rule/filesystem.go
+++ b/contrib/nydusify/pkg/checker/rule/filesystem.go
@@ -330,6 +330,19 @@ func (rule *FilesystemRule) Validate() error {
 		return nil
 	}
 
+	// Cleanup temporary directories
+	defer func() {
+		if err := os.RemoveAll(rule.SourcePath); err != nil {
+			logrus.WithError(err).Warnf("cleanup source image directory %s", rule.SourcePath)
+		}
+		if err := os.RemoveAll(rule.NydusdConfig.MountPath); err != nil {
+			logrus.WithError(err).Warnf("cleanup nydus image directory %s", rule.NydusdConfig.MountPath)
+		}
+		if err := os.RemoveAll(rule.NydusdConfig.BlobCacheDir); err != nil {
+			logrus.WithError(err).Warnf("cleanup nydus blob cache directory %s", rule.NydusdConfig.BlobCacheDir)
+		}
+	}()
+
 	image, err := rule.mountSourceImage()
 	if err != nil {
 		return err

--- a/contrib/nydusify/pkg/checker/rule/filesystem.go
+++ b/contrib/nydusify/pkg/checker/rule/filesystem.go
@@ -172,19 +172,22 @@ func (rule *FilesystemRule) pullSourceImage() (*tool.Image, error) {
 	layers := rule.SourceParsed.OCIImage.Manifest.Layers
 	worker := utils.NewWorkerPool(WorkerCount, uint(len(layers)))
 
-	for _, l := range layers {
-		layer := l
-		worker.Put(func() error {
-			reader, err := rule.SourceRemote.Pull(context.Background(), layer, true)
-			if err != nil {
-				return errors.Wrap(err, "pull source image layers from the remote registry")
-			}
+	for idx := range layers {
+		worker.Put(func(idx int) func() error {
+			return func() error {
+				layer := layers[idx]
+				reader, err := rule.SourceRemote.Pull(context.Background(), layer, true)
+				if err != nil {
+					return errors.Wrap(err, "pull source image layers from the remote registry")
+				}
 
-			if err = utils.UnpackTargz(context.Background(), filepath.Join(rule.SourcePath, layer.Digest.Encoded()), reader, true); err != nil {
-				return errors.Wrap(err, "unpack source image layers")
+				if err = utils.UnpackTargz(context.Background(), filepath.Join(rule.SourcePath, fmt.Sprintf("layer-%d", idx)), reader, true); err != nil {
+					return errors.Wrap(err, "unpack source image layers")
+				}
+
+				return nil
 			}
-			return nil
-		})
+		}(idx))
 	}
 
 	if err := <-worker.Waiter(); err != nil {

--- a/contrib/nydusify/pkg/checker/tool/image.go
+++ b/contrib/nydusify/pkg/checker/tool/image.go
@@ -60,8 +60,9 @@ func (image *Image) Mount() error {
 
 	var dirs []string
 	count := len(image.Layers)
-	for i := range image.Layers {
-		layerDir := filepath.Join(image.SourcePath, image.Layers[count-i-1].Digest.Encoded())
+	for idx := range image.Layers {
+		layerName := fmt.Sprintf("layer-%d", count-idx-1)
+		layerDir := filepath.Join(image.SourcePath, layerName)
 		dirs = append(dirs, strings.ReplaceAll(layerDir, ":", "\\:"))
 	}
 


### PR DESCRIPTION
To fix the error when mount OCI v1 image in check subcommand:

```
error: mount options is too long
```

The mount options has 4k buffer size limitation, we will
encounter the issue in a huge image with mass layers.

We need to shorten the length of lowerdir paths in overlayfs
option, change `sha256:xxx` to `layer-N` to alleviate the issue.

Signed-off-by: Yan Song <imeoer@linux.alibaba.com>