### PR TITLE
smoke: fix possible image name conflicts

### DIFF
--- a/smoke/go.mod
+++ b/smoke/go.mod
@@ -5,6 +5,7 @@ go 1.18
 require (
 	github.com/containerd/containerd v1.6.17
 	github.com/containerd/nydus-snapshotter v0.0.0-00010101000000-000000000000
+	github.com/google/uuid v1.2.0
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/pkg/errors v0.9.1
 	github.com/pkg/xattr v0.4.9

--- a/smoke/go.sum
+++ b/smoke/go.sum
@@ -369,6 +369,7 @@ github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm4
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.2.0 h1:qJYtXnJRWmpe7m/3XlyhrsLrEURqHRM2kxzoxXqyUDs=
 github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=

--- a/smoke/tests/image_test.go
+++ b/smoke/tests/image_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/dragonflyoss/image-service/smoke/tests/tool"
 	"github.com/dragonflyoss/image-service/smoke/tests/tool/test"
+	"github.com/google/uuid"
 )
 
 const (
@@ -59,13 +60,11 @@ func (i *ImageTestSuite) TestConvertImage(t *testing.T, ctx tool.Context, source
 	defer ctx.Destroy(t)
 
 	// Prepare options
-	ociRefSuffix := ""
 	enableOCIRef := ""
 	if ctx.Build.OCIRef {
-		ociRefSuffix = "-oci-ref"
 		enableOCIRef = "--oci-ref"
 	}
-	target := fmt.Sprintf("%s-nydus-v%s%s", source, ctx.Build.FSVersion, ociRefSuffix)
+	target := fmt.Sprintf("%s-nydus-%s", source, uuid.NewString())
 	fsVersion := fmt.Sprintf("--fs-version %s", ctx.Build.FSVersion)
 	logLevel := "--log-level warn"
 	if ctx.Binary.NydusifyOnlySupportV5 {


### PR DESCRIPTION
To avoid concurrency confliction between different nydus images
created by `nydusify convert` or `nydusify check`.