### PR TITLE
action: reuse rust caches

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -7,6 +7,7 @@ on:
   workflow_dispatch:
 
 env:
+  CARGO_TERM_COLOR: always
   IMAGE: wordpress
   TAG: 6.1.1
 
@@ -48,6 +49,7 @@ jobs:
       uses: Swatinem/rust-cache@v2.2.0
       with:
         cache-on-failure: true
+        shared-key: nydus-build
     - name: Build Nydus
       run: |
         rustup component add rustfmt clippy

--- a/.github/workflows/convert.yml
+++ b/.github/workflows/convert.yml
@@ -51,6 +51,7 @@ jobs:
       uses: Swatinem/rust-cache@v2.2.0
       with:
         cache-on-failure: true
+        shared-key: nydus-build
     - name: Build Nydus
       run: |
         rustup component add rustfmt clippy

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           ref: ${{ matrix.branch }}
       - name: Cache cargo
-        uses: Swatinem/rust-cache@v1
+        uses: Swatinem/rust-cache@v2.2.0
         with:
           target-dir: |
             ./target

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Cache cargo
-      uses: Swatinem/rust-cache@v1
+      uses: Swatinem/rust-cache@v2.2.0
       with:
         target-dir: |
           ./target
@@ -57,7 +57,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Cache cargo
-      uses: Swatinem/rust-cache@v1
+      uses: Swatinem/rust-cache@v2.2.0
       with:
         target-dir: |
           ./target

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -88,6 +88,7 @@ jobs:
       uses: Swatinem/rust-cache@v2
       with:
         cache-on-failure: true
+        shared-key: nydus-build
     - name: Build Nydus
       run: |
         rustup component add rustfmt clippy
@@ -112,6 +113,7 @@ jobs:
       uses: Swatinem/rust-cache@v2.2.0
       with:
         cache-on-failure: true
+        shared-key: nydus-build
     - name: Build Nydus
       run: |
         rustup component add rustfmt clippy
@@ -603,6 +605,7 @@ jobs:
       uses: Swatinem/rust-cache@v2
       with:
         cache-on-failure: true
+        shared-key: nydus-build
     - name: Install cargo nextest
       uses: taiki-e/install-action@nextest
     - name: Unit Test

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -85,7 +85,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
     - name: Rust Cache
-      uses: Swatinem/rust-cache@v2
+      uses: Swatinem/rust-cache@v2.2.0
       with:
         cache-on-failure: true
         shared-key: nydus-build
@@ -602,7 +602,7 @@ jobs:
     - name: Checkout
       uses: actions/checkout@v3
     - name: Rust Cache
-      uses: Swatinem/rust-cache@v2
+      uses: Swatinem/rust-cache@v2.2.0
       with:
         cache-on-failure: true
         shared-key: nydus-build
@@ -619,7 +619,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Rust Cache
-        uses: Swatinem/rust-cache@v2
+        uses: Swatinem/rust-cache@v2.2.0
         with:
           cache-on-failure: true
       - name: Install cargo-llvm-cov


### PR DESCRIPTION
### changes
1. update the Swatinem/rust-cache version
2. reuse the rust cache in ```nydus-build```, ```nydus-build-master``` and ``` nydus-unit-tes```.
### reason
1. ```nydus-build``` and ```nydus-build-master``` have same dep.
2. ```nydus-unit-test``` dependences have partial similarity with the ```nydus-build```, and it will use the cache create by ```nydus-build``` because of slower. So it will not block the smoke test.


close #1260.

