### PR TITLE
nydus: exclude some components when publishing crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1067,7 +1067,7 @@ dependencies = [
 
 [[package]]
 name = "nydus-api"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "dbs-uhttp",
  "http",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ authors = ["The Nydus Developers"]
 license = "Apache-2.0 OR BSD-3-Clause"
 homepage = "https://nydus.dev/"
 repository = "https://github.com/dragonflyoss/image-service"
+exclude = ["contrib/", "smoke/", "tests/"]
 edition = "2018"
 resolver = "2"
 


### PR DESCRIPTION
Exclude some components when publishing crate, otherwise the package gets too big and can't be published to crates.io due to maximum size (10MB) limitation.