### PR TITLE
action: replace cargo test with cargo nextest in CI

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -85,7 +85,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
     - name: Rust Cache
-      uses: Swatinem/rust-cache@v2.2.0
+      uses: Swatinem/rust-cache@v2
       with:
         cache-on-failure: true
     - name: Build Nydus
@@ -600,12 +600,14 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
     - name: Rust Cache
-      uses: Swatinem/rust-cache@v2.2.0
+      uses: Swatinem/rust-cache@v2
       with:
         cache-on-failure: true
+    - name: Install cargo nextest
+      uses: taiki-e/install-action@nextest
     - name: Unit Test
       run: |
-        make ut
+        make ut-nextest
 
   nydus-unit-test-coverage:
     runs-on: ubuntu-latest
@@ -614,7 +616,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Rust Cache
-        uses: Swatinem/rust-cache@v2.2.0
+        uses: Swatinem/rust-cache@v2
         with:
           cache-on-failure: true
       - name: Install cargo-llvm-cov

--- a/Makefile
+++ b/Makefile
@@ -109,8 +109,13 @@ install: release
 	@sudo install -m 755 target/release/nydus-image $(INSTALL_DIR_PREFIX)/nydus-image
 	@sudo install -m 755 target/release/nydusctl $(INSTALL_DIR_PREFIX)/nydusctl
 
+# unit test
 ut: .release_version
-	TEST_WORKDIR_PREFIX=$(TEST_WORKDIR_PREFIX) RUST_BACKTRACE=1 ${CARGO} test --workspace $(EXCLUDE_PACKAGES) $(CARGO_COMMON) $(CARGO_BUILD_FLAGS) -- --skip integration --nocapture --test-threads=8
+	TEST_WORKDIR_PREFIX=$(TEST_WORKDIR_PREFIX) RUST_BACKTRACE=1 ${CARGO} test --no-fail-fast --workspace $(EXCLUDE_PACKAGES) $(CARGO_COMMON) $(CARGO_BUILD_FLAGS) -- --skip integration --nocapture --test-threads=8
+
+# you need install cargo nextest first from: https://nexte.st/book/pre-built-binaries.html
+ut-nextest: .release_version
+	TEST_WORKDIR_PREFIX=$(TEST_WORKDIR_PREFIX) RUST_BACKTRACE=1 ${CARGO} nextest run --no-fail-fast --filter-expr 'test(test) - test(integration)' --workspace $(EXCLUDE_PACKAGES) $(CARGO_COMMON) $(CARGO_BUILD_FLAGS) --test-threads 8
 
 # install test dependencies
 pre-coverage:


### PR DESCRIPTION
1. Improve test speed and presents test results concisely.

Now we can see the execution time of all tests and optimize those slower ones.
```
        PASS [   0.004s] nydus-utils mpmc::tests::test_async_recv
        PASS [   0.011s] nydus-utils mpmc::tests::test_flush_channel
        PASS [   0.004s] nydus-utils mpmc::tests::test_new_channel
        PASS [   0.005s] nydus-utils reader::tests::test_file_range_reader
        PASS [   0.004s] nydus-utils tests::test_rounders
        PASS [   0.005s] nydus-utils trace::tests::test_event_trace
        PASS [   0.004s] nydus-utils types::tests::test_os_string_empty
        PASS [   0.004s] nydus-utils types::tests::test_os_string_size
        PASS [   0.004s] nydus-utils types::tests::test_pathbuf_size
        PASS [   0.006s] nydus-utils verity::tests::test_generate_mkl_tree_4097_entries
        PASS [   0.004s] nydus-utils verity::tests::test_generate_mkl_tree_one_entry
        PASS [   0.004s] nydus-utils verity::tests::test_generate_mkl_tree_two_entries
        PASS [   0.005s] nydus-utils verity::tests::test_generate_mkl_tree_zero_entry
        PASS [   0.004s] nydus-utils verity::tests::test_max_levels
        PASS [   0.978s] nydus-storage cache::state::blob_state_map::tests::test_chunk_map_perf
        PASS [   1.020s] nydus-storage cache::state::blob_state_map::tests::test_inflight_tracer_race
        PASS [   1.037s] nydus-storage cache::worker::tests::test_worker_mgr_new
        PASS [   5.019s] nydus-storage backend::http_proxy::tests::test_head_and_get
        PASS [   8.018s] nydus-storage cache::state::blob_state_map::tests::test_inflight_tracer
        PASS [  10.029s] nydus-storage cache::state::blob_state_map::tests::test_inflight_tracer_timeout
        PASS [  23.367s] nydus-storage cache::worker::tests::test_worker_mgr_rate_limiter
------------
     Summary [  24.259s] 215 tests run: 215 passed, 14 skipped
```