### PR TITLE
nydus-image: add `backend-config` support to `nydus-image unpack`

### DIFF
--- a/src/bin/nydus-image/unpack/mod.rs
+++ b/src/bin/nydus-image/unpack/mod.rs
@@ -10,15 +10,13 @@ use std::str;
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
-use nydus_api::{ConfigV2, LocalFsConfig};
+use nydus_api::ConfigV2;
 use nydus_rafs::{
     metadata::{RafsInodeExt, RafsSuper},
     RafsIterator,
 };
-use nydus_storage::{
-    backend::{localfs::LocalFs, BlobBackend, BlobReader},
-    device::BlobInfo,
-};
+use nydus_storage::backend::BlobBackend;
+use nydus_storage::device::BlobInfo;
 use tar::{Builder, Header};
 
 use self::pax::{
@@ -36,24 +34,27 @@ pub trait Unpacker {
 ///  A unpacker with the ability to convert bootstrap file and blob file to tar
 pub struct OCIUnpacker {
     bootstrap: PathBuf,
-    blob: Option<PathBuf>,
+    blob_backend: Option<Arc<dyn BlobBackend + Send + Sync>>,
     output: PathBuf,
 
     builder_factory: OCITarBuilderFactory,
 }
 
 impl OCIUnpacker {
-    pub fn new(bootstrap: &Path, blob: Option<&str>, output: &str) -> Result<Self> {
+    pub fn new(
+        bootstrap: &Path,
+        blob_backend: Option<Arc<dyn BlobBackend + Send + Sync>>,
+        output: &str,
+    ) -> Result<Self> {
         let bootstrap = bootstrap.to_path_buf();
         let output = PathBuf::from(output);
-        let blob = blob.map(PathBuf::from);
 
         let builder_factory = OCITarBuilderFactory::new();
 
         Ok(OCIUnpacker {
             builder_factory,
             bootstrap,
-            blob,
+            blob_backend,
             output,
         })
     }
@@ -72,15 +73,15 @@ impl OCIUnpacker {
 impl Unpacker for OCIUnpacker {
     fn unpack(&self, config: Arc<ConfigV2>) -> Result<()> {
         debug!(
-            "oci unpacker, bootstrap file: {:?}, blob file: {:?}, output file: {:?}",
-            self.bootstrap, self.blob, self.output
+            "oci unpacker, bootstrap file: {:?}, output file: {:?}",
+            self.bootstrap, self.output
         );
 
         let rafs = self.load_rafs(config)?;
 
         let mut builder = self
             .builder_factory
-            .create(&rafs, self.blob.as_deref(), &self.output)?;
+            .create(&rafs, &self.blob_backend, &self.output)?;
 
         for (node, path) in RafsIterator::new(&rafs) {
             builder.append(&*node, &path)?;
@@ -114,13 +115,13 @@ impl OCITarBuilderFactory {
     fn create(
         &self,
         meta: &RafsSuper,
-        blob_path: Option<&Path>,
+        blob_backend: &Option<Arc<dyn BlobBackend + Send + Sync>>,
         output_path: &Path,
     ) -> Result<Box<dyn TarBuilder>> {
         let writer = self.create_writer(output_path)?;
 
         let blob = meta.superblock.get_blob_infos().pop();
-        let builders = self.create_builders(blob, blob_path)?;
+        let builders = self.create_builders(blob, blob_backend)?;
 
         let builder = OCITarBuilder::new(builders, writer);
 
@@ -144,7 +145,7 @@ impl OCITarBuilderFactory {
     fn create_builders(
         &self,
         blob: Option<Arc<BlobInfo>>,
-        blob_path: Option<&Path>,
+        blob_backend: &Option<Arc<dyn BlobBackend + Send + Sync>>,
     ) -> Result<Vec<Box<dyn SectionBuilder>>> {
         // PAX basic builders
         let ext_builder = Rc::new(PAXExtensionSectionBuilder::new());
@@ -159,7 +160,7 @@ impl OCITarBuilderFactory {
         let fifo_builder = OCIFifoBuilder::new(special_builder.clone());
         let char_builder = OCICharBuilder::new(special_builder.clone());
         let block_builder = OCIBlockBuilder::new(special_builder);
-        let reg_builder = self.create_reg_builder(blob, blob_path)?;
+        let reg_builder = self.create_reg_builder(blob, blob_backend)?;
 
         // The order counts.
         let builders = vec![
@@ -179,16 +180,18 @@ impl OCITarBuilderFactory {
     fn create_reg_builder(
         &self,
         blob: Option<Arc<BlobInfo>>,
-        blob_path: Option<&Path>,
+        blob_backend: &Option<Arc<dyn BlobBackend + Send + Sync>>,
     ) -> Result<OCIRegBuilder> {
         let (reader, compressor) = match blob {
             None => (None, None),
             Some(ref blob) => {
-                if blob_path.is_none() {
-                    bail!("miss blob path")
-                }
+                let blob_backend = blob_backend
+                    .as_deref()
+                    .with_context(|| "both blob path or blob backend config are not specified")?;
+                let reader = blob_backend
+                    .get_reader("unpacker")
+                    .map_err(|err| anyhow!("fail to get reader, error {:?}", err))?;
 
-                let reader = self.create_blob_reader(blob_path.unwrap())?;
                 let compressor = blob.compressor();
 
                 (Some(reader), Some(compressor))
@@ -200,23 +203,6 @@ impl OCITarBuilderFactory {
             reader,
             compressor,
         ))
-    }
-
-    fn create_blob_reader(&self, blob_path: &Path) -> Result<Arc<dyn BlobReader>> {
-        let config = LocalFsConfig {
-            blob_file: blob_path.to_str().unwrap().to_owned(),
-            dir: Default::default(),
-            alt_dirs: Default::default(),
-        };
-
-        let backend = LocalFs::new(&config, Some("unpacker"))
-            .with_context(|| format!("fail to create local backend for {:?}", blob_path))?;
-
-        let reader = backend
-            .get_reader("")
-            .map_err(|err| anyhow!("fail to get reader, error {:?}", err))?;
-
-        Ok(reader)
     }
 }
 


### PR DESCRIPTION
The `nydus-image unpack` only support reading nydus blob from the blob files on local machine (by the argument `blob`) by now. This patch adds a new argument `backend-config` to this command to allow `nydus-image unpack` to read blob data from all kinds of backends.