### PR TITLE
smoke: make test log clearer

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -100,6 +100,15 @@ jobs:
           sudo tar xzf nydus-static-$version_arch.tgz -C nydus-$version
           sudo cp -r nydus-$version/nydus-static/* /usr/bin/nydus-$version/
         done
+    - name: Golang Cache
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod
+        key: ${{ runner.os }}-golang-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-golang-
     - name: Integration Test
       run: |
         sudo mkdir -p /usr/bin/nydus-latest /home/runner/work/workdir

--- a/smoke/tests/image_test.go
+++ b/smoke/tests/image_test.go
@@ -67,8 +67,10 @@ func (i *ImageTestSuite) TestConvertImage(t *testing.T, ctx tool.Context, source
 	}
 	target := fmt.Sprintf("%s-nydus-v%s%s", source, ctx.Build.FSVersion, ociRefSuffix)
 	fsVersion := fmt.Sprintf("--fs-version %s", ctx.Build.FSVersion)
+	logLevel := "--log-level warn"
 	if ctx.Binary.NydusifyOnlySupportV5 {
 		fsVersion = ""
+		logLevel = ""
 	}
 	compressor := "--compressor lz4_block"
 	if ctx.Binary.NydusifyNotSupportCompressor {
@@ -77,10 +79,10 @@ func (i *ImageTestSuite) TestConvertImage(t *testing.T, ctx tool.Context, source
 
 	// Convert image
 	convertCmd := fmt.Sprintf(
-		"%s convert --source %s --target %s %s %s --nydus-image %s --work-dir %s %s",
-		ctx.Binary.Nydusify, source, target, fsVersion, enableOCIRef, ctx.Binary.Builder, ctx.Env.WorkDir, compressor,
+		"%s %s convert --source %s --target %s %s %s --nydus-image %s --work-dir %s %s",
+		ctx.Binary.Nydusify, logLevel, source, target, fsVersion, enableOCIRef, ctx.Binary.Builder, ctx.Env.WorkDir, compressor,
 	)
-	tool.Run(t, convertCmd)
+	tool.RunWithoutOutput(t, convertCmd)
 
 	// Check image
 	nydusifyPath := ctx.Binary.Nydusify
@@ -88,10 +90,10 @@ func (i *ImageTestSuite) TestConvertImage(t *testing.T, ctx tool.Context, source
 		nydusifyPath = ctx.Binary.NydusifyChecker
 	}
 	checkCmd := fmt.Sprintf(
-		"%s check --source %s --target %s --nydus-image %s --nydusd %s --work-dir %s",
-		nydusifyPath, source, target, ctx.Binary.Builder, ctx.Binary.Nydusd, filepath.Join(ctx.Env.WorkDir, "check"),
+		"%s %s check --source %s --target %s --nydus-image %s --nydusd %s --work-dir %s",
+		nydusifyPath, logLevel, source, target, ctx.Binary.Builder, ctx.Binary.Nydusd, filepath.Join(ctx.Env.WorkDir, "check"),
 	)
-	tool.Run(t, checkCmd)
+	tool.RunWithoutOutput(t, checkCmd)
 }
 
 func (i *ImageTestSuite) prepareImage(t *testing.T, image string) string {

--- a/smoke/tests/tool/util.go
+++ b/smoke/tests/tool/util.go
@@ -6,6 +6,7 @@ package tool
 
 import (
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"strings"
@@ -23,6 +24,14 @@ var defaultBinary = map[string]string{
 func Run(t *testing.T, cmd string) {
 	_cmd := exec.Command("sh", "-c", cmd)
 	_cmd.Stdout = os.Stdout
+	_cmd.Stderr = os.Stderr
+	err := _cmd.Run()
+	assert.Nil(t, err)
+}
+
+func RunWithoutOutput(t *testing.T, cmd string) {
+	_cmd := exec.Command("sh", "-c", cmd)
+	_cmd.Stdout = io.Discard
 	_cmd.Stderr = os.Stderr
 	err := _cmd.Run()
 	assert.Nil(t, err)


### PR DESCRIPTION
```
Redirect the nydusify stdout to /dev/null, and keep the stderr
output for debugging.
```