### PR TITLE
Enhance `nydus-image merge` to support tarfs

### DIFF
--- a/rafs/src/builder/compact.rs
+++ b/rafs/src/builder/compact.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::hash_map::Entry;
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::io::Write;
 use std::ops::Deref;
 use std::path::PathBuf;
@@ -252,7 +252,7 @@ pub struct BlobCompactor {
     /// new blobs
     new_blob_mgr: BlobManager,
     /// inode list
-    nodes: Vec<Node>,
+    nodes: VecDeque<Node>,
     /// chunk --> list<node_idx, chunk_idx in node>
     c2nodes: HashMap<ChunkKey, Vec<(usize, usize)>>,
     /// original blob index --> list<node_idx, chunk_idx in node>
@@ -265,7 +265,7 @@ impl BlobCompactor {
     pub fn new(
         version: RafsVersion,
         ori_blob_mgr: BlobManager,
-        nodes: Vec<Node>,
+        nodes: VecDeque<Node>,
         backend: Arc<dyn BlobBackend + Send + Sync>,
         digester: digest::Algorithm,
     ) -> Result<Self> {
@@ -596,7 +596,7 @@ impl BlobCompactor {
         let tree = Tree::from_bootstrap(&rs, &mut _dict)?;
         let mut bootstrap = Bootstrap::new()?;
         bootstrap.build(&mut build_ctx, &mut bootstrap_ctx, tree)?;
-        let mut nodes = Vec::new();
+        let mut nodes = VecDeque::new();
         // move out nodes
         std::mem::swap(&mut bootstrap_ctx.nodes, &mut nodes);
         let mut compactor = Self::new(

--- a/rafs/src/builder/core/blob.rs
+++ b/rafs/src/builder/core/blob.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::borrow::Cow;
+use std::collections::VecDeque;
 use std::io::Write;
 use std::slice;
 
@@ -27,7 +28,7 @@ impl Blob {
     /// Dump blob file and generate chunks
     pub(crate) fn dump(
         ctx: &BuildContext,
-        nodes: &mut [Node],
+        nodes: &mut VecDeque<Node>,
         blob_mgr: &mut BlobManager,
         blob_writer: &mut ArtifactWriter,
     ) -> Result<()> {

--- a/rafs/src/builder/core/bootstrap.rs
+++ b/rafs/src/builder/core/bootstrap.rs
@@ -15,7 +15,7 @@ use crate::builder::{
     ArtifactStorage, BlobManager, BootstrapContext, BootstrapManager, BuildContext, Tree,
 };
 use crate::metadata::layout::{RafsBlobTable, RAFS_V5_ROOT_INODE};
-use crate::metadata::{RafsSuper, RafsSuperConfig};
+use crate::metadata::{RafsSuper, RafsSuperConfig, RafsSuperFlags};
 
 pub(crate) const STARGZ_DEFAULT_BLOCK_SIZE: u32 = 4 << 20;
 
@@ -295,6 +295,7 @@ impl Bootstrap {
             chunk_size: ctx.chunk_size,
             explicit_uidgid: ctx.explicit_uidgid,
             version: ctx.fs_version,
+            is_tarfs_mode: rs.meta.flags.contains(RafsSuperFlags::TARTFS_MODE),
         };
         config.check_compatibility(&rs.meta)?;
 

--- a/rafs/src/builder/core/chunk_dict.rs
+++ b/rafs/src/builder/core/chunk_dict.rs
@@ -264,6 +264,7 @@ mod tests {
             digester: digest::Algorithm::Blake3,
             chunk_size: 0x100000,
             explicit_uidgid: true,
+            is_tarfs_mode: false,
         };
         let dict =
             HashChunkDict::from_commandline_arg(path, Arc::new(ConfigV2::default()), &rafs_config)

--- a/rafs/src/builder/core/context.rs
+++ b/rafs/src/builder/core/context.rs
@@ -960,7 +960,7 @@ pub struct BootstrapContext {
     /// Cache node index for hardlinks, HashMap<(layer_index, real_inode, dev), Vec<index>>.
     pub(crate) inode_map: HashMap<(u16, Inode, u64), Vec<u64>>,
     /// Store all nodes in ascendant order, indexed by (node.index - 1).
-    pub nodes: Vec<Node>,
+    pub nodes: VecDeque<Node>,
     /// Current position to write in f_bootstrap
     pub(crate) offset: u64,
     pub(crate) writer: Box<dyn RafsIoWrite>,
@@ -979,7 +979,7 @@ impl BootstrapContext {
         Ok(Self {
             layered,
             inode_map: HashMap::new(),
-            nodes: Vec::new(),
+            nodes: VecDeque::new(),
             offset: EROFS_BLOCK_SIZE_4096,
             writer,
             v6_available_blocks: vec![

--- a/rafs/src/builder/core/layout.rs
+++ b/rafs/src/builder/core/layout.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
+use std::collections::VecDeque;
 
 use super::node::Node;
 use crate::builder::{Overlay, Prefetch};
@@ -11,7 +12,10 @@ use crate::builder::{Overlay, Prefetch};
 pub struct BlobLayout {}
 
 impl BlobLayout {
-    pub fn layout_blob_simple(prefetch: &Prefetch, nodes: &[Node]) -> Result<(Vec<usize>, usize)> {
+    pub fn layout_blob_simple(
+        prefetch: &Prefetch,
+        nodes: &VecDeque<Node>,
+    ) -> Result<(Vec<usize>, usize)> {
         let mut inodes = Vec::with_capacity(nodes.len());
 
         // Put all prefetch inodes at the head

--- a/rafs/src/builder/core/prefetch.rs
+++ b/rafs/src/builder/core/prefetch.rs
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, VecDeque};
 use std::path::PathBuf;
 use std::str::FromStr;
 
@@ -181,7 +181,7 @@ impl Prefetch {
     }
 
     /// Generate filesystem layer prefetch list for RAFS v5.
-    pub fn get_v5_prefetch_table(&mut self, nodes: &[Node]) -> Option<RafsV5PrefetchTable> {
+    pub fn get_v5_prefetch_table(&mut self, nodes: &VecDeque<Node>) -> Option<RafsV5PrefetchTable> {
         if self.policy == PrefetchPolicy::Fs {
             let mut prefetch_table = RafsV5PrefetchTable::new();
             for i in self.patterns.values().filter_map(|v| *v) {
@@ -199,7 +199,7 @@ impl Prefetch {
     /// Generate filesystem layer prefetch list for RAFS v6.
     pub fn get_v6_prefetch_table(
         &mut self,
-        nodes: &[Node],
+        nodes: &VecDeque<Node>,
         meta_addr: u64,
     ) -> Option<RafsV6PrefetchTable> {
         if self.policy == PrefetchPolicy::Fs {

--- a/rafs/src/builder/core/v6.rs
+++ b/rafs/src/builder/core/v6.rs
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, VecDeque};
 use std::ffi::{OsStr, OsString};
 use std::io::SeekFrom;
 use std::mem::size_of;
@@ -556,7 +556,7 @@ impl BuildContext {
 }
 
 impl Bootstrap {
-    pub(crate) fn v6_update_dirents(nodes: &mut Vec<Node>, tree: &Tree, parent_offset: u64) {
+    pub(crate) fn v6_update_dirents(nodes: &mut VecDeque<Node>, tree: &Tree, parent_offset: u64) {
         let node = &mut nodes[tree.node.index as usize - 1];
         let node_offset = node.v6_offset;
         if !node.is_dir() {

--- a/rafs/src/builder/merge.rs
+++ b/rafs/src/builder/merge.rs
@@ -8,15 +8,16 @@ use std::convert::TryFrom;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use anyhow::{Context, Result};
+use anyhow::{anyhow, bail, ensure, Context, Result};
 use hex::FromHex;
 use nydus_api::ConfigV2;
-use nydus_rafs::builder::{
+use nydus_storage::device::{BlobFeatures, BlobInfo};
+
+use super::{
     ArtifactStorage, BlobContext, BlobManager, Bootstrap, BootstrapContext, BuildContext,
     BuildOutput, ChunkSource, HashChunkDict, MetadataTreeBuilder, Overlay, Tree, WhiteoutSpec,
 };
-use nydus_rafs::metadata::{RafsInodeExt, RafsSuper, RafsVersion};
-use nydus_storage::device::{BlobFeatures, BlobInfo};
+use crate::metadata::{RafsInodeExt, RafsSuper, RafsVersion};
 
 /// Struct to generate the merged RAFS bootstrap for an image from per layer RAFS bootstraps.
 ///

--- a/rafs/src/builder/merge.rs
+++ b/rafs/src/builder/merge.rs
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashMap;
-use std::collections::HashSet;
+use std::collections::{HashSet, HashMap, VecDeque};
 use std::convert::TryFrom;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -219,7 +218,7 @@ impl Merger {
             }
 
             if let Some(tree) = &mut tree {
-                let mut nodes = Vec::new();
+                let mut nodes = VecDeque::new();
                 rs.walk_directory::<PathBuf>(
                     rs.superblock.root_ino(),
                     None,
@@ -249,8 +248,8 @@ impl Merger {
                         match node.whiteout_type(WhiteoutSpec::Oci) {
                             // Insert whiteouts at the head, so they will be handled first when
                             // applying to lower layer.
-                            Some(_) => nodes.insert(0, node),
-                            _ => nodes.push(node),
+                            Some(_) => nodes.push_front(node),
+                            _ => nodes.push_back(node),
                         }
                         Ok(())
                     },

--- a/rafs/src/builder/mod.rs
+++ b/rafs/src/builder/mod.rs
@@ -22,12 +22,14 @@ pub use self::core::overlay::{Overlay, WhiteoutSpec};
 pub use self::core::prefetch::{Prefetch, PrefetchPolicy};
 pub use self::core::tree::{MetadataTreeBuilder, Tree};
 pub use self::directory::DirectoryBuilder;
+pub use self::merge::Merger;
 pub use self::stargz::StargzBuilder;
 pub use self::tarball::TarballBuilder;
 
-pub mod compact;
+mod compact;
 mod core;
 mod directory;
+mod merge;
 mod stargz;
 mod tarball;
 

--- a/rafs/src/metadata/chunk.rs
+++ b/rafs/src/metadata/chunk.rs
@@ -15,7 +15,7 @@ use nydus_utils::digest::RafsDigest;
 
 use crate::metadata::cached_v5::CachedChunkInfoV5;
 use crate::metadata::direct_v5::DirectChunkInfoV5;
-use crate::metadata::direct_v6::DirectChunkInfoV6;
+use crate::metadata::direct_v6::{DirectChunkInfoV6, TarfsChunkInfo};
 use crate::metadata::layout::v5::RafsV5ChunkInfo;
 use crate::metadata::{RafsStore, RafsVersion};
 use crate::RafsIoWrite;
@@ -331,10 +331,12 @@ impl ChunkWrapper {
                 *self = Self::V6(to_rafs_v5_chunk_info(cki_v6));
             } else if let Some(cki_v6) = cki.as_any().downcast_ref::<DirectChunkInfoV6>() {
                 *self = Self::V6(to_rafs_v5_chunk_info(cki_v6));
+            } else if let Some(cki_v6) = cki.as_any().downcast_ref::<TarfsChunkInfo>() {
+                *self = Self::V6(to_rafs_v5_chunk_info(cki_v6));
             } else if let Some(cki_v5) = cki.as_any().downcast_ref::<CachedChunkInfoV5>() {
-                *self = Self::V6(to_rafs_v5_chunk_info(cki_v5));
+                *self = Self::V5(to_rafs_v5_chunk_info(cki_v5));
             } else if let Some(cki_v5) = cki.as_any().downcast_ref::<DirectChunkInfoV5>() {
-                *self = Self::V6(to_rafs_v5_chunk_info(cki_v5));
+                *self = Self::V5(to_rafs_v5_chunk_info(cki_v5));
             } else {
                 panic!("unknown chunk information struct");
             }
@@ -346,6 +348,8 @@ fn as_blob_v5_chunk_info(cki: &dyn BlobChunkInfo) -> &dyn BlobV5ChunkInfo {
     if let Some(cki_v6) = cki.as_any().downcast_ref::<BlobMetaChunk>() {
         cki_v6
     } else if let Some(cki_v6) = cki.as_any().downcast_ref::<DirectChunkInfoV6>() {
+        cki_v6
+    } else if let Some(cki_v6) = cki.as_any().downcast_ref::<TarfsChunkInfo>() {
         cki_v6
     } else if let Some(cki_v5) = cki.as_any().downcast_ref::<CachedChunkInfoV5>() {
         cki_v5

--- a/rafs/src/metadata/direct_v6.rs
+++ b/rafs/src/metadata/direct_v6.rs
@@ -1466,3 +1466,21 @@ impl BlobChunkInfo for TarfsChunkInfo {
         self
     }
 }
+
+impl BlobV5ChunkInfo for TarfsChunkInfo {
+    fn index(&self) -> u32 {
+        self.chunk_index
+    }
+
+    fn file_offset(&self) -> u64 {
+        0
+    }
+
+    fn flags(&self) -> BlobChunkFlags {
+        BlobChunkFlags::empty()
+    }
+
+    fn as_base(&self) -> &dyn BlobChunkInfo {
+        self
+    }
+}

--- a/rafs/src/metadata/mod.rs
+++ b/rafs/src/metadata/mod.rs
@@ -369,6 +369,8 @@ pub struct RafsSuperConfig {
     pub chunk_size: u32,
     /// Whether `explicit_uidgid` enabled or not.
     pub explicit_uidgid: bool,
+    /// RAFS in TARFS mode.
+    pub is_tarfs_mode: bool,
 }
 
 impl RafsSuperConfig {
@@ -403,6 +405,11 @@ impl RafsSuperConfig {
                 self.digester,
                 meta.get_digester()
             )));
+        }
+
+        let is_tarfs_mode = meta.flags.contains(RafsSuperFlags::TARTFS_MODE);
+        if is_tarfs_mode != self.is_tarfs_mode {
+            return Err(einval!(format!("Using inconsistent RAFS TARFS mode")));
         }
 
         Ok(())
@@ -519,6 +526,7 @@ impl RafsSuperMeta {
             digester: self.get_digester(),
             chunk_size: self.chunk_size,
             explicit_uidgid: self.explicit_uidgid(),
+            is_tarfs_mode: self.flags.contains(RafsSuperFlags::TARTFS_MODE),
         }
     }
 }

--- a/src/bin/nydus-image/main.rs
+++ b/src/bin/nydus-image/main.rs
@@ -30,7 +30,7 @@ use nydus_app::setup_logging;
 use nydus_rafs::builder::{
     parse_chunk_dict_arg, ArtifactStorage, BlobCompactor, BlobManager, BootstrapManager,
     BuildContext, BuildOutput, Builder, ConversionType, DirectoryBuilder, Feature, Features,
-    HashChunkDict, Prefetch, PrefetchPolicy, StargzBuilder, TarballBuilder, WhiteoutSpec,
+    HashChunkDict, Merger, Prefetch, PrefetchPolicy, StargzBuilder, TarballBuilder, WhiteoutSpec,
 };
 use nydus_rafs::metadata::{RafsSuper, RafsSuperConfig, RafsVersion};
 use nydus_storage::backend::localfs::LocalFs;
@@ -43,12 +43,10 @@ use nydus_utils::trace::{EventTracerClass, TimingTracerClass, TraceClass};
 use nydus_utils::{compress, digest, event_tracer, register_tracer, root_tracer, timing_tracer};
 use serde::{Deserialize, Serialize};
 
-use crate::merge::Merger;
 use crate::unpack::{OCIUnpacker, Unpacker};
 use crate::validator::Validator;
 
 mod inspect;
-mod merge;
 mod stat;
 mod unpack;
 mod validator;

--- a/src/bin/nydus-image/main.rs
+++ b/src/bin/nydus-image/main.rs
@@ -883,6 +883,7 @@ impl Command {
                 digester,
                 chunk_size,
                 explicit_uidgid: !repeatable,
+                is_tarfs_mode: false,
             };
             let rafs_config = Arc::new(build_ctx.configuration.as_ref().clone());
             // The separate chunk dict bootstrap doesn't support blob accessible.


### PR DESCRIPTION
Enhance `nydus-image merge` to support tarfs, so we can merge multiple RAFS filesystems in TARFS mode into a single one.