### PR TITLE
action: add zran-no-prefetch benchmark and make smoke.yml tidy

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -14,10 +14,8 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  SNAPSHOOTER_VERSION: 0.7.3
-  NERDCTL_VERSION: 1.3.0
-  CNI_PLUGINS_VERSION: 1.2.0
   IMAGE: wordpress
+  TAG: 6.1.1
 
 jobs:
   contrib-build:
@@ -148,23 +146,11 @@ jobs:
       with:
         name: nydusify-artifact
         path: contrib/nydusify/cmd
-    - name: Prepare Nerdctl Environment
+    - name: Prepare OCI Environment
       run: |
-        sudo install -D -m 755 contrib/nydusify/cmd/nydusify /usr/local/bin
-        sudo install -D -m 755 target/release/nydusd target/release/nydus-image /usr/local/bin
-        sudo wget https://github.com/containerd/nerdctl/releases/download/v${{env.NERDCTL_VERSION}}/nerdctl-${{env.NERDCTL_VERSION}}-linux-amd64.tar.gz
-        sudo tar -xzvf nerdctl-${{env.NERDCTL_VERSION}}-linux-amd64.tar.gz -C /usr/local/bin
-        sudo mkdir -p /opt/cni/bin
-        sudo wget https://github.com/containernetworking/plugins/releases/download/v${{env.CNI_PLUGINS_VERSION}}/cni-plugins-linux-amd64-v${{env.CNI_PLUGINS_VERSION}}.tgz 
-        sudo tar -xzvf cni-plugins-linux-amd64-v${{env.CNI_PLUGINS_VERSION}}.tgz -C /opt/cni/bin
-        sudo install -D misc/benchmark/cni_bridge.conf /etc/cni/net.d/bridge.conf
-    - name: Prepare OCI Registry Environment
-      run: |
-        sudo docker run -d --restart=always -p 5000:5000 --name registry registry
-        sudo docker pull ${{env.IMAGE}} && docker tag ${{env.IMAGE}}:latest localhost:5000/${{env.IMAGE}}:latest
-        sudo docker push localhost:5000/${{env.IMAGE}}:latest
-        git clone https://github.com/magnific0/wondershaper.git
-        sudo install -D -m 755 wondershaper/wondershaper /usr/local/bin
+        sudo bash misc/benchmark/prepare_env.sh oci
+        sudo docker pull ${{env.IMAGE}}:${{env.TAG}} && docker tag ${{env.IMAGE}}:${{env.TAG}} localhost:5000/${{env.IMAGE}}:${{env.TAG}}
+        sudo docker push localhost:5000/${{env.IMAGE}}:${{env.TAG}}
     - name: BenchMark Test
       run: |
         cd misc/benchmark
@@ -193,32 +179,11 @@ jobs:
         path: contrib/nydusify/cmd
     - name: Prepare Nydus Environment
       run: |
-        sudo install -D -m 755 contrib/nydusify/cmd/nydusify /usr/local/bin
-        sudo install -D -m 755 target/release/nydusd target/release/nydus-image /usr/local/bin
-        wget https://github.com/containerd/nydus-snapshotter/releases/download/v${{env.SNAPSHOOTER_VERSION}}/nydus-snapshotter-v${{env.SNAPSHOOTER_VERSION}}-x86_64.tgz
-        tar zxvf nydus-snapshotter-v${{env.SNAPSHOOTER_VERSION}}-x86_64.tgz
-        sudo install -D -m 755 nydus-snapshotter/containerd-nydus-grpc /usr/local/bin/
-        sudo wget https://github.com/containerd/nerdctl/releases/download/v${{env.NERDCTL_VERSION}}/nerdctl-${{env.NERDCTL_VERSION}}-linux-amd64.tar.gz
-        sudo tar -xzvf nerdctl-${{env.NERDCTL_VERSION}}-linux-amd64.tar.gz -C /usr/local/bin
-        sudo mkdir -p /opt/cni/bin
-        sudo wget https://github.com/containernetworking/plugins/releases/download/v${{env.CNI_PLUGINS_VERSION}}/cni-plugins-linux-amd64-v${{env.CNI_PLUGINS_VERSION}}.tgz 
-        sudo tar -xzvf cni-plugins-linux-amd64-v${{env.CNI_PLUGINS_VERSION}}.tgz -C /opt/cni/bin
-        sudo install -D misc/benchmark/cni_bridge.conf /etc/cni/net.d/bridge.conf
-        sudo install -D misc/benchmark/nydusd_config.json /etc/nydus/config.json
-        sudo install -D misc/benchmark/containerd_config.toml /etc/containerd/config.toml
-        sudo systemctl restart containerd
-        sudo install -D misc/benchmark/nydus-snapshotter.service /etc/systemd/system/nydus-snapshotter.service
-        sudo systemctl start nydus-snapshotter
-    - name: Prepare Nydus Registry Environment
-      run: |
-        sudo docker run -d --restart=always -p 5000:5000 --name registry registry
+        sudo bash misc/benchmark/prepare_env.sh nydus
         sudo DOCKER_CONFIG=$HOME/.docker nydusify convert \
