### PR TITLE
Revert "storage: return Ok(None) for check_range_ready_and_mark_pendi…

### DIFF
--- a/storage/src/cache/state/blob_state_map.rs
+++ b/storage/src/cache/state/blob_state_map.rs
@@ -206,11 +206,7 @@ impl RangeMap for BlobStateMap<IndexedChunkMap, u32> {
             }
         }
 
-        if res.is_empty() {
-            Ok(None)
-        } else {
-            Ok(Some(res))
-        }
+        Ok(Some(res))
     }
 
     fn set_range_ready_and_clear_pending(&self, start: Self::I, count: Self::I) -> Result<()> {


### PR DESCRIPTION
…ng () when needed"

This reverts commit 03326fd9216111a9f83ffcf94a082d87b339b34e.

The change may cause silent data corrupt because it disable bitmap.wait_for_range_ready() in function
FileCacheEntry::do_fetch_chunks()