### PR TITLE
nydusify: Fix nydusify help messages

### DIFF
--- a/contrib/nydusify/cmd/nydusify.go
+++ b/contrib/nydusify/cmd/nydusify.go
@@ -176,7 +176,7 @@ func main() {
 		FullTimestamp: true,
 	})
 
-	version := fmt.Sprintf("\nVersion		: %s\nRevision	: %s\nGo version	: %s\nBuild time	: %s", gitVersion, revision, runtime.Version(), buildTime)
+	version := fmt.Sprintf("\nVersion	: %s\nRevision	: %s\nGo version	: %s\nBuild time	: %s", gitVersion, revision, runtime.Version(), buildTime)
 
 	app := &cli.App{
 		Name:    "Nydusify",
@@ -315,7 +315,7 @@ func main() {
 				&cli.BoolFlag{
 					Name:    "merge-platform",
 					Value:   false,
-					Usage:   "Generate an OCI image index with both OCI and Nydus manifests for the image, please ensure that the OCI image exists in the target repository",
+					Usage:   "Generate an OCI image index with both OCI and Nydus manifests for the image",
 					EnvVars: []string{"MERGE_PLATFORM"},
 					Aliases: []string{"multi-platform"},
 				},


### PR DESCRIPTION
1. The "--merge-platform" flag in nydusify convert no longer need to push OCIv1 image first.
2. Fix wrong indentation in Version prompt.

Signed-off-by: Qinqi Qu <quqinqi@linux.alibaba.com>