-          --source ${{env.IMAGE}}:latest \
-          --target localhost:5000/${{env.IMAGE}}:latest_nydus \
-          --fs-version 6 \
-          --platform linux/amd64,linux/arm64
-        git clone https://github.com/magnific0/wondershaper.git
-        sudo install -D -m 755 wondershaper/wondershaper /usr/local/bin
+          --source ${{env.IMAGE}}:${{env.TAG}} \
+          --target localhost:5000/${{env.IMAGE}}:${{env.TAG}}_nydus \
+          --fs-version 6
     - name: BenchMark Test
       run: |
         cd misc/benchmark
@@ -227,6 +192,41 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: benchmark-nydus-no-prefetch
+        path: misc/benchmark/${{env.IMAGE}}.csv
+
+  benchmark-zran-no-prefetch:
+    runs-on: ubuntu-latest
+    needs: [contrib-build, nydus-build]
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Download Nydus
+      uses: actions/download-artifact@master
+      with:
+        name: nydus-artifact
+        path: target/release
+    - name: Download Nydusify
+      uses: actions/download-artifact@master
+      with:
+        name: nydusify-artifact
+        path: contrib/nydusify/cmd
+    - name: Prepare Nydus Environment
+      run: |
+        sudo bash misc/benchmark/prepare_env.sh nydus
+        sudo docker pull ${{env.IMAGE}}:${{env.TAG}} && docker tag ${{env.IMAGE}}:${{env.TAG}} localhost:5000/${{env.IMAGE}}:${{env.TAG}}
+        sudo docker push localhost:5000/${{env.IMAGE}}:${{env.TAG}}
+        sudo DOCKER_CONFIG=$HOME/.docker nydusify convert \
+          --source localhost:5000/${{env.IMAGE}}:${{env.TAG}} \
+          --target localhost:5000/${{env.IMAGE}}:${{env.TAG}}_nydus \
+          --fs-version 6
+    - name: BenchMark Test
+      run: |
+        cd misc/benchmark
+        sudo python3 benchmark.py --mode nydus-no-prefetch
+    - name: Save Test Result
+      uses: actions/upload-artifact@v3
+      with:
+        name: benchmark-zran-no-prefetch
         path: misc/benchmark/${{env.IMAGE}}.csv
 
   benchmark-nydus-all-prefetch:
@@ -247,32 +247,11 @@ jobs:
         path: contrib/nydusify/cmd
     - name: Prepare Nydus Environment
       run: |
