### PR TITLE
Optimize RAFS filesystem builder

### DIFF
--- a/rafs/src/builder/core/blob.rs
+++ b/rafs/src/builder/core/blob.rs
@@ -197,7 +197,7 @@ impl Blob {
         header.set_ci_compressed_offset(compressed_offset);
         header.set_ci_compressed_size(compressed_size as u64);
         header.set_ci_uncompressed_size(uncompressed_size as u64);
-        header.set_4k_aligned(true);
+        header.set_aligned(true);
         match blob_meta_info {
             BlobMetaChunkArray::V1(_) => header.set_chunk_info_v2(false),
             BlobMetaChunkArray::V2(_) => header.set_chunk_info_v2(true),

--- a/rafs/src/builder/core/context.rs
+++ b/rafs/src/builder/core/context.rs
@@ -457,7 +457,7 @@ impl BlobContext {
 
         blob_ctx
             .blob_meta_header
-            .set_4k_aligned(features.contains(BlobFeatures::ALIGNED));
+            .set_aligned(features.contains(BlobFeatures::ALIGNED));
         blob_ctx
             .blob_meta_header
             .set_inlined_fs_meta(features.contains(BlobFeatures::INLINED_FS_META));

--- a/rafs/src/builder/core/context.rs
+++ b/rafs/src/builder/core/context.rs
@@ -32,7 +32,8 @@ use nydus_storage::meta::{
 use nydus_utils::digest::DigestData;
 use nydus_utils::{compress, digest, div_round_up, round_down, BufReaderInfo};
 
-use super::node::{ChunkSource, Node};
+use super::node::ChunkSource;
+use crate::builder::core::tree::TreeNode;
 use crate::builder::{
     ChunkDict, Feature, Features, HashChunkDict, Prefetch, PrefetchPolicy, WhiteoutSpec,
 };
@@ -116,6 +117,7 @@ impl fmt::Display for ConversionType {
 }
 
 impl ConversionType {
+    /// Check whether the generated image references the original OCI image data.
     pub fn is_to_ref(&self) -> bool {
         matches!(
             self,
@@ -961,15 +963,15 @@ impl BlobManager {
 pub struct BootstrapContext {
     /// This build has a parent bootstrap.
     pub layered: bool,
-    /// Cache node index for hardlinks, HashMap<(layer_index, real_inode, dev), Vec<index>>.
-    pub(crate) inode_map: HashMap<(u16, Inode, u64), Vec<u64>>,
-    /// Store all nodes in ascendant order, indexed by (node.index - 1).
-    pub nodes: VecDeque<Node>,
+    /// Cache node index for hardlinks, HashMap<(layer_index, real_inode, dev), Vec<TreeNode>>.
+    pub(crate) inode_map: HashMap<(u16, Inode, u64), Vec<TreeNode>>,
     /// Current position to write in f_bootstrap
     pub(crate) offset: u64,
     pub(crate) writer: Box<dyn RafsIoWrite>,
     /// Not fully used blocks
     pub(crate) v6_available_blocks: Vec<VecDeque<u64>>,
+
+    next_ino: Inode,
 }
 
 impl BootstrapContext {
@@ -980,10 +982,11 @@ impl BootstrapContext {
         } else {
             Box::<ArtifactMemoryWriter>::default() as Box<dyn RafsIoWrite>
         };
+
         Ok(Self {
             layered,
             inode_map: HashMap::new(),
-            nodes: VecDeque::new(),
+            next_ino: 1,
             offset: EROFS_BLOCK_SIZE_4096,
             writer,
             v6_available_blocks: vec![
@@ -998,6 +1001,18 @@ impl BootstrapContext {
         if self.offset % align_size > 0 {
             self.offset = div_round_up(self.offset, align_size) * align_size;
         }
+    }
+
+    /// Get the next available inode number.
+    pub(crate) fn get_next_ino(&self) -> Inode {
+        self.next_ino
+    }
+
+    /// Generate next inode number.
+    pub(crate) fn generate_next_ino(&mut self) -> Inode {
+        let ino = self.next_ino;
+        self.next_ino += 1;
+        ino
     }
 
     // Only used to allocate space for metadata(inode / inode + inline data).

--- a/rafs/src/builder/core/layout.rs
+++ b/rafs/src/builder/core/layout.rs
@@ -3,43 +3,40 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::Result;
-use std::collections::VecDeque;
+use std::ops::Deref;
 
 use super::node::Node;
-use crate::builder::{Overlay, Prefetch};
+use crate::builder::{Overlay, Prefetch, Tree, TreeNode};
 
 #[derive(Clone)]
 pub struct BlobLayout {}
 
 impl BlobLayout {
-    pub fn layout_blob_simple(
-        prefetch: &Prefetch,
-        nodes: &VecDeque<Node>,
-    ) -> Result<(Vec<usize>, usize)> {
-        let mut inodes = Vec::with_capacity(nodes.len());
+    pub fn layout_blob_simple(prefetch: &Prefetch, tree: &Tree) -> Result<(Vec<TreeNode>, usize)> {
+        let mut inodes = Vec::with_capacity(10000);
 
         // Put all prefetch inodes at the head
         // NOTE: Don't try to sort readahead files by their sizes,  thus to keep files
         // belonging to the same directory arranged in adjacent in blob file. Together with
         // BFS style collecting descendants inodes, it will have a higher merging possibility.
         // Later, we might write chunks of data one by one according to inode number order.
-        let prefetches = prefetch.get_file_indexes();
-        for index in prefetches {
-            let index = index as usize - 1;
-            let node = &nodes[index];
-            if Self::should_dump_node(node) {
-                inodes.push(index);
+        let prefetches = prefetch.get_file_nodes();
+        for n in prefetches {
+            let node = n.lock().unwrap();
+            if Self::should_dump_node(node.deref()) {
+                inodes.push(n.clone());
             }
         }
         let prefetch_entries = inodes.len();
 
-        // Put all other non-prefetch inode at the tail
-        for (index, node) in nodes.iter().enumerate() {
+        tree.walk_bfs(true, &mut |n| -> Result<()> {
+            let node = n.lock_node();
             // Ignore lower layer node when dump blob
-            if !prefetch.contains(node) && Self::should_dump_node(node) {
-                inodes.push(index);
+            if !prefetch.contains(node.deref()) && Self::should_dump_node(node.deref()) {
+                inodes.push(n.node.clone());
             }
-        }
+            Ok(())
+        })?;
 
         Ok((inodes, prefetch_entries))
     }

--- a/rafs/src/builder/core/node.rs
+++ b/rafs/src/builder/core/node.rs
@@ -110,8 +110,6 @@ impl NodeChunk {
 /// Struct to host sharable fields of [Node].
 #[derive(Clone, Default, Debug)]
 pub struct NodeInfo {
-    /// Last status change time of the file, in nanoseconds.
-    pub ctime: i64,
     /// Whether the explicit UID/GID feature is enabled or not.
     pub explicit_uidgid: bool,
 
@@ -195,6 +193,23 @@ impl Display for Node {
 }
 
 impl Node {
+    /// Create a new instance of [Node].
+    pub fn new(inode: InodeWrapper, info: NodeInfo, layer_idx: u16) -> Self {
+        Node {
+            info: Arc::new(info),
+            index: 0,
+            overlay: Overlay::UpperAddition,
+            inode,
+            chunks: Vec::new(),
+            layer_idx,
+            v6_offset: 0,
+            v6_dirents: Vec::<(u64, OsString, u32)>::new(),
+            v6_datalayout: 0,
+            v6_compact_inode: false,
+            v6_dirents_offset: 0,
+        }
+    }
+
     /// Dump node data into the data blob, and generate chunk information.
     ///
     /// # Arguments
@@ -536,7 +551,6 @@ impl Node {
         let target = Self::generate_target(&path, &source);
         let target_vec = Self::generate_target_vec(&target);
         let info = NodeInfo {
-            ctime: 0,
             explicit_uidgid,
             src_ino: 0,
             src_dev: u64::MAX,
@@ -612,7 +626,6 @@ impl Node {
         info.src_ino = meta.st_ino();
         info.src_dev = meta.st_dev();
         info.rdev = meta.st_rdev();
-        info.ctime = meta.st_ctime();
 
         self.inode.set_mode(meta.st_mode());
         if info.explicit_uidgid {

--- a/rafs/src/builder/core/overlay.rs
+++ b/rafs/src/builder/core/overlay.rs
@@ -111,8 +111,6 @@ impl WhiteoutType {
 pub enum Overlay {
     Lower,
     UpperAddition,
-    UpperOpaque,
-    UpperRemoval,
     UpperModification,
 }
 
@@ -127,8 +125,6 @@ impl Display for Overlay {
         match self {
             Overlay::Lower => write!(f, "LOWER"),
             Overlay::UpperAddition => write!(f, "ADDED"),
-            Overlay::UpperOpaque => write!(f, "OPAQUED"),
-            Overlay::UpperRemoval => write!(f, "REMOVED"),
             Overlay::UpperModification => write!(f, "MODIFIED"),
         }
     }

--- a/rafs/src/builder/core/tree.rs
+++ b/rafs/src/builder/core/tree.rs
@@ -16,27 +16,33 @@
 //!   lower tree (MetadataTree).
 //! - Traverse the merged tree (OverlayTree) to dump bootstrap and data blobs.
 
-use std::ffi::{OsStr, OsString};
+use std::ffi::OsString;
+use std::os::unix::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex, MutexGuard};
 
-use anyhow::Result;
-use nydus_utils::{event_tracer, root_tracer, timing_tracer};
+use anyhow::{bail, Result};
+use nydus_utils::{root_tracer, timing_tracer};
 
 use super::node::{ChunkSource, Node, NodeChunk, NodeInfo};
 use super::overlay::{Overlay, WhiteoutType};
-use crate::builder::{ChunkDict, WhiteoutSpec};
+use crate::builder::core::overlay::OVERLAYFS_WHITEOUT_OPAQUE;
+use crate::builder::{BuildContext, ChunkDict};
 use crate::metadata::chunk::ChunkWrapper;
 use crate::metadata::inode::InodeWrapper;
 use crate::metadata::layout::{bytes_to_os_str, RafsXAttrs};
 use crate::metadata::{Inode, RafsInodeExt, RafsSuper};
 
+/// Type alias for tree internal node.
+pub type TreeNode = Arc<Mutex<Node>>;
+
 /// An in-memory tree structure to maintain information and topology of filesystem nodes.
 #[derive(Clone)]
 pub struct Tree {
     /// Filesystem node.
-    pub node: Node,
-    pub name: OsString,
+    pub node: TreeNode,
+    /// Cached base name.
+    name: Vec<u8>,
     /// Children tree nodes.
     pub children: Vec<Tree>,
 }
@@ -44,9 +50,9 @@ pub struct Tree {
 impl Tree {
     /// Create a new instance of `Tree` from a filesystem node.
     pub fn new(node: Node) -> Self {
-        let name = node.name().to_owned();
+        let name = node.name().as_bytes().to_vec();
         Tree {
-            node,
+            node: Arc::new(Mutex::new(node)),
             name,
             children: Vec::new(),
         }
@@ -55,204 +61,188 @@ impl Tree {
     /// Load a `Tree` from a bootstrap file, and optionally caches chunk information.
     pub fn from_bootstrap<T: ChunkDict>(rs: &RafsSuper, chunk_dict: &mut T) -> Result<Self> {
         let tree_builder = MetadataTreeBuilder::new(rs);
-        let root_inode = rs.get_extended_inode(rs.superblock.root_ino(), true)?;
+        let root_ino = rs.superblock.root_ino();
+        let root_inode = rs.get_extended_inode(root_ino, true)?;
         let root_node = MetadataTreeBuilder::parse_node(rs, root_inode, PathBuf::from("/"))?;
         let mut tree = Tree::new(root_node);
 
         tree.children = timing_tracer!(
-            {
-                tree_builder.load_children(
-                    rs.superblock.root_ino(),
-                    Option::<PathBuf>::None,
-                    chunk_dict,
-                    true,
-                )
-            },
+            { tree_builder.load_children(root_ino, Option::<PathBuf>::None, chunk_dict, true,) },
             "load_tree_from_bootstrap"
         )?;
 
         Ok(tree)
     }
 
-    /// Walk all nodes in deep first mode.
-    pub fn iterate<F>(&self, cb: &mut F) -> Result<()>
+    /// Get name of the tree node.
+    pub fn name(&self) -> &[u8] {
+        &self.name
+    }
+
+    /// Set `Node` associated with the tree node.
+    pub fn set_node(&mut self, node: Node) {
+        self.node = Arc::new(Mutex::new(node));
+    }
+
+    /// Get mutex guard to access the associated `Node` object.
+    pub fn lock_node(&self) -> MutexGuard<Node> {
+        self.node.lock().unwrap()
+    }
+
+    /// Walk all nodes in DFS mode.
+    pub fn walk_dfs<F1, F2>(&self, pre: &mut F1, post: &mut F2) -> Result<()>
     where
-        F: FnMut(&Node) -> bool,
+        F1: FnMut(&Tree) -> Result<()>,
+        F2: FnMut(&Tree) -> Result<()>,
     {
-        if !cb(&self.node) {
-            return Ok(());
-        }
+        pre(self)?;
         for child in &self.children {
-            child.iterate(cb)?;
+            child.walk_dfs(pre, post)?;
+        }
+        post(self)?;
+
+        Ok(())
+    }
+
+    /// Walk all nodes in pre DFS mode.
+    pub fn walk_dfs_pre<F>(&self, cb: &mut F) -> Result<()>
+    where
+        F: FnMut(&Tree) -> Result<()>,
+    {
+        self.walk_dfs(cb, &mut |_t| Ok(()))
+    }
+
+    /// Walk all nodes in post DFS mode.
+    pub fn walk_dfs_post<F>(&self, cb: &mut F) -> Result<()>
+    where
+        F: FnMut(&Tree) -> Result<()>,
+    {
+        self.walk_dfs(&mut |_t| Ok(()), cb)
+    }
+
+    /// Walk the tree in BFS mode.
+    pub fn walk_bfs<F>(&self, handle_self: bool, cb: &mut F) -> Result<()>
+    where
+        F: FnMut(&Tree) -> Result<()>,
+    {
+        if handle_self {
+            cb(self)?;
+        }
+
+        let mut dirs = Vec::with_capacity(32);
+        for child in &self.children {
+            cb(child)?;
+            if child.lock_node().is_dir() {
+                dirs.push(child);
+            }
+        }
+        for dir in dirs {
+            dir.walk_bfs(false, cb)?;
         }
 
         Ok(())
     }
 
-    /// Get index of child node with specified `name`.
-    #[allow(clippy::manual_find)]
-    pub fn get_child_idx(&self, name: &OsStr) -> Option<usize> {
-        for idx in 0..self.children.len() {
-            if self.children[idx].name == name {
-                return Some(idx);
-            }
-        }
-        None
-    }
-
-    /// Apply new node (upper layer) to node tree (lower layer).
-    ///
-    /// Support overlay defined in OCI image layer spec
-    /// (https://github.com/opencontainers/image-spec/blob/master/layer.md),
-    /// include change types Additions, Modifications, Removals and Opaques, return true if applied
-    pub fn apply(
-        &mut self,
-        target: &Node,
-        handle_whiteout: bool,
-        whiteout_spec: WhiteoutSpec,
-    ) -> Result<bool> {
-        // Handle whiteout objects
-        if handle_whiteout {
-            if let Some(whiteout_type) = target.whiteout_type(whiteout_spec) {
-                let origin_name = target.origin_name(whiteout_type);
-                let parent_name = if let Some(parent_path) = target.path().parent() {
-                    parent_path.file_name()
-                } else {
-                    None
-                };
-
-                event_tracer!("whiteout_files", +1);
-                if whiteout_type == WhiteoutType::OverlayFsOpaque {
-                    self.remove(target, whiteout_type, origin_name, parent_name)?;
-                    return self.apply(target, false, whiteout_spec);
-                }
-                return self.remove(target, whiteout_type, origin_name, parent_name);
-            }
-        }
-
-        let target_paths = target.target_vec();
-        let target_paths_len = target_paths.len();
-        let depth = self.node.target_vec().len();
-
-        // Handle root node modification
-        if target_paths_len == 1 && target.path() == Path::new("/") {
-            let mut node = target.clone();
-            node.overlay = Overlay::UpperModification;
-            self.node = node;
-            return Ok(true);
-        }
-
-        // Don't search if path recursive depth out of target path
-        if depth < target_paths_len {
-            for idx in 0..self.children.len() {
-                let child = &mut self.children[idx];
-                // Skip if path component name not match
-                if target_paths[depth] != child.name {
-                    continue;
-                }
-                // Modifications: Replace the node
-                if depth == target_paths_len - 1 {
-                    let mut node = target.clone();
-                    node.overlay = Overlay::UpperModification;
-                    child.node = node;
-                    return Ok(true);
-                }
-                if child.node.is_dir() {
-                    // Search the node recursively
-                    let found = child.apply(target, handle_whiteout, whiteout_spec)?;
-                    if found {
-                        return Ok(true);
-                    }
-                }
-            }
-        }
-
-        // Additions: Add new node to children
-        if depth == target_paths_len - 1 && target_paths[depth - 1] == self.name {
-            let mut node = target.clone();
-            node.overlay = Overlay::UpperAddition;
-            self.children.push(Tree::new(node));
-            return Ok(true);
-        }
-
-        Ok(false)
-    }
-
-    /// Remove node from node tree, return true if removed
-    fn remove(
-        &mut self,
-        target: &Node,
-        whiteout_type: WhiteoutType,
-        origin_name: Option<&OsStr>,
-        parent_name: Option<&OsStr>,
-    ) -> Result<bool> {
-        let target_paths = target.target_vec();
-        let target_paths_len = target_paths.len();
-        let node_paths = self.node.target_vec();
-        let depth = node_paths.len();
-
-        // Don't continue to search if current path not matched with target path or recursive depth
-        // out of target path
-        if depth >= target_paths_len || node_paths[depth - 1] != target_paths[depth - 1] {
-            return Ok(false);
-        }
-
-        // Handle Opaques for root path (/)
-        if depth == 1
-            && (whiteout_type == WhiteoutType::OciOpaque && target_paths_len == 2
-                || whiteout_type == WhiteoutType::OverlayFsOpaque && target_paths_len == 1)
+    /// Insert a new child node into the tree.
+    pub fn insert_child(&mut self, child: Tree) {
+        if let Err(idx) = self
+            .children
+            .binary_search_by_key(&&child.name, |n| &n.name)
         {
-            self.node.overlay = Overlay::UpperOpaque;
-            self.children.clear();
-            return Ok(true);
+            self.children.insert(idx, child);
         }
+    }
 
-        for idx in 0..self.children.len() {
-            let child = &mut self.children[idx];
+    /// Get index of child node with specified `name`.
+    pub fn get_child_idx(&self, name: &[u8]) -> Option<usize> {
+        self.children.binary_search_by_key(&name, |n| &n.name).ok()
+    }
 
-            // Handle Removals
-            if depth == target_paths_len - 1
-                && whiteout_type.is_removal()
-                && origin_name == Some(&child.name)
-            {
-                // Remove the whole lower node
-                self.children.remove(idx);
-                return Ok(true);
+    /// Get the tree node corresponding to the path.
+    pub fn get_node(&self, path: &Path) -> Option<&Tree> {
+        let target_vec = Node::generate_target_vec(path);
+        assert!(!target_vec.is_empty());
+        let mut tree = self;
+        for name in &target_vec[1..] {
+            match tree.get_child_idx(name.as_bytes()) {
+                Some(idx) => tree = &tree.children[idx],
+                None => return None,
             }
+        }
+        Some(tree)
+    }
 
-            // Handle Opaques
-            if whiteout_type == WhiteoutType::OciOpaque
-                && target_paths_len >= 2
-                && depth == target_paths_len - 2
-            {
-                if let Some(parent_name) = parent_name {
-                    if parent_name == child.name {
-                        child.node.overlay = Overlay::UpperOpaque;
-                        // Remove children of the lower node
-                        child.children.clear();
-                        return Ok(true);
+    /// Merge the upper layer tree into the lower layer tree, applying whiteout rules.
+    pub fn merge_overaly(&mut self, ctx: &BuildContext, upper: Tree) -> Result<()> {
+        assert_eq!(self.name, "/".as_bytes());
+        assert_eq!(upper.name, "/".as_bytes());
+
+        // Handle the root node.
+        upper.lock_node().overlay = Overlay::UpperModification;
+        self.node = upper.node.clone();
+
+        self.merge_children(ctx, &upper)
+    }
+
+    fn merge_children(&mut self, ctx: &BuildContext, upper: &Tree) -> Result<()> {
+        // Handle whiteout nodes in the first round, and handle other nodes in the second round.
+        let mut modified = Vec::with_capacity(upper.children.len());
+        for u in upper.children.iter() {
+            let mut u_node = u.lock_node();
+            match u_node.whiteout_type(ctx.whiteout_spec) {
+                Some(WhiteoutType::OciRemoval) => {
+                    if let Some(origin_name) = u_node.origin_name(WhiteoutType::OciRemoval) {
+                        if let Some(idx) = self.get_child_idx(origin_name.as_bytes()) {
+                            self.children.remove(idx);
+                        }
                     }
                 }
-            } else if whiteout_type == WhiteoutType::OverlayFsOpaque
-                && depth == target_paths_len - 1
-                && target.name() == child.name
-            {
-                // Remove all children under the opaque directory
-                child.node.overlay = Overlay::UpperOpaque;
-                child.children.clear();
-                return Ok(true);
-            }
-
-            if child.node.is_dir() {
-                // Search the node recursively
-                let found = child.remove(target, whiteout_type, origin_name, parent_name)?;
-                if found {
-                    return Ok(true);
+                Some(WhiteoutType::OciOpaque) => {
+                    self.children.clear();
                 }
+                Some(WhiteoutType::OverlayFsRemoval) => {
+                    if let Some(idx) = self.get_child_idx(&u.name) {
+                        self.children.remove(idx);
+                    }
+                }
+                Some(WhiteoutType::OverlayFsOpaque) => {
+                    if let Some(idx) = self.get_child_idx(&u.name) {
+                        self.children[idx].children.clear();
+                    }
+                    u_node.remove_xattr(&OsString::from(OVERLAYFS_WHITEOUT_OPAQUE));
+                    modified.push(u);
+                }
+                None => modified.push(u),
             }
         }
 
-        Ok(false)
+        let mut dirs = Vec::new();
+        for u in modified {
+            let mut u_node = u.lock_node();
+            if let Some(idx) = self.get_child_idx(&u.name) {
+                u_node.overlay = Overlay::UpperModification;
+                self.children[idx].node = u.node.clone();
+            } else {
+                u_node.overlay = Overlay::UpperAddition;
+                self.insert_child(Tree {
+                    node: u.node.clone(),
+                    name: u.name.clone(),
+                    children: vec![],
+                });
+            }
+            if u_node.is_dir() {
+                dirs.push(u);
+            }
+        }
+        for dir in dirs {
+            if let Some(idx) = self.get_child_idx(&dir.name) {
+                self.children[idx].merge_children(ctx, dir)?;
+            } else {
+                bail!("builder: can not find directory in merged tree");
+            }
+        }
+
+        Ok(())
     }
 }
 
@@ -289,7 +279,6 @@ impl<'a> MetadataTreeBuilder<'a> {
         let mut children = Vec::with_capacity(child_count as usize);
         for idx in 0..child_count {
             let child = inode.get_child_by_index(idx)?;
-            let child_ino = child.ino();
             let child_path = parent_path.join(child.name());
             let child = Self::parse_node(self.rs, child.clone(), child_path)?;
 
@@ -302,12 +291,19 @@ impl<'a> MetadataTreeBuilder<'a> {
                 }
             }
 
-            let mut child = Tree::new(child);
-            if child.node.is_dir() {
+            let child = Tree::new(child);
+            children.push(child);
+        }
+        children.sort_unstable_by(|a, b| a.name.cmp(&b.name));
+
+        for child in children.iter_mut() {
+            let child_node = child.lock_node();
+            if child_node.is_dir() {
+                let child_ino = child_node.inode.ino();
+                drop(child_node);
                 child.children =
                     self.load_children(child_ino, Some(&parent_path), chunk_dict, validate_digest)?;
             }
-            children.push(child);
         }
 
         Ok(children)
@@ -352,7 +348,6 @@ impl<'a> MetadataTreeBuilder<'a> {
         let target = Node::generate_target(&path, &source);
         let target_vec = Node::generate_target_vec(&target);
         let info = NodeInfo {
-            ctime: 0,
             explicit_uidgid: rs.meta.explicit_uidgid(),
             src_ino: inode.ino(),
             src_dev,
@@ -379,5 +374,127 @@ impl<'a> MetadataTreeBuilder<'a> {
             v6_compact_inode: false,
             v6_dirents_offset: 0,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::metadata::RafsVersion;
+    use storage::RAFS_DEFAULT_CHUNK_SIZE;
+    use vmm_sys_util::tempdir::TempDir;
+    use vmm_sys_util::tempfile::TempFile;
+
+    #[test]
+    fn test_set_lock_node() {
+        let tmpdir = TempDir::new().unwrap();
+        let tmpfile = TempFile::new_in(tmpdir.as_path()).unwrap();
+        let node = Node::from_fs_object(
+            RafsVersion::V6,
+            tmpdir.as_path().to_path_buf(),
+            tmpfile.as_path().to_path_buf(),
+            Overlay::UpperAddition,
+            RAFS_DEFAULT_CHUNK_SIZE as u32,
+            true,
+            false,
+        )
+        .unwrap();
+        let mut tree = Tree::new(node);
+        assert_eq!(tree.name, tmpfile.as_path().file_name().unwrap().as_bytes());
+        let node1 = tree.lock_node();
+        drop(node1);
+
+        let tmpfile = TempFile::new_in(tmpdir.as_path()).unwrap();
+        let node = Node::from_fs_object(
+            RafsVersion::V6,
+            tmpdir.as_path().to_path_buf(),
+            tmpfile.as_path().to_path_buf(),
+            Overlay::UpperAddition,
+            RAFS_DEFAULT_CHUNK_SIZE as u32,
+            true,
+            false,
+        )
+        .unwrap();
+        tree.set_node(node);
+        let node2 = tree.lock_node();
+        assert_eq!(node2.name(), tmpfile.as_path().file_name().unwrap());
+    }
+
+    #[test]
+    fn test_walk_tree() {
+        let tmpdir = TempDir::new().unwrap();
+        let tmpfile = TempFile::new_in(tmpdir.as_path()).unwrap();
+        let node = Node::from_fs_object(
+            RafsVersion::V6,
+            tmpdir.as_path().to_path_buf(),
+            tmpfile.as_path().to_path_buf(),
+            Overlay::UpperAddition,
+            RAFS_DEFAULT_CHUNK_SIZE as u32,
+            true,
+            false,
+        )
+        .unwrap();
+        let mut tree = Tree::new(node);
+
+        let tmpfile2 = TempFile::new_in(tmpdir.as_path()).unwrap();
+        let node = Node::from_fs_object(
+            RafsVersion::V6,
+            tmpdir.as_path().to_path_buf(),
+            tmpfile2.as_path().to_path_buf(),
+            Overlay::UpperAddition,
+            RAFS_DEFAULT_CHUNK_SIZE as u32,
+            true,
+            false,
+        )
+        .unwrap();
+        let tree2 = Tree::new(node);
+        tree.insert_child(tree2);
+
+        let tmpfile3 = TempFile::new_in(tmpdir.as_path()).unwrap();
+        let node = Node::from_fs_object(
+            RafsVersion::V6,
+            tmpdir.as_path().to_path_buf(),
+            tmpfile3.as_path().to_path_buf(),
+            Overlay::UpperAddition,
+            RAFS_DEFAULT_CHUNK_SIZE as u32,
+            true,
+            false,
+        )
+        .unwrap();
+        let tree3 = Tree::new(node);
+        tree.insert_child(tree3);
+
+        let mut count = 0;
+        tree.walk_bfs(true, &mut |_n| -> Result<()> {
+            count += 1;
+            Ok(())
+        })
+        .unwrap();
+        assert_eq!(count, 3);
+
+        let mut count = 0;
+        tree.walk_bfs(false, &mut |_n| -> Result<()> {
+            count += 1;
+            Ok(())
+        })
+        .unwrap();
+        assert_eq!(count, 2);
+
+        let mut count = 0;
+        tree.walk_bfs(true, &mut |_n| -> Result<()> {
+            count += 1;
+            bail!("test")
+        })
+        .unwrap_err();
+        assert_eq!(count, 1);
+
+        let idx = tree
+            .get_child_idx(tmpfile2.as_path().file_name().unwrap().as_bytes())
+            .unwrap();
+        assert!(idx == 0 || idx == 1);
+        let idx = tree
+            .get_child_idx(tmpfile3.as_path().file_name().unwrap().as_bytes())
+            .unwrap();
+        assert!(idx == 0 || idx == 1);
     }
 }

--- a/rafs/src/builder/core/v5.rs
+++ b/rafs/src/builder/core/v5.rs
@@ -10,9 +10,8 @@ use anyhow::{bail, Context, Result};
 use nydus_utils::digest::{DigestHasher, RafsDigest};
 use nydus_utils::{div_round_up, root_tracer, timing_tracer, try_round_up_4k};
 
-use super::bootstrap::STARGZ_DEFAULT_BLOCK_SIZE;
 use super::node::Node;
-use crate::builder::{Bootstrap, BootstrapContext, BuildContext, ConversionType, Tree};
+use crate::builder::{Bootstrap, BootstrapContext, BuildContext, Tree};
 use crate::metadata::inode::InodeWrapper;
 use crate::metadata::layout::v5::{
     RafsV5BlobTable, RafsV5ChunkInfo, RafsV5InodeTable, RafsV5InodeWrapper, RafsV5SuperBlock,
@@ -38,8 +37,6 @@ impl Node {
         ctx: &mut BuildContext,
         f_bootstrap: &mut dyn RafsIoWrite,
     ) -> Result<()> {
-        debug!("[{}]\t{}", self.overlay, self);
-
         if let InodeWrapper::V5(raw_inode) = &self.inode {
             // Dump inode info
             let name = self.name();
@@ -94,7 +91,7 @@ impl Node {
 
         let mut d_size = 0u64;
         for child in children.iter() {
-            d_size += child.node.inode.name_size() as u64 + RAFS_V5_VIRTUAL_ENTRY_SIZE;
+            d_size += child.lock_node().inode.name_size() as u64 + RAFS_V5_VIRTUAL_ENTRY_SIZE;
         }
         if d_size == 0 {
             self.inode.set_size(4096);
@@ -125,28 +122,17 @@ impl Node {
 
 impl Bootstrap {
     /// Calculate inode digest for directory.
-    fn v5_digest_node(
-        &self,
-        ctx: &mut BuildContext,
-        bootstrap_ctx: &mut BootstrapContext,
-        index: usize,
-    ) {
-        let node = &bootstrap_ctx.nodes[index];
+    fn v5_digest_node(&self, ctx: &mut BuildContext, tree: &Tree) {
+        let mut node = tree.lock_node();
 
         // We have set digest for non-directory inode in the previous dump_blob workflow.
         if node.is_dir() {
-            let child_index = node.inode.child_index();
-            let child_count = node.inode.child_count();
             let mut inode_hasher = RafsDigest::hasher(ctx.digester);
-
-            for idx in child_index..child_index + child_count {
-                let child = &bootstrap_ctx.nodes[(idx - 1) as usize];
+            for child in tree.children.iter() {
+                let child = child.lock_node();
                 inode_hasher.digest_update(child.inode.digest().as_ref());
             }
-
-            bootstrap_ctx.nodes[index]
-                .inode
-                .set_digest(inode_hasher.digest_finalize());
+            node.inode.set_digest(inode_hasher.digest_finalize());
         }
     }
 
@@ -158,24 +144,24 @@ impl Bootstrap {
         blob_table: &RafsV5BlobTable,
     ) -> Result<()> {
         // Set inode digest, use reverse iteration order to reduce repeated digest calculations.
-        for idx in (0..bootstrap_ctx.nodes.len()).rev() {
-            self.v5_digest_node(ctx, bootstrap_ctx, idx);
-        }
+        self.tree.walk_dfs_post(&mut |t| {
+            self.v5_digest_node(ctx, t);
+            Ok(())
+        })?;
 
         // Set inode table
         let super_block_size = size_of::<RafsV5SuperBlock>();
-        let inode_table_entries = bootstrap_ctx.nodes.len() as u32;
+        let inode_table_entries = bootstrap_ctx.get_next_ino() as u32 - 1;
         let mut inode_table = RafsV5InodeTable::new(inode_table_entries as usize);
         let inode_table_size = inode_table.size();
 
         // Set prefetch table
-        let (prefetch_table_size, prefetch_table_entries) = if let Some(prefetch_table) =
-            ctx.prefetch.get_v5_prefetch_table(&bootstrap_ctx.nodes)
-        {
-            (prefetch_table.size(), prefetch_table.len() as u32)
-        } else {
-            (0, 0u32)
-        };
+        let (prefetch_table_size, prefetch_table_entries) =
+            if let Some(prefetch_table) = ctx.prefetch.get_v5_prefetch_table() {
+                (prefetch_table.size(), prefetch_table.len() as u32)
+            } else {
+                (0, 0u32)
+            };
 
         // Set blob table, use sha256 string (length 64) as blob id if not specified
         let prefetch_table_offset = super_block_size + inode_table_size;
@@ -203,9 +189,6 @@ impl Bootstrap {
         if ctx.explicit_uidgid {
             super_block.set_explicit_uidgid();
         }
-        if ctx.conversion_type == ConversionType::EStargzIndexToRef {
-            super_block.set_block_size(STARGZ_DEFAULT_BLOCK_SIZE);
-        }
 
         // Set inodes and chunks
         let mut inode_offset = (super_block_size
@@ -215,7 +198,8 @@ impl Bootstrap {
             + extended_blob_table_size) as u32;
 
         let mut has_xattr = false;
-        for node in &mut bootstrap_ctx.nodes {
+        self.tree.walk_dfs_pre(&mut |t| {
+            let node = t.lock_node();
             inode_table.set(node.index, inode_offset)?;
             // Add inode size
             inode_offset += node.inode.inode_size() as u32;
@@ -231,7 +215,8 @@ impl Bootstrap {
             if node.is_reg() {
                 inode_offset += node.inode.child_count() * size_of::<RafsV5ChunkInfo>() as u32;
             }
-        }
+            Ok(())
+        })?;
         if has_xattr {
             super_block.set_has_xattr();
         }
@@ -247,7 +232,7 @@ impl Bootstrap {
             .context("failed to store inode table")?;
 
         // Dump prefetch table
-        if let Some(mut prefetch_table) = ctx.prefetch.get_v5_prefetch_table(&bootstrap_ctx.nodes) {
+        if let Some(mut prefetch_table) = ctx.prefetch.get_v5_prefetch_table() {
             prefetch_table
                 .store(bootstrap_ctx.writer.as_mut())
                 .context("failed to store prefetch table")?;
@@ -266,15 +251,13 @@ impl Bootstrap {
         // Dump inodes and chunks
         timing_tracer!(
             {
-                for node in &bootstrap_ctx.nodes {
-                    node.dump_bootstrap_v5(ctx, bootstrap_ctx.writer.as_mut())
-                        .context("failed to dump bootstrap")?;
-                }
-
-                Ok(())
+                self.tree.walk_dfs_pre(&mut |t| {
+                    t.lock_node()
+                        .dump_bootstrap_v5(ctx, bootstrap_ctx.writer.as_mut())
+                        .context("failed to dump bootstrap")
+                })
             },
-            "dump_bootstrap",
-            Result<()>
+            "dump_bootstrap"
         )?;
 
         Ok(())

--- a/rafs/src/builder/core/v6.rs
+++ b/rafs/src/builder/core/v6.rs
@@ -3,7 +3,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::{BTreeMap, VecDeque};
+use std::collections::BTreeMap;
 use std::ffi::{OsStr, OsString};
 use std::io::SeekFrom;
 use std::mem::size_of;
@@ -159,20 +159,18 @@ impl Node {
         let mut d_size = 0;
 
         // Sort all children if "." and ".." are not at the head after sorting.
-        if !tree.children.is_empty() && tree.children[0].name < *".." {
+        if !tree.children.is_empty() && tree.children[0].name() < "..".as_bytes() {
             let mut children = Vec::with_capacity(tree.children.len() + 2);
-            let dot = OsString::from(".");
-            let dotdot = OsString::from("..");
-            children.push(dot.as_os_str());
-            children.push(dotdot.as_os_str());
+            children.push(".".as_bytes());
+            children.push("..".as_bytes());
             for child in tree.children.iter() {
-                children.push(&child.name);
+                children.push(child.name());
             }
             children.sort_unstable();
 
             for c in children {
                 // Use length in byte, instead of length in character.
-                let len = c.as_bytes().len() + size_of::<RafsV6Dirent>();
+                let len = c.len() + size_of::<RafsV6Dirent>();
                 // erofs disk format requires dirent to be aligned to block size.
                 if (d_size % block_size) + len as u64 > block_size {
                     d_size = round_up(d_size as u64, block_size);
@@ -187,7 +185,7 @@ impl Node {
                 + "..".as_bytes().len()
                 + size_of::<RafsV6Dirent>()) as u64;
             for child in tree.children.iter() {
-                let len = child.name.as_bytes().len() + size_of::<RafsV6Dirent>();
+                let len = child.name().len() + size_of::<RafsV6Dirent>();
                 // erofs disk format requires dirent to be aligned to block size.
                 if (d_size % block_size) + len as u64 > block_size {
                     d_size = round_up(d_size as u64, block_size);
@@ -368,7 +366,7 @@ impl Node {
         );
         // fill dir blocks one by one
         for (offset, name, file_type) in self.v6_dirents.iter() {
-            let len = name.len() + size_of::<RafsV6Dirent>();
+            let len = name.as_bytes().len() + size_of::<RafsV6Dirent>();
             // write to bootstrap when it will exceed EROFS_BLOCK_SIZE
             if used + len as u64 > block_size {
                 for (entry, name) in dirents.iter_mut() {
@@ -430,7 +428,7 @@ impl Node {
                 entry.set_name_offset(nameoff as u16);
                 dir_data.extend(entry.as_ref());
                 entry_names.push(*name);
-                nameoff += name.len() as u64;
+                nameoff += name.as_bytes().len() as u64;
             }
             for name in entry_names.iter() {
                 dir_data.extend(name.as_bytes());
@@ -580,8 +578,8 @@ impl BuildContext {
 }
 
 impl Bootstrap {
-    pub(crate) fn v6_update_dirents(nodes: &mut VecDeque<Node>, tree: &Tree, parent_offset: u64) {
-        let node = &mut nodes[tree.node.index as usize - 1];
+    pub(crate) fn v6_update_dirents(parent: &Tree, parent_offset: u64) {
+        let mut node = parent.lock_node();
         let node_offset = node.v6_offset;
         if !node.is_dir() {
             return;
@@ -600,20 +598,15 @@ impl Bootstrap {
         }
 
         let mut dirs: Vec<&Tree> = Vec::new();
-        for child in tree.children.iter() {
-            trace!(
-                "{:?} child {:?} offset {}, mode {}",
-                node.name(),
-                child.name,
-                child.node.v6_offset,
-                child.node.inode.mode()
+        for child in parent.children.iter() {
+            let child_node = child.lock_node();
+            let entry = (
+                child_node.v6_offset,
+                OsStr::from_bytes(child.name()).to_owned(),
+                child_node.inode.mode(),
             );
-            node.v6_dirents.push((
-                child.node.v6_offset,
-                child.name.to_os_string(),
-                child.node.inode.mode(),
-            ));
-            if child.node.is_dir() {
+            node.v6_dirents.push(entry);
+            if child_node.is_dir() {
                 dirs.push(child);
             }
         }
@@ -621,7 +614,7 @@ impl Bootstrap {
             .sort_unstable_by(|a, b| a.1.as_os_str().cmp(b.1.as_os_str()));
 
         for dir in dirs {
-            Self::v6_update_dirents(nodes, dir, node_offset);
+            Self::v6_update_dirents(dir, node_offset);
         }
     }
 
@@ -660,13 +653,14 @@ impl Bootstrap {
             blob_table_size
         );
 
+        let fs_prefetch_rule_count = ctx.prefetch.fs_prefetch_rule_count();
         let (prefetch_table_offset, prefetch_table_size) =
             // If blob_table_size equal to 0, there is no prefetch.
-            if ctx.prefetch.fs_prefetch_rule_count() > 0 && blob_table_size > 0 {
+            if fs_prefetch_rule_count > 0 && blob_table_size > 0 {
                 // Prefetch table is very close to blob devices table
                 let offset = blob_table_offset + blob_table_size;
                 // Each prefetched file has is nid of `u32` filled into prefetch table.
-                let size = ctx.prefetch.fs_prefetch_rule_count() * size_of::<u32>() as u32;
+                let size = fs_prefetch_rule_count * size_of::<u32>() as u32;
                 trace!("prefetch table locates at offset {} size {}", offset, size);
                 (offset, size)
             } else {
@@ -679,7 +673,8 @@ impl Bootstrap {
         // When using nid 0 as root nid,
         // the root directory will not be shown by glibc's getdents/readdir.
         // Because in some OS, ino == 0 represents corresponding file is deleted.
-        let orig_meta_addr = bootstrap_ctx.nodes[0].v6_offset - EROFS_BLOCK_SIZE_4096;
+        let root_node_offset = self.tree.lock_node().v6_offset;
+        let orig_meta_addr = root_node_offset - EROFS_BLOCK_SIZE_4096;
         let meta_addr = if blob_table_size > 0 {
             align_offset(
                 blob_table_offset + blob_table_size + prefetch_table_size as u64,
@@ -688,12 +683,8 @@ impl Bootstrap {
         } else {
             orig_meta_addr
         };
-
-        // get devt_slotoff
-        let root_nid = calculate_nid(
-            bootstrap_ctx.nodes[0].v6_offset + (meta_addr - orig_meta_addr),
-            meta_addr,
-        );
+        let meta_offset = meta_addr - orig_meta_addr;
+        let root_nid = calculate_nid(root_node_offset + meta_offset, meta_addr);
 
         // Prepare extended super block
         let mut ext_sb = RafsV6SuperBlockExt::new();
@@ -714,29 +705,23 @@ impl Bootstrap {
         // Dump bootstrap
         timing_tracer!(
             {
-                for node in &mut bootstrap_ctx.nodes {
-                    node.dump_bootstrap_v6(
+                self.tree.walk_bfs(true, &mut |n| {
+                    n.lock_node().dump_bootstrap_v6(
                         ctx,
                         bootstrap_ctx.writer.as_mut(),
                         orig_meta_addr,
                         meta_addr,
                         &mut chunk_cache,
                     )
-                    .context("failed to dump bootstrap")?;
-                }
-
-                Ok(())
+                })
             },
-            "dump_bootstrap",
-            Result<()>
+            "dump_bootstrap"
         )?;
         Self::v6_align_to_4k(bootstrap_ctx)?;
 
         // `Node` offset might be updated during above inodes dumping. So `get_prefetch_table` after it.
         if prefetch_table_size > 0 {
-            let prefetch_table = ctx
-                .prefetch
-                .get_v6_prefetch_table(&bootstrap_ctx.nodes, meta_addr);
+            let prefetch_table = ctx.prefetch.get_v6_prefetch_table(meta_addr);
             if let Some(mut pt) = prefetch_table {
                 assert!(pt.len() * size_of::<u32>() <= prefetch_table_size as usize);
                 // Device slots are very close to extended super block.
@@ -821,7 +806,7 @@ impl Bootstrap {
         if ctx.conversion_type == ConversionType::TarToTarfs {
             sb.set_block_bits(EROFS_BLOCK_BITS_9);
         }
-        sb.set_inos(bootstrap_ctx.nodes.len() as u64);
+        sb.set_inos(bootstrap_ctx.get_next_ino() - 1);
         sb.set_blocks(block_count);
         sb.set_root_nid(root_nid as u16);
         sb.set_meta_addr(meta_addr);

--- a/rafs/src/builder/directory.rs
+++ b/rafs/src/builder/directory.rs
@@ -13,9 +13,7 @@ use super::core::context::{
     ArtifactWriter, BlobManager, BootstrapContext, BootstrapManager, BuildContext, BuildOutput,
 };
 use super::core::node::Node;
-use super::core::overlay::Overlay;
-use super::core::tree::Tree;
-use super::{build_bootstrap, dump_bootstrap, finalize_blob, Builder};
+use super::{build_bootstrap, dump_bootstrap, finalize_blob, Builder, Overlay, Tree, TreeNode};
 
 struct FilesystemTreeBuilder {}
 
@@ -30,10 +28,11 @@ impl FilesystemTreeBuilder {
         &self,
         ctx: &mut BuildContext,
         bootstrap_ctx: &mut BootstrapContext,
-        parent: &mut Node,
+        parent: &TreeNode,
         layer_idx: u16,
     ) -> Result<Vec<Tree>> {
         let mut result = Vec::new();
+        let parent = parent.lock().unwrap();
         if !parent.is_dir() {
             return Ok(result);
         }
@@ -67,10 +66,14 @@ impl FilesystemTreeBuilder {
             }
 
             let mut child = Tree::new(child);
-            child.children = self.load_children(ctx, bootstrap_ctx, &mut child.node, layer_idx)?;
-            child.node.v5_set_dir_size(ctx.fs_version, &child.children);
+            child.children = self.load_children(ctx, bootstrap_ctx, &child.node, layer_idx)?;
+            child
+                .lock_node()
+                .v5_set_dir_size(ctx.fs_version, &child.children);
             result.push(child);
         }
+
+        result.sort_unstable_by(|a, b| a.name().cmp(b.name()));
 
         Ok(result)
     }
@@ -104,10 +107,11 @@ impl DirectoryBuilder {
         let tree_builder = FilesystemTreeBuilder::new();
 
         tree.children = timing_tracer!(
-            { tree_builder.load_children(ctx, bootstrap_ctx, &mut tree.node, layer_idx) },
+            { tree_builder.load_children(ctx, bootstrap_ctx, &tree.node, layer_idx) },
             "load_from_directory"
         )?;
-        tree.node.v5_set_dir_size(ctx.fs_version, &tree.children);
+        tree.lock_node()
+            .v5_set_dir_size(ctx.fs_version, &tree.children);
 
         Ok(tree)
     }
@@ -144,7 +148,7 @@ impl Builder for DirectoryBuilder {
 
         // Dump blob file
         timing_tracer!(
-            { Blob::dump(ctx, &mut bootstrap_ctx.nodes, blob_mgr, &mut blob_writer,) },
+            { Blob::dump(ctx, &bootstrap.tree, blob_mgr, &mut blob_writer,) },
             "dump_blob"
         )?;
 

--- a/rafs/src/metadata/inode.rs
+++ b/rafs/src/metadata/inode.rs
@@ -201,6 +201,28 @@ impl InodeWrapper {
         }
     }
 
+    /// Set whether the inode has HARDLINK flag set.
+    pub fn set_has_hardlink(&mut self, enable: bool) {
+        self.ensure_owned();
+        match self {
+            InodeWrapper::V5(i) => {
+                if enable {
+                    i.i_flags |= RafsInodeFlags::HARDLINK;
+                } else {
+                    i.i_flags &= !RafsInodeFlags::HARDLINK;
+                }
+            }
+            InodeWrapper::V6(i) => {
+                if enable {
+                    i.i_flags |= RafsInodeFlags::HARDLINK;
+                } else {
+                    i.i_flags &= !RafsInodeFlags::HARDLINK;
+                }
+            }
+            InodeWrapper::Ref(_i) => unimplemented!(),
+        }
+    }
+
     /// Check whether the inode has associated xattrs.
     pub fn has_xattr(&self) -> bool {
         match self {

--- a/rafs/src/metadata/layout/v5.rs
+++ b/rafs/src/metadata/layout/v5.rs
@@ -391,9 +391,13 @@ impl RafsV5InodeTable {
     /// Set inode offset in the metadata blob for an inode.
     pub fn set(&mut self, ino: Inode, offset: u32) -> Result<()> {
         if ino == 0 || ino > self.data.len() as u64 {
-            return Err(einval!("invalid inode number"));
+            return Err(einval!(format!(
+                "invalid inode number {}, max {}",
+                ino,
+                self.data.len()
+            )));
         } else if offset as usize <= RAFSV5_SUPERBLOCK_SIZE || offset & 0x7 != 0 {
-            return Err(einval!("invalid inode offset"));
+            return Err(einval!(format!("invalid inode offset 0x{:x}", offset)));
         }
 
         // The offset is aligned with 8 bytes to make it easier to validate RafsV5Inode.
@@ -411,7 +415,10 @@ impl RafsV5InodeTable {
 
         let offset = u32::from_le(self.data[(ino - 1) as usize]) as usize;
         if offset <= (RAFSV5_SUPERBLOCK_SIZE >> 3) || offset >= (1usize << 29) {
-            return Err(einval!("invalid inode offset"));
+            return Err(einval!(format!(
+                "invalid offset 0x{:x} for inode {}",
+                offset, ino
+            )));
         }
 
         Ok((offset << 3) as u32)

--- a/src/bin/nydus-image/main.rs
+++ b/src/bin/nydus-image/main.rs
@@ -990,7 +990,9 @@ impl Command {
 
         let mut builder: Box<dyn Builder> = match conversion_type {
             ConversionType::DirectoryToRafs => Box::new(DirectoryBuilder::new()),
-            ConversionType::EStargzIndexToRef => Box::new(StargzBuilder::new(blob_data_size)),
+            ConversionType::EStargzIndexToRef => {
+                Box::new(StargzBuilder::new(blob_data_size, &build_ctx))
+            }
             ConversionType::EStargzToRafs
             | ConversionType::TargzToRafs
             | ConversionType::TarToRafs => Box::new(TarballBuilder::new(conversion_type)),
@@ -1134,7 +1136,7 @@ impl Command {
             .with_context(|| format!("invalid config file {}", config_file_path))?;
 
         if let Some(build_output) =
-            BlobCompactor::do_compact(rs, dst_bootstrap, chunk_dict, backend, &config)?
+            BlobCompactor::compact(rs, dst_bootstrap, chunk_dict, backend, &config)?
         {
             OutputSerializer::dump(matches, build_output, build_info)?;
         }

--- a/src/bin/nydus-image/validator.rs
+++ b/src/bin/nydus-image/validator.rs
@@ -28,15 +28,17 @@ impl Validator {
         let err = "failed to load bootstrap for validator";
         let tree = Tree::from_bootstrap(&self.sb, &mut ()).context(err)?;
 
-        tree.iterate(&mut |node| {
+        let pre = &mut |t: &Tree| -> Result<()> {
+            let node = t.lock_node();
             if verbosity {
                 println!("inode: {}", node);
                 for chunk in &node.chunks {
                     println!("\t chunk: {}", chunk);
                 }
             }
-            true
-        })?;
+            Ok(())
+        };
+        tree.walk_dfs_pre(pre)?;
 
         Ok(self.sb.superblock.get_blob_infos())
     }

--- a/storage/src/device.rs
+++ b/storage/src/device.rs
@@ -50,7 +50,7 @@ pub(crate) const BLOB_FEATURE_INCOMPAT_VALUE: u32 = 0x0000_00ff;
 bitflags! {
     /// Features bits for blob management.
     pub struct BlobFeatures: u32 {
-        /// Uncompressed chunk data is 4K aligned.
+        /// Uncompressed chunk data is aligned.
         const ALIGNED = 0x0000_0001;
         /// RAFS meta data is inlined in the data blob.
         const INLINED_FS_META = 0x0000_0002;

--- a/storage/src/meta/mod.rs
+++ b/storage/src/meta/mod.rs
@@ -231,8 +231,8 @@ impl BlobCompressionContextHeader {
         self.has_feature(BlobFeatures::ALIGNED)
     }
 
-    /// Set flag indicating whether uncompressed chunks are 4k aligned.
-    pub fn set_4k_aligned(&mut self, aligned: bool) {
+    /// Set flag indicating whether uncompressed chunks are aligned.
+    pub fn set_aligned(&mut self, aligned: bool) {
         if aligned {
             self.s_features |= BlobFeatures::ALIGNED.bits();
         } else {


### PR DESCRIPTION
rafs: optimize the way to build RAFS filesystem
    
The current way to build RAFS filesystem is:
- build the lower tree from parent bootstrap
- convert the lower tree into an array
- build the upper tree from source
- merge the upper tree into the lower tree
- convert the merged tree into another array
- dump nodes from the array
    
Now we optimize it as:
- build the lower tree from parent bootstrap
- build the upper tree from source
- merge the upper tree into the lower tree
- dump the merged tree
