### PR TITLE
rafs: reserve bits in RafsSuperFlags to be compatible with v2.2

### DIFF
--- a/rafs/src/metadata/mod.rs
+++ b/rafs/src/metadata/mod.rs
@@ -255,6 +255,19 @@ bitflags! {
         const COMPRESS_GZIP = 0x0000_0040;
         // V5: Data chunks are compressed with zstd
         const COMPRESS_ZSTD = 0x0000_0080;
+
+        // Reserved for v2.2: chunk digests are inlined in RAFS v6 data blob.
+        const PRESERVED_INLINED_CHUNK_DIGEST = 0x0000_0100;
+
+        // Reserved for future compatible changes.
+        const PRESERVED_COMPAT_7 = 0x0100_0000;
+        const PRESERVED_COMPAT_6 = 0x0200_0000;
+        const PRESERVED_COMPAT_5 = 0x0400_0000;
+        const PRESERVED_COMPAT_4 = 0x0800_0000;
+        const PRESERVED_COMPAT_3 = 0x1000_0000;
+        const PRESERVED_COMPAT_2 = 0x2000_0000;
+        const PRESERVED_COMPAT_1 = 0x4000_0000;
+        const PRESERVED_COMPAT_0 = 0x8000_0000;
     }
 }
 


### PR DESCRIPTION
Reserve bits in RafsSuperFlags so images generated by nydus 2.2 can be mounted by v2.1.4 and later.