### PR TITLE
rafs: refine definition of INLINED_CHUNK_DIGEST

### DIFF
--- a/rafs/src/metadata/mod.rs
+++ b/rafs/src/metadata/mod.rs
@@ -271,8 +271,6 @@ bitflags! {
         const COMPRESSION_GZIP = 0x0000_0040;
         /// Data chunks are compressed with zstd
         const COMPRESSION_ZSTD = 0x0000_0080;
-        /// Chunk digests are inlined in RAFS v6 data blob.
-        const INLINED_CHUNK_DIGEST = 0x0000_0100;
 
         // Reserved for future compatible changes.
         const PRESERVED_COMPAT_7 = 0x0100_0000;
@@ -282,7 +280,8 @@ bitflags! {
         const PRESERVED_COMPAT_3 = 0x1000_0000;
         const PRESERVED_COMPAT_2 = 0x2000_0000;
         const PRESERVED_COMPAT_1 = 0x4000_0000;
-        const PRESERVED_COMPAT_0 = 0x8000_0000;
+        /// Chunk digests are inlined in RAFS v6 data blob.
+        const INLINED_CHUNK_DIGEST = 0x8000_0000;
     }
 }
 


### PR DESCRIPTION
Refine definition of INLINED_CHUNK_DIGEST so compatible flags are grouped together.