### PR TITLE
[backport stable/v2.2] action: upgrade golangci-lint to v1.51.2

### DIFF
--- a/.github/workflows/convert.yml
+++ b/.github/workflows/convert.yml
@@ -34,7 +34,7 @@ jobs:
           ${{ runner.os }}-golang-
     - name: Build Contrib
       run: |
-        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sudo sh -s -- -b /usr/local/bin v1.47.3
+        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sudo sh -s -- -b /usr/local/bin v1.51.2
         make -e DOCKER=false nydusify-release
     - name: Upload Nydusify
       uses: actions/upload-artifact@master

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -36,7 +36,7 @@ jobs:
           ${{ runner.os }}-golang-
     - name: Build Contrib
       run: |
-        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sudo sh -s -- -b /usr/bin v1.47.3
+        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sudo sh -s -- -b /usr/bin v1.51.2
         make -e DOCKER=false nydusify-release
         make -e DOCKER=false contrib-test
     - name: Upload Nydusify
@@ -125,7 +125,7 @@ jobs:
           export NYDUS_NYDUSIFY_$version_export=/usr/bin/nydus-$version/nydusify
         done
 
-        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sudo sh -s -- -b /usr/bin v1.47.3
+        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sudo sh -s -- -b /usr/bin v1.51.2
         sudo -E make smoke-only
 
   nydus-unit-test:

