### PR TITLE
builder: delay free data structure to reduce image build time

### DIFF
--- a/rafs/src/builder/directory.rs
+++ b/rafs/src/builder/directory.rs
@@ -6,7 +6,7 @@ use std::fs;
 use std::fs::DirEntry;
 
 use anyhow::{anyhow, Context, Result};
-use nydus_utils::{event_tracer, root_tracer, timing_tracer};
+use nydus_utils::{event_tracer, lazy_drop, root_tracer, timing_tracer};
 
 use super::core::blob::Blob;
 use super::core::context::{
@@ -189,6 +189,8 @@ impl Builder for DirectoryBuilder {
                 "dump_bootstrap"
             )?;
         }
+
+        lazy_drop(bootstrap_ctx);
 
         BuildOutput::new(blob_mgr, &bootstrap_mgr.bootstrap_storage)
     }

--- a/rafs/src/builder/stargz.rs
+++ b/rafs/src/builder/stargz.rs
@@ -20,7 +20,7 @@ use nydus_storage::{RAFS_MAX_CHUNKS_PER_BLOB, RAFS_MAX_CHUNK_SIZE};
 use nydus_utils::compact::makedev;
 use nydus_utils::compress::{self, compute_compressed_gzip_size};
 use nydus_utils::digest::{self, DigestData, RafsDigest};
-use nydus_utils::{root_tracer, timing_tracer, try_round_up_4k, ByteSize};
+use nydus_utils::{lazy_drop, root_tracer, timing_tracer, try_round_up_4k, ByteSize};
 use serde::{Deserialize, Serialize};
 
 use super::core::blob::Blob;
@@ -896,6 +896,8 @@ impl Builder for StargzBuilder {
                 "dump_bootstrap"
             )?;
         }
+
+        lazy_drop(bootstrap_ctx);
 
         BuildOutput::new(blob_mgr, &bootstrap_mgr.bootstrap_storage)
     }

--- a/rafs/src/builder/tarball.rs
+++ b/rafs/src/builder/tarball.rs
@@ -32,7 +32,7 @@ use nydus_utils::compact::makedev;
 use nydus_utils::compress::zlib_random::{ZranReader, ZRAN_READER_BUF_SIZE};
 use nydus_utils::compress::ZlibDecoder;
 use nydus_utils::digest::RafsDigest;
-use nydus_utils::{div_round_up, root_tracer, timing_tracer, BufReaderInfo, ByteSize};
+use nydus_utils::{div_round_up, lazy_drop, root_tracer, timing_tracer, BufReaderInfo, ByteSize};
 
 use super::core::blob::Blob;
 use super::core::context::{
@@ -584,6 +584,8 @@ impl Builder for TarballBuilder {
                 "dump_bootstrap"
             )?;
         }
+
+        lazy_drop(bootstrap_ctx);
 
         BuildOutput::new(blob_mgr, &bootstrap_mgr.bootstrap_storage)
     }

--- a/src/bin/nydus-image/main.rs
+++ b/src/bin/nydus-image/main.rs
@@ -39,7 +39,9 @@ use nydus_storage::factory::BlobFactory;
 use nydus_storage::meta::{format_blob_features, BatchContextGenerator};
 use nydus_storage::{RAFS_DEFAULT_CHUNK_SIZE, RAFS_MAX_CHUNK_SIZE};
 use nydus_utils::trace::{EventTracerClass, TimingTracerClass, TraceClass};
-use nydus_utils::{compress, digest, event_tracer, register_tracer, root_tracer, timing_tracer};
+use nydus_utils::{
+    compress, digest, event_tracer, lazy_drop, register_tracer, root_tracer, timing_tracer,
+};
 use serde::{Deserialize, Serialize};
 
 use crate::unpack::{OCIUnpacker, Unpacker};
@@ -1025,6 +1027,8 @@ impl Command {
             },
             "total_build"
         )?;
+
+        lazy_drop(build_ctx);
 
         // Some operations like listing xattr pairs of certain namespace need the process
         // to be privileged. Therefore, trace what euid and egid are.

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -110,6 +110,21 @@ impl Delayer {
     }
 }
 
+struct LazyDrop<T> {
+    v: T,
+}
+
+unsafe impl<T> Send for LazyDrop<T> {}
+
+/// Lazy drop of object.
+pub fn lazy_drop<T: 'static>(v: T) {
+    let v = LazyDrop { v };
+    std::thread::spawn(move || {
+        std::thread::sleep(Duration::from_secs(600));
+        let _ = v.v;
+    });
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
According to perf flame graph, it takes a long time to free objects used by image builder. In most common cases, the builder will only run once and exit, so it's unnecessary to free those used objects.

## Types of changes

_What types of changes does your PullRequest introduce? Put an `x` in all the boxes that apply:_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Go over all the following points, and put an `x` in all the boxes that apply._

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.