### PR TITLE
Minor improvements to nydus-image

### DIFF
--- a/src/bin/nydus-image/builder/directory.rs
+++ b/src/bin/nydus-image/builder/directory.rs
@@ -117,10 +117,10 @@ impl Builder for DirectoryBuilder {
         bootstrap_mgr: &mut BootstrapManager,
         blob_mgr: &mut BlobManager,
     ) -> Result<BuildOutput> {
-        let mut bootstrap_ctx = bootstrap_mgr.create_ctx(ctx.blob_inline_meta)?;
+        let mut bootstrap_ctx = bootstrap_mgr.create_ctx()?;
         let layer_idx = u16::from(bootstrap_ctx.layered);
         let mut blob_writer = if let Some(blob_stor) = ctx.blob_storage.clone() {
-            ArtifactWriter::new(blob_stor, ctx.blob_inline_meta)?
+            ArtifactWriter::new(blob_stor)?
         } else {
             return Err(anyhow!(
                 "target blob path should always be valid for directory builder"

--- a/src/bin/nydus-image/builder/stargz.rs
+++ b/src/bin/nydus-image/builder/stargz.rs
@@ -811,10 +811,10 @@ impl Builder for StargzBuilder {
         bootstrap_mgr: &mut BootstrapManager,
         blob_mgr: &mut BlobManager,
     ) -> Result<BuildOutput> {
-        let mut bootstrap_ctx = bootstrap_mgr.create_ctx(ctx.blob_inline_meta)?;
+        let mut bootstrap_ctx = bootstrap_mgr.create_ctx()?;
         let layer_idx = u16::from(bootstrap_ctx.layered);
         let mut blob_writer = if let Some(blob_stor) = ctx.blob_storage.clone() {
-            Some(ArtifactWriter::new(blob_stor, ctx.blob_inline_meta)?)
+            Some(ArtifactWriter::new(blob_stor)?)
         } else {
             return Err(anyhow!("missing configuration for target path"));
         };

--- a/src/bin/nydus-image/builder/tarball.rs
+++ b/src/bin/nydus-image/builder/tarball.rs
@@ -549,7 +549,7 @@ impl Builder for TarballBuilder {
         bootstrap_mgr: &mut BootstrapManager,
         blob_mgr: &mut BlobManager,
     ) -> Result<BuildOutput> {
-        let mut bootstrap_ctx = bootstrap_mgr.create_ctx(ctx.blob_inline_meta)?;
+        let mut bootstrap_ctx = bootstrap_mgr.create_ctx()?;
         let layer_idx = u16::from(bootstrap_ctx.layered);
         let mut blob_writer = match self.ty {
             ConversionType::EStargzToRafs
@@ -558,7 +558,7 @@ impl Builder for TarballBuilder {
             | ConversionType::EStargzToRef
             | ConversionType::TargzToRef => {
                 if let Some(blob_stor) = ctx.blob_storage.clone() {
-                    ArtifactWriter::new(blob_stor, ctx.blob_inline_meta)?
+                    ArtifactWriter::new(blob_stor)?
                 } else {
                     return Err(anyhow!("missing configuration for target path"));
                 }

--- a/src/bin/nydus-image/core/blob_compact.rs
+++ b/src/bin/nydus-image/core/blob_compact.rs
@@ -129,7 +129,7 @@ impl ChunkSet {
         aligned_chunk: bool,
         backend: &Arc<dyn BlobBackend + Send + Sync>,
     ) -> Result<Vec<(ChunkWrapper, ChunkWrapper)>> {
-        let mut blob_writer = ArtifactWriter::new(blob_storage, build_ctx.blob_inline_meta)?;
+        let mut blob_writer = ArtifactWriter::new(blob_storage)?;
 
         // sort chunks first, don't break order in original blobs
         let mut chunks = self.chunks.values().collect::<Vec<&ChunkWrapper>>();
@@ -578,7 +578,7 @@ impl BlobCompactor {
         );
         let mut bootstrap_mgr =
             BootstrapManager::new(Some(ArtifactStorage::SingleFile(d_bootstrap)), None);
-        let mut bootstrap_ctx = bootstrap_mgr.create_ctx(false)?;
+        let mut bootstrap_ctx = bootstrap_mgr.create_ctx()?;
         let mut ori_blob_mgr = BlobManager::new(rs.meta.get_digester());
         ori_blob_mgr.extend_from_blob_table(&build_ctx, rs.superblock.get_blob_infos())?;
         if let Some(dict) = chunk_dict {

--- a/src/bin/nydus-image/core/node.rs
+++ b/src/bin/nydus-image/core/node.rs
@@ -1469,7 +1469,7 @@ mod tests {
 
         let bootstrap_path = TempFile::new().unwrap();
         let storage = ArtifactStorage::SingleFile(bootstrap_path.as_path().to_path_buf());
-        let mut bootstrap_ctx = BootstrapContext::new(Some(storage), false, false).unwrap();
+        let mut bootstrap_ctx = BootstrapContext::new(Some(storage), false).unwrap();
         bootstrap_ctx.offset = 0;
 
         // reg file.

--- a/src/bin/nydus-image/merge.rs
+++ b/src/bin/nydus-image/merge.rs
@@ -254,7 +254,7 @@ impl Merger {
             ctx.chunk_size = chunk_size;
         }
 
-        let mut bootstrap_ctx = BootstrapContext::new(Some(target.clone()), false, false)?;
+        let mut bootstrap_ctx = BootstrapContext::new(Some(target.clone()), false)?;
         let mut bootstrap = Bootstrap::new()?;
         bootstrap.build(ctx, &mut bootstrap_ctx, &mut tree)?;
         let blob_table = blob_mgr.to_blob_table(ctx)?;


### PR DESCRIPTION
Minor improvements to nydus-image,
- optionally remove chunk info array from metadata blob
- better handle argument `chunk-size`.
- simplify ArtifactWriter::new()