### PR TITLE
nydusify: upgrade deps to fix lost prefetch table

### DIFF
--- a/contrib/nydusify/go.mod
+++ b/contrib/nydusify/go.mod
@@ -128,7 +128,7 @@ require (
 replace github.com/opencontainers/runc => github.com/opencontainers/runc v1.1.2
 
 // It will be updated to official repo once acceleration-service release.
-replace github.com/goharbor/acceleration-service => github.com/imeoer/acceleration-service v0.0.33
+replace github.com/goharbor/acceleration-service => github.com/imeoer/acceleration-service v0.0.34
 
 // It will be updated to official repo once nydus-snapshotter release.
-replace github.com/containerd/nydus-snapshotter => github.com/imeoer/nydus-snapshotter v0.3.31
+replace github.com/containerd/nydus-snapshotter => github.com/imeoer/nydus-snapshotter v0.3.32

--- a/contrib/nydusify/go.sum
+++ b/contrib/nydusify/go.sum
@@ -888,10 +888,10 @@ github.com/imdario/mergo v0.3.8/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/imdario/mergo v0.3.10/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
-github.com/imeoer/acceleration-service v0.0.33 h1:GEiITKf1atp5oSVN7LYgUuIyOOUx6QXXAcSbTZfgdrA=
-github.com/imeoer/acceleration-service v0.0.33/go.mod h1:tbciUlt68Xf0BzHJ182NxrVyyOKAMh3Fyt6Etxcpszk=
-github.com/imeoer/nydus-snapshotter v0.3.31 h1:83cLhi+4JV2868UkUAr/n7nHwQX9MaberG+hYCmE2ao=
-github.com/imeoer/nydus-snapshotter v0.3.31/go.mod h1:U9m10GYZKisnSKOdgIjfkU8Ad0UTSYJ6CpP3I0SJBD0=
+github.com/imeoer/acceleration-service v0.0.34 h1:suggb+fiQm0rqx2fuIn+GuDUVgAsDe2pNtle7SuveTI=
+github.com/imeoer/acceleration-service v0.0.34/go.mod h1:TieZbvu5DlRwST1+c287Rz1bLKucV8Mu0fEPNA6MqaI=
+github.com/imeoer/nydus-snapshotter v0.3.32 h1:x86wZ9HUwKgR82asme0wU9bRtP4AkotPLrYNIb33afE=
+github.com/imeoer/nydus-snapshotter v0.3.32/go.mod h1:U9m10GYZKisnSKOdgIjfkU8Ad0UTSYJ6CpP3I0SJBD0=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
 github.com/intel/goresctrl v0.2.0/go.mod h1:+CZdzouYFn5EsxgqAQTEzMfwKwuc0fVdMrT9FCCAVRQ=

--- a/smoke/go.mod
+++ b/smoke/go.mod
@@ -36,4 +36,4 @@ require (
 )
 
 // It will be updated to official repo once nydus-snapshotter release.
-replace github.com/containerd/nydus-snapshotter => github.com/imeoer/nydus-snapshotter v0.3.31
+replace github.com/containerd/nydus-snapshotter => github.com/imeoer/nydus-snapshotter v0.3.32

--- a/smoke/go.sum
+++ b/smoke/go.sum
@@ -401,8 +401,8 @@ github.com/imdario/mergo v0.3.8/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/imdario/mergo v0.3.10/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
-github.com/imeoer/nydus-snapshotter v0.3.31 h1:83cLhi+4JV2868UkUAr/n7nHwQX9MaberG+hYCmE2ao=
-github.com/imeoer/nydus-snapshotter v0.3.31/go.mod h1:U9m10GYZKisnSKOdgIjfkU8Ad0UTSYJ6CpP3I0SJBD0=
+github.com/imeoer/nydus-snapshotter v0.3.32 h1:x86wZ9HUwKgR82asme0wU9bRtP4AkotPLrYNIb33afE=
+github.com/imeoer/nydus-snapshotter v0.3.32/go.mod h1:U9m10GYZKisnSKOdgIjfkU8Ad0UTSYJ6CpP3I0SJBD0=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/j-keck/arping v0.0.0-20160618110441-2cf9dc699c56/go.mod h1:ymszkNOg6tORTn+6F6j+Jc8TOr5osrynvN6ivFWZ2GA=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=


### PR DESCRIPTION
The `PrefetchPatterns` option should be passed to the builder (nydus-image)
merge subcommand, otherwise the prefetch feature table will not work in the
final bootstrap (used in nydus image).

See related commit: https://github.com/containerd/nydus-snapshotter/pull/352/commits/01fba5d171ba9a9056504526b55db4073b7652a8