### PR TITLE
action: add benchmark on schedule

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -1,0 +1,297 @@
+name: Benchmark
+
+on:
+  schedule:
+    # Run at 03:00 clock UTC on Monday and Wednesday
+    - cron: "0 03 * * 1,3"
+  workflow_dispatch:
+
+env:
+  IMAGE: wordpress
+  TAG: 6.1.1
+
+jobs:
+  contrib-build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Setup Golang
+      uses: actions/setup-go@v3
+      with:
+        go-version: ~1.18
+    - name: Golang Cache
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod
+        key: ${{ runner.os }}-golang-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-golang-
+    - name: Build Contrib
+      run: |
+        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sudo sh -s -- -b /usr/local/bin v1.51.2
+        make -e DOCKER=false nydusify-release
+    - name: Upload Nydusify
+      uses: actions/upload-artifact@master
+      with:
+        name: nydusify-artifact
+        path: contrib/nydusify/cmd/nydusify
+
+  nydus-build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Rust Cache
+      uses: Swatinem/rust-cache@v2.2.0
+      with:
+        cache-on-failure: true
+    - name: Build Nydus
+      run: |
+        rustup component add rustfmt clippy
+        make
+    - name: Upload Nydus Binaries
+      uses: actions/upload-artifact@master
+      with:
+        name: nydus-artifact
+        path: |
+          target/release/nydus-image
+          target/release/nydusd
+
+  benchmark-oci:
+    runs-on: ubuntu-latest
+    needs: [contrib-build, nydus-build]
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Download Nydus
+      uses: actions/download-artifact@master
+      with:
+        name: nydus-artifact
+        path: target/release
+    - name: Download Nydusify
+      uses: actions/download-artifact@master
+      with:
+        name: nydusify-artifact
+        path: contrib/nydusify/cmd
+    - name: Prepare OCI Environment
+      run: |
+        sudo bash misc/benchmark/prepare_env.sh oci
+        sudo docker pull ${{env.IMAGE}}:${{env.TAG}} && docker tag ${{env.IMAGE}}:${{env.TAG}} localhost:5000/${{env.IMAGE}}:${{env.TAG}}
+        sudo docker push localhost:5000/${{env.IMAGE}}:${{env.TAG}}
+    - name: BenchMark Test
+      run: |
+        cd misc/benchmark
+        sudo python3 benchmark.py --mode oci
+    - name: Save Test Result
+      uses: actions/upload-artifact@v3
+      with:
+        name: benchmark-oci
+        path: misc/benchmark/${{env.IMAGE}}.csv
+
+  benchmark-nydus-no-prefetch:
+    runs-on: ubuntu-latest
+    needs: [contrib-build, nydus-build]
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Download Nydus
+      uses: actions/download-artifact@master
+      with:
+        name: nydus-artifact
+        path: target/release
+    - name: Download Nydusify
+      uses: actions/download-artifact@master
+      with:
+        name: nydusify-artifact
+        path: contrib/nydusify/cmd
+    - name: Prepare Nydus Environment
+      run: |
+        sudo bash misc/benchmark/prepare_env.sh nydus
+        sudo DOCKER_CONFIG=$HOME/.docker nydusify convert \
+          --source ${{env.IMAGE}}:${{env.TAG}} \
+          --target localhost:5000/${{env.IMAGE}}:${{env.TAG}}_nydus \
+          --fs-version 6
+    - name: BenchMark Test
+      run: |
+        cd misc/benchmark
+        sudo python3 benchmark.py --mode nydus-no-prefetch
+    - name: Save Test Result
+      uses: actions/upload-artifact@v3
+      with:
+        name: benchmark-nydus-no-prefetch
+        path: misc/benchmark/${{env.IMAGE}}.csv
+
+  benchmark-zran-no-prefetch:
+    runs-on: ubuntu-latest
+    needs: [contrib-build, nydus-build]
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Download Nydus
+      uses: actions/download-artifact@master
+      with:
+        name: nydus-artifact
+        path: target/release
+    - name: Download Nydusify
+      uses: actions/download-artifact@master
+      with:
+        name: nydusify-artifact
+        path: contrib/nydusify/cmd
+    - name: Prepare Nydus Environment
+      run: |
+        sudo bash misc/benchmark/prepare_env.sh nydus
+        sudo docker pull ${{env.IMAGE}}:${{env.TAG}} && docker tag ${{env.IMAGE}}:${{env.TAG}} localhost:5000/${{env.IMAGE}}:${{env.TAG}}
+        sudo docker push localhost:5000/${{env.IMAGE}}:${{env.TAG}}
+        sudo DOCKER_CONFIG=$HOME/.docker nydusify convert \
+          --source localhost:5000/${{env.IMAGE}}:${{env.TAG}} \
+          --target localhost:5000/${{env.IMAGE}}:${{env.TAG}}_nydus \
+          --fs-version 6 \
+          --oci-ref
+    - name: BenchMark Test
+      run: |
+        cd misc/benchmark
+        sudo python3 benchmark.py --mode nydus-no-prefetch
+    - name: Save Test Result
+      uses: actions/upload-artifact@v3
+      with:
+        name: benchmark-zran-no-prefetch
+        path: misc/benchmark/${{env.IMAGE}}.csv
+
+  benchmark-nydus-all-prefetch:
+    runs-on: ubuntu-latest
+    needs: [contrib-build, nydus-build]
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Download Nydus
+      uses: actions/download-artifact@master
+      with:
+        name: nydus-artifact
+        path: target/release
+    - name: Download Nydusify
+      uses: actions/download-artifact@master
+      with:
+        name: nydusify-artifact
+        path: contrib/nydusify/cmd
+    - name: Prepare Nydus Environment
+      run: |
+        sudo bash misc/benchmark/prepare_env.sh nydus
+        sudo DOCKER_CONFIG=$HOME/.docker nydusify convert \
+          --source ${{env.IMAGE}}:${{env.TAG}} \
+          --target localhost:5000/${{env.IMAGE}}:${{env.TAG}}_nydus \
+          --fs-version 6
+    - name: BenchMark Test
+      run: |
+        cd misc/benchmark
+        sudo python3 benchmark.py --mode nydus-all-prefetch
+    - name: Save Test Result
+      uses: actions/upload-artifact@v3
+      with:
+        name: benchmark-nydus-all-prefetch
+        path: misc/benchmark/${{env.IMAGE}}.csv
+
+  benchmark-zran-all-prefetch:
+    runs-on: ubuntu-latest
+    needs: [contrib-build, nydus-build]
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Download Nydus
+      uses: actions/download-artifact@master
+      with:
+        name: nydus-artifact
+        path: target/release
+    - name: Download Nydusify
+      uses: actions/download-artifact@master
+      with:
+        name: nydusify-artifact
+        path: contrib/nydusify/cmd
+    - name: Prepare Nydus Environment
+      run: |
+        sudo bash misc/benchmark/prepare_env.sh nydus
+        sudo docker pull ${{env.IMAGE}}:${{env.TAG}} && docker tag ${{env.IMAGE}}:${{env.TAG}} localhost:5000/${{env.IMAGE}}:${{env.TAG}}
+        sudo docker push localhost:5000/${{env.IMAGE}}:${{env.TAG}}
+        sudo DOCKER_CONFIG=$HOME/.docker nydusify convert \
+          --source localhost:5000/${{env.IMAGE}}:${{env.TAG}} \
+          --target localhost:5000/${{env.IMAGE}}:${{env.TAG}}_nydus \
+          --fs-version 6 \
+          --oci-ref
+    - name: BenchMark Test
+      run: |
+        cd misc/benchmark
+        sudo python3 benchmark.py --mode nydus-all-prefetch
+    - name: Save Test Result
+      uses: actions/upload-artifact@v3
+      with:
+        name: benchmark-zran-all-prefetch
+        path: misc/benchmark/${{env.IMAGE}}.csv
+
+  benchmark-nydus-filelist-prefetch:
+    runs-on: ubuntu-latest
+    needs: [contrib-build, nydus-build]
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Download Nydus
+      uses: actions/download-artifact@master
+      with:
+        name: nydus-artifact
+        path: target/release
+    - name: Download Nydusify
+      uses: actions/download-artifact@master
+      with:
+        name: nydusify-artifact
+        path: contrib/nydusify/cmd
+    - name: Prepare Nydus Environment
+      run: |
+        sudo bash misc/benchmark/prepare_env.sh nydus
+        sudo DOCKER_CONFIG=$HOME/.docker nydusify convert \
+          --source ${{env.IMAGE}}:${{env.TAG}} \
+          --target localhost:5000/${{env.IMAGE}}:${{env.TAG}}_nydus \
+          --fs-version 6
+    - name: BenchMark Test
+      run: |
+        cd misc/benchmark
+        sudo python3 benchmark.py --mode nydus-filelist-prefetch
+    - name: Save Test Result
+      uses: actions/upload-artifact@v3
+      with:
+        name: benchmark-nydus-filelist-prefetch
+        path: misc/benchmark/${{env.IMAGE}}.csv
+
+  benchmark-result:
+    runs-on: ubuntu-latest
+    needs: [benchmark-oci, benchmark-zran-all-prefetch, benchmark-zran-no-prefetch, benchmark-nydus-no-prefetch, benchmark-nydus-all-prefetch, benchmark-nydus-filelist-prefetch]
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Get Date
+      id: get-date
+      run: |
+        echo "date=$(date  +%s)" >> $GITHUB_OUTPUT
+      shell: bash
+    - name: Restore benchmark result
+      uses: actions/cache/restore@v3
+      with:
+        path: benchmark-result
+        key: benchmark-${{ steps.get-date.outputs.date }}
+        restore-keys: |
+         benchmark-
+    - uses: actions/download-artifact@v3
+    - uses: geekyeggo/delete-artifact@v2
+      with:
+        name: '*'
+    - name: Benchmark
+      run: |
+        if [ ! -d "benchmark-result" ]; then
+          mkdir benchmark-result
+        fi
+        sudo python3 misc/benchmark/benchmark_summary.py --mode benchmark-schedule > $GITHUB_STEP_SUMMARY
+    - name: Save Benchmark Result
+      uses: actions/cache/save@v3
+      with:
+        path: benchmark-result
+        key: benchmark-${{ steps.get-date.outputs.date }}

