### PR TITLE
service: fix a bug to correct shutdown service manager

### DIFF
--- a/service/src/daemon.rs
+++ b/service/src/daemon.rs
@@ -360,7 +360,7 @@ impl DaemonController {
 
         Self {
             active: AtomicBool::new(true),
-            singleton_mode: AtomicBool::new(true),
+            singleton_mode: AtomicBool::new(false),
             daemon: Mutex::new(None),
             blob_cache_mgr: Mutex::new(None),
             fs_service: Mutex::new(None),
@@ -452,7 +452,7 @@ impl DaemonController {
                 }
 
                 if event.is_readable() && event.token() == Token(1) {
-                    if self.active.load(Ordering::Acquire) {
+                    if !self.active.load(Ordering::Acquire) {
                         return;
                     } else if !self.singleton_mode.load(Ordering::Acquire) {
                         self.active.store(false, Ordering::Relaxed);


### PR DESCRIPTION
Fix a bug to correct shutdown service manager, the condition to exit serivce loop is wrong.