### PR TITLE
feat:  nydusify can dump metrics created by converter

### DIFF
--- a/contrib/nydusify/cmd/nydusify.go
+++ b/contrib/nydusify/cmd/nydusify.go
@@ -409,6 +409,12 @@ func main() {
 					Usage:   "Path to the nydus-image binary, default to search in PATH",
 					EnvVars: []string{"NYDUS_IMAGE"},
 				},
+				&cli.BoolFlag{
+					Name:    "output-json",
+					Value:   false,
+					Usage:   "Enable saving the metrics collected during conversion in JSON file output.json",
+					EnvVars: []string{"OUTPUT_JSON"},
+				},
 			},
 			Action: func(c *cli.Context) error {
 				setupLogLevel(c)
@@ -503,6 +509,8 @@ func main() {
 					OCIRef:       c.Bool("oci-ref"),
 					AllPlatforms: c.Bool("all-platforms"),
 					Platforms:    c.String("platform"),
+
+					OutputJSON: c.Bool("output-json"),
 				}
 
 				return converter.Convert(context.Background(), opt)

--- a/contrib/nydusify/go.mod
+++ b/contrib/nydusify/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/containerd/containerd v1.7.0
 	github.com/docker/cli v23.0.1+incompatible
 	github.com/docker/distribution v2.8.2+incompatible
-	github.com/goharbor/acceleration-service v0.2.2
+	github.com/goharbor/acceleration-service v0.2.4
 	github.com/google/uuid v1.3.0
 	github.com/hashicorp/go-hclog v1.3.1
 	github.com/hashicorp/go-plugin v1.4.5
@@ -53,7 +53,7 @@ require (
 	github.com/containerd/cgroups v1.1.0 // indirect
 	github.com/containerd/continuity v0.3.0 // indirect
 	github.com/containerd/fifo v1.1.0 // indirect
-	github.com/containerd/nydus-snapshotter v0.7.3 // indirect
+	github.com/containerd/nydus-snapshotter v0.8.0 // indirect
 	github.com/containerd/stargz-snapshotter v0.14.3 // indirect
 	github.com/containerd/stargz-snapshotter/estargz v0.14.3 // indirect
 	github.com/containerd/ttrpc v1.2.1 // indirect
@@ -106,6 +106,6 @@ require (
 	golang.org/x/tools v0.7.0 // indirect
 	google.golang.org/genproto v0.0.0-20230306155012-7f2fa6fef1f4 // indirect
 	google.golang.org/grpc v1.53.0 // indirect
-	google.golang.org/protobuf v1.29.1 // indirect
+	google.golang.org/protobuf v1.30.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/contrib/nydusify/go.sum
+++ b/contrib/nydusify/go.sum
@@ -66,8 +66,8 @@ github.com/containerd/continuity v0.3.0 h1:nisirsYROK15TAMVukJOUyGJjz4BNQJBVsNvA
 github.com/containerd/continuity v0.3.0/go.mod h1:wJEAIwKOm/pBZuBd0JmeTvnLquTB1Ag8espWhkykbPM=
 github.com/containerd/fifo v1.1.0 h1:4I2mbh5stb1u6ycIABlBw9zgtlK8viPI9QkQNRQEEmY=
 github.com/containerd/fifo v1.1.0/go.mod h1:bmC4NWMbXlt2EZ0Hc7Fx7QzTFxgPID13eH0Qu+MAb2o=
-github.com/containerd/nydus-snapshotter v0.7.3 h1:2IxbSZWtX72/8vTIIgR0y9PwUhDjBFXQWfeESOZHF00=
-github.com/containerd/nydus-snapshotter v0.7.3/go.mod h1:cYFdbdN+TigfXXRt/tIvlG6Vh4ZmxkW9rQU13MFEsxE=
+github.com/containerd/nydus-snapshotter v0.8.0 h1:3Hlz/oZBUlOmM0Tf6Y1SrYc3+OOvfZ0q/CFKoGXGtxQ=
+github.com/containerd/nydus-snapshotter v0.8.0/go.mod h1:UJILTN5LVBRY+dt8BGJbp72Xy729hUZsOugObEI3/O8=
 github.com/containerd/stargz-snapshotter v0.14.3 h1:OTUVZoPSPs8mGgmQUE1dqw3WX/3nrsmsurW7UPLWl1U=
 github.com/containerd/stargz-snapshotter v0.14.3/go.mod h1:j2Ya4JeA5gMZJr8BchSkPjlcCEh++auAxp4nidPI6N0=
 github.com/containerd/stargz-snapshotter/estargz v0.14.3 h1:OqlDCK3ZVUO6C3B/5FSkDwbkEETK84kQgEeFwDC+62k=
@@ -114,8 +114,8 @@ github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5x
 github.com/godbus/dbus/v5 v5.0.6/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
-github.com/goharbor/acceleration-service v0.2.2 h1:Yt6hwqnR1h+e8Nhqj0J/Cds9Et20IcvYNIJYu/Vj9cA=
-github.com/goharbor/acceleration-service v0.2.2/go.mod h1:wCUIIFNPOUdlqeQ33fpm4Y1NmnyphjhtvXg/0zmHfYU=
+github.com/goharbor/acceleration-service v0.2.4 h1:lrrKS70L6sOMdFlu03Jx8uxXkx1KUgApM0lnQkqSsnc=
+github.com/goharbor/acceleration-service v0.2.4/go.mod h1:eztG5FA3YEC2RqKncgsR7QXBtrGWGJB8dOzh7bejsGU=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=
@@ -375,8 +375,8 @@ google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlba
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 google.golang.org/protobuf v1.27.1/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
-google.golang.org/protobuf v1.29.1 h1:7QBf+IK2gx70Ap/hDsOmam3GE0v9HicjfEdAxE62UoM=
-google.golang.org/protobuf v1.29.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+google.golang.org/protobuf v1.30.0 h1:kPPoIgf3TsEvrm0PFe15JQ+570QVxYzEvvHqChK+cng=
+google.golang.org/protobuf v1.30.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=

--- a/contrib/nydusify/pkg/converter/converter.go
+++ b/contrib/nydusify/pkg/converter/converter.go
@@ -48,6 +48,8 @@ type Opt struct {
 
 	AllPlatforms bool
 	Platforms    string
+
+	OutputJSON bool
 }
 
 func Convert(ctx context.Context, opt Opt) error {
@@ -87,6 +89,9 @@ func Convert(ctx context.Context, opt Opt) error {
 		return err
 	}
 
-	_, err = cvt.Convert(ctx, opt.Source, opt.Target)
+	metric, err := cvt.Convert(ctx, opt.Source, opt.Target)
+	if opt.OutputJSON {
+		dumpMetric(metric, opt.WorkDir)
+	}
 	return err
 }

--- a/contrib/nydusify/pkg/converter/converter.go
+++ b/contrib/nydusify/pkg/converter/converter.go
@@ -87,5 +87,6 @@ func Convert(ctx context.Context, opt Opt) error {
 		return err
 	}
 
-	return cvt.Convert(ctx, opt.Source, opt.Target)
+	_, err = cvt.Convert(ctx, opt.Source, opt.Target)
+	return err
 }

--- a/contrib/nydusify/pkg/converter/metric.go
+++ b/contrib/nydusify/pkg/converter/metric.go
@@ -1,0 +1,28 @@
+// Copyright 2023 Nydus Developers. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package converter
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+
+	"github.com/goharbor/acceleration-service/pkg/converter"
+	"github.com/pkg/errors"
+)
+
+func dumpMetric(metric *converter.Metric, workDir string) error {
+	file, err := os.Create(filepath.Join(workDir, "output.json"))
+	if err != nil {
+		return errors.Wrap(err, "Create file for metric")
+	}
+	defer file.Close()
+
+	encoder := json.NewEncoder(file)
+	if err := encoder.Encode(metric); err != nil {
+		return errors.Wrap(err, "Encode JSON from metric")
+	}
+	return nil
+}


### PR DESCRIPTION
### We are introducing a new arg called "output-json" that will allow us to save the metrics generated by convert. This will enable us to successfully implement https://github.com/dragonflyoss/image-service/issues/1263 through nydusify. 
For additional information, please see https://github.com/goharbor/acceleration-service/pull/133.