### PR TITLE
builder: fix inode xattr flag for tar2rafs build

### DIFF
--- a/src/bin/nydus-image/builder/tarball.rs
+++ b/src/bin/nydus-image/builder/tarball.rs
@@ -331,10 +331,11 @@ impl<'a> TarballTreeBuilder<'a> {
             i_mtime_nsec: 0,
             i_reserved: [0; 8],
         };
-        let inode = match self.ctx.fs_version {
+        let mut inode = match self.ctx.fs_version {
             RafsVersion::V5 => InodeWrapper::V5(v5_inode),
             RafsVersion::V6 => InodeWrapper::V6(v5_inode),
         };
+        inode.set_has_xattr(!xattrs.is_empty());
 
         let source = PathBuf::from("/");
         let target = Node::generate_target(path.as_ref(), &source);


### PR DESCRIPTION
We forgot to set inode xattr flag in tar2rafs build workflow, this causes
a broken chunk info offset calculation in the `_get_chunk_info` method:

```
let mut offset = self.offset + inode.size();
if inode.has_xattr() {
    let xattrs = state.file_map.get_ref::<RafsV5XAttrsTable>(offset)?;
    offset += size_of::<RafsV5XAttrsTable>() + xattrs.aligned_size();
}
offset += size_of::<RafsV5ChunkInfo>() * idx as usize;
```

Then causes to get invalid chunk info:

```
invalid inode digest X, expected Y, ino: 1 name: "file-1"
```

This patch fixes it by setting the xattr flag for tar2rafs build.