### PR TITLE
service: fix a unused variable warning on macos

### DIFF
--- a/service/src/singleton.rs
+++ b/service/src/singleton.rs
@@ -237,7 +237,7 @@ impl DaemonStateMachineSubscriber for ServiceController {
 }
 
 /// Create and start a Nydus daemon to host fscache and fusedev services.
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, unused)]
 pub fn create_daemon(
     id: Option<String>,
     supervisor: Option<String>,


### PR DESCRIPTION
Fix a unused variable warning on macos.