### PR TITLE
rafs: fix a bug in calculate offset for dirent name

### DIFF
--- a/rafs/src/metadata/direct_v6.rs
+++ b/rafs/src/metadata/direct_v6.rs
@@ -534,7 +534,11 @@ impl OndiskInodeWrapper {
                 // Because the other blocks should be fully used, while the last may not.
                 let len = if div_round_up(self.size(), EROFS_BLOCK_SIZE) as usize == block_index + 1
                 {
-                    (self.size() % EROFS_BLOCK_SIZE - s) as usize
+                    if self.size() % EROFS_BLOCK_SIZE == 0 {
+                        EROFS_BLOCK_SIZE as usize
+                    } else {
+                        (self.size() % EROFS_BLOCK_SIZE - s) as usize
+                    }
                 } else {
                     (EROFS_BLOCK_SIZE - s) as usize
                 };


### PR DESCRIPTION
There's a bug in calculate offset and size for RAFS v6 Dirent name, it will be treat as 0 instead of 4096 if the last block is 4096 bytes.

Fixes: https://github.com/dragonflyoss/image-service/issues/1098