### PR TITLE
ci test: fix bug of compiling nydus-snapshotter

### DIFF
--- a/tests/bats/compile_nydus_snapshotter.bats
+++ b/tests/bats/compile_nydus_snapshotter.bats
@@ -9,7 +9,7 @@ setup() {
 }
 
 @test "compile nydus snapshotter" {
-        docker run --rm -v /tmp/nydus-snapshotter:/nydus-snapshotter $compile_image bash -c 'cd /nydus-snapshotter && make clear && make'
+        docker run --rm -v /tmp/nydus-snapshotter:/nydus-snapshotter $compile_image bash -c 'cd /nydus-snapshotter && make clean && make'
         if [ -f "/tmp/nydus-snapshotter/bin/containerd-nydus-grpc" ]; then
                 /usr/bin/cp -f /tmp/nydus-snapshotter/bin/containerd-nydus-grpc /usr/local/bin/
                 echo "nydus-snapshotter version"


### PR DESCRIPTION
Since developers changed "make clear" to "make clean" in the Makefile in nydus-snapshotter, it also needs to be updated in ci test.
Signed-off-by: Yiqun Leng <yqleng@linux.alibaba.com>