### PR TITLE
rafs: do not include chunk info array in the metadata blob

### DIFF
--- a/src/bin/nydus-image/main.rs
+++ b/src/bin/nydus-image/main.rs
@@ -1077,9 +1077,9 @@ impl Command {
         };
         let config =
             Self::get_configuration(matches).context("failed to get configuration information")?;
-        config
-            .internal
-            .set_blob_accessible(matches.get_one::<String>("config").is_some());
+        let blob_accessible = matches.get_one::<String>("config").is_some()
+            || matches.get_one::<String>("blob-dir").is_some();
+        config.internal.set_blob_accessible(blob_accessible);
         let mut ctx = BuildContext {
             prefetch: Self::get_prefetch(matches)?,
             ..Default::default()


### PR DESCRIPTION
Now we can reconstruct chunk info from RAFS v6 data blob with embedded chunk digest, so no need to embed the chunk info array in the metadata blob anymore, which helps to dramatically reduce size of metadata blob for big images.