### PR TITLE
upgrad fuse-backend-rs to 0.10.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -494,9 +494,9 @@ dependencies = [
 
 [[package]]
 name = "fuse-backend-rs"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91aa2575daf333bef77ad5026d28d5ebdb04ec8e5d7a4ac9b1bb03976c2d673a"
+checksum = "08af89cb80a7c5693bd63a2b1ee7ac31a307670977c18fda036b3aa94be8c47f"
 dependencies = [
  "arc-swap",
  "bitflags",

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 [dependencies]
 bytes = { version = "1", optional = true }
 dbs-allocator = { version = "0.1.1", optional = true }
-fuse-backend-rs = "0.10.1"
+fuse-backend-rs = "0.10.2"
 libc = "0.2"
 log = "0.4.8"
 mio = { version = "0.8", features = ["os-poll", "os-ext"] }


### PR DESCRIPTION
There is a bug in fuse-backend-rs 0.10.1 which leads nydusd quit with segment fault. Luckly, it has been fixed in 0.10.2. See [1].

[1] https://github.com/cloud-hypervisor/fuse-backend-rs/commit/2f2b242ed276c97afdf197227a8260597defb536