### PR TITLE
change the pull_request event to pull_request_target

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: ["*", "**"]
     paths-ignore: [ '**.md', '**.png', '**.jpg', '**.svg', '**/docs/**' ]
-  pull_request:
+  pull_request_target:
     branches: ["*", "**"]
     paths-ignore: [ '**.md', '**.png', '**.jpg', '**.svg', '**/docs/**' ]
   schedule:


### PR DESCRIPTION
In #1219 , [we can't comment on PR](https://github.com/dragonflyoss/image-service/actions/runs/4739197938/jobs/8413885944), so can we change the event from pull_request to pull_request_target to enable the action havs permission to comment on PR.

**But I'm not sure if this will cause any security issues?**