### PR TITLE
smoke: fix compatibility test

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -89,8 +89,8 @@ jobs:
     - name: Prepare Older Binaries
       id: prepare-binaries
       run: |
-        versions=(v0.1.0 v2.1.2)
-        version_archs=(v0.1.0-x86_64 v2.1.2-linux-amd64)
+        versions=(v0.1.0 v2.1.4)
+        version_archs=(v0.1.0-x86_64 v2.1.4-linux-amd64)
         for i in ${!versions[@]}; do
           version=${versions[$i]}
           version_arch=${version_archs[$i]}
@@ -115,8 +115,8 @@ jobs:
         sudo install -D -m 755 contrib/nydusify/cmd/nydusify /usr/bin/nydus-latest
         sudo install -D -m 755 target/release/nydusd target/release/nydus-image /usr/bin/nydus-latest
 
-        versions=(v0.1.0 v2.1.2 latest)
-        version_exports=(v0_1_0 v2_1_2 latest)
+        versions=(v0.1.0 v2.1.4 latest)
+        version_exports=(v0_1_0 v2_1_4 latest)
         for i in ${!version_exports[@]}; do
           version=${versions[$i]}
           version_export=${version_exports[$i]}

--- a/contrib/nydusify/go.mod
+++ b/contrib/nydusify/go.mod
@@ -129,7 +129,7 @@ require (
 replace github.com/opencontainers/runc => github.com/opencontainers/runc v1.1.2
 
 // It will be updated to official repo once acceleration-service release.
-replace github.com/goharbor/acceleration-service => github.com/imeoer/acceleration-service v0.0.34
+replace github.com/goharbor/acceleration-service => github.com/imeoer/acceleration-service v0.0.35
 
 // It will be updated to official repo once nydus-snapshotter release.
-replace github.com/containerd/nydus-snapshotter => github.com/imeoer/nydus-snapshotter v0.3.32
+replace github.com/containerd/nydus-snapshotter => github.com/imeoer/nydus-snapshotter v0.3.33

--- a/contrib/nydusify/go.sum
+++ b/contrib/nydusify/go.sum
@@ -897,10 +897,10 @@ github.com/imdario/mergo v0.3.8/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/imdario/mergo v0.3.10/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
-github.com/imeoer/acceleration-service v0.0.34 h1:suggb+fiQm0rqx2fuIn+GuDUVgAsDe2pNtle7SuveTI=
-github.com/imeoer/acceleration-service v0.0.34/go.mod h1:TieZbvu5DlRwST1+c287Rz1bLKucV8Mu0fEPNA6MqaI=
-github.com/imeoer/nydus-snapshotter v0.3.32 h1:x86wZ9HUwKgR82asme0wU9bRtP4AkotPLrYNIb33afE=
-github.com/imeoer/nydus-snapshotter v0.3.32/go.mod h1:U9m10GYZKisnSKOdgIjfkU8Ad0UTSYJ6CpP3I0SJBD0=
+github.com/imeoer/acceleration-service v0.0.35 h1:WvfdfPaqmaAaIP/mJkged9tWlLVDjTdJBQuK1EqXYvw=
+github.com/imeoer/acceleration-service v0.0.35/go.mod h1:JI3wTdN9Sf+YZa39k2GoIrLAwdUtlwmZJBJOFqsR+so=
+github.com/imeoer/nydus-snapshotter v0.3.33 h1:s9YNYOdfNYNZ4LdfR4jt3ZLB4Q8AhT3DZiLwIzSWPEI=
+github.com/imeoer/nydus-snapshotter v0.3.33/go.mod h1:U9m10GYZKisnSKOdgIjfkU8Ad0UTSYJ6CpP3I0SJBD0=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
 github.com/intel/goresctrl v0.2.0/go.mod h1:+CZdzouYFn5EsxgqAQTEzMfwKwuc0fVdMrT9FCCAVRQ=

--- a/smoke/Makefile
+++ b/smoke/Makefile
@@ -28,8 +28,9 @@ test: build lint
 # NYDUS_BUILDER_v0_1_0=/path/to/v0.1.0/nydus-image \
 # NYDUS_NYDUSD_v0_1_0=/path/to/v0.1.0/nydusd \
 # NYDUS_NYDUSIFY_v0_1_0=/path/to/v0.1.0/nydusify \
-# NYDUS_BUILDER_v2_1_2=/path/to/v2.1.2/nydus-image \
-# NYDUS_NYDUSD_v2_1_2=/path/to/v2.1.2/nydusd \
-# NYDUS_NYDUSIFY_v2_1_2=/path/to/v2.1.2/nydusify
+# NYDUS_BUILDER_v2_1_4=/path/to/v2.1.4/nydus-image \
+# NYDUS_NYDUSD_v2_1_4=/path/to/v2.1.4/nydusd \
+# NYDUS_NYDUSIFY_v2_1_4=/path/to/v2.1.4/nydusify \
+# make test TESTS=TestCompatibility
 test-compatibility: build lint
 	make test TESTS=TestCompatibility

--- a/smoke/go.mod
+++ b/smoke/go.mod
@@ -37,4 +37,4 @@ require (
 )
 
 // It will be updated to official repo once nydus-snapshotter release.
-replace github.com/containerd/nydus-snapshotter => github.com/imeoer/nydus-snapshotter v0.3.32
+replace github.com/containerd/nydus-snapshotter => github.com/imeoer/nydus-snapshotter v0.3.33

--- a/smoke/go.sum
+++ b/smoke/go.sum
@@ -402,8 +402,8 @@ github.com/imdario/mergo v0.3.8/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJ
 github.com/imdario/mergo v0.3.10/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.11/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
 github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=
-github.com/imeoer/nydus-snapshotter v0.3.32 h1:x86wZ9HUwKgR82asme0wU9bRtP4AkotPLrYNIb33afE=
-github.com/imeoer/nydus-snapshotter v0.3.32/go.mod h1:U9m10GYZKisnSKOdgIjfkU8Ad0UTSYJ6CpP3I0SJBD0=
+github.com/imeoer/nydus-snapshotter v0.3.33 h1:s9YNYOdfNYNZ4LdfR4jt3ZLB4Q8AhT3DZiLwIzSWPEI=
+github.com/imeoer/nydus-snapshotter v0.3.33/go.mod h1:U9m10GYZKisnSKOdgIjfkU8Ad0UTSYJ6CpP3I0SJBD0=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/j-keck/arping v0.0.0-20160618110441-2cf9dc699c56/go.mod h1:ymszkNOg6tORTn+6F6j+Jc8TOr5osrynvN6ivFWZ2GA=
 github.com/jmespath/go-jmespath v0.0.0-20160202185014-0b12d6b521d8/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/smoke/tests/compatibility_test.go
+++ b/smoke/tests/compatibility_test.go
@@ -29,9 +29,9 @@ func (c *CompatibilityTestSuite) TestConvertImages() test.Generator {
 	scenarios.
 		Dimension(paramImage, []interface{}{"nginx:latest"}).
 		Dimension(paramFSVersion, []interface{}{"5", "6"}).
-		Dimension(paramNydusImageVersion, []interface{}{"v0.1.0", "v2.1.2", "latest"}).
-		Dimension(paramNydusifyVersion, []interface{}{"v0.1.0", "v2.1.2", "latest"}).
-		Dimension(paramNydusdVersion, []interface{}{"v0.1.0", "v2.1.2", "latest"}).
+		Dimension(paramNydusImageVersion, []interface{}{"v0.1.0", "v2.1.4", "latest"}).
+		Dimension(paramNydusifyVersion, []interface{}{"v0.1.0", "v2.1.4", "latest"}).
+		Dimension(paramNydusdVersion, []interface{}{"v0.1.0", "v2.1.4", "latest"}).
 		Skip(func(param *tool.DescartesItem) bool {
 
 			// Nydus-image 0.1.0 only works with nydus-nydusify 0.1.0, vice versa.

--- a/storage/src/meta/toc.rs
+++ b/storage/src/meta/toc.rs
@@ -80,7 +80,7 @@ pub struct TocEntry {
     compressed_size: u64,
     /// Size of uncompressed data
     uncompressed_size: u64,
-    reserved2: [u8; 44],
+    reserved2: [u8; 48],
 }
 
 impl Default for TocEntry {
@@ -93,7 +93,7 @@ impl Default for TocEntry {
             compressed_offset: 0,
             compressed_size: 0,
             uncompressed_size: 0,
-            reserved2: [0u8; 44],
+            reserved2: [0u8; 48],
         }
     }
 }
@@ -319,7 +319,7 @@ impl TocEntryList {
             compressed_offset,
             compressed_size,
             uncompressed_size,
-            reserved2: [0u8; 44],
+            reserved2: [0u8; 48],
         };
         entry.set_compressor(compressor)?;
         self.entries.push(entry);


### PR DESCRIPTION
**smoke: fix compatibility test**

Nydusd 2.1.3 is not work with nydus-image 2.2+ for rafs v6,
upgrade to 2.1.4 to pass the test.

**builder: fix toc entry struct alignment**

Otherwise the serialized data on disk will be filled with
unexpected non-zero data.