-        sudo install -D -m 755 contrib/nydusify/cmd/nydusify /usr/local/bin
-        sudo install -D -m 755 target/release/nydusd target/release/nydus-image /usr/local/bin
-        wget https://github.com/containerd/nydus-snapshotter/releases/download/v${{env.SNAPSHOOTER_VERSION}}/nydus-snapshotter-v${{env.SNAPSHOOTER_VERSION}}-x86_64.tgz
-        tar zxvf nydus-snapshotter-v${{env.SNAPSHOOTER_VERSION}}-x86_64.tgz
-        sudo install -D -m 755 nydus-snapshotter/containerd-nydus-grpc /usr/local/bin/
-        sudo wget https://github.com/containerd/nerdctl/releases/download/v${{env.NERDCTL_VERSION}}/nerdctl-${{env.NERDCTL_VERSION}}-linux-amd64.tar.gz
-        sudo tar -xzvf nerdctl-${{env.NERDCTL_VERSION}}-linux-amd64.tar.gz -C /usr/local/bin
-        sudo mkdir -p /opt/cni/bin
-        sudo wget https://github.com/containernetworking/plugins/releases/download/v${{env.CNI_PLUGINS_VERSION}}/cni-plugins-linux-amd64-v${{env.CNI_PLUGINS_VERSION}}.tgz 
-        sudo tar -xzvf cni-plugins-linux-amd64-v${{env.CNI_PLUGINS_VERSION}}.tgz -C /opt/cni/bin
-        sudo install -D misc/benchmark/cni_bridge.conf /etc/cni/net.d/bridge.conf
-        sudo install -D misc/benchmark/nydusd_config.json /etc/nydus/config.json
-        sudo install -D misc/benchmark/containerd_config.toml /etc/containerd/config.toml
-        sudo systemctl restart containerd
-        sudo install -D misc/benchmark/nydus-snapshotter.service /etc/systemd/system/nydus-snapshotter.service
-        sudo systemctl start nydus-snapshotter
-    - name: Prepare Nydus Registry Environment
-      run: |
-        sudo docker run -d --restart=always -p 5000:5000 --name registry registry
+        sudo bash misc/benchmark/prepare_env.sh nydus
         sudo DOCKER_CONFIG=$HOME/.docker nydusify convert \
-          --source ${{env.IMAGE}}:latest \
-          --target localhost:5000/${{env.IMAGE}}:latest_nydus \
-          --fs-version 6 \
-          --platform linux/amd64,linux/arm64
-        git clone https://github.com/magnific0/wondershaper.git
-        sudo install -D -m 755 wondershaper/wondershaper /usr/local/bin
+          --source ${{env.IMAGE}}:${{env.TAG}} \
+          --target localhost:5000/${{env.IMAGE}}:${{env.TAG}}_nydus \
+          --fs-version 6
     - name: BenchMark Test
       run: |
         cd misc/benchmark
@@ -301,35 +280,14 @@ jobs:
         path: contrib/nydusify/cmd
     - name: Prepare Nydus Environment
       run: |
-        sudo install -D -m 755 contrib/nydusify/cmd/nydusify /usr/local/bin
-        sudo install -D -m 755 target/release/nydusd target/release/nydus-image /usr/local/bin
-        wget https://github.com/containerd/nydus-snapshotter/releases/download/v${{env.SNAPSHOOTER_VERSION}}/nydus-snapshotter-v${{env.SNAPSHOOTER_VERSION}}-x86_64.tgz
-        tar zxvf nydus-snapshotter-v${{env.SNAPSHOOTER_VERSION}}-x86_64.tgz
-        sudo install -D -m 755 nydus-snapshotter/containerd-nydus-grpc /usr/local/bin/
-        sudo wget https://github.com/containerd/nerdctl/releases/download/v${{env.NERDCTL_VERSION}}/nerdctl-${{env.NERDCTL_VERSION}}-linux-amd64.tar.gz
-        sudo tar -xzvf nerdctl-${{env.NERDCTL_VERSION}}-linux-amd64.tar.gz -C /usr/local/bin
-        sudo mkdir -p /opt/cni/bin
-        sudo wget https://github.com/containernetworking/plugins/releases/download/v${{env.CNI_PLUGINS_VERSION}}/cni-plugins-linux-amd64-v${{env.CNI_PLUGINS_VERSION}}.tgz 
-        sudo tar -xzvf cni-plugins-linux-amd64-v${{env.CNI_PLUGINS_VERSION}}.tgz -C /opt/cni/bin
-        sudo install -D misc/benchmark/cni_bridge.conf /etc/cni/net.d/bridge.conf
-        sudo install -D misc/benchmark/nydusd_config.json /etc/nydus/config.json
-        sudo install -D misc/benchmark/containerd_config.toml /etc/containerd/config.toml
-        sudo systemctl restart containerd
-        sudo install -D misc/benchmark/nydus-snapshotter.service /etc/systemd/system/nydus-snapshotter.service
-        sudo systemctl start nydus-snapshotter
-    - name: Prepare Nydus Registry Environment
-      run: |
-        sudo docker run -d --restart=always -p 5000:5000 --name registry registry
-        sudo docker pull ${{env.IMAGE}} && docker tag ${{env.IMAGE}}:latest localhost:5000/${{env.IMAGE}}:latest
-        sudo docker push localhost:5000/${{env.IMAGE}}:latest
+        sudo bash misc/benchmark/prepare_env.sh nydus
+        sudo docker pull ${{env.IMAGE}}:${{env.TAG}} && docker tag ${{env.IMAGE}}:${{env.TAG}} localhost:5000/${{env.IMAGE}}:${{env.TAG}}
+        sudo docker push localhost:5000/${{env.IMAGE}}:${{env.TAG}}
         sudo DOCKER_CONFIG=$HOME/.docker nydusify convert \
