### PR TITLE
Fixes two bugs for rafs v5

### DIFF
--- a/rafs/src/builder/core/bootstrap.rs
+++ b/rafs/src/builder/core/bootstrap.rs
@@ -65,6 +65,14 @@ impl Bootstrap {
         }
         ctx.prefetch.insert_if_need(&tree.node);
         nodes.push_back(tree.node.clone());
+        bootstrap_ctx.inode_map.insert(
+            (
+                tree.node.layer_idx,
+                tree.node.info.src_ino,
+                tree.node.info.src_dev,
+            ),
+            vec![tree.node.index],
+        );
 
         Self::build_rafs(ctx, bootstrap_ctx, &mut tree, &mut nodes)?;
         if ctx.fs_version.is_v6() && !bootstrap_ctx.layered {

--- a/rafs/src/metadata/md_v5.rs
+++ b/rafs/src/metadata/md_v5.rs
@@ -172,12 +172,12 @@ impl RafsSuper {
             if let Ok(ni) = self.get_inode(next_ino, false) {
                 if ni.is_reg() {
                     let next_size = ni.size();
-                    let next_size = if next_size < window_size {
+                    let next_size = if next_size == 0 {
+                        continue;
+                    } else if next_size < window_size {
                         next_size
                     } else if window_size >= self.meta.chunk_size as u64 {
                         window_size / self.meta.chunk_size as u64 * self.meta.chunk_size as u64
-                    } else if next_size == 0 {
-                        continue;
                     } else {
                         break;
                     };


### PR DESCRIPTION
Fixes two bugs for rafs v5:
- record correct inode number for v5
- avoid a possible panic for v5