### PR TITLE
fix warnings in Release and Integration Test

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -45,11 +45,8 @@ jobs:
       - name: Cache cargo
         uses: Swatinem/rust-cache@v2.2.0
         with:
-          target-dir: |
-            ./target
           cache-on-failure: true
           key: ${{ runner.os }}-cargo-${{ matrix.arch }}
-
       - name: Build nydus-rs
         run: |
           declare -A rust_target_map=( ["amd64"]="x86_64-unknown-linux-musl" ["arm64"]="aarch64-unknown-linux-musl")

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         arch: [amd64, arm64, ppc64le, riscv64]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Cache cargo
       uses: Swatinem/rust-cache@v2.2.0
       with:
@@ -38,7 +38,7 @@ jobs:
         sudo cp -r misc/configs .
         sudo chown -R $(id -un):$(id -gn) . ~/.cargo/
     - name: store-artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: nydus-artifacts-linux-${{ matrix.arch }}
         path: |
@@ -53,7 +53,7 @@ jobs:
       matrix:
         arch: [amd64, arm64]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Cache cargo
       uses: Swatinem/rust-cache@v2.2.0
       with:
@@ -66,7 +66,7 @@ jobs:
         sudo cp -r misc/configs .
         sudo chown -R $(id -un):$(id -gn) . ~/.cargo/
     - name: store-artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: nydus-artifacts-darwin-${{ matrix.arch }}
         path: |
@@ -83,12 +83,12 @@ jobs:
     env:
       DOCKER: false
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-go@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-go@v3
       with:
         go-version: '1.18'
     - name: cache go mod
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: /go/pkg/mod
         key: ${{ runner.os }}-go-${{ hashFiles('**/contrib/nydusify/go.sum', '**/contrib/ctr-remote/go.sum', '**/contrib/nydus-overlayfs/go.sum') }}
@@ -101,7 +101,7 @@ jobs:
         sudo mv contrib/nydusify/cmd/nydusify .
         sudo mv contrib/nydus-overlayfs/bin/nydus-overlayfs .
     - name: store-artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: nydus-artifacts-linux-${{ matrix.arch }}
         path: |
@@ -119,7 +119,7 @@ jobs:
     needs: [nydus-linux, contrib-linux]
     steps:
     - name: download artifacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: nydus-artifacts-${{ matrix.os }}-${{ matrix.arch }}
         path: nydus-static
@@ -135,7 +135,7 @@ jobs:
         sha256sum $tarball > $shasum
         echo "tarball_shasum=${shasum}" >> $GITHUB_ENV
     - name: store-artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: nydus-release-tarball
         path: |
@@ -152,7 +152,7 @@ jobs:
     needs: [nydus-macos]
     steps:
     - name: download artifacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: nydus-artifacts-${{ matrix.os }}-${{ matrix.arch }}
         path: nydus-static
@@ -168,7 +168,7 @@ jobs:
         sha256sum $tarball > $shasum
         echo "tarball_shasum=${shasum}" >> $GITHUB_ENV
     - name: store-artifacts
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: nydus-release-tarball
         path: |
@@ -180,7 +180,7 @@ jobs:
     needs: [prepare-tarball-linux, prepare-tarball-darwin]
     steps:
     - name: download artifacts
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: nydus-release-tarball
         path: nydus-tarball

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,8 +23,6 @@ jobs:
     - name: Cache cargo
       uses: Swatinem/rust-cache@v2.2.0
       with:
-        target-dir: |
-          ./target
         cache-on-failure: true
         key: ${{ runner.os }}-cargo-${{ matrix.arch }}
     - name: Build nydus-rs
@@ -59,8 +57,6 @@ jobs:
     - name: Cache cargo
       uses: Swatinem/rust-cache@v2.2.0
       with:
-        target-dir: |
-          ./target
         cache-on-failure: true
         key: ${{ runner.os }}-cargo-${{ matrix.arch }}
     - name: build


### PR DESCRIPTION
### Update actions version
1. Since we update the rust cache version in release from v1 to v2.2.0 in #1260 , the target-dir is useless, and the ./target will be cached default.
2. We should update the actions to use Node.js 16: actions/checkout@v2, actions/setup-go@v2, actions/cache@v2, actions/upload-artifact@v2.

### changelogs
1. https://github.com/Swatinem/rust-cache/releases/tag/v2.0.0 
2. https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

**Ref: warnings in https://github.com/dragonflyoss/image-service/actions/runs/4903861322**