### PR TITLE
Introduce new tarfs mode to Nydus

### DIFF
--- a/rafs/src/builder/core/blob.rs
+++ b/rafs/src/builder/core/blob.rs
@@ -55,6 +55,7 @@ impl Blob {
                 Self::finalize_blob_data(ctx, blob_mgr, blob_writer)?;
             }
             ConversionType::TarToRef
+            | ConversionType::TarToTarfs
             | ConversionType::TargzToRef
             | ConversionType::EStargzToRef => {
                 // Use `sha256(tarball)` as `blob_id` for ref-type conversions.
@@ -68,6 +69,9 @@ impl Blob {
                         }
                     } else if let Some(tar_reader) = &ctx.blob_tar_reader {
                         blob_ctx.compressed_blob_size = tar_reader.position();
+                        if ctx.conversion_type == ConversionType::TarToTarfs {
+                            blob_ctx.uncompressed_blob_size = blob_ctx.compressed_blob_size;
+                        }
                         if blob_ctx.blob_id.is_empty() {
                             let hash = tar_reader.get_hash_object();
                             blob_ctx.blob_id = format!("{:x}", hash.finalize());

--- a/rafs/src/builder/core/bootstrap.rs
+++ b/rafs/src/builder/core/bootstrap.rs
@@ -152,6 +152,7 @@ impl Bootstrap {
         let index = nodes.len() as u32 + 1;
         let parent = &mut nodes[tree.node.index as usize - 1];
         let parent_ino = parent.inode.ino();
+        let block_size = ctx.v6_block_size();
 
         // Maybe the parent is not a directory in multi-layers build scenario, so we check here.
         if parent.is_dir() {
@@ -162,7 +163,8 @@ impl Bootstrap {
             parent.inode.set_child_index(index);
             parent.inode.set_child_count(tree.children.len() as u32);
             if ctx.fs_version.is_v6() {
-                parent.v6_set_dir_offset(bootstrap_ctx, tree.node.v6_dirent_size(tree)?)?;
+                let d_size = tree.node.v6_dirent_size(ctx, tree)?;
+                parent.v6_set_dir_offset(bootstrap_ctx, d_size, block_size)?;
             }
         }
 
@@ -216,7 +218,7 @@ impl Bootstrap {
             if !child.node.is_dir() && ctx.fs_version.is_v6() {
                 child
                     .node
-                    .v6_set_offset(bootstrap_ctx, v6_hardlink_offset)?;
+                    .v6_set_offset(bootstrap_ctx, v6_hardlink_offset, block_size)?;
             }
 
             // Store node for bootstrap & blob dump.

--- a/rafs/src/builder/core/context.rs
+++ b/rafs/src/builder/core/context.rs
@@ -482,6 +482,9 @@ impl BlobContext {
         blob_ctx
             .blob_meta_header
             .set_cap_tar_toc(features.contains(BlobFeatures::CAP_TAR_TOC));
+        blob_ctx
+            .blob_meta_header
+            .set_tarfs(features.contains(BlobFeatures::TARFS));
 
         blob_ctx
     }
@@ -1123,6 +1126,9 @@ impl BuildContext {
         if features.is_enabled(Feature::BlobToc) {
             blob_features |= BlobFeatures::HAS_TOC;
             blob_features |= BlobFeatures::HAS_TAR_HEADER;
+        }
+        if conversion_type == ConversionType::TarToTarfs {
+            blob_features |= BlobFeatures::TARFS;
         }
 
         BuildContext {

--- a/rafs/src/fs.rs
+++ b/rafs/src/fs.rs
@@ -39,7 +39,7 @@ use nydus_utils::{
 };
 
 use crate::metadata::{
-    Inode, RafsInode, RafsInodeWalkAction, RafsSuper, RafsSuperMeta, DOT, DOTDOT,
+    Inode, RafsInode, RafsInodeWalkAction, RafsSuper, RafsSuperFlags, RafsSuperMeta, DOT, DOTDOT,
 };
 use crate::{RafsError, RafsIoReader, RafsResult};
 
@@ -616,6 +616,10 @@ impl FileSystem for Rafs {
         }
 
         let real_size = cmp::min(size as u64, inode_size - offset);
+        if self.sb.meta.flags.contains(RafsSuperFlags::TARTFS_MODE) {
+            return Err(enosys!("rafs: `TARFS` mode is not supported by FUSE yet"));
+        }
+
         let mut result = 0;
         let mut descs = inode.alloc_bio_vecs(&self.device, offset, real_size as usize, true)?;
         assert!(!descs.is_empty() && !descs[0].is_empty());

--- a/rafs/src/metadata/direct_v6.rs
+++ b/rafs/src/metadata/direct_v6.rs
@@ -1369,3 +1369,64 @@ impl BlobV5ChunkInfo for DirectChunkInfoV6 {
     impl_chunkinfo_getter!(file_offset, u64);
     impl_chunkinfo_getter!(flags, BlobChunkFlags);
 }
+
+/// Rafs v6 fake ChunkInfo for Tarfs.
+pub(crate) struct TarfsChunkInfo {
+    blob_index: u32,
+    chunk_index: u32,
+    offset: u64,
+    size: u32,
+}
+
+impl TarfsChunkInfo {
+    /// Create a new instance of [TarfsChunkInfo].
+    #[allow(unused)]
+    pub fn new(blob_index: u32, chunk_index: u32, offset: u64, size: u32) -> Self {
+        TarfsChunkInfo {
+            blob_index,
+            chunk_index,
+            offset,
+            size,
+        }
+    }
+}
+
+const TARFS_DIGEST: RafsDigest = RafsDigest { data: [0u8; 32] };
+
+impl BlobChunkInfo for TarfsChunkInfo {
+    fn chunk_id(&self) -> &RafsDigest {
+        &TARFS_DIGEST
+    }
+
+    fn id(&self) -> u32 {
+        self.chunk_index
+    }
+
+    fn blob_index(&self) -> u32 {
+        self.blob_index
+    }
+
+    fn compressed_offset(&self) -> u64 {
+        self.offset
+    }
+
+    fn compressed_size(&self) -> u32 {
+        self.size
+    }
+
+    fn uncompressed_offset(&self) -> u64 {
+        self.offset
+    }
+
+    fn uncompressed_size(&self) -> u32 {
+        self.size
+    }
+
+    fn is_compressed(&self) -> bool {
+        false
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}

--- a/rafs/src/metadata/direct_v6.rs
+++ b/rafs/src/metadata/direct_v6.rs
@@ -40,14 +40,15 @@ use crate::metadata::layout::v5::RafsV5ChunkInfo;
 use crate::metadata::layout::v6::{
     rafsv6_load_blob_extra_info, recover_namespace, RafsV6BlobTable, RafsV6Dirent,
     RafsV6InodeChunkAddr, RafsV6InodeCompact, RafsV6InodeExtended, RafsV6OndiskInode,
-    RafsV6XattrEntry, RafsV6XattrIbodyHeader, EROFS_BLOCK_SIZE_4096, EROFS_INODE_CHUNK_BASED,
-    EROFS_INODE_FLAT_INLINE, EROFS_INODE_FLAT_PLAIN, EROFS_INODE_SLOT_SIZE,
-    EROFS_I_DATALAYOUT_BITS, EROFS_I_VERSION_BIT, EROFS_I_VERSION_BITS,
+    RafsV6XattrEntry, RafsV6XattrIbodyHeader, EROFS_BLOCK_SIZE_4096, EROFS_BLOCK_SIZE_512,
+    EROFS_INODE_CHUNK_BASED, EROFS_INODE_FLAT_INLINE, EROFS_INODE_FLAT_PLAIN,
+    EROFS_INODE_SLOT_SIZE, EROFS_I_DATALAYOUT_BITS, EROFS_I_VERSION_BIT, EROFS_I_VERSION_BITS,
 };
 use crate::metadata::layout::{bytes_to_os_str, MetaRange, XattrName, XattrValue};
 use crate::metadata::{
     Attr, Entry, Inode, RafsBlobExtraInfo, RafsInode, RafsInodeWalkAction, RafsInodeWalkHandler,
-    RafsSuperBlock, RafsSuperInodes, RafsSuperMeta, RAFS_ATTR_BLOCK_SIZE, RAFS_MAX_NAME,
+    RafsSuperBlock, RafsSuperFlags, RafsSuperInodes, RafsSuperMeta, RAFS_ATTR_BLOCK_SIZE,
+    RAFS_MAX_NAME,
 };
 use crate::{MetaType, RafsError, RafsInodeExt, RafsIoReader, RafsResult};
 
@@ -77,6 +78,18 @@ impl DirectMappingState {
             map: FileMapState::default(),
         }
     }
+
+    fn is_tarfs(&self) -> bool {
+        self.meta.flags.contains(RafsSuperFlags::TARTFS_MODE)
+    }
+
+    fn block_size(&self) -> u64 {
+        if self.is_tarfs() {
+            EROFS_BLOCK_SIZE_512
+        } else {
+            EROFS_BLOCK_SIZE_4096
+        }
+    }
 }
 
 struct DirectCachedInfo {
@@ -100,7 +113,8 @@ impl DirectSuperBlockV6 {
     /// Create a new instance of `DirectSuperBlockV6`.
     pub fn new(meta: &RafsSuperMeta) -> Self {
         let state = DirectMappingState::new(meta);
-        let meta_offset = meta.meta_blkaddr as usize * EROFS_BLOCK_SIZE_4096 as usize;
+        let block_size = state.block_size();
+        let meta_offset = meta.meta_blkaddr as usize * block_size as usize;
         let info = DirectCachedInfo {
             meta_offset,
             root_ino: meta.root_nid as Inode,
@@ -220,6 +234,7 @@ impl DirectSuperBlockV6 {
             return Ok(chunk_map);
         }
 
+        let block_size = state.block_size();
         let unit_size = size_of::<RafsV5ChunkInfo>();
         if size % unit_size != 0 {
             return Err(std::io::Error::from_raw_os_error(libc::EINVAL));
@@ -230,7 +245,7 @@ impl DirectSuperBlockV6 {
             let mut v6_chunk = RafsV6InodeChunkAddr::new();
             v6_chunk.set_blob_index(chunk.blob_index());
             v6_chunk.set_blob_ci_index(chunk.id());
-            v6_chunk.set_block_addr((chunk.uncompressed_offset() / EROFS_BLOCK_SIZE_4096) as u32);
+            v6_chunk.set_block_addr((chunk.uncompressed_offset() / block_size) as u32);
             chunk_map.insert(v6_chunk, idx);
         }
 
@@ -240,8 +255,9 @@ impl DirectSuperBlockV6 {
 
 impl RafsSuperInodes for DirectSuperBlockV6 {
     fn get_max_ino(&self) -> Inode {
+        let state = self.state.load();
         // The maximum inode number supported by RAFSv6 is smaller than limit of fuse-backend-rs.
-        (0xffff_ffffu64) * EROFS_BLOCK_SIZE_4096 / EROFS_INODE_SLOT_SIZE as u64
+        (0xffff_ffffu64) * state.block_size() / EROFS_INODE_SLOT_SIZE as u64
     }
 
     /// Find inode offset by ino from inode table and mmap to OndiskInode.
@@ -326,7 +342,7 @@ impl OndiskInodeWrapper {
         offset: usize,
     ) -> Result<Self> {
         let inode = DirectSuperBlockV6::disk_inode(state, offset)?;
-        let blocks_count = div_round_up(inode.size(), EROFS_BLOCK_SIZE_4096);
+        let blocks_count = div_round_up(inode.size(), state.block_size());
 
         Ok(OndiskInodeWrapper {
             mapping,
@@ -360,8 +376,8 @@ impl OndiskInodeWrapper {
         block_index: usize,
         index: usize,
     ) -> RafsResult<&'a RafsV6Dirent> {
-        let offset = self.data_block_offset(inode, block_index)?;
-        if size_of::<RafsV6Dirent>() * (index + 1) >= EROFS_BLOCK_SIZE_4096 as usize {
+        let offset = self.data_block_offset(state, inode, block_index)?;
+        if size_of::<RafsV6Dirent>() * (index + 1) >= state.block_size() as usize {
             Err(RafsError::InvalidImageData)
         } else if let Some(offset) = offset.checked_add(size_of::<RafsV6Dirent>() * index) {
             state
@@ -384,12 +400,13 @@ impl OndiskInodeWrapper {
         max_entries: usize,
     ) -> RafsResult<&'a OsStr> {
         assert!(max_entries > 0);
-        let offset = self.data_block_offset(inode, block_index)?;
+        let block_size = state.block_size();
+        let offset = self.data_block_offset(state, inode, block_index)?;
         let de = self.get_entry(state, inode, block_index, index)?;
         let buf: &[u8] = match index.cmp(&(max_entries - 1)) {
             Ordering::Less => {
                 let next_de = self.get_entry(state, inode, block_index, index + 1)?;
-                if next_de.e_nameoff as u64 >= EROFS_BLOCK_SIZE_4096 {
+                if next_de.e_nameoff as u64 >= block_size {
                     return Err(RafsError::InvalidImageData);
                 }
                 let len = next_de.e_nameoff.checked_sub(de.e_nameoff).ok_or_else(|| {
@@ -410,7 +427,7 @@ impl OndiskInodeWrapper {
             }
             Ordering::Equal => {
                 let base = de.e_nameoff as u64;
-                if base >= EROFS_BLOCK_SIZE_4096 {
+                if base >= block_size {
                     return Err(RafsError::InvalidImageData);
                 }
 
@@ -419,12 +436,12 @@ impl OndiskInodeWrapper {
                 // Because the other blocks should be fully used, while the last may not.
                 let block_count = self.blocks_count() as usize;
                 let len = match block_count.cmp(&(block_index + 1)) {
-                    Ordering::Greater => (EROFS_BLOCK_SIZE_4096 - base) as usize,
+                    Ordering::Greater => (block_size - base) as usize,
                     Ordering::Equal => {
-                        if self.size() % EROFS_BLOCK_SIZE_4096 == 0 {
-                            EROFS_BLOCK_SIZE_4096 as usize
+                        if self.size() % block_size == 0 {
+                            block_size as usize
                         } else {
-                            (self.size() % EROFS_BLOCK_SIZE_4096 - base) as usize
+                            (self.size() % block_size - base) as usize
                         }
                     }
                     Ordering::Less => return Err(RafsError::InvalidImageData),
@@ -462,7 +479,12 @@ impl OndiskInodeWrapper {
     // 3 - inode compression D: inode, [xattrs], map_header, extents ... | ...
     // 4 - inode chunk-based E: inode, [xattrs], chunk indexes ... | ...
     // 5~7 - reserved
-    fn data_block_offset(&self, inode: &dyn RafsV6OndiskInode, index: usize) -> RafsResult<usize> {
+    fn data_block_offset<'a>(
+        &self,
+        state: &'a Guard<Arc<DirectMappingState>>,
+        inode: &dyn RafsV6OndiskInode,
+        index: usize,
+    ) -> RafsResult<usize> {
         const VALID_MODE_BITS: u16 = ((1 << EROFS_I_DATALAYOUT_BITS) - 1) << EROFS_I_VERSION_BITS
             | ((1 << EROFS_I_VERSION_BITS) - 1);
         if inode.format() & !VALID_MODE_BITS != 0 || index > u32::MAX as usize {
@@ -471,9 +493,9 @@ impl OndiskInodeWrapper {
 
         let layout = inode.format() >> EROFS_I_VERSION_BITS;
         match layout {
-            EROFS_INODE_FLAT_PLAIN => Self::flat_data_block_offset(inode, index),
+            EROFS_INODE_FLAT_PLAIN => Self::flat_data_block_offset(state, inode, index),
             EROFS_INODE_FLAT_INLINE => match self.blocks_count().cmp(&(index as u64 + 1)) {
-                Ordering::Greater => Self::flat_data_block_offset(inode, index),
+                Ordering::Greater => Self::flat_data_block_offset(state, inode, index),
                 Ordering::Equal => {
                     Ok(self.offset as usize + Self::inode_size(inode) + Self::xattr_size(inode))
                 }
@@ -483,13 +505,17 @@ impl OndiskInodeWrapper {
         }
     }
 
-    fn flat_data_block_offset(inode: &dyn RafsV6OndiskInode, index: usize) -> RafsResult<usize> {
+    fn flat_data_block_offset(
+        state: &Guard<Arc<DirectMappingState>>,
+        inode: &dyn RafsV6OndiskInode,
+        index: usize,
+    ) -> RafsResult<usize> {
         // `i_u` points to the Nth block
         let base = inode.union() as usize;
         if base.checked_add(index).is_none() || base + index > u32::MAX as usize {
             Err(RafsError::InvalidImageData)
         } else {
-            Ok((base + index) * EROFS_BLOCK_SIZE_4096 as usize)
+            Ok((base + index) * state.block_size() as usize)
         }
     }
 
@@ -1001,7 +1027,7 @@ impl RafsInode for OndiskInodeWrapper {
             )));
         }
         let offset = self
-            .data_block_offset(inode, 0)
+            .data_block_offset(&state, inode, 0)
             .map_err(err_invalidate_data)?;
         let buf: &[u8] = state.map.get_slice(offset, inode.size() as usize)?;
         Ok(bytes_to_os_str(buf).to_os_string())
@@ -1257,6 +1283,17 @@ impl RafsInodeExt for OndiskInodeWrapper {
                         blob_index, chunk_index
                     ))
                 })
+        } else if state.is_tarfs() {
+            let blob_index = chunk_addr.blob_index();
+            let chunk_index = chunk_addr.blob_ci_index();
+            let offset = (chunk_addr.block_addr() as u64) << 9;
+            let size = if idx == self.get_chunk_count() - 1 {
+                (self.size() % self.chunk_size() as u64) as u32
+            } else {
+                self.chunk_size()
+            };
+            let chunk = TarfsChunkInfo::new(blob_index, chunk_index, offset, size);
+            Ok(Arc::new(chunk))
         } else {
             let mut chunk_map = self.mapping.info.chunk_map.lock().unwrap();
             if chunk_map.is_none() {
@@ -1380,7 +1417,6 @@ pub(crate) struct TarfsChunkInfo {
 
 impl TarfsChunkInfo {
     /// Create a new instance of [TarfsChunkInfo].
-    #[allow(unused)]
     pub fn new(blob_index: u32, chunk_index: u32, offset: u64, size: u32) -> Self {
         TarfsChunkInfo {
             blob_index,

--- a/rafs/src/metadata/mod.rs
+++ b/rafs/src/metadata/mod.rs
@@ -286,6 +286,8 @@ bitflags! {
         const COMPRESSION_ZSTD = 0x0000_0080;
         /// Chunk digests are inlined in RAFS v6 data blob.
         const INLINED_CHUNK_DIGEST = 0x0000_0100;
+        /// RAFS works in Tarfs mode, which directly uses tar streams as data blobs.
+        const TARTFS_MODE = 0x0000_0200;
 
         // Reserved for future compatible changes.
         const PRESERVED_COMPAT_7 = 0x0100_0000;

--- a/storage/src/cache/fscache/mod.rs
+++ b/storage/src/cache/fscache/mod.rs
@@ -201,6 +201,10 @@ impl FileCacheEntry {
         if blob_info.has_feature(BlobFeatures::_V5_NO_EXT_BLOB_TABLE) {
             return Err(einval!("fscache does not support Rafs v5 blobs"));
         }
+        let is_tarfs = blob_info.features().is_tarfs();
+        if is_tarfs {
+            return Err(einval!("fscache does not support RAFS in tarfs mode"));
+        }
 
         let file = blob_info
             .get_fscache_file()
@@ -273,6 +277,7 @@ impl FileCacheEntry {
             is_raw_data: false,
             is_direct_chunkmap: true,
             is_legacy_stargz: blob_info.is_legacy_stargz(),
+            is_tarfs,
             is_zran,
             dio_enabled: true,
             need_validation,

--- a/storage/src/device.rs
+++ b/storage/src/device.rs
@@ -44,7 +44,7 @@ use crate::cache::BlobCache;
 use crate::factory::BLOB_FACTORY;
 
 pub(crate) const BLOB_FEATURE_INCOMPAT_MASK: u32 = 0x0000_ffff;
-pub(crate) const BLOB_FEATURE_INCOMPAT_VALUE: u32 = 0x0000_003f;
+pub(crate) const BLOB_FEATURE_INCOMPAT_VALUE: u32 = 0x0000_007f;
 
 bitflags! {
     /// Features bits for blob management.
@@ -61,6 +61,8 @@ bitflags! {
         const SEPARATE = 0x0000_0010;
         /// Chunk digest array is inlined in the data blob.
         const INLINED_CHUNK_DIGEST = 0x0000_0020;
+        /// Blob is for RAFS filesystems in TARFS mode.
+        const TARFS = 0x0000_0040;
         /// Blob has TAR headers to separate contents.
         const HAS_TAR_HEADER = 0x1000_0000;
         /// Blob has Table of Content (ToC) at the tail.
@@ -76,6 +78,13 @@ bitflags! {
 impl Default for BlobFeatures {
     fn default() -> Self {
         BlobFeatures::empty()
+    }
+}
+
+impl BlobFeatures {
+    /// Check whether the blob is for RAFS filesystems in TARFS mode.
+    pub fn is_tarfs(&self) -> bool {
+        self.contains(BlobFeatures::CAP_TAR_TOC) && self.contains(BlobFeatures::TARFS)
     }
 }
 

--- a/storage/src/meta/mod.rs
+++ b/storage/src/meta/mod.rs
@@ -309,6 +309,15 @@ impl BlobCompressionContextHeader {
         }
     }
 
+    /// Set flag indicating the blob is for RAFS filesystem in TARFS mode.
+    pub fn set_tarfs(&mut self, enable: bool) {
+        if enable {
+            self.s_features |= BlobFeatures::TARFS.bits();
+        } else {
+            self.s_features &= !BlobFeatures::TARFS.bits();
+        }
+    }
+
     /// Get blob meta feature flags.
     pub fn features(&self) -> u32 {
         self.s_features

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -63,6 +63,13 @@ pub fn round_down_4k(x: u64) -> u64 {
     x & (!4095u64)
 }
 
+/// Round down the value `n` to by `d`.
+pub fn round_down(n: u64, d: u64) -> u64 {
+    debug_assert!(d != 0);
+    debug_assert!(d.is_power_of_two());
+    n / d * d
+}
+
 pub enum DelayType {
     Fixed,
     // an exponential delay between each attempts


### PR DESCRIPTION
When using containerd overlayfs snapshotter to handle OCIv1 images, it works as below:
- download compressed blobs from registry
- uncompress compressed blobs into tar streams/files
- unpack tar streams to directories on local filesystem
- mount multiple directories into a container rootfs by overlayfs
    
Here we introduce a new work mode to nydus, called as TARFS, which works as below:
- download compressed blobs from registry
- uncompress compressed blobs into tar streams/files
- build RAFS/EROFS meta blob from tar streams/files
- optionally merge multiple RAFS/EROFS meta blobs into one
- mount the generated RAFS filesystem by mount.erofs
    
By introducing TARFS mode to RAFS, it helps to avoid generating a bunch of small files by `untar`, which speeds up image preparation and garbage collection. It may also help to reduce levels of overlayfs by merging multiple image layers into one final RAFS filesystem.
    
The TARFS mode of RAFS filesystem has several special behavior, compared to current RAFS, as below:
- Instead of generating RAFS data blob, it directly use tar files as RAFS data blob.
- Tar files are uncompressed, so data blobs for TARFS mode are uncompressed.
- Tar files will also be directly used as local cache files.
- There's no chunk compression info, chunk digest, TOC etc, generated for TARFS mode.
- Block size is 512 bytes instead of 4K, because tar files are 512 bytes aligned.
    
 Now we have three ways to make of OCIv1 images:
| Mode     |    TAR-TARFS   | TARGZ-REF  | TARGZ-RAFS |
| -------- | -------| --------|--------| 
| Generate meta blob? |            Y |                      Y      |                 Y |
|    Generate chunk data?       |     N           |            N            |           Y |
|    Generate blob.meta?        |     N            |           Y              |         Y |
|    Generate data blobs?       |     N            |           Y(for blob.meta)  |      Y
|    Data in data blobs?           |  Not generated   |        blob.meta       |        chunk data & blob.meta |
|    Chunk alignment?             |   512            |         4096            |        4096 |
|    Chunk dedup?                   | N                 |      Y                      |  Y |
|    Lazy loading?                    |  N                |       Y                     |  Y |
    
    Note: RAFS in TARFS mode is designed to be used locally only. In other words, it's a way to implement snapshotter, instead of an image format for sharing.
