### PR TITLE
Add `export` subcommand to `nydus-image`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ nydus-api = { version = "0.2.2", path = "api", features = ["handler"] }
 nydus-app = { version = "0.3.2", path = "app" }
 nydus-error = { version = "0.2.3", path = "error" }
 nydus-rafs = { version = "0.2.2", path = "rafs", features = ["builder"] }
-nydus-service = { version = "0.2.0", path = "service" }
+nydus-service = { version = "0.2.0", path = "service", features = ["block-device"] }
 nydus-storage = { version = "0.6.2", path = "storage" }
 nydus-utils = { version = "0.4.1", path = "utils" }
 

--- a/service/src/block_device.rs
+++ b/service/src/block_device.rs
@@ -12,16 +12,22 @@
 //! device, so it can be directly mounted by Linux EROFS fs driver.
 
 use std::cmp::min;
+use std::fs::OpenOptions;
 use std::io::Result;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use dbs_allocator::{Constraint, IntervalTree, NodeState, Range};
+use nydus_api::BlobCacheEntry;
 use nydus_rafs::metadata::layout::v6::{
     EROFS_BLOCK_BITS_12, EROFS_BLOCK_BITS_9, EROFS_BLOCK_SIZE_4096, EROFS_BLOCK_SIZE_512,
 };
+use nydus_storage::utils::alloc_buf;
 use tokio_uring::buf::IoBufMut;
 
-use crate::blob_cache::{BlobCacheMgr, BlobConfig, DataBlob, MetaBlob};
+use crate::blob_cache::{generate_blob_key, BlobCacheMgr, BlobConfig, DataBlob, MetaBlob};
+
+const BLOCK_DEVICE_EXPORT_BATCH_SIZE: usize = 0x80000;
 
 enum BlockRange {
     Hole,
@@ -81,7 +87,7 @@ impl BlockDevice {
                 meta_blob_config.blob_id()
             ))
         })?;
-        ranges.update(&range, BlockRange::MetaBlob(meta_blob.clone()));
+        ranges.update(&range, BlockRange::MetaBlob(meta_blob));
 
         let mut pos = blocks;
         let data_blobs = meta_blob_config.get_blobs();
@@ -272,6 +278,127 @@ impl BlockDevice {
 
         (Ok(total_size), buf)
     }
