### PR TITLE
contrib: support nydus-overlayfs and ctr-remote on different platforms

### DIFF
--- a/contrib/ctr-remote/Makefile
+++ b/contrib/ctr-remote/Makefile
@@ -1,7 +1,7 @@
 GIT_COMMIT := $(shell git rev-list -1 HEAD)
 BUILD_TIME := $(shell date -u +%Y%m%d.%H%M)
 PACKAGES ?= $(shell go list ./... | grep -v /vendor/)
-GOARCH ?= amd64
+GOARCH ?= $(shell go env GOARCH)
 GOPROXY ?= https://goproxy.io
 
 ifdef GOPROXY

--- a/contrib/nydus-overlayfs/Makefile
+++ b/contrib/nydus-overlayfs/Makefile
@@ -1,7 +1,7 @@
 GIT_COMMIT := $(shell git rev-parse --verify HEAD --short=7)
 BUILD_TIME := $(shell date -u +%Y%m%d.%H%M)
 PACKAGES ?= $(shell go list ./... | grep -v /vendor/)
-GOARCH ?= amd64
+GOARCH ?= $(shell go env GOARCH)
 GOPROXY ?= https://goproxy.io
 
 ifdef GOPROXY


### PR DESCRIPTION
Otherwise, the binary we compiled cannot run on other platforms such as arm.