--- a/misc/benchmark/benchmark_summary.py
+++ b/misc/benchmark/benchmark_summary.py
@@ -2,6 +2,7 @@
 
 import csv
 import subprocess
+import os
 from argparse import ArgumentParser
 
 COMMANDS_BENCHMARK = [
@@ -39,6 +40,9 @@ FILE_LIST_COMPARE = [
     ("nydus-filelist-prefetch-master.csv", "nydus-filelist-prefetch.csv")
 ]
 
+BENCHMARK_CACHE = "benchmark-result/result.md"
+
+
 class BenchmarkSummary:
     def __init__(self, mode):
         self.mode = mode
@@ -47,8 +51,10 @@ class BenchmarkSummary:
         self.prepare_csv()
         if self.mode == "benchmark-result":
             self.print_csv_result()
-        else:
+        elif self.mode == "benchmark-compare":
             self.print_csv_compare()
+        else:
+            self.print_csv_schedule()
 
     def print_csv_result(self):
         print("| bench-result | pull(s) | create(s) | run(s) | total(s) | size(MB) | read-amount(MB) | read-count |")
@@ -65,6 +71,25 @@ class BenchmarkSummary:
             else:
                 print_compare(item[0], item[1])
 
+    def print_csv_schedule(self):
+        print("| bench-result(current vs last) | pull(s) | create(s) | run(s) | total(s) | size(MB) | read-amount(MB) | read-count |")
+        print("|:------------------------------|:-------:|:---------:|:------:|:--------:|:--------:|:---------------:|:----------:|")
+        data = []
+        if os.path.exists(BENCHMARK_CACHE):
+            with open(BENCHMARK_CACHE, "r", newline='') as f:
+                reader = csv.reader(f, delimiter='|')
+                next(reader)  # head
+                next(reader)  # line
+                next(reader)  # oci
+                for row in reader:
+                    data.append(row[2:-1])
+        for index, file in enumerate(FILE_LIST):
+            if(file == "oci.csv") or index > len(data):
+                print_schedule(file)
+            else:
+                print_schedule(file, data[index-1])
+        self.save_cache()
+
     def prepare_csv(self):
         """
             move the csv to current workdir
@@ -74,6 +99,18 @@ class BenchmarkSummary:
         if self.mode == "benchmark-compare":
             for cmd in COMMANDS_BENCHMARK_COMPARE:
                 subprocess.run(cmd, shell=True)
+
+    def save_cache(self):
+        with open(BENCHMARK_CACHE, 'w') as cache:
+            print("| bench-result | pull(s) | create(s) | run(s) | total(s) | size(MB) | read-amount(MB) | read-count |", file=cache)
+            print("|:-------------|:-------:|:---------:|:------:|:--------:|:--------:|:---------------:|:----------:|", file=cache)
+            for file in FILE_LIST:
+                with open(file, 'r') as f:
+                    filename = file.rstrip(".csv")
+                    rows = csv.reader(f)
+                    for row in rows:
+                        pull_elapsed, create_elapsed, run_elapsed, total_elapsed, image_size, read_amount, read_count = row
+                        print(f"|{filename}|{pull_elapsed}|{create_elapsed}|{run_elapsed}|{total_elapsed}|{image_size}|{read_amount}|{read_count}|", file=cache)
 
 
 def print_csv(file: str):
@@ -95,15 +132,34 @@ def print_compare(file_master: str, file: str):
         rows = csv.reader(f)
         for row in rows:
             pull_elapsed_master, create_elapsed_master, run_elapsed_master, total_elapsed_master, image_size_master, read_amount_master, read_count_master = row
-    pull_elapsed_compare = compare(pull_elapsed,pull_elapsed_master)
+    pull_elapsed_compare = compare(pull_elapsed, pull_elapsed_master)
     create_elapsed_compare = compare(create_elapsed, create_elapsed_master)
     run_elapsed_compare = compare(run_elapsed, run_elapsed_master)
-    total_elapsed_compare = compare(total_elapsed, total_elapsed_master,True)
+    total_elapsed_compare = compare(total_elapsed, total_elapsed_master, True)
     image_size_compare = compare(image_size, image_size_master, True)
     read_amount_compare = compare(read_amount, read_amount_master, True)
     read_count_compare = compare(read_count, read_count_master, True)
 
     print(f"|{filename}|{pull_elapsed_compare}|{create_elapsed_compare}|{run_elapsed_compare}|{total_elapsed_compare}|{image_size_compare}|{read_amount_compare}|{read_count_compare}|")
+
+
+def print_schedule(file: str, data=[]):
+    with open(file, 'r', newline='') as f:
+        filename = file.rstrip(".csv")
+        rows = csv.reader(f)
+        for row in rows:
+            pull_elapsed, create_elapsed, run_elapsed, total_elapsed, image_size, read_amount, read_count = row
+            if filename != "oci":
+                pull_elapsed = compare(pull_elapsed, data[0])
+                create_elapsed = compare(create_elapsed, data[1])
+                run_elapsed = compare(run_elapsed, data[2])
+                total_elapsed = compare(total_elapsed, data[3], True)
+                image_size = compare(image_size, data[4], True)
+                read_amount = compare(read_amount, data[5], True)
+                read_count = compare(read_count, data[6], True)
+
+            print(f"|{filename}|{pull_elapsed}|{create_elapsed}|{run_elapsed}|{total_elapsed}|{image_size}|{read_amount}|{read_count}|")
+
 
 def compare(data_current: str, data_master: str, compare: bool = False) -> str:
     data_current = float(data_current)
@@ -111,15 +167,16 @@ def compare(data_current: str, data_master: str, compare: bool = False) -> str:
     if abs(data_current - data_master) > data_master * 0.05 and compare:
         if data_current > data_master:
             return f"{data_current}/{data_master}↑"
-        else: 
+        else:
             return f"{data_current}/{data_master}↓"
     return f"{data_current}/{data_master}"
+
 
 def main():
     parser = ArgumentParser()
     parser.add_argument(
         "--mode",
-        choices=["benchmark-result", "benchmark-compare"],
+        choices=["benchmark-result", "benchmark-compare", "benchmark-schedule"],
         dest="mode",
         type=str,
         required=True,


### PR DESCRIPTION
## Add the benchmark workflow
1. We will cache each benchmark result and compare with the last result.
2. See [docs.github](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#usage-limits-and-eviction-policy), gitHub will remove any cache entries that have not been accessed in over 7 days. We schedule benchmark on every Monday and Wednesday. You can also do this manually.

## Add benchmark-schedule mode on benchmark summary
You can see the result in [1](https://github.com/dragonflyoss/image-service/actions/runs/4851221114/attempts/1#summary-13144939774), [2](https://github.com/dragonflyoss/image-service/actions/runs/4851221114/attempts/3#summary-13145178832), [3](https://github.com/dragonflyoss/image-service/actions/runs/4851221114/attempts/4#summary-13145339659), [4](https://github.com/dragonflyoss/image-service/actions/runs/4851221114/attempts/4#summary-13145339659).

> The pull request trigger for dev was deleted in [compare](https://github.com/dragonflyoss/image-service/compare/34c2d457ad31e7c70296bcabc6e53105c8ef4fac..83fbf80b335570b4bca99faeccdc43fee7626a25).
> Next work: add more images in benchmark.

## Ref:https://github.com/dragonflyoss/image-service/issues/1220