### PR TITLE
builder: fix configuration error on chunk dict load

### DIFF
--- a/src/bin/nydus-image/main.rs
+++ b/src/bin/nydus-image/main.rs
@@ -814,8 +814,11 @@ impl Command {
                 chunk_size,
                 explicit_uidgid: !repeatable,
             };
+            let rafs_config = Arc::new(build_ctx.configuration.as_ref().clone());
+            // The separate chunk dict bootstrap doesn't support blob accessible.
+            rafs_config.internal.set_blob_accessible(false);
             blob_mgr.set_chunk_dict(timing_tracer!(
-                { import_chunk_dict(chunk_dict_arg, build_ctx.configuration.clone(), &config,) },
+                { import_chunk_dict(chunk_dict_arg, rafs_config, &config,) },
                 "import_chunk_dict"
             )?);
         }


### PR DESCRIPTION
This patch fix the error when enable blob-toc feature with `--chunk-dict`:

```
$ nydus-image create --chunk-dict bootstrap=/path/to/chunk-dict-bootstrap --features blob-toc ...

Error: failed to open bootstrap file "/path/to/chunk-dict-bootstrap"  module=builder
```

The separate chunk dict bootstrap doesn't support blob accessible.

Signed-off-by: Yan Song <imeoer@linux.alibaba.com>