### PR TITLE
nydus-image: support small chunks mergence

### DIFF
--- a/rafs/src/builder/core/bootstrap.rs
+++ b/rafs/src/builder/core/bootstrap.rs
@@ -296,6 +296,7 @@ impl Bootstrap {
             compressor: ctx.compressor,
             digester: ctx.digester,
             chunk_size: ctx.chunk_size,
+            batch_size: ctx.batch_size,
             explicit_uidgid: ctx.explicit_uidgid,
             version: ctx.fs_version,
             is_tarfs_mode: rs.meta.flags.contains(RafsSuperFlags::TARTFS_MODE),

--- a/rafs/src/builder/core/chunk_dict.rs
+++ b/rafs/src/builder/core/chunk_dict.rs
@@ -263,6 +263,7 @@ mod tests {
             compressor: compress::Algorithm::Lz4Block,
             digester: digest::Algorithm::Blake3,
             chunk_size: 0x100000,
+            batch_size: 0,
             explicit_uidgid: true,
             is_tarfs_mode: false,
         };

--- a/rafs/src/metadata/chunk.rs
+++ b/rafs/src/metadata/chunk.rs
@@ -248,6 +248,27 @@ impl ChunkWrapper {
         }
     }
 
+    /// Set flag for whether chunk is batch chunk.
+    pub fn set_batch(&mut self, batch: bool) {
+        self.ensure_owned();
+        match self {
+            ChunkWrapper::V5(c) => c.flags.set(BlobChunkFlags::BATCH, batch),
+            ChunkWrapper::V6(c) => c.flags.set(BlobChunkFlags::BATCH, batch),
+            ChunkWrapper::Ref(_c) => panic!("unexpected"),
+        }
+    }
+
+    /// Check whether the chunk is batch chunk or not.
+    pub fn is_batch(&self) -> bool {
+        match self {
+            ChunkWrapper::V5(c) => c.flags.contains(BlobChunkFlags::BATCH),
+            ChunkWrapper::V6(c) => c.flags.contains(BlobChunkFlags::BATCH),
+            ChunkWrapper::Ref(c) => as_blob_v5_chunk_info(c.deref())
+                .flags()
+                .contains(BlobChunkFlags::BATCH),
+        }
+    }
+
     #[allow(clippy::too_many_arguments)]
     /// Set a group of chunk information fields.
     pub fn set_chunk_info(

--- a/rafs/src/metadata/inode.rs
+++ b/rafs/src/metadata/inode.rs
@@ -276,7 +276,7 @@ impl InodeWrapper {
         }
     }
 
