### PR TITLE
feat: support more images for benchmark

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -90,7 +90,7 @@ jobs:
     - name: BenchMark Test
       run: |
         cd misc/benchmark
-        sudo python3 benchmark.py --mode oci
+        sudo python3 benchmark.py --mode oci --image ${{env.IMAGE}}:${{env.TAG}}
     - name: Save Test Result
       uses: actions/upload-artifact@v3
       with:
@@ -123,7 +123,7 @@ jobs:
     - name: BenchMark Test
       run: |
         cd misc/benchmark
-        sudo python3 benchmark.py --mode nydus-no-prefetch
+        sudo python3 benchmark.py --mode nydus-no-prefetch --image ${{env.IMAGE}}:${{env.TAG}}
     - name: Save Test Result
       uses: actions/upload-artifact@v3
       with:
@@ -159,7 +159,7 @@ jobs:
     - name: BenchMark Test
       run: |
         cd misc/benchmark
-        sudo python3 benchmark.py --mode nydus-no-prefetch
+        sudo python3 benchmark.py --mode nydus-no-prefetch --image ${{env.IMAGE}}:${{env.TAG}}
     - name: Save Test Result
       uses: actions/upload-artifact@v3
       with:
@@ -192,7 +192,7 @@ jobs:
     - name: BenchMark Test
       run: |
         cd misc/benchmark
-        sudo python3 benchmark.py --mode nydus-all-prefetch
+        sudo python3 benchmark.py --mode nydus-all-prefetch --image ${{env.IMAGE}}:${{env.TAG}}
     - name: Save Test Result
       uses: actions/upload-artifact@v3
       with:
@@ -228,7 +228,7 @@ jobs:
     - name: BenchMark Test
       run: |
         cd misc/benchmark
-        sudo python3 benchmark.py --mode nydus-all-prefetch
+        sudo python3 benchmark.py --mode nydus-all-prefetch --image ${{env.IMAGE}}:${{env.TAG}}
     - name: Save Test Result
       uses: actions/upload-artifact@v3
       with:
@@ -261,7 +261,7 @@ jobs:
     - name: BenchMark Test
       run: |
         cd misc/benchmark
-        sudo python3 benchmark.py --mode nydus-filelist-prefetch
+        sudo python3 benchmark.py --mode nydus-filelist-prefetch --image ${{env.IMAGE}}:${{env.TAG}}
     - name: Save Test Result
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -212,7 +212,7 @@ jobs:
     - name: BenchMark Test
       run: |
         cd misc/benchmark
-        sudo python3 benchmark.py --mode oci
+        sudo python3 benchmark.py --mode oci --image ${{env.IMAGE}}:${{env.TAG}}
     - name: Save Test Result
       uses: actions/upload-artifact@v3
       with:
@@ -245,7 +245,7 @@ jobs:
     - name: BenchMark Test
       run: |
         cd misc/benchmark
-        sudo python3 benchmark.py --mode nydus-no-prefetch
+        sudo python3 benchmark.py --mode nydus-no-prefetch --image ${{env.IMAGE}}:${{env.TAG}}
     - name: Save Test Result
       uses: actions/upload-artifact@v3
       with:
@@ -279,7 +279,7 @@ jobs:
     - name: BenchMark Test
       run: |
         cd misc/benchmark
-        sudo python3 benchmark.py --mode nydus-no-prefetch
+        sudo python3 benchmark.py --mode nydus-no-prefetch --image ${{env.IMAGE}}:${{env.TAG}}
     - name: Save Test Result
       uses: actions/upload-artifact@v3
       with:
@@ -315,7 +315,7 @@ jobs:
     - name: BenchMark Test
       run: |
         cd misc/benchmark
-        sudo python3 benchmark.py --mode nydus-no-prefetch
+        sudo python3 benchmark.py --mode nydus-no-prefetch --image ${{env.IMAGE}}:${{env.TAG}}
     - name: Save Test Result
       uses: actions/upload-artifact@v3
       with:
@@ -352,7 +352,7 @@ jobs:
     - name: BenchMark Test
       run: |
         cd misc/benchmark
-        sudo python3 benchmark.py --mode nydus-no-prefetch
+        sudo python3 benchmark.py --mode nydus-no-prefetch --image ${{env.IMAGE}}:${{env.TAG}}
     - name: Save Test Result
       uses: actions/upload-artifact@v3
       with:
@@ -385,7 +385,7 @@ jobs:
     - name: BenchMark Test
       run: |
         cd misc/benchmark
-        sudo python3 benchmark.py --mode nydus-all-prefetch
+        sudo python3 benchmark.py --mode nydus-all-prefetch --image ${{env.IMAGE}}:${{env.TAG}}
     - name: Save Test Result
       uses: actions/upload-artifact@v3
       with:
@@ -419,7 +419,7 @@ jobs:
     - name: BenchMark Test
       run: |
         cd misc/benchmark
