### PR TITLE
action: add read-amount and read-count for benchmark

### DIFF
--- a/misc/benchmark/benchmark.py
+++ b/misc/benchmark/benchmark.py
@@ -43,9 +43,9 @@ def main():
 
 def collect_metrics(cfg: dict, image: str) -> str:
     """
-    collect metrics
+    collect container access metrics
     """
-    return metrics.collect(cfg["local_registry"], cfg["insecure_local_registry"], util.image_nydus(image))
+    return metrics.collect_access(cfg["local_registry"], cfg["insecure_local_registry"], util.image_nydus(image))
 
 
 def start_bench(cfg: dict, image: str, mode: str):
@@ -53,7 +53,7 @@ def start_bench(cfg: dict, image: str, mode: str):
     bench oci, nydus without prefetch, nydus with all prefetch, nydus witch prefetch file list
     """
     f = open(util.image_repo(image) + ".csv", "w")
-    csv_headers = "repo,pull_elapsed(s),create_elapsed(s),run_elapsed(s),total_elapsed(s)"
+    csv_headers = "repo,pull_elapsed(s),create_elapsed(s),run_elapsed(s),total_elapsed(s),read_amount(MB),read_count"
     f.writelines(csv_headers + "\n")
     f.flush()
     if mode == "oci":

--- a/misc/benchmark/benchmark_summary.sh
+++ b/misc/benchmark/benchmark_summary.sh
@@ -7,21 +7,26 @@ sudo install -m 755 benchmark-nydus-no-prefetch/wordpress.csv nydus-no-prefetch.
 sudo install -m 755 benchmark-nydus-all-prefetch/wordpress.csv nydus-all-prefetch.csv
 sudo install -m 755 benchmark-nydus-filelist-prefetch/wordpress.csv nydus-filelist-prefetch.csv
 
-echo "| benchmark-result | pull-elapsed(s) | create-elapsed(s) | run-elapsed(s) | total-elapsed(s) |"
-echo "|:-------|:-----------------:|:-------------------:|:----------------:|:------------------:|"
+echo "| bench-result | pull-elapsed(s) | create-elapsed(s) | run-elapsed(s) | total-elapsed(s) |read-amount(MB) |read-count |"
+echo "|:-------------|:---------------:|:-----------------:|:--------------:|:----------------:|:--------------:|:---------:|"
 
 files=(oci.csv nydus-all-prefetch.csv zran-all-prefetch.csv nydus-no-prefetch.csv zran-no-prefetch.csv nydus-filelist-prefetch.csv)
 
 for file in "${files[@]}"; do
-if ! [ -f "$file" ]; then
-    continue
-fi
-filename=$(basename "$file" .csv)
-tail -n +2 "$file" | while read line; do
-    pull=$(echo "$line" | cut -d ',' -f 2)
-    create=$(echo "$line" | cut -d ',' -f 3)
-    run=$(echo "$line" | cut -d ',' -f 4)
-    total=$(echo "$line" | cut -d ',' -f 5)
-    printf "| %s | %s | %s | %s | %s |\n" "$filename" "$pull" "$create" "$run" "$total"
-done
+    if ! [ -f "$file" ]; then
+        continue
+    fi
+    filename=$(basename "$file" .csv)
+    tail -n +2 "$file" | while read line; do
+        if [ -z "$line" ]; then
+            continue
+        fi
+        pull=$(echo "$line" | cut -d ',' -f 2)
+        create=$(echo "$line" | cut -d ',' -f 3)
+        run=$(echo "$line" | cut -d ',' -f 4)
+        total=$(echo "$line" | cut -d ',' -f 5)
+        amount=$(echo "$line" | cut -d ',' -f 6)
+        count=$(echo "$line" | cut -d ',' -f 7)
+        printf "| %s | %s | %s | %s | %s | %s | %s |\n" "$filename" "$pull" "$create" "$run" "$total" "$amount" "$count"
+    done
 done


### PR DESCRIPTION
We should add the ```read-amount``` and ```read-count``` for nydus benchmark to compare nydus, zran with different batchsize, config and so on.
> For oci benchmark we use "-" for these fields. 