### PR TITLE
service: improve the resuability of create_daemon

### DIFF
--- a/service/src/singleton.rs
+++ b/service/src/singleton.rs
@@ -237,6 +237,7 @@ impl DaemonStateMachineSubscriber for ServiceController {
 }
 
 /// Create and start a Nydus daemon to host fscache and fusedev services.
+#[allow(clippy::too_many_arguments)]
 pub fn create_daemon(
     id: Option<String>,
     supervisor: Option<String>,


### PR DESCRIPTION
In order to improve the reusability of the function create_daemon, the parameter processing logic is moved from the create_daemon and initialize_fscache_service functions to the upper layer function process_singleton_arguments