-        sudo python3 benchmark.py --mode nydus-all-prefetch
+        sudo python3 benchmark.py --mode nydus-all-prefetch --image ${{env.IMAGE}}:${{env.TAG}}
     - name: Save Test Result
       uses: actions/upload-artifact@v3
       with:
@@ -455,7 +455,7 @@ jobs:
     - name: BenchMark Test
       run: |
         cd misc/benchmark
-        sudo python3 benchmark.py --mode nydus-all-prefetch
+        sudo python3 benchmark.py --mode nydus-all-prefetch --image ${{env.IMAGE}}:${{env.TAG}}
     - name: Save Test Result
       uses: actions/upload-artifact@v3
       with:
@@ -492,7 +492,7 @@ jobs:
     - name: BenchMark Test
       run: |
         cd misc/benchmark
-        sudo python3 benchmark.py --mode nydus-all-prefetch
+        sudo python3 benchmark.py --mode nydus-all-prefetch --image ${{env.IMAGE}}:${{env.TAG}}
     - name: Save Test Result
       uses: actions/upload-artifact@v3
       with:
@@ -525,7 +525,7 @@ jobs:
     - name: BenchMark Test
       run: |
         cd misc/benchmark
-        sudo python3 benchmark.py --mode nydus-filelist-prefetch
+        sudo python3 benchmark.py --mode nydus-filelist-prefetch --image ${{env.IMAGE}}:${{env.TAG}}
     - name: Save Test Result
       uses: actions/upload-artifact@v3
       with:
@@ -559,7 +559,7 @@ jobs:
     - name: BenchMark Test
       run: |
         cd misc/benchmark
-        sudo python3 benchmark.py --mode nydus-filelist-prefetch
+        sudo python3 benchmark.py --mode nydus-filelist-prefetch --image ${{env.IMAGE}}:${{env.TAG}}
     - name: Save Test Result
       uses: actions/upload-artifact@v3
       with:

--- a/misc/benchmark/benchmark.py
+++ b/misc/benchmark/benchmark.py
@@ -26,8 +26,16 @@ def main():
         required=True,
         help="The mode of benchmark. Available modes are: oci, nydus-none_prefetch, nydus-all-prefetch, nydus-filelist-prefetch."
     )
+    parser.add_argument(
+        "--image",
+        dest="image",
+        type=str,
+        required=True,
+        help="The benchmark image."
+    )
     args = parser.parse_args()
     mode = args.mode
+    image = args.image
 
     # read config.yml
     cfg = {}
@@ -39,7 +47,7 @@ def main():
             print(inst)
             exit(-1)
     # bench
-    start_bench(cfg, cfg["image"], mode)
+    start_bench(cfg, image, mode)
 
 
 def collect_metrics(cfg: dict, image: str) -> str:

