### PR TITLE
rafs: optimize Node::name() to reduce image build time

### DIFF
--- a/rafs/src/builder/core/node.rs
+++ b/rafs/src/builder/core/node.rs
@@ -711,7 +711,9 @@ impl Node {
 
     /// Get filename of the inode.
     pub fn name(&self) -> &OsStr {
-        if self.path() == &self.info.source {
+        if let Some(name) = self.target_vec().last() {
+            name
+        } else if self.path() == &self.info.source {
             OsStr::from_bytes(ROOT_PATH_NAME)
         } else {
             // Safe to unwrap because `path` is returned from `path()` which is canonicalized


### PR DESCRIPTION
According to perf flamegraph, Node::name() costs too much time when generating nydus images from tar files. So optimize it.