### PR TITLE
[backport] action: fix smoke test for branch pattern

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -2,10 +2,10 @@ name: Smoke Test
 
 on:
   push:
-    branches: ["**"]
+    branches: ["**", "stable/**"]
     paths-ignore: [ '**.md', '**.png', '**.jpg', '**.svg', '**/docs/**' ]
-  pull_request:
-    branches: ["**"]
+  pull_request_target:
+    branches: ["**", "stable/**"]
     paths-ignore: [ '**.md', '**.png', '**.jpg', '**.svg', '**/docs/**' ]
   schedule:
     # Run daily sanity check at 03:00 clock UTC


### PR DESCRIPTION
To match `master` and `stable/*` branches at least.