-          --source localhost:5000/${{env.IMAGE}}:latest \
-          --target localhost:5000/${{env.IMAGE}}:latest_nydus \
+          --source localhost:5000/${{env.IMAGE}}:${{env.TAG}} \
+          --target localhost:5000/${{env.IMAGE}}:${{env.TAG}}_nydus \
           --fs-version 6 \
-          --oci-ref \
-          --platform linux/amd64,linux/arm64
-        git clone https://github.com/magnific0/wondershaper.git
-        sudo install -D -m 755 wondershaper/wondershaper /usr/local/bin
+          --oci-ref
     - name: BenchMark Test
       run: |
         cd misc/benchmark
@@ -358,32 +316,11 @@ jobs:
         path: contrib/nydusify/cmd
     - name: Prepare Nydus Environment
       run: |
-        sudo install -D -m 755 contrib/nydusify/cmd/nydusify /usr/local/bin
-        sudo install -D -m 755 target/release/nydusd target/release/nydus-image /usr/local/bin
-        wget https://github.com/containerd/nydus-snapshotter/releases/download/v${{env.SNAPSHOOTER_VERSION}}/nydus-snapshotter-v${{env.SNAPSHOOTER_VERSION}}-x86_64.tgz
-        tar zxvf nydus-snapshotter-v${{env.SNAPSHOOTER_VERSION}}-x86_64.tgz
-        sudo install -D -m 755 nydus-snapshotter/containerd-nydus-grpc /usr/local/bin/
-        sudo wget https://github.com/containerd/nerdctl/releases/download/v${{env.NERDCTL_VERSION}}/nerdctl-${{env.NERDCTL_VERSION}}-linux-amd64.tar.gz
-        sudo tar -xzvf nerdctl-${{env.NERDCTL_VERSION}}-linux-amd64.tar.gz -C /usr/local/bin
-        sudo mkdir -p /opt/cni/bin
-        sudo wget https://github.com/containernetworking/plugins/releases/download/v${{env.CNI_PLUGINS_VERSION}}/cni-plugins-linux-amd64-v${{env.CNI_PLUGINS_VERSION}}.tgz 
-        sudo tar -xzvf cni-plugins-linux-amd64-v${{env.CNI_PLUGINS_VERSION}}.tgz -C /opt/cni/bin
-        sudo install -D misc/benchmark/cni_bridge.conf /etc/cni/net.d/bridge.conf
-        sudo install -D misc/benchmark/nydusd_config.json /etc/nydus/config.json
-        sudo install -D misc/benchmark/containerd_config.toml /etc/containerd/config.toml
-        sudo systemctl restart containerd
-        sudo install -D misc/benchmark/nydus-snapshotter.service /etc/systemd/system/nydus-snapshotter.service
-        sudo systemctl start nydus-snapshotter
-    - name: Prepare Nydus Registry Environment
-      run: |
-        sudo docker run -d --restart=always -p 5000:5000 --name registry registry
+        sudo bash misc/benchmark/prepare_env.sh nydus
         sudo DOCKER_CONFIG=$HOME/.docker nydusify convert \