--- a/misc/benchmark/benchmark_summary.py
+++ b/misc/benchmark/benchmark_summary.py
@@ -6,20 +6,20 @@ import subprocess
 from argparse import ArgumentParser
 
 COMMANDS_BENCHMARK = [
-    "sudo install -m 755 benchmark-oci/wordpress.csv oci.csv",
-    "sudo install -m 755 benchmark-nydus-all-prefetch/wordpress.csv nydus-all-prefetch.csv",
-    "sudo install -m 755 benchmark-nydus-no-prefetch/wordpress.csv nydus-no-prefetch.csv",
-    "sudo install -m 755 benchmark-zran-all-prefetch/wordpress.csv zran-all-prefetch.csv",
-    "sudo install -m 755 benchmark-zran-no-prefetch/wordpress.csv zran-no-prefetch.csv",
-    "sudo install -m 755 benchmark-nydus-filelist-prefetch/wordpress.csv nydus-filelist-prefetch.csv"
+    "sudo install -m 755 benchmark-oci/*.csv oci.csv",
+    "sudo install -m 755 benchmark-nydus-all-prefetch/*.csv nydus-all-prefetch.csv",
+    "sudo install -m 755 benchmark-nydus-no-prefetch/*.csv nydus-no-prefetch.csv",
+    "sudo install -m 755 benchmark-zran-all-prefetch/*.csv zran-all-prefetch.csv",
+    "sudo install -m 755 benchmark-zran-no-prefetch/*.csv zran-no-prefetch.csv",
+    "sudo install -m 755 benchmark-nydus-filelist-prefetch/*.csv nydus-filelist-prefetch.csv"
 ]
 
 COMMANDS_BENCHMARK_COMPARE = [
-    "sudo install -m 755 benchmark-zran-all-prefetch-master/wordpress.csv zran-all-prefetch-master.csv",
-    "sudo install -m 755 benchmark-zran-no-prefetch-master/wordpress.csv zran-no-prefetch-master.csv",
-    "sudo install -m 755 benchmark-nydus-no-prefetch-master/wordpress.csv nydus-no-prefetch-master.csv",
-    "sudo install -m 755 benchmark-nydus-all-prefetch-master/wordpress.csv nydus-all-prefetch-master.csv",
-    "sudo install -m 755 benchmark-nydus-filelist-prefetch-master/wordpress.csv nydus-filelist-prefetch-master.csv"
+    "sudo install -m 755 benchmark-zran-all-prefetch-master/*.csv zran-all-prefetch-master.csv",
+    "sudo install -m 755 benchmark-zran-no-prefetch-master/*.csv zran-no-prefetch-master.csv",
+    "sudo install -m 755 benchmark-nydus-no-prefetch-master/*.csv nydus-no-prefetch-master.csv",
+    "sudo install -m 755 benchmark-nydus-all-prefetch-master/*.csv nydus-all-prefetch-master.csv",
+    "sudo install -m 755 benchmark-nydus-filelist-prefetch-master/*.csv nydus-filelist-prefetch-master.csv"
 ]
 
 FILE_LIST = [

--- a/misc/benchmark/config.yml
+++ b/misc/benchmark/config.yml
@@ -3,4 +3,3 @@ insecure_source_registry: False
 local_registry: localhost:5000
 insecure_local_registry: True
 bandwith: 81920
-image: wordpress:6.1.1

--- a/misc/benchmark/convert.py
+++ b/misc/benchmark/convert.py
@@ -50,6 +50,7 @@ class Image:
         convert oci image to nydus image (prefetchfile is optional)
         """
         print(self.convert_cmd())
+        rc = os.system(f"sudo cat {self.prefetch}")
         rc = os.system(self.convert_cmd())
         assert rc == 0
 

--- a/misc/benchmark/go/main.go
+++ b/misc/benchmark/go/main.go
@@ -1,0 +1,6 @@
+package main
+import "fmt"
+
+func main() {
+	fmt.Println("hello")
+}

--- a/misc/benchmark/java/Main.java
+++ b/misc/benchmark/java/Main.java
@@ -1,0 +1,5 @@
+class Main {
+  public static void main(String[] args) {
+    System.out.println("hello");
+  }
+}

--- a/misc/benchmark/metrics.py
+++ b/misc/benchmark/metrics.py
@@ -90,17 +90,21 @@ class MetricsCollector:
 
     def collect(self, repo) -> str:
         """
-            TODO: update to the condition, here is just for wait the wordpress up
+            collect the access files
         """
         # wait wordpress response in 80 port
-        while True:
-            try:
-                req = urllib.request.urlopen("http://localhost:80")
-                print(req.status)
-                req.close()
-                break
-            except:
-                time.sleep(0.01)
+        if self.image == "wordpress":
+            while True:
+                try:
+                    req = urllib.request.urlopen("http://localhost:80")
+                    print(req.status)
+                    req.close()
+                    break
+                except:
+                    time.sleep(0.01)
+        # TODO: support more images
+        else:
+            time.sleep(10)
         socket = search_file(API_DIR, "api.sock")
         if socket == None:
             print("can't find the api.sock")

--- a/misc/benchmark/node/index.js
+++ b/misc/benchmark/node/index.js
@@ -1,0 +1,10 @@
+// Load the http module to create an http server.
+var http = require('http');
+
+// Configure our HTTP server to respond with Hello World to all requests.
+var server = http.createServer(function (request, response) {
+  response.writeHead(200, {"Content-Type": "text/plain"});
+  response.end("hello\n");
+});
+
+server.listen(80);


### PR DESCRIPTION
## To support more images in benchamrk on schedule.
### 1.  move image arg from config.yml to runtime arg.
### 2.  support more images in benchamrk.
| image | status |workflow|stable version test|                                                                                                                                 
| :----:|:------:|:-------|:-------------:|
| wordpress |✅|wait the 80 port response|[6.1.1](https://github.com/dragonflyoss/image-service/actions/runs/4905410815#summary-13290406408)|
|node|✅ |node misc/benchmark/node/index.js & wait the 80 port response|[19.8](https://github.com/dragonflyoss/image-service/actions/runs/4905270374#summary-13290108714)|
|python|✅ |python -c 'print(\"hello\")'|[3.10.7](https://github.com/dragonflyoss/image-service/actions/runs/4905347730#summary-13290238833)|
|golang|✅ |go run misc/benchmark/go/main.go|[1.19.3](https://github.com/dragonflyoss/image-service/actions/runs/4905380439#summary-13290308178)|
|ruby|✅ |ruby -e "puts \\"hello\\""|[3.1.3](https://github.com/dragonflyoss/image-service/actions/runs/4905403314#summary-13290357533)|
|java(amazoncorretto)|✅ |javac msic/becnhmark/java/Main.java & java Main|[8-al2022-jdk](https://github.com/dragonflyoss/image-service/actions/runs/4905408629#summary-13290380744)|