-    /// Set inode content size of regular file, directory and symlink.
+    /// Get inode content size of regular file, directory and symlink.
     pub fn size(&self) -> u64 {
         match self {
             InodeWrapper::V5(i) => i.i_size,
@@ -285,7 +285,7 @@ impl InodeWrapper {
         }
     }
 
-    /// Get inode content size.
+    /// Set inode content size.
     pub fn set_size(&mut self, size: u64) {
         self.ensure_owned();
         match self {

--- a/rafs/src/metadata/layout/v6.rs
+++ b/rafs/src/metadata/layout/v6.rs
@@ -1634,7 +1634,8 @@ impl RafsV6Blob {
 
         let count = chunk_count as u64;
         if blob_features.contains(BlobFeatures::CHUNK_INFO_V2)
-            && blob_features.contains(BlobFeatures::ZRAN)
+            && (blob_features.contains(BlobFeatures::BATCH)
+                || blob_features.contains(BlobFeatures::ZRAN))
         {
             if ci_uncompr_size < count * size_of::<BlobChunkInfoV2Ondisk>() as u64 {
                 error!(
@@ -1651,7 +1652,9 @@ impl RafsV6Blob {
                 );
                 return false;
             }
-        } else if blob_features.contains(BlobFeatures::ZRAN) {
+        } else if blob_features.contains(BlobFeatures::BATCH)
+            || blob_features.contains(BlobFeatures::ZRAN)
+        {
             error!(
                 "RafsV6Blob: idx {} invalid feature bits {}",
                 blob_index,

--- a/rafs/src/metadata/mod.rs
+++ b/rafs/src/metadata/mod.rs
@@ -367,6 +367,8 @@ pub struct RafsSuperConfig {
     pub digester: digest::Algorithm,
     /// Size of data chunks.
     pub chunk_size: u32,
+    /// Size of batch data chunks.
+    pub batch_size: u32,
     /// Whether `explicit_uidgid` enabled or not.
     pub explicit_uidgid: bool,
     /// RAFS in TARFS mode.
@@ -429,6 +431,8 @@ pub struct RafsSuperMeta {
     pub root_inode: Inode,
     /// Chunk size.
     pub chunk_size: u32,
+    /// Batch chunk size.
+    pub batch_size: u32,
     /// Number of inodes in the filesystem.
     pub inodes_count: u64,
     /// V5: superblock flags for Rafs v5.
@@ -525,6 +529,7 @@ impl RafsSuperMeta {
             compressor: self.get_compressor(),
             digester: self.get_digester(),
             chunk_size: self.chunk_size,
+            batch_size: self.batch_size,
             explicit_uidgid: self.explicit_uidgid(),
             is_tarfs_mode: self.flags.contains(RafsSuperFlags::TARTFS_MODE),
         }
@@ -540,6 +545,7 @@ impl Default for RafsSuperMeta {
             inodes_count: 0,
             root_inode: 0,
             chunk_size: 0,
+            batch_size: 0,
             flags: RafsSuperFlags::empty(),
             inode_table_entries: 0,
             inode_table_offset: 0,

--- a/storage/src/device.rs
+++ b/storage/src/device.rs
@@ -45,7 +45,7 @@ use crate::cache::BlobCache;
 use crate::factory::BLOB_FACTORY;
 
 pub(crate) const BLOB_FEATURE_INCOMPAT_MASK: u32 = 0x0000_ffff;
-pub(crate) const BLOB_FEATURE_INCOMPAT_VALUE: u32 = 0x0000_007f;
+pub(crate) const BLOB_FEATURE_INCOMPAT_VALUE: u32 = 0x0000_00ff;
 
 bitflags! {
     /// Features bits for blob management.
@@ -64,6 +64,8 @@ bitflags! {
         const INLINED_CHUNK_DIGEST = 0x0000_0020;
         /// Blob is for RAFS filesystems in TARFS mode.
         const TARFS = 0x0000_0040;
+        /// Small file chunk are merged into batch chunk.
+        const BATCH = 0x0000_0080;
         /// Blob has TAR headers to separate contents.
         const HAS_TAR_HEADER = 0x1000_0000;
         /// Blob has Table of Content (ToC) at the tail.
@@ -546,6 +548,8 @@ bitflags! {
         const _HOLECHUNK = 0x0000_0002;
         /// Chunk data is encrypted.
         const ENCYPTED = 0x0000_0004;
+        /// Chunk data is merged into a batch chunk.
+        const BATCH = 0x0000_0008;
     }
 }
 

--- a/storage/src/meta/batch.rs
+++ b/storage/src/meta/batch.rs
@@ -1,0 +1,143 @@
+// Copyright (C) 2022 Alibaba Cloud. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use std::io::Result;
+use std::mem::size_of;
+use std::slice;
+
+use crate::meta::chunk_info_v2::BlobChunkInfoV2Ondisk;
+use crate::meta::BlobMetaChunkInfo;
+
+/// Context information to support batch chunk.
+/// Each one corresponds to a whole batch chunk containing multiple small chunks.
+#[repr(C, packed)]
+pub struct BatchInflateContext {
+    /// Offset of the batch chunk data into the compressed data blob.
+    compressed_offset: u64,
+    /// Compressed size of the whole batch chunk data.
+    compressed_size: u32,
+    /// Uncompressed size of the whole batch chunk data without 4K aligned.
+    uncompressed_batch_size: u32,
+    __reserved1: u64,
+    __reserved2: u64,
+    __reserved3: u64,
+}
+
+impl BatchInflateContext {
+    /// Get offset of the batch chunk data into the compressed data blob.
+    pub fn compressed_offset(&self) -> u64 {
+        u64::from_le(self.compressed_offset)
+    }
+
+    /// Set offset of the batch chunk data into the compressed data blob.
+    pub fn set_compressed_offset(&mut self, compressed_offset: u64) {
+        self.compressed_offset = u64::to_le(compressed_offset);
+    }
+
+    /// Get compressed size of the whole batch chunk data.
+    pub fn compressed_size(&self) -> u32 {
+        u32::from_le(self.compressed_size)
+    }
+
+    /// Set compressed size of the whole batch chunk data.
+    pub fn set_compressed_size(&mut self, compressed_size: u32) {
+        self.compressed_size = u32::to_le(compressed_size);
+    }
+
+    /// Convert to an immutable u8 slice.
+    pub fn as_slice(&self) -> &[u8] {
+        unsafe {
+            slice::from_raw_parts(
+                self as *const BatchInflateContext as *const u8,
+                size_of::<BatchInflateContext>(),
+            )
+        }
+    }
+}
+
+/// Struct to generate [BatchInflateContext] objects for batch chunks.
+pub struct BatchContextGenerator {
+    /// Buffering the to be dumped chunk data for Chunk Merging.
+    chunk_data_buf: Vec<u8>,
+    /// Storing all `BatchInflateContext` of current blob.
+    contexts: Vec<BatchInflateContext>,
+}
+
+impl BatchContextGenerator {
+    /// Get the buffer of to be dumped chunk data for batch chunk.
+    pub fn chunk_data_buf(&self) -> &Vec<u8> {
+        &self.chunk_data_buf
+    }
+
+    /// Check whether the chunk data buffer is empty.
+    pub fn chunk_data_buf_is_empty(&self) -> bool {
+        self.chunk_data_buf.is_empty()
+    }
+
+    /// Get the lenth of chunk data buffer.
+    pub fn chunk_data_buf_len(&self) -> usize {
+        self.chunk_data_buf.len()
+    }
+
+    /// Append new chunk data to the chunk data buffer.
+    pub fn append_chunk_data_buf(&mut self, chunk_data: &[u8]) {
+        self.chunk_data_buf.extend_from_slice(chunk_data);
+    }
+
+    /// Clear the chunk data buffer.
+    pub fn clear_chunk_data_buf(&mut self) {
+        self.chunk_data_buf.clear();
+    }
+
+    /// Add a batch context for a dumped batch chunk.
+    pub fn add_context(&mut self, compressed_offset: u64, compressed_size: u32) {
+        let ctx = BatchInflateContext {
+            compressed_offset: u64::to_le(compressed_offset),
+            compressed_size: u32::to_le(compressed_size),
+            uncompressed_batch_size: self.chunk_data_buf_len() as u32,
+            __reserved1: u64::to_le(0),
+            __reserved2: u64::to_le(0),
+            __reserved3: u64::to_le(0),
+        };
+        self.contexts.push(ctx);
+    }
+
+    /// Create a new instance of [BatchInflateContext].
+    pub fn new(batch_size: u32) -> Result<Self> {
+        Ok(Self {
+            chunk_data_buf: Vec::with_capacity(batch_size as usize),
+            contexts: Vec::with_capacity(10240),
+        })
+    }
+
+    /// Generate and return a v2 chunk info struct.
+    pub fn generate_chunk_info(
+        &mut self,
+        uncompressed_offset: u64,
+        uncompressed_size: u32,
+    ) -> Result<BlobChunkInfoV2Ondisk> {
+        let mut chunk = BlobChunkInfoV2Ondisk::default();
+        chunk.set_compressed_offset(0);
+        chunk.set_compressed_size(0);
+        chunk.set_uncompressed_offset(uncompressed_offset);
+        chunk.set_uncompressed_size(uncompressed_size);
+        chunk.set_batch(true);
+        chunk.set_batch_index(self.contexts.len() as u32);
+        chunk.set_uncompressed_offset_in_batch_buf(self.chunk_data_buf_len() as u32);
+        chunk.set_compressed(true);
+
+        Ok(chunk)
+    }
+
+    /// Convert all the batch chunk information to a u8 vector.
+    pub fn to_vec(&self) -> Result<(Vec<u8>, u32)> {
+        let mut data = Vec::new();
+
+        for ctx in &self.contexts {
+            data.extend_from_slice(ctx.as_slice());
+        }
+
+        Ok((data, self.contexts.len() as u32))
+    }
+}

--- a/storage/src/meta/chunk_info_v1.rs
+++ b/storage/src/meta/chunk_info_v1.rs
@@ -95,11 +95,23 @@ impl BlobMetaChunkInfo for BlobChunkInfoV1Ondisk {
         false
     }
 
+    fn is_batch(&self) -> bool {
+        false
+    }
+
     fn get_zran_index(&self) -> u32 {
         unimplemented!()
     }
 
     fn get_zran_offset(&self) -> u32 {
+        unimplemented!()
+    }
+
+    fn get_batch_index(&self) -> u32 {
+        unimplemented!()
+    }
+
+    fn get_uncompressed_offset_in_batch_buf(&self) -> u32 {
         unimplemented!()
     }
 

--- a/storage/src/meta/chunk_info_v2.rs
+++ b/storage/src/meta/chunk_info_v2.rs
@@ -61,13 +61,15 @@ impl BlobChunkInfoV2Ondisk {
     }
 
     pub(crate) fn set_zran_index(&mut self, index: u32) {
-        let mut data = u64::from_le(self.data) & !0xffff_ffff_0000_0000;
+        assert!(self.is_zran());
+        let mut data = u64::from_le(self.data) & 0x0000_0000_ffff_ffff;
         data |= (index as u64) << 32;
         self.data = u64::to_le(data);
     }
 
     pub(crate) fn set_zran_offset(&mut self, offset: u32) {
-        let mut data = u64::from_le(self.data) & !0x0000_0000_ffff_ffff;
+        assert!(self.is_zran());
+        let mut data = u64::from_le(self.data) & 0xffff_ffff_0000_0000;
         data |= offset as u64;
         self.data = u64::to_le(data);
     }

--- a/storage/src/meta/mod.rs
+++ b/storage/src/meta/mod.rs
@@ -1005,6 +1005,7 @@ impl BlobMetaChunkArray {
     }
 
     /// Add an entry of v2 chunk compression information into the array.
+    #[allow(clippy::too_many_arguments)]
     pub fn add_v2(
         &mut self,
         compressed_offset: u64,
@@ -1012,6 +1013,7 @@ impl BlobMetaChunkArray {
         uncompressed_offset: u64,
         uncompressed_size: u32,
         compressed: bool,
+        is_batch: bool,
         data: u64,
     ) {
         match self {
@@ -1022,6 +1024,7 @@ impl BlobMetaChunkArray {
                 meta.set_uncompressed_offset(uncompressed_offset);
                 meta.set_uncompressed_size(uncompressed_size);
                 meta.set_compressed(compressed);
+                meta.set_batch(is_batch);
                 meta.set_data(data);
                 v.push(meta);
             }

--- a/storage/src/meta/zran.rs
+++ b/storage/src/meta/zran.rs
@@ -173,9 +173,9 @@ impl<R: Read> ZranContextGenerator<R> {
         chunk.set_compressed_size(info.in_len);
         chunk.set_uncompressed_offset(self.uncomp_pos);
         chunk.set_uncompressed_size(info.ci_len);
+        chunk.set_zran(true);
         chunk.set_zran_index(info.ci_index);
         chunk.set_zran_offset(info.ci_offset);
-        chunk.set_zran(true);
         chunk.set_compressed(true);
 
         self.uncomp_pos += round_up_4k(info.ci_len as u64);
@@ -183,7 +183,7 @@ impl<R: Read> ZranContextGenerator<R> {
         Ok(chunk)
     }
 
-    /// Save the zlib/gzip random access information to a file.
+    /// Convert all the zlib/gzip random access information to a u8 vector.
     pub fn to_vec(&self) -> Result<(Vec<u8>, u32)> {
         let mut data = Vec::new();
         let records = self.generator.get_compression_ctx_array();


### PR DESCRIPTION
Add the support of merging small file chunks into one batch chunk, for `ConversionType::DirectoryToRafs`, `ConversionType::EStargzToRafs`, `ConversionType::TargzToRafs`, and `ConversionType::TarToRafs`.

# basic usage

Add the `--batch-size` arg to command to enable chunk mergence for supported conversion types:

```shell
nydus-image create --bootstrap ~/bootstrap --blob-dir ~/blobs ~/source --batch-size 0x100000

nydus-image create --type estargz-rafs --bootstrap ~/bootstrap --blob-dir ~/blobs ~/source.tar.gz --batch-size 0x100000

nydus-image create --type targz-rafs --bootstrap ~/bootstrap --blob-dir ~/blobs ~/source.tar.gz --batch-size 0x100000

nydus-image create --type tar-rafs --bootstrap ~/bootstrap --blob-dir ~/blobs ~/source.tar --batch-size 0x100000
```
# benchmarks

- 4K-aligned: append zeros to chunk data buffer so that the data to be compressed is 4K aligned.
- continuous: a big chunk between small chunks will cut the batch chunk.
- 1/2 filtered: do not merge chunks with their uncompressed size bigger than 1/2 batch size.

| repositories | tags | 4K-aligned | continuous | 1/2 filtered | size (MiB) | % | 
|--|--|:--:|:--:|:--:|--:|--:|
| wordpress | latest | - | - | - | 207.36 | - |
| wordpress | latest-rafs | - | - | - | 211.17 | +1.84% |
| wordpress | latest-rafs-batch-64K | ✖ | ✖ | ✖ | 205.63 | -0.83% |
| wordpress | latest-rafs-batch-64K | ✖ | ✖ | ✔ | 205.62 | -0.84% |
| wordpress | latest-rafs-batch-64K | ✖ | ✔ | ✖ | 205.76 | -0.77% |
| wordpress | latest-rafs-batch-64K | ✔ | ✖ | ✖ | 206.17 | -0.57% |
| wordpress | latest-rafs-batch-64K | ✔ | ✖ | ✔ | 206.16 | -0.58% |
| wordpress | latest-rafs-batch-64K | ✖ | ✔ | ✔ | 205.85 | -0.72% |
| wordpress | latest-rafs-batch-64K | ✔ | ✔ | ✖ | 206.28 | -0.52% |
| wordpress | latest-rafs-batch-64K | ✔ | ✔ | ✔ | 206.36 | -0.48% |
| wordpress | latest-rafs-batch-128K | ✖ | ✖ | ✖ | 204.01 | -1.62% |
| wordpress | latest-rafs-batch-128K | ✖ | ✖ | ✔ | 203.91 | -1.66% |
| wordpress | latest-rafs-batch-128K | ✖ | ✔ | ✖ | 204.06 | -1.59% |
| wordpress | latest-rafs-batch-128K | ✔ | ✖ | ✖ | 204.41 | -1.42% |
| wordpress | latest-rafs-batch-128K | ✔ | ✖ | ✔ | 204.41 | -1.42% |
| wordpress | latest-rafs-batch-128K | ✖ | ✔ | ✔ | 204.19 | -1.53% |
| wordpress | latest-rafs-batch-128K | ✔ | ✔ | ✖ | 204.48 | -1.39% |
| wordpress | latest-rafs-batch-128K | ✔ | ✔ | ✔ | 204.61 | -1.32% |
| wordpress | latest-rafs-batch-256K | ✖ | ✖ | ✖ | 201.39 | -2.88% |
| wordpress | latest-rafs-batch-256K | ✖ | ✖ | ✔ | 201.28 | -2.93% |
| wordpress | latest-rafs-batch-256K | ✖ | ✔ | ✖ | 201.44 | -2.85% |
| wordpress | latest-rafs-batch-256K | ✔ | ✖ | ✖ | 201.92 | -2.62% |
| wordpress | latest-rafs-batch-256K | ✔ | ✖ | ✔ | 201.77 | -2.69% |
| wordpress | latest-rafs-batch-256K | ✖ | ✔ | ✔ | 201.45 | -2.85% |
| wordpress | latest-rafs-batch-256K | ✔ | ✔ | ✖ | 201.89 | -2.64% |
| wordpress | latest-rafs-batch-256K | ✔ | ✔ | ✔ | 201.96 | -2.61% |
| wordpress | latest-rafs-batch-512K | ✖ | ✖ | ✖ | 199.23 | -3.92% |
| wordpress | latest-rafs-batch-512K | ✖ | ✖ | ✔ | 199.32 | -3.88% |
| wordpress | latest-rafs-batch-512K | ✖ | ✔ | ✖ | 199.26 | -3.90% |
| wordpress | latest-rafs-batch-512K | ✔ | ✖ | ✖ | 199.35 | -3.86% |
| wordpress | latest-rafs-batch-512K | ✔ | ✖ | ✔ | 199.23 | -3.92% |
| wordpress | latest-rafs-batch-512K | ✖ | ✔ | ✔ | 199.07 | -4.00% |
| wordpress | latest-rafs-batch-512K | ✔ | ✔ | ✖ | 199.43 | -3.82% |
| wordpress | latest-rafs-batch-512K | ✔ | ✔ | ✔ | 199.50 | -3.79% |
| wordpress | latest-rafs-batch-1M | ✖ | ✖ | ✖ | 196.65 | -5.16% |
| wordpress | latest-rafs-batch-1M | ✖ | ✖ | ✔ | 196.67 | -5.16% |
| wordpress | latest-rafs-batch-1M | ✖ | ✔ | ✖ | 196.67 | -5.15% |
| wordpress | latest-rafs-batch-1M | ✔ | ✖ | ✖ | 197.31 | -4.84% |
| wordpress | latest-rafs-batch-1M | ✔ | ✖ | ✔ | 197.25 | -4.87% |
| wordpress | latest-rafs-batch-1M | ✖ | ✔ | ✔ | 196.71 | -5.14% |
| wordpress | latest-rafs-batch-1M | ✔ | ✔ | ✖ | 197.34 | -4.83% |
| wordpress | latest-rafs-batch-1M | ✔ | ✔ | ✔ | 197.41 | -4.80% |
| wordpress | php8.2-fpm-alpine | - | - | - | 98.31 | - |
| wordpress | php8.2-fpm-alpine-rafs | - | - | - | 99.15 | +0.85% |
| wordpress | php8.2-fpm-alpine-rafs-batch-64K | ✖ | ✖ | ✖ | 97.04 | -1.30% |
| wordpress | php8.2-fpm-alpine-rafs-batch-64K | ✖ | ✖ | ✔ | 97.01 | -1.32% |
| wordpress | php8.2-fpm-alpine-rafs-batch-64K | ✖ | ✔ | ✖ | 97.10 | -1.23% |
| wordpress | php8.2-fpm-alpine-rafs-batch-64K | ✔ | ✖ | ✖ | 97.23 | -1.10% |
| wordpress | php8.2-fpm-alpine-rafs-batch-64K | ✔ | ✖ | ✔ | 97.23 | -1.10% |
| wordpress | php8.2-fpm-alpine-rafs-batch-64K | ✖ | ✔ | ✔ | 97.13 | -1.21% |
| wordpress | php8.2-fpm-alpine-rafs-batch-64K | ✔ | ✔ | ✖ | 97.30 | -1.03% |
| wordpress | php8.2-fpm-alpine-rafs-batch-64K | ✔ | ✔ | ✔ | 97.34 | -0.99% |
| wordpress | php8.2-fpm-alpine-rafs-batch-128K | ✖ | ✖ | ✖ | 96.54 | -1.80% |
| wordpress | php8.2-fpm-alpine-rafs-batch-128K | ✖ | ✖ | ✔ | 96.48 | -1.86% |
| wordpress | php8.2-fpm-alpine-rafs-batch-128K | ✖ | ✔ | ✖ | 96.58 | -1.76% |
| wordpress | php8.2-fpm-alpine-rafs-batch-128K | ✔ | ✖ | ✖ | 96.68 | -1.67% |
| wordpress | php8.2-fpm-alpine-rafs-batch-128K | ✔ | ✖ | ✔ | 96.66 | -1.69% |
| wordpress | php8.2-fpm-alpine-rafs-batch-128K | ✖ | ✔ | ✔ | 96.63 | -1.71% |
| wordpress | php8.2-fpm-alpine-rafs-batch-128K | ✔ | ✔ | ✖ | 96.71 | -1.63% |
| wordpress | php8.2-fpm-alpine-rafs-batch-128K | ✔ | ✔ | ✔ | 96.76 | -1.58% |
| wordpress | php8.2-fpm-alpine-rafs-batch-256K | ✖ | ✖ | ✖ | 95.91 | -2.45% |
| wordpress | php8.2-fpm-alpine-rafs-batch-256K | ✖ | ✖ | ✔ | 95.89 | -2.46% |
| wordpress | php8.2-fpm-alpine-rafs-batch-256K | ✖ | ✔ | ✖ | 95.92 | -2.43% |
| wordpress | php8.2-fpm-alpine-rafs-batch-256K | ✔ | ✖ | ✖ | 96.02 | -2.34% |
| wordpress | php8.2-fpm-alpine-rafs-batch-256K | ✔ | ✖ | ✔ | 96.03 | -2.32% |
| wordpress | php8.2-fpm-alpine-rafs-batch-256K | ✖ | ✔ | ✔ | 95.98 | -2.37% |
| wordpress | php8.2-fpm-alpine-rafs-batch-256K | ✔ | ✔ | ✖ | 96.02 | -2.33% |
| wordpress | php8.2-fpm-alpine-rafs-batch-256K | ✔ | ✔ | ✔ | 96.11 | -2.24% |
| wordpress | php8.2-fpm-alpine-rafs-batch-512K | ✖ | ✖ | ✖ | 95.23 | -3.14% |
| wordpress | php8.2-fpm-alpine-rafs-batch-512K | ✖ | ✖ | ✔ | 95.35 | -3.01% |
| wordpress | php8.2-fpm-alpine-rafs-batch-512K | ✖ | ✔ | ✖ | 95.27 | -3.10% |
| wordpress | php8.2-fpm-alpine-rafs-batch-512K | ✔ | ✖ | ✖ | 95.35 | -3.01% |
| wordpress | php8.2-fpm-alpine-rafs-batch-512K | ✔ | ✖ | ✔ | 95.43 | -2.93% |
| wordpress | php8.2-fpm-alpine-rafs-batch-512K | ✖ | ✔ | ✔ | 95.42 | -2.94% |
| wordpress | php8.2-fpm-alpine-rafs-batch-512K | ✔ | ✔ | ✖ | 95.31 | -3.05% |
| wordpress | php8.2-fpm-alpine-rafs-batch-512K | ✔ | ✔ | ✔ | 95.49 | -2.88% |
| wordpress | php8.2-fpm-alpine-rafs-batch-1M | ✖ | ✖ | ✖ | 94.66 | -3.72% |
| wordpress | php8.2-fpm-alpine-rafs-batch-1M | ✖ | ✖ | ✔ | 94.61 | -3.76% |
| wordpress | php8.2-fpm-alpine-rafs-batch-1M | ✖ | ✔ | ✖ | 94.59 | -3.78% |
| wordpress | php8.2-fpm-alpine-rafs-batch-1M | ✔ | ✖ | ✖ | 94.94 | -3.43% |
| wordpress | php8.2-fpm-alpine-rafs-batch-1M | ✔ | ✖ | ✔ | 94.67 | -3.71% |
| wordpress | php8.2-fpm-alpine-rafs-batch-1M | ✖ | ✔ | ✔ | 94.64 | -3.73% |
| wordpress | php8.2-fpm-alpine-rafs-batch-1M | ✔ | ✔ | ✖ | 94.87 | -3.50% |
| wordpress | php8.2-fpm-alpine-rafs-batch-1M | ✔ | ✔ | ✔ | 94.91 | -3.46% |
| python | latest | - | - | - | 335.56 | - |
| python | latest-rafs | - | - | - | 324.83 | - 3.20% |
| python | latest-rafs-batch-64K | ✖ | ✖ | ✖ | 317.84 | -5.28% |
| python | latest-rafs-batch-64K | ✖ | ✖ | ✔ | 317.75 | -5.31% |
| python | latest-rafs-batch-64K | ✖ | ✔ | ✖ | 317.92 | -5.26% |
| python | latest-rafs-batch-64K | ✔ | ✖ | ✖ | 318.48 | -5.09% |
| python | latest-rafs-batch-64K | ✔ | ✖ | ✔ | 318.38 | -5.12% |
| python | latest-rafs-batch-64K | ✖ | ✔ | ✔ | 318.08 | -5.21% |
| python | latest-rafs-batch-64K | ✔ | ✔ | ✖ | 318.59 | -5.06% |
| python | latest-rafs-batch-64K | ✔ | ✔ | ✔ | 318.67 | -5.03% |
| python | latest-rafs-batch-128K | ✖ | ✖ | ✖ | 315.59 | -5.95% |
| python | latest-rafs-batch-128K | ✖ | ✖ | ✔ | 315.40 | -6.01% |
| python | latest-rafs-batch-128K | ✖ | ✔ | ✖ | 315.63 | -5.94% |
| python | latest-rafs-batch-128K | ✔ | ✖ | ✖ | 315.95 | -5.85% |
| python | latest-rafs-batch-128K | ✔ | ✖ | ✔ | 315.94 | -5.85% |
| python | latest-rafs-batch-128K | ✖ | ✔ | ✔ | 315.73 | -5.91% |
| python | latest-rafs-batch-128K | ✔ | ✔ | ✖ | 316.09 | -5.80% |
| python | latest-rafs-batch-128K | ✔ | ✔ | ✔ | 316.23 | -5.76% |
| python | latest-rafs-batch-256K | ✖ | ✖ | ✖ | 312.31 | -6.93% |
| python | latest-rafs-batch-256K | ✖ | ✖ | ✔ | 312.01 | -7.02% |
| python | latest-rafs-batch-256K | ✖ | ✔ | ✖ | 312.42 | -6.90% |
| python | latest-rafs-batch-256K | ✔ | ✖ | ✖ | 312.66 | -6.82% |
| python | latest-rafs-batch-256K | ✔ | ✖ | ✔ | 312.47 | -6.88% |
| python | latest-rafs-batch-256K | ✖ | ✔ | ✔ | 312.54 | -6.86% |
| python | latest-rafs-batch-256K | ✔ | ✔ | ✖ | 312.81 | -6.78% |
| python | latest-rafs-batch-256K | ✔ | ✔ | ✔ | 312.97 | -6.73% |
| python | latest-rafs-batch-512K | ✖ | ✖ | ✖ | 309.06 | -7.90% |
| python | latest-rafs-batch-512K | ✖ | ✖ | ✔ | 308.97 | -7.92% |
| python | latest-rafs-batch-512K | ✖ | ✔ | ✖ | 309.06 | -7.90% |
| python | latest-rafs-batch-512K | ✔ | ✖ | ✖ | 309.23 | -7.85% |
| python | latest-rafs-batch-512K | ✔ | ✖ | ✔ | 309.19 | -7.86% |
| python | latest-rafs-batch-512K | ✖ | ✔ | ✔ | 308.86 | -7.96% |
| python | latest-rafs-batch-512K | ✔ | ✔ | ✖ | 309.38 | -7.80% |
| python | latest-rafs-batch-512K | ✔ | ✔ | ✔ | 309.49 | -7.77% |
| python | latest-rafs-batch-1M | ✖ | ✖ | ✖ | 304.29 | -9.32% |
| python | latest-rafs-batch-1M | ✖ | ✖ | ✔ | 304.67 | -9.21% |
| python | latest-rafs-batch-1M | ✖ | ✔ | ✖ | 304.31 | -9.31% |
| python | latest-rafs-batch-1M | ✔ | ✖ | ✖ | 304.62 | -9.22% |
| python | latest-rafs-batch-1M | ✔ | ✖ | ✔ | 304.90 | -9.14% |
| python | latest-rafs-batch-1M | ✖ | ✔ | ✔ | 304.74 | -9.18% |
| python | latest-rafs-batch-1M | ✔ | ✔ | ✖ | 304.55 | -9.24% |
| python | latest-rafs-batch-1M | ✔ | ✔ | ✔ | 305.08 | -9.08% |
| python | alpine3.17 | - | - | - | 18.64 | - |
| python | alpine3.17-rafs | - | - | - | 20.01 | +7.35% |
| python | alpine3.17-rafs-batch-64K | ✖ | ✖ | ✖ | 19.23 | +3.16% |
| python | alpine3.17-rafs-batch-64K | ✖ | ✖ | ✔ | 19.22 | +3.11% |
| python | alpine3.17-rafs-batch-64K | ✖ | ✔ | ✖ | 19.24 | +3.22% |
| python | alpine3.17-rafs-batch-64K | ✔ | ✖ | ✖ | 19.36 | +3.88% |
| python | alpine3.17-rafs-batch-64K | ✔ | ✖ | ✔ | 19.35 | +3.84% |
| python | alpine3.17-rafs-batch-64K | ✖ | ✔ | ✔ | 19.27 | +3.38% |
| python | alpine3.17-rafs-batch-64K | ✔ | ✔ | ✖ | 19.36 | +3.88% |
| python | alpine3.17-rafs-batch-64K | ✔ | ✔ | ✔ | 19.37 | +3.93% |
| python | alpine3.17-rafs-batch-128K | ✖ | ✖ | ✖ | 19.02 | +2.04% |
| python | alpine3.17-rafs-batch-128K | ✖ | ✖ | ✔ | 19.00 | +1.93% |
| python | alpine3.17-rafs-batch-128K | ✖ | ✔ | ✖ | 19.02 | +2.07% |
| python | alpine3.17-rafs-batch-128K | ✔ | ✖ | ✖ | 19.11 | +2.55% |
| python | alpine3.17-rafs-batch-128K | ✔ | ✖ | ✔ | 19.10 | +2.50% |
| python | alpine3.17-rafs-batch-128K | ✖ | ✔ | ✔ | 19.03 | +2.11% |
| python | alpine3.17-rafs-batch-128K | ✔ | ✔ | ✖ | 19.13 | +2.64% |
| python | alpine3.17-rafs-batch-128K | ✔ | ✔ | ✔ | 19.13 | +2.63% |
| python | alpine3.17-rafs-batch-256K | ✖ | ✖ | ✖ | 18.76 | +0.64% |
| python | alpine3.17-rafs-batch-256K | ✖ | ✖ | ✔ | 18.75 | +0.59% |
| python | alpine3.17-rafs-batch-256K | ✖ | ✔ | ✖ | 18.77 | +0.70% |
| python | alpine3.17-rafs-batch-256K | ✔ | ✖ | ✖ | 18.85 | +1.17% |
| python | alpine3.17-rafs-batch-256K | ✔ | ✖ | ✔ | 18.83 | +1.05% |
| python | alpine3.17-rafs-batch-256K | ✖ | ✔ | ✔ | 18.78 | +0.76% |
| python | alpine3.17-rafs-batch-256K | ✔ | ✔ | ✖ | 18.86 | +1.19% |
| python | alpine3.17-rafs-batch-256K | ✔ | ✔ | ✔ | 18.86 | +1.18% |
| python | alpine3.17-rafs-batch-512K | ✖ | ✖ | ✖ | 18.55 | -0.44% |
| python | alpine3.17-rafs-batch-512K | ✖ | ✖ | ✔ | 18.53 | -0.59% |
| python | alpine3.17-rafs-batch-512K | ✖ | ✔ | ✖ | 18.55 | -0.44% |
| python | alpine3.17-rafs-batch-512K | ✔ | ✖ | ✖ | 18.67 | +0.19% |
| python | alpine3.17-rafs-batch-512K | ✔ | ✖ | ✔ | 18.66 | +0.11% |
| python | alpine3.17-rafs-batch-512K | ✖ | ✔ | ✔ | 18.53 | -0.54% |
| python | alpine3.17-rafs-batch-512K | ✔ | ✔ | ✖ | 18.68 | +0.25% |
| python | alpine3.17-rafs-batch-512K | ✔ | ✔ | ✔ | 18.70 | +0.35% |
| python | alpine3.17-rafs-batch-1M | ✖ | ✖ | ✖ | 18.38 | -1.40% |
| python | alpine3.17-rafs-batch-1M | ✖ | ✖ | ✔ | 18.37 | -1.45% |
| python | alpine3.17-rafs-batch-1M | ✖ | ✔ | ✖ | 18.38 | -1.39% |
| python | alpine3.17-rafs-batch-1M | ✔ | ✖ | ✖ | 18.36 | -1.49% |
| python | alpine3.17-rafs-batch-1M | ✔ | ✖ | ✔ | 18.36 | -1.50% |
| python | alpine3.17-rafs-batch-1M | ✖ | ✔ | ✔ | 18.38 | -1.40% |
| python | alpine3.17-rafs-batch-1M | ✔ | ✔ | ✖ | 18.36 | -1.47% |
| python | alpine3.17-rafs-batch-1M | ✔ | ✔ | ✔ | 18.36 | -1.47% |
| node | latest | - | - | - | 353.79 | - |
| node | latest-rafs | - | - | - | 335.46 | - 5.18% |
| node | latest-rafs-batch-64K | ✖ | ✖ | ✖ | 328.16 | -7.25% |
| node | latest-rafs-batch-64K | ✖ | ✖ | ✔ | 328.07 | -7.27% |
| node | latest-rafs-batch-64K | ✖ | ✔ | ✖ | 328.24 | -7.22% |
| node | latest-rafs-batch-64K | ✔ | ✖ | ✖ | 328.87 | -7.04% |
| node | latest-rafs-batch-64K | ✔ | ✖ | ✔ | 328.79 | -7.07% |
| node | latest-rafs-batch-64K | ✖ | ✔ | ✔ | 328.40 | -7.18% |
| node | latest-rafs-batch-64K | ✔ | ✔ | ✖ | 328.98 | -7.01% |
| node | latest-rafs-batch-64K | ✔ | ✔ | ✔ | 329.07 | -6.99% |
| node | latest-rafs-batch-128K | ✖ | ✖ | ✖ | 325.92 | -7.88% |
| node | latest-rafs-batch-128K | ✖ | ✖ | ✔ | 325.75 | -7.93% |
| node | latest-rafs-batch-128K | ✖ | ✔ | ✖ | 325.98 | -7.86% |
| node | latest-rafs-batch-128K | ✔ | ✖ | ✖ | 326.32 | -7.76% |
| node | latest-rafs-batch-128K | ✔ | ✖ | ✔ | 326.33 | -7.76% |
| node | latest-rafs-batch-128K | ✖ | ✔ | ✔ | 326.07 | -7.84% |
| node | latest-rafs-batch-128K | ✔ | ✔ | ✖ | 326.46 | -7.73% |
| node | latest-rafs-batch-128K | ✔ | ✔ | ✔ | 326.58 | -7.69% |
| node | latest-rafs-batch-256K | ✖ | ✖ | ✖ | 322.75 | -8.78% |
| node | latest-rafs-batch-256K | ✖ | ✖ | ✔ | 322.43 | -8.86% |
| node | latest-rafs-batch-256K | ✖ | ✔ | ✖ | 322.84 | -8.75% |
| node | latest-rafs-batch-256K | ✔ | ✖ | ✖ | 323.10 | -8.68% |
| node | latest-rafs-batch-256K | ✔ | ✖ | ✔ | 322.92 | -8.73% |
| node | latest-rafs-batch-256K | ✖ | ✔ | ✔ | 322.91 | -8.73% |
| node | latest-rafs-batch-256K | ✔ | ✔ | ✖ | 323.25 | -8.63% |
| node | latest-rafs-batch-256K | ✔ | ✔ | ✔ | 323.36 | -8.60% |
| node | latest-rafs-batch-512K | ✖ | ✖ | ✖ | 319.57 | -9.67% |
| node | latest-rafs-batch-512K | ✖ | ✖ | ✔ | 319.57 | -9.67% |
| node | latest-rafs-batch-512K | ✖ | ✔ | ✖ | 319.57 | -9.67% |
| node | latest-rafs-batch-512K | ✔ | ✖ | ✖ | 319.83 | -9.60% |
| node | latest-rafs-batch-512K | ✔ | ✖ | ✔ | 319.82 | -9.60% |
| node | latest-rafs-batch-512K | ✖ | ✔ | ✔ | 319.40 | -9.72% |
| node | latest-rafs-batch-512K | ✔ | ✔ | ✖ | 319.96 | -9.56% |
| node | latest-rafs-batch-512K | ✔ | ✔ | ✔ | 320.07 | -9.53% |
| node | latest-rafs-batch-1M | ✖ | ✖ | ✖ | 315.13 | -10.93% |
| node | latest-rafs-batch-1M | ✖ | ✖ | ✔ | 315.51 | -10.82% |
| node | latest-rafs-batch-1M | ✖ | ✔ | ✖ | 315.19 | -10.91% |
| node | latest-rafs-batch-1M | ✔ | ✖ | ✖ | 315.50 | -10.82% |
| node | latest-rafs-batch-1M | ✔ | ✖ | ✔ | 315.79 | -10.74% |
| node | latest-rafs-batch-1M | ✖ | ✔ | ✔ | 315.61 | -10.79% |
| node | latest-rafs-batch-1M | ✔ | ✔ | ✖ | 315.52 | -10.82% |
| node | latest-rafs-batch-1M | ✔ | ✔ | ✔ | 315.95 | -10.70% |
| node | 19-alpine | - | - | - | 51.47 | - |
| node | 19-alpine-rafs | - | - | - | 43.89 | - 14.73% |
| node | 19-alpine-rafs-batch-64K | ✖ | ✖ | ✖ | 43.10 | -16.27% |
| node | 19-alpine-rafs-batch-64K | ✖ | ✖ | ✔ | 43.09 | -16.28% |
| node | 19-alpine-rafs-batch-64K | ✖ | ✔ | ✖ | 43.10 | -16.25% |
| node | 19-alpine-rafs-batch-64K | ✔ | ✖ | ✖ | 43.22 | -16.03% |
| node | 19-alpine-rafs-batch-64K | ✔ | ✖ | ✔ | 43.22 | -16.03% |
| node | 19-alpine-rafs-batch-64K | ✖ | ✔ | ✔ | 43.12 | -16.23% |
| node | 19-alpine-rafs-batch-64K | ✔ | ✔ | ✖ | 43.21 | -16.04% |
| node | 19-alpine-rafs-batch-64K | ✔ | ✔ | ✔ | 43.23 | -16.01% |
| node | 19-alpine-rafs-batch-128K | ✖ | ✖ | ✖ | 42.94 | -16.57% |
| node | 19-alpine-rafs-batch-128K | ✖ | ✖ | ✔ | 42.93 | -16.59% |
| node | 19-alpine-rafs-batch-128K | ✖ | ✔ | ✖ | 42.94 | -16.57% |
| node | 19-alpine-rafs-batch-128K | ✔ | ✖ | ✖ | 43.03 | -16.40% |
| node | 19-alpine-rafs-batch-128K | ✔ | ✖ | ✔ | 43.02 | -16.42% |
| node | 19-alpine-rafs-batch-128K | ✖ | ✔ | ✔ | 42.94 | -16.57% |
| node | 19-alpine-rafs-batch-128K | ✔ | ✔ | ✖ | 43.03 | -16.40% |
| node | 19-alpine-rafs-batch-128K | ✔ | ✔ | ✔ | 43.02 | -16.40% |
| node | 19-alpine-rafs-batch-256K | ✖ | ✖ | ✖ | 42.78 | -16.89% |
| node | 19-alpine-rafs-batch-256K | ✖ | ✖ | ✔ | 42.77 | -16.90% |
| node | 19-alpine-rafs-batch-256K | ✖ | ✔ | ✖ | 42.77 | -16.90% |
| node | 19-alpine-rafs-batch-256K | ✔ | ✖ | ✖ | 42.86 | -16.72% |
| node | 19-alpine-rafs-batch-256K | ✔ | ✖ | ✔ | 42.86 | -16.73% |
| node | 19-alpine-rafs-batch-256K | ✖ | ✔ | ✔ | 42.78 | -16.89% |
| node | 19-alpine-rafs-batch-256K | ✔ | ✔ | ✖ | 42.88 | -16.68% |
| node | 19-alpine-rafs-batch-256K | ✔ | ✔ | ✔ | 42.88 | -16.68% |
| node | 19-alpine-rafs-batch-512K | ✖ | ✖ | ✖ | 42.67 | -17.09% |
| node | 19-alpine-rafs-batch-512K | ✖ | ✖ | ✔ | 42.67 | -17.10% |
| node | 19-alpine-rafs-batch-512K | ✖ | ✔ | ✖ | 42.67 | -17.09% |
| node | 19-alpine-rafs-batch-512K | ✔ | ✖ | ✖ | 42.76 | -16.92% |
| node | 19-alpine-rafs-batch-512K | ✔ | ✖ | ✔ | 42.76 | -16.92% |
| node | 19-alpine-rafs-batch-512K | ✖ | ✔ | ✔ | 42.67 | -17.09% |
| node | 19-alpine-rafs-batch-512K | ✔ | ✔ | ✖ | 42.74 | -16.95% |
| node | 19-alpine-rafs-batch-512K | ✔ | ✔ | ✔ | 42.74 | -16.95% |
| node | 19-alpine-rafs-batch-1M | ✖ | ✖ | ✖ | 42.59 | -17.25% |
| node | 19-alpine-rafs-batch-1M | ✖ | ✖ | ✔ | 42.58 | -17.27% |
| node | 19-alpine-rafs-batch-1M | ✖ | ✔ | ✖ | 42.61 | -17.21% |
| node | 19-alpine-rafs-batch-1M | ✔ | ✖ | ✖ | 42.69 | -17.05% |
| node | 19-alpine-rafs-batch-1M | ✔ | ✖ | ✔ | 42.69 | -17.06% |
| node | 19-alpine-rafs-batch-1M | ✖ | ✔ | ✔ | 42.61 | -17.21% |
| node | 19-alpine-rafs-batch-1M | ✔ | ✔ | ✖ | 42.66 | -17.11% |
| node | 19-alpine-rafs-batch-1M | ✔ | ✔ | ✔ | 42.66 | -17.11% |

This PR is related to https://github.com/dragonflyoss/image-service/issues/884, https://github.com/dragonflyoss/image-service/issues/885, https://github.com/dragonflyoss/Dragonfly2/issues/1858