-          --source ${{env.IMAGE}}:latest \
-          --target localhost:5000/${{env.IMAGE}}:latest_nydus \
-          --fs-version 6 \
-          --platform linux/amd64,linux/arm64
-        git clone https://github.com/magnific0/wondershaper.git
-        sudo install -D -m 755 wondershaper/wondershaper /usr/local/bin
+          --source ${{env.IMAGE}}:${{env.TAG}} \
+          --target localhost:5000/${{env.IMAGE}}:${{env.TAG}}_nydus \
+          --fs-version 6
     - name: BenchMark Test
       run: |
         cd misc/benchmark
@@ -396,58 +333,18 @@ jobs:
 
   benchmark-result:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
-    needs: [benchmark-oci, benchmark-zran-all-prefetch, benchmark-nydus-no-prefetch, benchmark-nydus-all-prefetch, benchmark-nydus-filelist-prefetch]
+    needs: [benchmark-oci, benchmark-zran-all-prefetch, benchmark-zran-no-prefetch, benchmark-nydus-no-prefetch, benchmark-nydus-all-prefetch, benchmark-nydus-filelist-prefetch]
     steps:
-      - name: Download benchmark-oci
-        uses: actions/download-artifact@master
+      - name: Checkout
+        uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
+      - uses: geekyeggo/delete-artifact@v2
         with:
-          name: benchmark-oci
-          path: benchmark-oci
-      - name: Download benchmark-zran-all-prefetch
-        uses: actions/download-artifact@master
-        with:
-          name: benchmark-zran-all-prefetch
-          path: benchmark-zran-all-prefetch
-      - name: Download benchmark-nydus-no-prefetch
-        uses: actions/download-artifact@master
-        with:
-          name: benchmark-nydus-no-prefetch
-          path: benchmark-nydus-no-prefetch
-      - name: Download benchmark-nydus-all-prefetch
-        uses: actions/download-artifact@master
-        with:
-          name: benchmark-nydus-all-prefetch
-          path: benchmark-nydus-all-prefetch
-      - name: Download benchmark-nydus-filelist-prefetch
-        uses: actions/download-artifact@master
-        with:
-          name: benchmark-nydus-filelist-prefetch
-          path: benchmark-nydus-filelist-prefetch
+          name: '*'
       - name: Save Result
         run: |
-          sudo install -m 755 benchmark-oci/wordpress.csv oci.csv
-          sudo install -m 755 benchmark-zran-all-prefetch/wordpress.csv zran-all-prefetch.csv
-          sudo install -m 755 benchmark-nydus-no-prefetch/wordpress.csv nydus-no-prefetch.csv
-          sudo install -m 755 benchmark-nydus-all-prefetch/wordpress.csv nydus-all-prefetch.csv
-          sudo install -m 755 benchmark-nydus-filelist-prefetch/wordpress.csv nydus-filelist-prefetch.csv
+          sudo bash misc/benchmark/benchmark_summary.sh > $GITHUB_STEP_SUMMARY
 
-          echo "| benchmark-result | pull-elapsed(s) | create-elapsed(s) | run-elapsed(s) | total-elapsed(s) |" > $GITHUB_STEP_SUMMARY
-          echo "|:-------|:-----------------:|:-------------------:|:----------------:|:------------------:|" >> $GITHUB_STEP_SUMMARY
-          
-          for file in *.csv; do
-            if ! [ -f "$file" ]; then
-              continue
-            fi
-            filename=$(basename "$file" .csv)
-            tail -n +2 "$file" | while read line; do
-              pull=$(echo "$line" | cut -d ',' -f 2)
-              create=$(echo "$line" | cut -d ',' -f 3)
-              run=$(echo "$line" | cut -d ',' -f 4)
-              total=$(echo "$line" | cut -d ',' -f 5)
-              printf "| %s | %s | %s | %s | %s |\n" "$filename" "$pull" "$create" "$run" "$total"
-            done >> $GITHUB_STEP_SUMMARY
-          done
   nydus-unit-test:
     runs-on: ubuntu-latest
     steps:

--- a/misc/benchmark/benchmark.py
+++ b/misc/benchmark/benchmark.py
@@ -40,8 +40,6 @@ def main():
             exit(-1)
     # bench
     start_bench(cfg, cfg["image"], mode)
-    util.show_csv(util.image_repo(cfg["image"]) + ".csv")
-
 
 def collect_metrics(cfg: dict, image: str) -> str:
     """

--- a/misc/benchmark/benchmark_summary.sh
+++ b/misc/benchmark/benchmark_summary.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+sudo install -m 755 benchmark-oci/wordpress.csv oci.csv
+sudo install -m 755 benchmark-zran-all-prefetch/wordpress.csv zran-all-prefetch.csv
+sudo install -m 755 benchmark-zran-no-prefetch/wordpress.csv zran-no-prefetch.csv
+sudo install -m 755 benchmark-nydus-no-prefetch/wordpress.csv nydus-no-prefetch.csv
+sudo install -m 755 benchmark-nydus-all-prefetch/wordpress.csv nydus-all-prefetch.csv
+sudo install -m 755 benchmark-nydus-filelist-prefetch/wordpress.csv nydus-filelist-prefetch.csv
+
+echo "| benchmark-result | pull-elapsed(s) | create-elapsed(s) | run-elapsed(s) | total-elapsed(s) |"
+echo "|:-------|:-----------------:|:-------------------:|:----------------:|:------------------:|"
+
+files=(oci.csv nydus-all-prefetch.csv zran-all-prefetch.csv nydus-no-prefetch.csv zran-no-prefetch.csv nydus-filelist-prefetch.csv)
+
+for file in "${files[@]}"; do
+if ! [ -f "$file" ]; then
+    continue
+fi
+filename=$(basename "$file" .csv)
+tail -n +2 "$file" | while read line; do
+    pull=$(echo "$line" | cut -d ',' -f 2)
+    create=$(echo "$line" | cut -d ',' -f 3)
+    run=$(echo "$line" | cut -d ',' -f 4)
+    total=$(echo "$line" | cut -d ',' -f 5)
+    printf "| %s | %s | %s | %s | %s |\n" "$filename" "$pull" "$create" "$run" "$total"
+done
+done

--- a/misc/benchmark/config.yml
+++ b/misc/benchmark/config.yml
@@ -3,4 +3,4 @@ insecure_source_registry: False
 local_registry: localhost:5000
 insecure_local_registry: True
 bandwith: 81920
-image: wordpress:latest
+image: wordpress:6.1.1

--- a/misc/benchmark/prepare_env.sh
+++ b/misc/benchmark/prepare_env.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+readonly SNAPSHOOTER_VERSION=0.7.3
+readonly NERDCTL_VERSION=1.3.0
+readonly CNI_PLUGINS_VERSION=1.2.0
+
+# setup nerdctl and nydusd env
+case "$1" in
+  "oci")
+    sudo install -D -m 755 contrib/nydusify/cmd/nydusify /usr/local/bin
+    sudo install -D -m 755 target/release/nydusd target/release/nydus-image /usr/local/bin
+    sudo wget https://github.com/containerd/nerdctl/releases/download/v$NERDCTL_VERSION/nerdctl-$NERDCTL_VERSION-linux-amd64.tar.gz
+    sudo tar -xzvf nerdctl-$NERDCTL_VERSION-linux-amd64.tar.gz -C /usr/local/bin
+    sudo mkdir -p /opt/cni/bin
+    sudo wget https://github.com/containernetworking/plugins/releases/download/v$CNI_PLUGINS_VERSION/cni-plugins-linux-amd64-v$CNI_PLUGINS_VERSION.tgz 
+    sudo tar -xzvf cni-plugins-linux-amd64-v$CNI_PLUGINS_VERSION.tgz -C /opt/cni/bin
+    sudo install -D misc/benchmark/cni_bridge.conf /etc/cni/net.d/bridge.conf
+    ;;
+  "nydus")
+    sudo install -D -m 755 contrib/nydusify/cmd/nydusify /usr/local/bin
+    sudo install -D -m 755 target/release/nydusd target/release/nydus-image /usr/local/bin
+    wget https://github.com/containerd/nydus-snapshotter/releases/download/v$SNAPSHOOTER_VERSION/nydus-snapshotter-v$SNAPSHOOTER_VERSION-x86_64.tgz
+    tar zxvf nydus-snapshotter-v$SNAPSHOOTER_VERSION-x86_64.tgz
+    sudo install -D -m 755 nydus-snapshotter/containerd-nydus-grpc /usr/local/bin/
+    sudo wget https://github.com/containerd/nerdctl/releases/download/v$NERDCTL_VERSION/nerdctl-$NERDCTL_VERSION-linux-amd64.tar.gz
+    sudo tar -xzvf nerdctl-$NERDCTL_VERSION-linux-amd64.tar.gz -C /usr/local/bin
+    sudo mkdir -p /opt/cni/bin
+    sudo wget https://github.com/containernetworking/plugins/releases/download/v$CNI_PLUGINS_VERSION/cni-plugins-linux-amd64-v$CNI_PLUGINS_VERSION.tgz 
+    sudo tar -xzvf cni-plugins-linux-amd64-v$CNI_PLUGINS_VERSION.tgz -C /opt/cni/bin
+    sudo install -D misc/benchmark/cni_bridge.conf /etc/cni/net.d/bridge.conf
+    sudo install -D misc/benchmark/nydusd_config.json /etc/nydus/config.json
+    sudo install -D misc/benchmark/containerd_config.toml /etc/containerd/config.toml
+    sudo systemctl restart containerd
+    sudo install -D misc/benchmark/nydus-snapshotter.service /etc/systemd/system/nydus-snapshotter.service
+    sudo systemctl start nydus-snapshotter
+    ;;
+  *)
+    echo "Unknown command: $1"
+    ;;
+esac
+# setup registry env
+sudo docker run -d --restart=always -p 5000:5000 --name registry registry
+git clone https://github.com/magnific0/wondershaper.git
+sudo install -D -m 755 wondershaper/wondershaper /usr/local/bin

--- a/misc/benchmark/util.py
+++ b/misc/benchmark/util.py
@@ -59,13 +59,5 @@ def image_nydus_prefetch(ref: str) -> str:
     return image_repo(ref) + ":" + image_tag(ref) + "_nydus_prefetch"
 
 
-def show_csv(file_path: str):
-    with open(file_path, mode='r') as f:
-        reader = csv.reader(f)
-        for row in reader:
-            formatted_row = [f'{cell}' for cell in row]
-            print(','.join(formatted_row))
-
-
 def enable_wondersphaper(bandwith: int):
     os.system("sudo wondershaper -a docker0 -u " + str(bandwith) + " -d" + str(bandwith))


### PR DESCRIPTION
- Benchmark in smoke test has too many same steps, we can move them to shell and make [smoke.yml](https://github.com/dragonflyoss/image-service/tree/master/.github/workflows/smoke.yml) tidy by prepare_env.sh and benchmark_summary.sh.
- Add zran-no-prefetch benchmark.
- Change the benchmark-result order, set the oci in the first.
- Since https://github.com/dragonflyoss/image-service/pull/1238, we move the benchmark-result from PR comment to action summary, we should enable benchmark-result in push and schedule.
- Use the stable wordpress tag 6.11.
- Delete the artifacts after benchmark-result download all artifacts. Certainly, the nydus-integration-test had downloaded the artifacts.