+
+    /// Export a RAFS filesystem as a raw block disk image.
+    pub fn export(
+        blob_entry: BlobCacheEntry,
+        output: Option<String>,
+        localfs_dir: Option<String>,
+        _threads: u32,
+    ) -> Result<()> {
+        let cache_mgr = Arc::new(BlobCacheMgr::new());
+        cache_mgr.add_blob_entry(&blob_entry).map_err(|e| {
+            eother!(format!(
+                "block_device: failed to add blob into CacheMgr, {}",
+                e
+            ))
+        })?;
+        let blob_id = generate_blob_key(&blob_entry.domain_id, &blob_entry.blob_id);
+        let block_device = BlockDevice::new(blob_id.clone(), cache_mgr.clone()).map_err(|e| {
+            eother!(format!(
+                "block_device: failed to create block device object, {}",
+                e
+            ))
+        })?;
+        let block_device = Arc::new(block_device);
+
+        let path = match output {
+            Some(v) => PathBuf::from(v),
+            None => {
+                let path = match cache_mgr.get_config(&blob_id) {
+                    Some(BlobConfig::MetaBlob(meta)) => meta.path().to_path_buf(),
+                    _ => return Err(enoent!("block_device: failed to get meta blob")),
+                };
+                if !path.is_file() {
+                    return Err(eother!(format!(
+                        "block_device: meta blob {} is not a file",
+                        path.display()
+                    )));
+                }
+                let name = path
+                    .file_name()
+                    .ok_or_else(|| {
+                        eother!(format!(
+                            "block_device: failed to get file name from {}",
+                            path.display()
+                        ))
+                    })?
+                    .to_str()
+                    .ok_or_else(|| {
+                        eother!(format!(
+                            "block_device: failed to get file name from {}",
+                            path.display()
+                        ))
+                    })?;
+                let dir = localfs_dir
+                    .ok_or_else(|| einval!("block_device: parameter `localfs_dir` is missing"))?;
+                let path = PathBuf::from(dir);
+                path.join(name.to_string() + ".disk")
+            }
+        };
+
+        let output_file = OpenOptions::new()
+            .create_new(true)
+            .read(true)
+            .write(true)
+            .open(&path)
+            .map_err(|e| {
+                eother!(format!(
+                    "block_device: failed to create output file {}, {}",
+                    path.display(),
+                    e
+                ))
+            })?;
+        let output_file = Arc::new(tokio_uring::fs::File::from_std(output_file));
+
+        tokio_uring::start(async move {
+            Self::do_export(block_device.clone(), output_file, 0, block_device.blocks()).await
+        })?;
+
+        Ok(())
+    }
+
+    async fn do_export(
+        block_device: Arc<BlockDevice>,
+        output_file: Arc<tokio_uring::fs::File>,
+        start: u32,
+        mut blocks: u32,
+    ) -> Result<()> {
+        let batch_size = BLOCK_DEVICE_EXPORT_BATCH_SIZE as u32 / block_device.block_size() as u32;
+        let mut pos = start;
+        let mut buf = alloc_buf(BLOCK_DEVICE_EXPORT_BATCH_SIZE);
+
+        while blocks > 0 {
+            let count = min(batch_size, blocks);
+            let (res, buf1) = block_device.async_read(pos, count, buf).await;
+            let sz = res?;
+            if sz != count as usize * block_device.block_size() as usize {
+                return Err(eio!(
+                    "block_device: failed to read data, got less data than requested"
+                ));
+            }
+            buf = buf1;
+
+            if sz != buf.len() {
+                buf.resize(sz, 0);
+            }
+            let (res, buf2) = output_file
+                .write_at(buf, block_device.blocks_to_size(pos))
+                .await;
+            let sz1 = res?;
+            if sz1 != sz {
+                return Err(eio!(
+                    "block_device: failed to write data to disk image file, written less data than requested"
+                ));
+            }
+            buf = buf2;
+
+            pos += count;
+            blocks -= count;
+        }
+
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -337,7 +464,7 @@ mod tests {
         assert!(mgr.get_config(&key).is_some());
 
         let mgr = Arc::new(mgr);
-        let device = BlockDevice::new(blob_id.clone(), mgr).unwrap();
+        let device = BlockDevice::new(blob_id, mgr).unwrap();
         assert_eq!(device.blocks(), 0x209);
 
         tokio_uring::start(async move {

--- a/src/bin/nydus-image/main.rs
+++ b/src/bin/nydus-image/main.rs
@@ -153,11 +153,30 @@ fn prepare_cmd_args(bti_string: &'static str) -> App {
         .help("Configuration file for storage backend, cache and RAFS FUSE filesystem.")
         .required(false);
 
-    App::new("")
+    let app = App::new("")
         .version(bti_string)
         .author(crate_authors!())
         .about("Build, analyze, inspect or validate RAFS filesystems/Nydus accelerated container images")
-        .subcommand(
+        .arg(
+            Arg::new("log-file")
+                .long("log-file")
+                .short('L')
+                .help("Log file path")
+                .required(false)
+                .global(true),
+        )
+        .arg(
+            Arg::new("log-level")
+                .long("log-level")
+                .short('l')
+                .help("Log level:")
+                .default_value("info")
+                .value_parser(["trace", "debug", "info", "warn", "error"])
+                .required(false)
+                .global(true),
+        );
+
+    let app = app.subcommand(
             App::new("create")
                 .about("Create RAFS filesystems from directories, tar files or OCI images")
                 .arg(
@@ -314,138 +333,138 @@ fn prepare_cmd_args(bti_string: &'static str) -> App {
                 .arg(
                     arg_output_json.clone(),
                 )
-        )
-        .subcommand(
-            App::new("merge")
-                .about("Merge multiple bootstraps into a overlaid bootstrap")
-                .arg(
-                    Arg::new("parent-bootstrap")
-                        .long("parent-bootstrap")
-                        .help("File path of the parent/referenced RAFS metadata blob (optional)")
-                        .required(false),
-                )
-                .arg(
-                    Arg::new("bootstrap")
-                        .long("bootstrap")
-                        .short('B')
-                        .help("Output path of nydus overlaid bootstrap"),
-                )
-                .arg(
-                    Arg::new("blob-dir")
-                        .long("blob-dir")
-                        .short('D')
-                        .help("Directory path to save generated RAFS metadata and data blobs"),
-                )
-                .arg(
-                    arg_chunk_dict.clone(),
-                )
-                .arg(
-                    arg_prefetch_policy,
-                )
-                .arg(
-                    arg_output_json.clone(),
-                )
-                .arg(
-                    Arg::new("blob-digests")
+        );
+
+    let app = app.subcommand(
+        App::new("merge")
+            .about("Merge multiple bootstraps into a overlaid bootstrap")
+            .arg(
+                Arg::new("parent-bootstrap")
+                    .long("parent-bootstrap")
+                    .help("File path of the parent/referenced RAFS metadata blob (optional)")
+                    .required(false),
+            )
+            .arg(
+                Arg::new("bootstrap")
+                    .long("bootstrap")
+                    .short('B')
+                    .help("Output path of nydus overlaid bootstrap"),
+            )
+            .arg(
+                Arg::new("blob-dir")
+                    .long("blob-dir")
+                    .short('D')
+                    .help("Directory path to save generated RAFS metadata and data blobs"),
+            )
+            .arg(arg_chunk_dict.clone())
+            .arg(arg_prefetch_policy)
+            .arg(arg_output_json.clone())
+            .arg(
+                Arg::new("blob-digests")
                     .long("blob-digests")
-                        .required(false)
-                        .help("RAFS blob digest list separated by comma"),
-                )
-                .arg(
-                    Arg::new("blob-sizes")
+                    .required(false)
+                    .help("RAFS blob digest list separated by comma"),
+            )
+            .arg(
+                Arg::new("blob-sizes")
                     .long("blob-sizes")
-                        .required(false)
-                        .help("RAFS blob size list separated by comma"),
-                )
-                .arg(
-                    Arg::new("blob-toc-digests")
-                        .long("blob-toc-digests")
-                        .required(false)
-                        .help("RAFS blob toc digest list separated by comma"),
-                )
-                .arg(
-                    Arg::new("blob-toc-sizes")
-                        .long("blob-toc-sizes")
-                        .required(false)
-                        .help("RAFS blob toc size list separated by comma"),
-                )
-                .arg(arg_config.clone())
-                .arg(
-                    Arg::new("SOURCE")
-                        .help("bootstrap paths (allow one or more)")
-                        .required(true)
-                        .num_args(1..),
-                )
-        )
-        .subcommand(
-            App::new("check")
-                .about("Validate RAFS filesystem metadata")
-                .arg(
-                    Arg::new("BOOTSTRAP")
-                        .help("File path of RAFS metadata")
-                        .required_unless_present("bootstrap"),
-                )
-                .arg(
-                    Arg::new("bootstrap")
-                        .short('B')
-                        .long("bootstrap")
-                        .help("[Deprecated] File path of RAFS meta blob/bootstrap")
-                        .conflicts_with("BOOTSTRAP")
-                        .required(false),
-                )
-                .arg(
-                    Arg::new("blob-dir")
-                        .long("blob-dir")
-                        .short('D')
-                        .conflicts_with("config")
-                        .help("Directory for localfs storage backend, hosting data blobs and cache files"),
-                )
-                .arg(arg_config.clone())
-                .arg(
-                    Arg::new("verbose")
-                        .long("verbose")
-                        .short('v')
-                        .help("Output message in verbose mode")
-                        .action(ArgAction::SetTrue)
-                        .required(false),
-                )
-                .arg(
-                    arg_output_json.clone(),
-                )
-        )
-        .subcommand(
-            App::new("inspect")
-                .about("Inspect RAFS filesystem metadata in interactive or request mode")
-                .arg(
-                    Arg::new("BOOTSTRAP")
-                        .help("File path of RAFS metadata")
-                        .required_unless_present("bootstrap"),
-                )
-                .arg(
-                    Arg::new("bootstrap")
-                        .short('B')
-                        .long("bootstrap")
-                        .help("[Deprecated] File path of RAFS meta blob/bootstrap")
-                        .conflicts_with("BOOTSTRAP")
-                        .required(false),
-                )
-                .arg(
-                    Arg::new("blob-dir")
-                        .long("blob-dir")
-                        .short('D')
-                        .conflicts_with("config")
-                        .help("Directory for localfs storage backend, hosting data blobs and cache files"),
-                )
-                .arg(arg_config.clone())
-                .arg(
-                    Arg::new("request")
-                        .long("request")
-                        .short('R')
-                        .help("Inspect RAFS filesystem metadata in request mode")
-                        .required(false),
-                )
-        )
-        .subcommand(
+                    .required(false)
+                    .help("RAFS blob size list separated by comma"),
+            )
+            .arg(
+                Arg::new("blob-toc-digests")
+                    .long("blob-toc-digests")
+                    .required(false)
+                    .help("RAFS blob toc digest list separated by comma"),
+            )
+            .arg(
+                Arg::new("blob-toc-sizes")
+                    .long("blob-toc-sizes")
+                    .required(false)
+                    .help("RAFS blob toc size list separated by comma"),
+            )
+            .arg(arg_config.clone())
+            .arg(
+                Arg::new("SOURCE")
+                    .help("bootstrap paths (allow one or more)")
+                    .required(true)
+                    .num_args(1..),
+            ),
+    );
+
+    let app = app.subcommand(
+        App::new("check")
+            .about("Validate RAFS filesystem metadata")
+            .arg(
+                Arg::new("BOOTSTRAP")
+                    .help("File path of RAFS metadata")
+                    .required_unless_present("bootstrap"),
+            )
+            .arg(
+                Arg::new("bootstrap")
+                    .short('B')
+                    .long("bootstrap")
+                    .help("[Deprecated] File path of RAFS meta blob/bootstrap")
+                    .conflicts_with("BOOTSTRAP")
+                    .required(false),
+            )
+            .arg(
+                Arg::new("blob-dir")
+                    .long("blob-dir")
+                    .short('D')
+                    .conflicts_with("config")
+                    .help(
+                        "Directory for localfs storage backend, hosting data blobs and cache files",
+                    ),
+            )
+            .arg(arg_config.clone())
+            .arg(
+                Arg::new("verbose")
+                    .long("verbose")
+                    .short('v')
+                    .help("Output message in verbose mode")
+                    .action(ArgAction::SetTrue)
+                    .required(false),
+            )
+            .arg(arg_output_json.clone()),
+    );
+
+    let app = app.subcommand(
+        App::new("inspect")
+            .about("Inspect RAFS filesystem metadata in interactive or request mode")
+            .arg(
+                Arg::new("BOOTSTRAP")
+                    .help("File path of RAFS metadata")
+                    .required_unless_present("bootstrap"),
+            )
+            .arg(
+                Arg::new("bootstrap")
+                    .short('B')
+                    .long("bootstrap")
+                    .help("[Deprecated] File path of RAFS meta blob/bootstrap")
+                    .conflicts_with("BOOTSTRAP")
+                    .required(false),
+            )
+            .arg(
+                Arg::new("blob-dir")
+                    .long("blob-dir")
+                    .short('D')
+                    .conflicts_with("config")
+                    .help(
+                        "Directory for localfs storage backend, hosting data blobs and cache files",
+                    ),
+            )
+            .arg(arg_config.clone())
+            .arg(
+                Arg::new("request")
+                    .long("request")
+                    .short('R')
+                    .help("Inspect RAFS filesystem metadata in request mode")
+                    .required(false),
+            ),
+    );
+
+    let app = app.subcommand(
             App::new("stat")
                 .about("Generate statistics information for RAFS filesystems")
                 .arg(
@@ -481,8 +500,9 @@ fn prepare_cmd_args(bti_string: &'static str) -> App {
                 .arg(
                     arg_output_json.clone(),
                 )
-        )
-        .subcommand(
+        );
+
+    let app = app.subcommand(
             App::new("compact")
                 .about("(experimental)Compact specific nydus image, remove unused chunks in blobs, merge small blobs")
                 .arg(
@@ -515,69 +535,54 @@ fn prepare_cmd_args(bti_string: &'static str) -> App {
                 .arg(
                     arg_output_json,
                 )
-        )
-        .subcommand(
-            App::new("unpack")
+        );
+
+    app.subcommand(
+        App::new("unpack")
             .about("Unpack a RAFS filesystem to a tar file")
-                .arg(
-                    Arg::new("BOOTSTRAP")
-                        .help("File path of RAFS metadata")
-                        .required_unless_present("bootstrap"),
-                )
-                .arg(
-                    Arg::new("backend-config")
-                        .long("backend-config")
-                        .help("config file of backend")
-                        .required(false),
-                )
-                .arg(
-                    Arg::new("bootstrap")
-                        .short('B')
-                        .long("bootstrap")
-                        .help("[Deprecated] File path of RAFS meta blob/bootstrap")
-                        .conflicts_with("BOOTSTRAP")
-                        .required(false),
-                )
+            .arg(
+                Arg::new("BOOTSTRAP")
+                    .help("File path of RAFS metadata")
+                    .required_unless_present("bootstrap"),
+            )
+            .arg(
+                Arg::new("backend-config")
+                    .long("backend-config")
+                    .help("config file of backend")
+                    .required(false),
+            )
+            .arg(
+                Arg::new("bootstrap")
+                    .short('B')
+                    .long("bootstrap")
+                    .help("[Deprecated] File path of RAFS meta blob/bootstrap")
+                    .conflicts_with("BOOTSTRAP")
+                    .required(false),
+            )
             .arg(
                 Arg::new("blob")
-                .long("blob")
-                .short('b')
-                .help("path to RAFS data blob file")
-                .required(false),
-                )
+                    .long("blob")
+                    .short('b')
+                    .help("path to RAFS data blob file")
+                    .required(false),
+            )
             .arg(
                 Arg::new("blob-dir")
                     .long("blob-dir")
                     .short('D')
                     .conflicts_with("config")
-                    .help("Directory for localfs storage backend, hosting data blobs and cache files"),
+                    .help(
+                        "Directory for localfs storage backend, hosting data blobs and cache files",
+                    ),
             )
             .arg(arg_config)
             .arg(
                 Arg::new("output")
-                .long("output")
-                .help("path for output tar file")
-                .required(true),
-                )
-        )
-        .arg(
-            Arg::new("log-file")
-                .long("log-file")
-                .short('L')
-                .help("Log file path")
-                .required(false)
-                .global(true),
-        )
-        .arg(
-            Arg::new("log-level")
-                .long("log-level")
-                .short('l')
-                .help("Log level:")
-                .default_value("info")
-                .value_parser(["trace", "debug", "info", "warn", "error"])
-                .required(false)
-                .global(true),
-        )
+                    .long("output")
+                    .help("path for output tar file")
+                    .required(true),
+            ),
+    )
 }
 
 fn init_log(matches: &ArgMatches) -> Result<()> {


### PR DESCRIPTION
Add `export` subcommand to `nydus-image`, which exports RAFS filesystems as raw block device images or tar files.
It will be enhanced to generate integrity data for `dm-verity` and/or `fs-verity`.