### PR TITLE
rafs: reserve bits in RafsSuperFlags for future compatible changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1067,7 +1067,7 @@ dependencies = [
 
 [[package]]
 name = "nydus-api"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "dbs-uhttp",
  "http",
@@ -1141,7 +1141,7 @@ dependencies = [
 
 [[package]]
 name = "nydus-rafs"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1237,7 +1237,7 @@ dependencies = [
 
 [[package]]
 name = "nydus-storage"
-version = "0.6.0"
+version = "0.6.1"
 dependencies = [
  "arc-swap",
  "base64",
@@ -1274,7 +1274,7 @@ dependencies = [
 
 [[package]]
 name = "nydus-utils"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "blake3",
  "flate2",

--- a/rafs/src/metadata/mod.rs
+++ b/rafs/src/metadata/mod.rs
@@ -273,6 +273,16 @@ bitflags! {
         const COMPRESSION_ZSTD = 0x0000_0080;
         /// Chunk digests are inlined in RAFS v6 data blob.
         const INLINED_CHUNK_DIGEST = 0x0000_0100;
+
+        // Reserved for future compatible changes.
+        const PRESERVED_COMPAT_7 = 0x0100_0000;
+        const PRESERVED_COMPAT_6 = 0x0200_0000;
+        const PRESERVED_COMPAT_5 = 0x0400_0000;
+        const PRESERVED_COMPAT_4 = 0x0800_0000;
+        const PRESERVED_COMPAT_3 = 0x1000_0000;
+        const PRESERVED_COMPAT_2 = 0x2000_0000;
+        const PRESERVED_COMPAT_1 = 0x4000_0000;
+        const PRESERVED_COMPAT_0 = 0x8000_0000;
     }
 }
 


### PR DESCRIPTION
Reserve several bits in RafsSuperFlags for future compatible changes.

Signed-off-by: Jiang Liu <gerry@linux.alibaba.com>