--- a/smoke/tests/tool/iterator.go
+++ b/smoke/tests/tool/iterator.go
@@ -51,31 +51,30 @@ func (d *DescartesItem) Str() string {
 //
 // An example is below:
 //
-//	import (
-//        "fmt"
-//        "github.com/dragonflyoss/image-service/smoke/tests/tool"
-//    )
+//		import (
+//	       "fmt"
+//	       "github.com/dragonflyoss/image-service/smoke/tests/tool"
+//	   )
 //
-//	products := tool.DescartesIterator{}
-//	products.
-//		Dimension("name", []interface{}{"foo", "imoer", "morgan"}).
-//		Dimension("age", []interface{}{"20", "30"}).
-//		Skip(func(item *tool.DescartesItem) bool {
-//    		// skip ("morgan", "30")
-//    		return item.GetString("name") == "morgan" && param.GetString("age") == "30"
-//		})
+//		products := tool.DescartesIterator{}
+//		products.
+//			Dimension("name", []interface{}{"foo", "imoer", "morgan"}).
+//			Dimension("age", []interface{}{"20", "30"}).
+//			Skip(func(item *tool.DescartesItem) bool {
+//	   		// skip ("morgan", "30")
+//	   		return item.GetString("name") == "morgan" && param.GetString("age") == "30"
+//			})
 //
-//    // output:
-//    //       age: 20, name: foo
-//    //       age: 20, name: imoer
-//    //       age: 20, name: morgan
-//    //       age: 30, name: foo
-//    //       age: 30, name: imoer
-//    for products.HasNext(){
-//        item := products.Next()
-//        fmt.Println(item.Str())
-//    }
-//
+//	   // output:
+//	   //       age: 20, name: foo
+//	   //       age: 20, name: imoer
+//	   //       age: 20, name: morgan
+//	   //       age: 30, name: foo
+//	   //       age: 30, name: imoer
+//	   for products.HasNext(){
+//	       item := products.Next()
+//	       fmt.Println(item.Str())
+//	   }
 type DescartesIterator struct {
 	cursores  []int
 	valLists  [][]interface{}

--- a/smoke/tests/tool/test/suite.go
+++ b/smoke/tests/tool/test/suite.go
@@ -45,134 +45,134 @@ type Generator func() (name string, testCase Case)
 //
 // Example1: synchronized way
 //
-//        import (
-//            "fmt"
-//            "testing"
+//	import (
+//	    "fmt"
+//	    "testing"
 //
-//            "github.com/stretchr/testify/require"
-//        )
+//	    "github.com/stretchr/testify/require"
+//	)
 //
-//        type TestSuite struct{}
+//	type TestSuite struct{}
 //
-//        func (s *TestSuite) TestOk(t *testing.T) {
-//            require.Equal(t, 1, 1)
-//        }
+//	func (s *TestSuite) TestOk(t *testing.T) {
+//	    require.Equal(t, 1, 1)
+//	}
 //
-//        func (s *TestSuite) TestFail(t *testing.T) {
-//            require.Equal(t, 1, 2)
-//        }
+//	func (s *TestSuite) TestFail(t *testing.T) {
+//	    require.Equal(t, 1, 2)
+//	}
 //
-//        func (s *TestSuite) TestDynamicTest() TestGenerator {
-//            caseNum := 0
-//            return func() (name string, testCase TestCase) {
-//                if caseNum <= 5 {
-//                    testCase = func(t *testing.T) {
-//                        require.Equal(t, 1, 2)
-//                    }
-//                }
-//                caseNum++
-//                return fmt.Sprintf("dynamic_test_%v", caseNum), testCase
-//            }
-//        }
+//	func (s *TestSuite) TestDynamicTest() TestGenerator {
+//	    caseNum := 0
+//	    return func() (name string, testCase TestCase) {
+//	        if caseNum <= 5 {
+//	            testCase = func(t *testing.T) {
+//	                require.Equal(t, 1, 2)
+//	            }
+//	        }
+//	        caseNum++
+//	        return fmt.Sprintf("dynamic_test_%v", caseNum), testCase
+//	    }
+//	}
 //
-//        func Test1(t *testing.T) {
-//            Run(t, &TestSuite{}, Sync)
-//        }
+//	func Test1(t *testing.T) {
+//	    Run(t, &TestSuite{}, Sync)
+//	}
 //
 // Output:
-//        `go test -v --parallel 4`
-//            1. The cases are serialized executed.
-//            2. The dynamic tests are generated and executed.
 //
-//        === RUN   Test1
-//        === RUN   Test1/dynamic_test_1
-//        === RUN   Test1/dynamic_test_2
-//        === RUN   Test1/dynamic_test_3
-//        === RUN   Test1/dynamic_test_4
-//        === RUN   Test1/dynamic_test_5
-//        === RUN   Test1/dynamic_test_6
-//        === RUN   Test1/TestFail
-//            suite_test.go:18:
-//                        Error Trace:    suite_test.go:18
-//                        Error:          Not equal:
-//                                        expected: 1
-//                                        actual  : 2
-//                        Test:           Test1/TestFail
-//        === RUN   Test1/TestOk
-//        --- FAIL: Test1 (0.00s)
-//            --- PASS: Test1/dynamic_test_1 (0.00s)
-//            --- PASS: Test1/dynamic_test_2 (0.00s)
-//            --- PASS: Test1/dynamic_test_3 (0.00s)
-//            --- PASS: Test1/dynamic_test_4 (0.00s)
-//            --- PASS: Test1/dynamic_test_5 (0.00s)
-//            --- PASS: Test1/dynamic_test_6 (0.00s)
-//            --- FAIL: Test1/TestFail (0.00s)
-//            --- PASS: Test1/TestOk (0.00s)
+//	`go test -v --parallel 4`
+//	    1. The cases are serialized executed.
+//	    2. The dynamic tests are generated and executed.
+//
+//	=== RUN   Test1
+//	=== RUN   Test1/dynamic_test_1
+//	=== RUN   Test1/dynamic_test_2
+//	=== RUN   Test1/dynamic_test_3
+//	=== RUN   Test1/dynamic_test_4
+//	=== RUN   Test1/dynamic_test_5
+//	=== RUN   Test1/dynamic_test_6
+//	=== RUN   Test1/TestFail
+//	    suite_test.go:18:
+//	                Error Trace:    suite_test.go:18
+//	                Error:          Not equal:
+//	                                expected: 1
+//	                                actual  : 2
+//	                Test:           Test1/TestFail
+//	=== RUN   Test1/TestOk
+//	--- FAIL: Test1 (0.00s)
+//	    --- PASS: Test1/dynamic_test_1 (0.00s)
+//	    --- PASS: Test1/dynamic_test_2 (0.00s)
+//	    --- PASS: Test1/dynamic_test_3 (0.00s)
+//	    --- PASS: Test1/dynamic_test_4 (0.00s)
+//	    --- PASS: Test1/dynamic_test_5 (0.00s)
+//	    --- PASS: Test1/dynamic_test_6 (0.00s)
+//	    --- FAIL: Test1/TestFail (0.00s)
+//	    --- PASS: Test1/TestOk (0.00s)
 //
 // Example2: asynchronized way
 //
-//        import (
-//            "fmt"
-//            "testing"
-//            "time"
-//        )
+//	import (
+//	    "fmt"
+//	    "testing"
+//	    "time"
+//	)
 //
-//        type AsyncTestSuite struct{}
+//	type AsyncTestSuite struct{}
 //
-//        func (s *AsyncTestSuite) Test1(t *testing.T) {
-//            for i := 0; i < 5; i++ {
-//                time.Sleep(time.Second)
-//            }
-//        }
+//	func (s *AsyncTestSuite) Test1(t *testing.T) {
+//	    for i := 0; i < 5; i++ {
+//	        time.Sleep(time.Second)
+//	    }
+//	}
 //
-//        func (s *AsyncTestSuite) Test2(t *testing.T) {
-//            for i := 0; i < 5; i++ {
-//                time.Sleep(time.Second)
-//            }
-//        }
+//	func (s *AsyncTestSuite) Test2(t *testing.T) {
+//	    for i := 0; i < 5; i++ {
+//	        time.Sleep(time.Second)
+//	    }
+//	}
 //
-//        func (s *AsyncTestSuite) Test3(t *testing.T) {
-//            for i := 0; i < 5; i++ {
-//                time.Sleep(time.Second)
-//            }
-//        }
+//	func (s *AsyncTestSuite) Test3(t *testing.T) {
+//	    for i := 0; i < 5; i++ {
+//	        time.Sleep(time.Second)
+//	    }
+//	}
 //
-//        func (s *AsyncTestSuite) TestDynamicTest() TestGenerator {
-//            caseNum := 0
-//            return func() (name string, testCase TestCase) {
-//                if caseNum <= 5 {
-//                    testCase = func(t *testing.T) {
-//                        for i := 0; i < 5; i++ {
-//                            time.Sleep(time.Second)
-//                        }
-//                    }
-//                }
-//                caseNum++
-//                return "", testCase
-//            }
-//        }
+//	func (s *AsyncTestSuite) TestDynamicTest() TestGenerator {
+//	    caseNum := 0
+//	    return func() (name string, testCase TestCase) {
+//	        if caseNum <= 5 {
+//	            testCase = func(t *testing.T) {
+//	                for i := 0; i < 5; i++ {
+//	                    time.Sleep(time.Second)
+//	                }
+//	            }
+//	        }
+//	        caseNum++
+//	        return "", testCase
+//	    }
+//	}
 //
-//        func Test1(t *testing.T) {
-//            Run(t, &AsyncTestSuite{})
-//        }
+//	func Test1(t *testing.T) {
+//	    Run(t, &AsyncTestSuite{})
+//	}
 //
 // Output:
-//        `go test -v --parallel 4`
-//            1. The cases are parallel executed, which leads to random completion.
-//            2. The dynamic tests are named automicly in lack of customized name.
 //
-//            --- PASS: Test1 (0.00s)
-//                --- PASS: Test1/TestDynamicTest_4 (5.00s)
-//                --- PASS: Test1/Test1 (5.00s)
-//                --- PASS: Test1/TestDynamicTest_6 (5.00s)
-//                --- PASS: Test1/TestDynamicTest_5 (5.00s)
-//                --- PASS: Test1/TestDynamicTest_2 (5.00s)
-//                --- PASS: Test1/TestDynamicTest_3 (5.00s)
-//                --- PASS: Test1/TestDynamicTest_1 (5.00s)
-//                --- PASS: Test1/Test3 (5.00s)
-//                --- PASS: Test1/Test2 (5.00s)
+//	`go test -v --parallel 4`
+//	    1. The cases are parallel executed, which leads to random completion.
+//	    2. The dynamic tests are named automicly in lack of customized name.
 //
-//
+//	    --- PASS: Test1 (0.00s)
+//	        --- PASS: Test1/TestDynamicTest_4 (5.00s)
+//	        --- PASS: Test1/Test1 (5.00s)
+//	        --- PASS: Test1/TestDynamicTest_6 (5.00s)
+//	        --- PASS: Test1/TestDynamicTest_5 (5.00s)
+//	        --- PASS: Test1/TestDynamicTest_2 (5.00s)
+//	        --- PASS: Test1/TestDynamicTest_3 (5.00s)
+//	        --- PASS: Test1/TestDynamicTest_1 (5.00s)
+//	        --- PASS: Test1/Test3 (5.00s)
+//	        --- PASS: Test1/Test2 (5.00s)
 func Run(t *testing.T, suite interface{}, opts ...Option) {
 
 	cases := reflect.ValueOf(suite)


### PR DESCRIPTION
To resolve the panic when run golangci-lint:

```
panic: load embedded ruleguard rules: rules/rules.go:13: can't load fmt
```