### PR TITLE
backport(storage): add support for non-continuous chunks to amplify IO

### DIFF
--- a/storage/src/lib.rs
+++ b/storage/src/lib.rs
@@ -72,6 +72,8 @@ macro_rules! impl_getter {
 pub const RAFS_DEFAULT_CHUNK_SIZE: u64 = 1024 * 1024;
 /// Maximum blob chunk size, 16MB.
 pub const RAFS_MAX_CHUNK_SIZE: u64 = 1024 * 1024 * 16;
+/// Generate maximum gap between chunks from merging size.
+pub const RAFS_BATCH_SIZE_TO_GAP_SHIFT: u64 = 7;
 
 /// Error codes related to storage subsystem.
 #[derive(Debug)]

--- a/storage/src/meta/mod.rs
+++ b/storage/src/meta/mod.rs
@@ -1080,6 +1080,9 @@ mod tests {
         let pos = 0;
         w.write_all(data).unwrap();
 
+        let header = BlobMetaHeaderOndisk::default();
+        w.write_all(header.as_bytes()).unwrap();
+
         let mut blob_info = BlobInfo::new(
             0,
             "dummy".to_string(),
@@ -1097,14 +1100,15 @@ mod tests {
             compress::Algorithm::None as u32,
         );
 
-        let mut buffer = alloc_buf(data.len());
+        let mut buffer =
+            alloc_buf(round_up_4k(data.len()) + std::mem::size_of::<BlobMetaHeaderOndisk>());
         let reader: Arc<dyn BlobReader> = Arc::new(DummyBlobReader {
             metrics: BackendMetrics::new("dummy", "localfs"),
             file: r,
         });
         BlobMetaInfo::read_metadata(&blob_info, &reader, &mut buffer).unwrap();
 
-        assert_eq!(buffer, data);
+        assert_eq!(&buffer[0..data.len()], data);
     }
 
     #[test]
@@ -1144,6 +1148,8 @@ mod tests {
 
         let pos = 0;
         w.write_all(&buf).unwrap();
+        let header = BlobMetaHeaderOndisk::default();
+        w.write_all(header.as_bytes()).unwrap();
 
         let compressed_size = buf.len();
         let uncompressed_size = data.len();
@@ -1164,13 +1170,14 @@ mod tests {
             compress::Algorithm::Lz4Block as u32,
         );
 
-        let mut buffer = alloc_buf(uncompressed_size);
+        let mut buffer =
+            alloc_buf(round_up_4k(uncompressed_size) + std::mem::size_of::<BlobMetaHeaderOndisk>());
         let reader: Arc<dyn BlobReader> = Arc::new(DummyBlobReader {
             metrics: BackendMetrics::new("dummy", "localfs"),
             file: r,
         });
         BlobMetaInfo::read_metadata(&blob_info, &reader, &mut buffer).unwrap();
 
-        assert_eq!(buffer, data);
+        assert_eq!(&buffer[0..uncompressed_size], data);
     }
 }

--- a/storage/src/meta/mod.rs
+++ b/storage/src/meta/mod.rs
@@ -621,7 +621,7 @@ impl BlobMetaInfo {
     }
 
     #[inline]
-    fn validate_chunk(&self, entry: &BlobChunkInfoOndisk) -> Result<()> {
+    pub fn validate_chunk(&self, entry: &BlobChunkInfoOndisk) -> Result<()> {
         // For stargz blob, self.state.compressed_size == 0, so don't validate it.
         if (!self.state.is_stargz && entry.compressed_end() > self.state.compressed_size)
             || entry.uncompressed_end() > self.state.uncompressed_size
@@ -711,7 +711,7 @@ pub struct BlobMetaState {
     // chunks, it usually refers to a blob file in cache(e.g. filecache).
     uncompressed_size: u64,
     chunk_count: u32,
-    chunks: ManuallyDrop<Vec<BlobChunkInfoOndisk>>,
+    pub chunks: ManuallyDrop<Vec<BlobChunkInfoOndisk>>,
     base: *const u8,
     unmap_len: usize,
     /// The blob meta is for an stargz image.

--- a/storage/src/meta/mod.rs
+++ b/storage/src/meta/mod.rs
@@ -15,6 +15,7 @@
 //! optimize the communication between blob manager and blob manager clients such as virtiofsd.
 
 use std::any::Any;
+use std::borrow::Cow;
 use std::fs::OpenOptions;
 use std::io::Result;
 use std::mem::{size_of, ManuallyDrop};
@@ -380,12 +381,8 @@ impl BlobMetaInfo {
             }
 
             let buffer = unsafe { std::slice::from_raw_parts_mut(base as *mut u8, expected_size) };
-            buffer[info_size..].fill(0);
-            Self::read_metadata(
-                blob_info,
-                reader.as_ref().unwrap(),
-                &mut buffer[..info_size],
-            )?;
+            buffer[0..].fill(0);
+            Self::read_metadata(blob_info, reader.as_ref().unwrap(), buffer)?;
             header.s_features = u32::to_le(blob_info.meta_flags());
             header.s_ci_offset = u64::to_le(blob_info.meta_ci_offset());
             header.s_ci_compressed_size = u64::to_le(blob_info.meta_ci_compressed_size());
@@ -516,7 +513,12 @@ impl BlobMetaInfo {
         size: u64,
         batch_size: u64,
     ) -> Result<Vec<Arc<dyn BlobChunkInfo>>> {
-        let end = start.checked_add(size).ok_or_else(|| einval!())?;
+        let end = start.checked_add(size).ok_or_else(|| {
+            einval!(einval!(format!(
+                "get_chunks_compressed: invalid start {}/size {}",
+                start, size
+            )))
+        })?;
         if end > self.state.compressed_size {
             return Err(einval!(format!(
                 "get_chunks_compressed: end {} compressed_size {}",
@@ -652,30 +654,28 @@ impl BlobMetaInfo {
             blob_info.meta_ci_uncompressed_size(),
         );
 
-        if blob_info.meta_ci_compressor() == compress::Algorithm::None {
-            let size = reader
-                .read(buffer, blob_info.meta_ci_offset())
-                .map_err(|e| {
-                    eio!(format!(
-                        "failed to read metadata from backend(compressor is none), {:?}",
-                        e
-                    ))
-                })?;
-            if size as u64 != blob_info.meta_ci_uncompressed_size() {
-                return Err(eio!(
-                    "failed to read blob metadata from backend(compressor is None)"
-                ));
-            }
-        } else {
-            let compressed_size = blob_info.meta_ci_compressed_size();
-            let mut buf = alloc_buf(compressed_size as usize);
-            let size = reader
-                .read(&mut buf, blob_info.meta_ci_offset())
-                .map_err(|e| eio!(format!("failed to read metadata from backend, {:?}", e)))?;
-            if size as u64 != compressed_size {
-                return Err(eio!("failed to read blob metadata from backend"));
-            }
+        let compressed_size = blob_info.meta_ci_compressed_size();
+        let uncompressed_size = blob_info.meta_ci_uncompressed_size();
+        let aligned_uncompressed_size = round_up_4k(uncompressed_size);
+        let expected_raw_size = (compressed_size + BLOB_METADATA_HEADER_SIZE) as usize;
+        let mut raw_data = alloc_buf(expected_raw_size);
 
+        let read_size = reader
+            .read(&mut raw_data, blob_info.meta_ci_offset())
+            .map_err(|e| eio!(format!("failed to read metadata from backend, {:?}", e)))?;
+        if read_size != expected_raw_size {
+            return Err(eio!(format!(
+                "failed to read blob metadata from backend, compressor {}",
+                blob_info.meta_ci_compressor()
+            )));
+        }
+
+        let (uncompressed, header) = if blob_info.meta_ci_compressor() == compress::Algorithm::None
+        {
+            let uncompressed = &raw_data[0..uncompressed_size as usize];
+            let header = &raw_data[uncompressed_size as usize..expected_raw_size];
+            (Cow::Borrowed(uncompressed), header)
+        } else {
             // Lz4 does not support concurrent decompression of the same data into
             // the same piece of memory. There will be multiple containers mmap the
             // same file, causing the buffer to be shared between different
@@ -688,16 +688,25 @@ impl BlobMetaInfo {
             // execute the process once when the blob.meta is created for the first
             // time, the memory consumption and performance impact are relatively
             // small.
-            let mut uncom_buf = vec![0u8; buffer.len()];
-            compress::decompress(&buf, None, &mut uncom_buf, blob_info.meta_ci_compressor())
-                .map_err(|e| {
-                    error!("failed to decompress metadata: {}", e);
-                    e
-                })?;
-            buffer.copy_from_slice(&uncom_buf);
-        }
+            let mut uncompressed = vec![0u8; uncompressed_size as usize];
+            let header = &raw_data[compressed_size as usize..expected_raw_size];
+            compress::decompress(
+                &raw_data[0..compressed_size as usize],
+                None,
+                &mut uncompressed,
+                blob_info.meta_ci_compressor(),
+            )
+            .map_err(|e| {
+                error!("failed to decompress metadata: {}", e);
+                e
+            })?;
+            (Cow::Owned(uncompressed), header)
+        };
 
-        // TODO: validate metadata
+        buffer[0..uncompressed_size as usize].copy_from_slice(&uncompressed);
+        buffer[aligned_uncompressed_size as usize
+            ..(aligned_uncompressed_size + BLOB_METADATA_HEADER_SIZE) as usize]
+            .copy_from_slice(header);
 
         Ok(())
     }


### PR DESCRIPTION
1. Amplify I/O to reduce small requests to the backend.
2. Amplify prefetch IO to reduce the number of requests.
3. Read the blob meta header when reading the meta information.

Related PRs: https://github.com/dragonflyoss/image-service/pull/833/commits/d550dfd7bd1da4d703ba0b202b31e88e88915557, https://github.com/dragonflyoss/image-service/pull/833/commits/198746a9b599474494f10565a88c773c4a7a109e.