### PR TITLE
service: add coco feature in Cargo.toml

### DIFF
--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -55,3 +55,8 @@ virtiofs = [
 
 block-device = [ "dbs-allocator", "tokio/fs"]
 block-nbd = ["block-device", "bytes"]
+
+coco = [
+    "fuse-backend-rs/fusedev",
+    "nydus-storage/backend-registry",
+]


### PR DESCRIPTION
Add feature coco to Cargo.toml, so that confidential containers can apply this feature to use nydus to download images.