### PR TITLE
storage: add runtime support for batch chunk

### DIFF
--- a/smoke/tests/compatibility_test.go
+++ b/smoke/tests/compatibility_test.go
@@ -77,6 +77,7 @@ func (c *CompatibilityTestSuite) TestConvertImages() test.Generator {
 		ctx.Build.Compressor = "lz4_block"
 		ctx.Build.ChunkSize = "0x100000"
 		ctx.Build.OCIRef = false
+		ctx.Build.BatchSize = "0"
 
 		image := c.prepareImage(c.t, scenario.GetString(paramImage))
 		return scenario.Str(), func(t *testing.T) {

--- a/smoke/tests/native_layer_test.go
+++ b/smoke/tests/native_layer_test.go
@@ -41,6 +41,7 @@ func (n *NativeLayerTestSuite) TestMakeLayers() test.Generator {
 		Dimension(paramCacheCompressed, []interface{}{true, false}).
 		Dimension(paramRafsMode, []interface{}{"direct", "cached"}).
 		Dimension(paramEnablePrefetch, []interface{}{false, true}).
+		Dimension(paramBatch, []interface{}{"0", "0x100000"}).
 		Skip(func(param *tool.DescartesItem) bool {
 
 			// rafs v6 not support cached mode nor dummy cache
@@ -50,6 +51,11 @@ func (n *NativeLayerTestSuite) TestMakeLayers() test.Generator {
 
 			// dummy cache not support prefetch
 			if param.GetString(paramCacheType) == "" && param.GetBool(paramEnablePrefetch) {
+				return true
+			}
+
+			// Batch not work with rafs v5.
+			if param.GetString(paramFSVersion) == "5" && param.GetString(paramBatch) != "0" {
 				return true
 			}
 

--- a/smoke/tests/tool/context.go
+++ b/smoke/tests/tool/context.go
@@ -28,6 +28,7 @@ type BuildContext struct {
 	ChunkSize  string
 	OCIRef     bool
 	OCIRefGzip bool
+	BatchSize  string
 }
 
 type RuntimeContext struct {

--- a/storage/src/cache/cachedfile.rs
+++ b/storage/src/cache/cachedfile.rs
@@ -406,6 +406,18 @@ impl FileCacheEntry {
                 .ok_or_else(|| einval!("failed to get ZRan context for chunk"))?;
             let blob_end = ctx.in_offset + ctx.in_len as u64;
             (blob_start, blob_end)
+        } else if self.is_batch {
+            let meta = self
+                .get_blob_meta_info()?
+                .ok_or_else(|| einval!("failed to get blob meta object"))?;
+
+            let (c_offset, _) = meta.get_compressed_info(chunks[0].id())?;
+            let blob_start = c_offset;
+
+            let (c_offset, c_size) = meta.get_compressed_info(chunks[chunks.len() - 1].id())?;
+            let blob_end = c_offset + c_size as u64;
+
+            (blob_start, blob_end)
         } else {
             let last = chunks.len() - 1;
             (chunks[0].compressed_offset(), chunks[last].compressed_end())

--- a/storage/src/cache/cachedfile.rs
+++ b/storage/src/cache/cachedfile.rs
@@ -157,6 +157,8 @@ pub(crate) struct FileCacheEntry {
     pub(crate) is_legacy_stargz: bool,
     // The blob is for an RAFS filesystem in `TARFS` mode.
     pub(crate) is_tarfs: bool,
+    // The blob contains batch chunks.
+    pub(crate) is_batch: bool,
     // The blob is based on ZRan decompression algorithm.
     pub(crate) is_zran: bool,
     // True if direct IO is enabled for the `self.file`, supported for fscache only.
@@ -457,6 +459,10 @@ impl BlobCache for FileCacheEntry {
 
     fn is_legacy_stargz(&self) -> bool {
         self.is_legacy_stargz
+    }
+
+    fn is_batch(&self) -> bool {
+        self.is_batch
     }
 
     fn is_zran(&self) -> bool {

--- a/storage/src/cache/filecache/mod.rs
+++ b/storage/src/cache/filecache/mod.rs
@@ -182,6 +182,7 @@ impl FileCacheEntry {
     ) -> Result<Self> {
         let is_separate_meta = blob_info.has_feature(BlobFeatures::SEPARATE);
         let is_tarfs = blob_info.features().is_tarfs();
+        let is_batch = blob_info.has_feature(BlobFeatures::BATCH);
         let is_zran = blob_info.has_feature(BlobFeatures::ZRAN);
         let blob_id = blob_info.blob_id();
         let blob_meta_id = if is_separate_meta {
@@ -296,12 +297,13 @@ impl FileCacheEntry {
         };
 
         trace!(
-            "filecache entry: is_raw_data {}, direct {}, legacy_stargz {}, separate_meta {}, tarfs {}, zran {}",
+            "filecache entry: is_raw_data {}, direct {}, legacy_stargz {}, separate_meta {}, tarfs {}, batch {}, zran {}",
             mgr.cache_raw_data,
             is_direct_chunkmap,
             is_legacy_stargz,
             is_separate_meta,
             is_tarfs,
+            is_batch,
             is_zran,
         );
         Ok(FileCacheEntry {
@@ -326,6 +328,7 @@ impl FileCacheEntry {
             is_direct_chunkmap,
             is_legacy_stargz,
             is_tarfs,
+            is_batch,
             is_zran,
             dio_enabled: false,
             need_validation,

--- a/storage/src/cache/fscache/mod.rs
+++ b/storage/src/cache/fscache/mod.rs
@@ -210,6 +210,7 @@ impl FileCacheEntry {
             .get_fscache_file()
             .ok_or_else(|| einval!("No fscache file associated with the blob_info"))?;
         let is_separate_meta = blob_info.has_feature(BlobFeatures::SEPARATE);
+        let is_batch = blob_info.has_feature(BlobFeatures::BATCH);
         let is_zran = blob_info.has_feature(BlobFeatures::ZRAN);
         let cache_cipher = blob_info.cipher();
         let is_cache_encrypted = cache_cipher.is_encryption_enabled();
@@ -283,6 +284,7 @@ impl FileCacheEntry {
             is_cache_encrypted,
             is_legacy_stargz: blob_info.is_legacy_stargz(),
             is_tarfs,
+            is_batch,
             is_zran,
             dio_enabled: true,
             need_validation,

--- a/storage/src/meta/batch.rs
+++ b/storage/src/meta/batch.rs
@@ -45,6 +45,16 @@ impl BatchInflateContext {
         self.compressed_size = u32::to_le(compressed_size);
     }
 
+    /// Get compressed offset of the end of the whole batch chunk data.
+    pub fn compressed_end(&self) -> u64 {
+        self.compressed_offset() + self.compressed_size() as u64
+    }
+
+    /// Get uncompressed size of the whole batch chunk data.
+    pub fn uncompressed_batch_size(&self) -> u32 {
+        u32::from_le(self.uncompressed_batch_size)
+    }
+
     /// Convert to an immutable u8 slice.
     pub fn as_slice(&self) -> &[u8] {
         unsafe {

--- a/storage/src/meta/chunk_info_v1.rs
+++ b/storage/src/meta/chunk_info_v1.rs
@@ -223,42 +223,42 @@ mod tests {
         assert_eq!(
             state
                 .chunk_info_array
-                .get_chunk_index_nocheck(0, false)
+                .get_chunk_index_nocheck(&state, 0, false)
                 .unwrap(),
             0
         );
         assert_eq!(
             state
                 .chunk_info_array
-                .get_chunk_index_nocheck(0x1fff, false)
+                .get_chunk_index_nocheck(&state, 0x1fff, false)
                 .unwrap(),
             0
         );
         assert_eq!(
             state
                 .chunk_info_array
-                .get_chunk_index_nocheck(0x100000, false)
+                .get_chunk_index_nocheck(&state, 0x100000, false)
                 .unwrap(),
             1
         );
         assert_eq!(
             state
                 .chunk_info_array
-                .get_chunk_index_nocheck(0x101fff, false)
+                .get_chunk_index_nocheck(&state, 0x101fff, false)
                 .unwrap(),
             1
         );
         state
             .chunk_info_array
-            .get_chunk_index_nocheck(0x2000, false)
+            .get_chunk_index_nocheck(&state, 0x2000, false)
             .unwrap_err();
         state
             .chunk_info_array
-            .get_chunk_index_nocheck(0xfffff, false)
+            .get_chunk_index_nocheck(&state, 0xfffff, false)
             .unwrap_err();
         state
             .chunk_info_array
-            .get_chunk_index_nocheck(0x102000, false)
+            .get_chunk_index_nocheck(&state, 0x102000, false)
             .unwrap_err();
     }
 

--- a/storage/src/meta/chunk_info_v1.rs
+++ b/storage/src/meta/chunk_info_v1.rs
@@ -148,8 +148,6 @@ mod tests {
     use std::sync::Arc;
 
     use nydus_utils::compress;
-    use nydus_utils::digest::RafsDigest;
-    use nydus_utils::filemap::FileMapState;
     use nydus_utils::metrics::BackendMetrics;
     use vmm_sys_util::tempfile::TempFile;
 
@@ -209,10 +207,6 @@ mod tests {
     #[test]
     fn test_get_chunk_index_with_hole() {
         let state = BlobCompressionContext {
-            blob_index: 0,
-            blob_features: 0,
-            compressed_size: 0,
-            uncompressed_size: 0,
             chunk_info_array: ManuallyDrop::new(BlobMetaChunkArray::V1(vec![
                 BlobChunkInfoV1Ondisk {
                     uncomp_info: u64::to_le(0x01ff_f000_0000_0000),
@@ -223,12 +217,7 @@ mod tests {
                     comp_info: u64::to_le(0x00ff_f000_0010_0000),
                 },
             ])),
-            chunk_digest_array: Default::default(),
-            zran_info_array: Default::default(),
-            zran_dict_table: Default::default(),
-            blob_meta_file_map: FileMapState::default(),
-            chunk_digest_file_map: FileMapState::default(),
-            chunk_digest_default: RafsDigest::default(),
+            ..Default::default()
         };
 
         assert_eq!(
@@ -302,12 +291,7 @@ mod tests {
                     comp_info: u64::to_le(0x00ff_f000_0000_5000),
                 },
             ])),
-            chunk_digest_array: Default::default(),
-            zran_info_array: Default::default(),
-            zran_dict_table: Default::default(),
-            blob_meta_file_map: FileMapState::default(),
-            chunk_digest_file_map: FileMapState::default(),
-            chunk_digest_default: RafsDigest::default(),
+            ..Default::default()
         };
         let info = BlobCompressionContextInfo {
             state: Arc::new(state),

--- a/storage/src/meta/chunk_info_v2.rs
+++ b/storage/src/meta/chunk_info_v2.rs
@@ -197,17 +197,18 @@ impl BlobMetaChunkInfo for BlobChunkInfoV2Ondisk {
         if self.compressed_end() > state.compressed_size
             || self.uncompressed_end() > state.uncompressed_size
             || self.uncompressed_size() == 0
-            || (!state.is_separate() && self.compressed_size() == 0)
+            || (!state.is_separate() && !self.is_batch() && self.compressed_size() == 0)
             || (!self.is_compressed() && self.uncompressed_size() != self.compressed_size())
         {
             return Err(einval!(format!(
-                "invalid chunk, blob: index {}/c_end 0x{:}/d_end 0x{:x}, chunk: c_end 0x{:x}/d_end 0x{:x}/compressed {} zran {}",
+                "invalid chunk, blob: index {}/c_size 0x{:}/d_size 0x{:x}, chunk: c_end 0x{:x}/d_end 0x{:x}/compressed {} batch {} zran {}",
                 state.blob_index,
                 state.compressed_size,
                 state.uncompressed_size,
                 self.compressed_end(),
                 self.uncompressed_end(),
                 self.is_compressed(),
+                self.is_batch(),
                 self.is_zran(),
             )));
         }
@@ -264,8 +265,6 @@ impl Display for BlobChunkInfoV2Ondisk {
 mod tests {
     use super::*;
     use crate::meta::BlobMetaChunkArray;
-    use nydus_utils::digest::RafsDigest;
-    use nydus_utils::filemap::FileMapState;
     use std::mem::ManuallyDrop;
 
     #[test]
@@ -323,10 +322,6 @@ mod tests {
     #[test]
     fn test_get_chunk_index_with_hole() {
         let state = BlobCompressionContext {
-            blob_index: 0,
-            blob_features: 0,
-            compressed_size: 0,
-            uncompressed_size: 0,
             chunk_info_array: ManuallyDrop::new(BlobMetaChunkArray::V2(vec![
                 BlobChunkInfoV2Ondisk {
                     uncomp_info: u64::to_le(0x0100_1fff_0000_0000),
@@ -339,12 +334,7 @@ mod tests {
                     data: 0,
                 },
             ])),
-            chunk_digest_array: Default::default(),
-            zran_info_array: Default::default(),
-            zran_dict_table: Default::default(),
-            blob_meta_file_map: FileMapState::default(),
-            chunk_digest_file_map: FileMapState::default(),
-            chunk_digest_default: RafsDigest::default(),
+            ..Default::default()
         };
 
         assert_eq!(

--- a/storage/src/meta/chunk_info_v2.rs
+++ b/storage/src/meta/chunk_info_v2.rs
@@ -340,42 +340,42 @@ mod tests {
         assert_eq!(
             state
                 .chunk_info_array
-                .get_chunk_index_nocheck(0, false)
+                .get_chunk_index_nocheck(&state, 0, false)
                 .unwrap(),
             0
         );
         assert_eq!(
             state
                 .chunk_info_array
-                .get_chunk_index_nocheck(0x1fff, false)
+                .get_chunk_index_nocheck(&state, 0x1fff, false)
                 .unwrap(),
             0
         );
         assert_eq!(
             state
                 .chunk_info_array
-                .get_chunk_index_nocheck(0x100000, false)
+                .get_chunk_index_nocheck(&state, 0x100000, false)
                 .unwrap(),
             1
         );
         assert_eq!(
             state
                 .chunk_info_array
-                .get_chunk_index_nocheck(0x101fff, false)
+                .get_chunk_index_nocheck(&state, 0x101fff, false)
                 .unwrap(),
             1
         );
         state
             .chunk_info_array
-            .get_chunk_index_nocheck(0x2000, false)
+            .get_chunk_index_nocheck(&state, 0x2000, false)
             .unwrap_err();
         state
             .chunk_info_array
-            .get_chunk_index_nocheck(0xfffff, false)
+            .get_chunk_index_nocheck(&state, 0xfffff, false)
             .unwrap_err();
         state
             .chunk_info_array
-            .get_chunk_index_nocheck(0x102000, false)
+            .get_chunk_index_nocheck(&state, 0x102000, false)
             .unwrap_err();
     }
 }


### PR DESCRIPTION
Add the runtime support for small chunk mergence.

# basic usage

Add the `--batch-size` arg to command to enable chunk mergence for supported conversion types:

```shell
nydus-image create --bootstrap ~/bootstrap --blob-dir ~/blobs ~/source --batch-size 0x100000

nydus-image create --type estargz-rafs --bootstrap ~/bootstrap --blob-dir ~/blobs ~/source.tar.gz --batch-size 0x100000

nydus-image create --type targz-rafs --bootstrap ~/bootstrap --blob-dir ~/blobs ~/source.tar.gz --batch-size 0x100000

nydus-image create --type tar-rafs --bootstrap ~/bootstrap --blob-dir ~/blobs ~/source.tar --batch-size 0x100000

nydusify convert --source node:latest --target node:latest-nydus-batch-256K --batch-size 0x40000
```

# benchmarks

Tested on 4C4G VM, pulled from private harbor registry in the same Campus Network. Cleaned containerd images and nydus-snapshotter cache before each run. Each value is averaged over five runs.

| repositories| command | tags | prefetch | startup e2e time (s) | % | 
|--|--|--|:--:|--:|--:|
| python | python --version | latest-rafs | ✔ | 2.746 | - |
| python | python --version | latest-rafs (second run) | ✔ | 2.995 | +9.08% |
| python | python --version | latest-rafs-batch-64K | ✔ | 2.202 | -19.80% |
| python | python --version | latest-rafs-batch-128K | ✔ | 2.580 | -6.05% |
| python | python --version | latest-rafs-batch-256K | ✔ | 2.272 | -17.27% |
| python | python --version | latest-rafs-batch-512K | ✔ | 2.157 | -21.44% |
| python | python --version | latest-rafs-batch-1M | ✔ | 1.628 | -40.71% |
| python | python --version | latest-rafs | ✖ | 1.369 | - |
| python | python --version | latest-rafs (second run) | ✖ | 1.174 | -14.25% |
| python | python --version | latest-rafs-batch-64K | ✖ | 1.052 | -23.15% |
| python | python --version | latest-rafs-batch-128K | ✖ | 1.081 | -21.05% |
| python | python --version | latest-rafs-batch-256K | ✖ | 1.075 | -21.48% |
| python | python --version | latest-rafs-batch-512K | ✖ | 1.100 | -19.62% |
| python | python --version | latest-rafs-batch-1M | ✖ | 1.100 | -19.60% |
| python | python --version | alpine3.17-rafs | ✔ | 0.784 | - |
| python | python --version | alpine3.17-rafs (second run) | ✔ | 0.803 | +2.42% |
| python | python --version | alpine3.17-rafs-batch-64K | ✔ | 0.811 | +3.41% |
| python | python --version | alpine3.17-rafs-batch-128K | ✔ | 0.818 | +4.30% |
| python | python --version | alpine3.17-rafs-batch-256K | ✔ | 0.764 | -2.58% |
| python | python --version | alpine3.17-rafs-batch-512K | ✔ | 0.776 | -0.96% |
| python | python --version | alpine3.17-rafs-batch-1M | ✔ | 0.750 | -4.33% |
| python | python --version | alpine3.17-rafs | ✖ | 0.850 | - |
| python | python --version | alpine3.17-rafs (second run) | ✖ | 0.911 | +7.17% |
| python | python --version | alpine3.17-rafs-batch-64K | ✖ | 0.805 | -5.22% |
| python | python --version | alpine3.17-rafs-batch-128K | ✖ | 0.834 | -1.86% |
| python | python --version | alpine3.17-rafs-batch-256K | ✖ | 0.813 | -4.35% |
| python | python --version | alpine3.17-rafs-batch-512K | ✖ | 0.829 | -2.47% |
| python | python --version | alpine3.17-rafs-batch-1M | ✖ | 0.805 | -5.21% |
| node | npm -v | latest-rafs | ✔ | 8.395 | - |
| node | npm -v | latest-rafs (second run) | ✔ | 11.928 | +42.08% |
| node | npm -v | latest-rafs-batch-64K | ✔ | 12.704 | +51.32% |
| node | npm -v | latest-rafs-batch-128K | ✔ | 9.614 | +14.51% |
| node | npm -v | latest-rafs-batch-256K | ✔ | 9.164 | +9.15% |
| node | npm -v | latest-rafs-batch-512K | ✔ | 5.605 | -33.24% |
| node | npm -v | latest-rafs-batch-1M | ✔ | 4.192 | -50.07% |
| node | npm -v | latest-rafs | ✖ | 1.593 | - |
| node | npm -v | latest-rafs (second run) | ✖ | 1.595 | +0.11% |
| node | npm -v | latest-rafs-batch-64K | ✖ | 1.576 | -1.07% |
| node | npm -v | latest-rafs-batch-128K | ✖ | 1.506 | -5.48% |
| node | npm -v | latest-rafs-batch-256K | ✖ | 1.517 | -4.78% |
| node | npm -v | latest-rafs-batch-512K | ✖ | 1.543 | -3.14% |
| node | npm -v | latest-rafs-batch-1M | ✖ | 1.589 | -0.22% |
| node | npm -v | 19-alpine-rafs | ✔ | 2.829 | - |
| node | npm -v | 19-alpine-rafs (second run) | ✔ | 2.667 | -5.72% |
| node | npm -v | 19-alpine-rafs-batch-64K | ✔ | 3.423 | +21.01% |
| node | npm -v | 19-alpine-rafs-batch-128K | ✔ | 3.097 | +9.50% |
| node | npm -v | 19-alpine-rafs-batch-256K | ✔ | 3.249 | +14.85% |
| node | npm -v | 19-alpine-rafs-batch-512K | ✔ | 3.054 | +7.95% |
| node | npm -v | 19-alpine-rafs-batch-1M | ✔ | 2.792 | -1.32% |
| node | npm -v | 19-alpine-rafs | ✖ | 1.372 | - |
| node | npm -v | 19-alpine-rafs (second run) | ✖ | 1.414 | +3.06% |
| node | npm -v | 19-alpine-rafs-batch-64K | ✖ | 1.392 | +1.46% |
| node | npm -v | 19-alpine-rafs-batch-128K | ✖ | 1.396 | +1.73% |
| node | npm -v | 19-alpine-rafs-batch-256K | ✖ | 1.430 | +4.19% |
| node | npm -v | 19-alpine-rafs-batch-512K | ✖ | 1.393 | +1.50% |
| node | npm -v | 19-alpine-rafs-batch-1M | ✖ | 1.411 | +2.86% |


This PR is related to https://github.com/dragonflyoss/image-service/pull/1202, https://github.com/dragonflyoss/image-service/issues/884, https://github.com/dragonflyoss/image-service/issues/885, https://github.com/dragonflyoss/Dragonfly2/issues/1858