### PR TITLE
Correctly generate mapped-blkaddr for RAFS devslot array

### DIFF
--- a/src/bin/nydus-image/core/bootstrap.rs
+++ b/src/bin/nydus-image/core/bootstrap.rs
@@ -583,7 +583,7 @@ impl Bootstrap {
             EROFS_BLOCK_SIZE as u64,
         );
         let blob_table_entries = blobs.len();
-        assert!(blob_table_entries < u16::MAX as usize);
+        assert!(blob_table_entries < u8::MAX as usize);
         trace!(
             "devtable len {} blob table offset {} blob table size {}",
             devtable_len,


### PR DESCRIPTION
Correctly generate `mapped-blkaddr` for RAFS devslot array, it helps to expose a RAFS v6 image as a block device.