### PR TITLE
action: add unit test coverage check workflow

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,25 @@
+coverage:
+  status:
+    project:
+      default:
+        enabled: yes
+        target: auto  # auto compares coverage to the previous base commit
+        # adjust accordingly based on how flaky your tests are
+        # this allows a 1% drop from the previous base commit coverage
+        threshold: 1%
+    patch:
+      default:
+        target: 25%   # the required coverage value in each patch
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: false # if true: only post the comment if coverage changes
+
+codecov:
+  require_ci_to_pass: false
+  notify:
+    wait_for_ci: false
+
+# When modifying this file, please validate using
+# curl -X POST --data-binary @codecov.yml https://codecov.io/validate

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -141,6 +141,26 @@ jobs:
       run: |
         make ut
 
+  nydus-unit-test-coverage:
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_COLOR: always
+    steps:
+      - uses: actions/checkout@v3
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2.2.0
+        with:
+          cache-on-failure: true
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Generate code coverage
+        run: make coverage-codecov
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          files: codecov.json
+          fail_ci_if_error: true
+
   nydus-cargo-deny:
     name: cargo-deny
     runs-on: ubuntu-latest


### PR DESCRIPTION
1. Introduce `make coverage` to print coverage in console.
2. Github CI use `make coverage-codecov` to get coverage info.