### PR TITLE
rafs: fix incorrect blob id in merged TARFS

### DIFF
--- a/rafs/src/builder/merge.rs
+++ b/rafs/src/builder/merge.rs
@@ -179,7 +179,9 @@ impl Merger {
                     }
                     parent_blob_added = true;
 
-                    if ctx.configuration.internal.blob_accessible() {
+                    if ctx.configuration.internal.blob_accessible()
+                        || ctx.conversion_type == ConversionType::TarToTarfs
+                    {
                         // `blob.blob_id()` should have been fixed when loading the bootstrap.
                         blob_ctx.blob_id = blob.blob_id();
                     } else {


### PR DESCRIPTION
When merging multiple RAFS filesystems in TARFS mode into one, the generated data blob is incorrectly, it actually the meta blob id instead of data blob id.