### PR TITLE
nydusify: enable pigz by default

### DIFF
--- a/contrib/nydusify/cmd/nydusify.go
+++ b/contrib/nydusify/cmd/nydusify.go
@@ -874,11 +874,6 @@ func main() {
 		},
 	}
 
-	// With linux/arm64 platform, containerd/compression prioritizes `unpigz`
-	// to decompress tar.gz file, which may generate corrupted data somehow.
-	// Keep the same behavior with x86_64 platform by disabling pigz.
-	os.Setenv("CONTAINERD_DISABLE_PIGZ", "1")
-
 	if !utils.IsSupportedArch(runtime.GOARCH) {
 		logrus.Fatal("Nydusify can only work under architecture 'amd64' and 'arm64'")
 	}


### PR DESCRIPTION
We should use pigz for supporting parallel gzip decompression, so that improve the conversion speed when unpack gzip layer for source image.

We still allow users to specify the env `CONTAINERD_DISABLE_PIGZ=1` to disable the feature when encounter any decompression error.

See https://github.com/containerd/containerd/blob/33c0eafb17dff6de43f4a530fcf05b02ed24330b/archive/compression/compression.go#L261