### PR TITLE
 cargo: Add rusqlite package to dependencies and nydus-image: Store chunk and blob metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "ahash"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -116,6 +127,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6776fc96284a0bb647b615056fc496d1fe1644a7ab01829818a6d91cae888b84"
+
+[[package]]
 name = "blake3"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -200,7 +217,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335867764ed2de42325fafe6d18b8af74ba97ee0c590fa016f157535b42ab04b"
 dependencies = [
  "atty",
- "bitflags",
+ "bitflags 1.3.2",
  "clap_derive",
  "clap_lex",
  "once_cell",
@@ -413,6 +430,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
 name = "fastrand"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -499,7 +528,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58a8f2394690faff745335f120fad1d7d8bd737069690c856c11befa7bca1b18"
 dependencies = [
  "arc-swap",
- "bitflags",
+ "bitflags 1.3.2",
  "caps",
  "core-foundation-sys",
  "lazy_static",
@@ -642,7 +671,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5dd7365d734a70ac5dd7be791b0c96083852188df015b8c665bb2dadb108a743"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "crc",
  "log",
  "uuid",
@@ -672,6 +701,24 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+
+[[package]]
+name = "hashbrown"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0761a1b9491c4f2e3d66aa0f62d0fba0af9a0e2852e4d48ea506632a4b56e6aa"
+dependencies = [
+ "hashbrown 0.13.2",
+]
 
 [[package]]
 name = "heck"
@@ -829,7 +876,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -857,7 +904,7 @@ version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ba34abb5175052fc1a2227a10d2275b7386c9990167de9786c0b88d8b062330"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "libc",
 ]
 
@@ -913,6 +960,17 @@ name = "libc"
 version = "0.2.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afc22eff61b133b115c6e8c74e818c628d6d5e7a502afea6f64dee076dd94326"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "libz-sys"
@@ -1063,7 +1121,7 @@ version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "195cdbc1741b8134346d515b3a56a1c94b0912758009cfd53f99ea0f57b065fc"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "libc",
  "memoffset",
@@ -1155,7 +1213,7 @@ dependencies = [
  "arc-swap",
  "assert_matches",
  "base64 0.13.1",
- "bitflags",
+ "bitflags 1.3.2",
  "blake3",
  "fuse-backend-rs",
  "futures",
@@ -1203,6 +1261,7 @@ dependencies = [
  "nydus-utils",
  "openssl",
  "rlimit",
+ "rusqlite",
  "serde",
  "serde_json",
  "tar",
@@ -1253,7 +1312,7 @@ version = "0.6.2"
 dependencies = [
  "arc-swap",
  "base64 0.13.1",
- "bitflags",
+ "bitflags 1.3.2",
  "fuse-backend-rs",
  "gpt",
  "hex",
@@ -1319,9 +1378,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.13.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
+checksum = "b7e5500299e16ebb147ae15a00a942af264cf3688f47923b8fc2cd5858f23ad3"
 
 [[package]]
 name = "openssl"
@@ -1329,7 +1388,7 @@ version = "0.10.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "518915b97df115dd36109bfa429a48b8f737bd05508cf9588977b599648926d2"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -1505,7 +1564,7 @@ version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62f25bc4c7e55e0b0b7a1d43fb893f4fa1361d0abe38b9ce4f323c2adfe6ef42"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -1572,6 +1631,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusqlite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "549b9d036d571d42e6e85d1c1425e2ac83491075078ca9a15be021c56b1641f2"
+dependencies = [
+ "bitflags 2.3.1",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+]
+
+[[package]]
 name = "rust-fsm"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1602,7 +1675,7 @@ version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fdebc4b395b7fbb9ab11e462e20ed9051e7b16e42d24042c776eca0ac81b03"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",
@@ -1649,7 +1722,7 @@ version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dc14f172faf8a0194a3aded622712b0de276821addc574fa54fc0a1167e10dc"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "core-foundation",
  "core-foundation-sys",
  "libc",
@@ -2057,7 +2130,7 @@ version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79243657c76e5c90dcbf60187c842614f6dfc7123972c55bb3bcc446792aca93"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "libc",
  "vm-memory",
  "vmm-sys-util",
@@ -2113,7 +2186,7 @@ version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08604d7be03eb26e33b3cee3ed4aef2bf550b305d1cca60e84da5d28d3790b62"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "libc",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ log-panics = { version = "2.1.0", features = ["with-backtrace"] }
 mio = { version = "0.8", features = ["os-poll", "os-ext"] }
 nix = "0.24.0"
 rlimit = "0.9.0"
+rusqlite = { version = "0.29.0", features = ["bundled"] }
 serde = { version = "1.0.110", features = ["serde_derive", "rc"] }
 serde_json = "1.0.51"
 tar = "0.4.38"
@@ -58,13 +59,17 @@ openssl = { version = "0.10.48", features = ["vendored"] }
 
 nydus-api = { version = "0.2.2", path = "api", features = ["handler"] }
 nydus-rafs = { version = "0.2.2", path = "rafs", features = ["builder"] }
-nydus-service = { version = "0.2.0", path = "service", features = ["block-device"] }
+nydus-service = { version = "0.2.0", path = "service", features = [
+    "block-device",
+] }
 nydus-storage = { version = "0.6.2", path = "storage" }
 nydus-utils = { version = "0.4.1", path = "utils" }
 
 vhost = { version = "0.5.0", features = ["vhost-user-slave"], optional = true }
 vhost-user-backend = { version = "0.7.0", optional = true }
-virtio-bindings = { version = "0.1", features = ["virtio-v5_0_0"], optional = true }
+virtio-bindings = { version = "0.1", features = [
+    "virtio-v5_0_0",
+], optional = true }
 virtio-queue = { version = "0.6.0", optional = true }
 vm-memory = { version = "0.9.0", features = ["backend-mmap"], optional = true }
 vmm-sys-util = { version = "0.10.0", optional = true }
@@ -94,9 +99,7 @@ virtiofs = [
     "vm-memory",
     "vmm-sys-util",
 ]
-block-nbd = [
-    "nydus-service/block-nbd"
-]
+block-nbd = ["nydus-service/block-nbd"]
 
 backend-http-proxy = ["nydus-storage/backend-http-proxy"]
 backend-localdisk = ["nydus-storage/backend-localdisk"]

--- a/src/bin/nydus-image/deduplicate.rs
+++ b/src/bin/nydus-image/deduplicate.rs
@@ -1,0 +1,239 @@
+// Copyright 2020 Ant Group. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//! Deduplicate for Chunk
+
+use std::path::Path;
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use nydus_api::ConfigV2;
+use nydus_rafs::builder::Tree;
+use nydus_rafs::metadata::RafsSuper;
+use nydus_storage::device::BlobInfo;
+use nydus_storage::meta::format_blob_features;
+use rusqlite::{params, Connection};
+pub struct Deduplicate {
+    sb: RafsSuper,
+}
+
+impl Deduplicate {
+    pub fn new(bootstrap_path: &Path, config: Arc<ConfigV2>) -> Result<Self> {
+        let (sb, _) = RafsSuper::load_from_file(bootstrap_path, config, false)?;
+        Ok(Self { sb })
+    }
+
+    /// save metadata to database: chunk and blob info
+    pub fn save_metadata_to_database(&mut self) -> Result<Vec<Arc<BlobInfo>>> {
+        let err = "failed to load bootstrap for deduplicate";
+        let tree = Tree::from_bootstrap(&self.sb, &mut ()).context(err)?;
+
+        // Connect to the database
+        let database_file: &str = "metadata.db";
+        let conn = Connection::open(database_file)?;
+
+        // Create blob table and chunk table
+        ChunkTable::creat_table(&conn)?;
+        BlobTable::creat_table(&conn)?;
+
+        let blob_infos = self.sb.superblock.get_blob_infos();
+        for blob in &blob_infos {
+            BlobTable::insert_data_into_table(
+                &conn,
+                &BlobTable {
+                    blob_id: blob.blob_id().to_string(),
+                    blob_size: blob.uncompressed_size().to_string(),
+                    image_name: format_blob_features(blob.features()),
+                },
+            )?;
+        }
+        let pre = &mut |t: &Tree| -> Result<()> {
+            let node = t.lock_node();
+            for chunk in &node.chunks {
+                let index: u32 = chunk.inner.blob_index();
+                // Get blob id
+                let chunk_blob_id = blob_infos[index as usize].blob_id();
+                // Insert chunk into chunk table
+                ChunkTable::insert_data_into_table(
+                    &conn,
+                    &ChunkTable {
+                        id: 1,
+                        chunk_blob_id,
+                        chunk_digest: chunk.inner.id().to_string(),
+                        chunk_compressed_size: chunk.inner.compressed_size(),
+                        chunk_uncompressed_size: chunk.inner.uncompressed_size(),
+                        chunk_compressed_offset: chunk.inner.compressed_offset(),
+                        chunk_uncompressed_offset: chunk.inner.uncompressed_offset(),
+                    },
+                )?;
+            }
+            Ok(())
+        };
+        tree.walk_dfs_pre(pre)?;
+    
+        Ok(self.sb.superblock.get_blob_infos())
+    }    
+}
+
+#[allow(dead_code)]
+pub trait Table: Sync + Send + Sized + 'static {
+    // clear table
+    fn clear(conn: Connection) -> Result<()>;
+
+    //crate table
+    fn creat_table(conn: &Connection) -> Result<()>;
+
+    //insert
+    fn insert_data_into_table(conn: &Connection, table: &Self) -> Result<()>;
+
+    // search
+    fn get_data_from_table(conn: &Connection) -> Result<Vec<Self>>;
+
+    //delete
+
+    //modify
+}
+
+#[derive(Debug)]
+#[allow(dead_code)]
+struct ChunkTable {
+    id: i64,
+    chunk_blob_id: String,
+    chunk_digest: String,
+    chunk_compressed_size: u32,
+    chunk_uncompressed_size: u32,
+    chunk_compressed_offset: u64,
+    chunk_uncompressed_offset: u64,
+}
+
+impl Table for ChunkTable {
+    fn clear(conn: Connection) -> Result<()> {
+        let _ = conn.execute("DROP TABLE chunk", [])?;
+        Ok(())
+    }
+
+    fn creat_table(conn: &Connection) -> Result<()> {
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS chunk (
+                id               INTEGER PRIMARY KEY ,
+                chunk_blob_id    TEXT NOT NULL,
+                chunk_digest     TEXT,
+                chunk_compressed_size  INT,
+                chunk_uncompressed_size  INT,
+                chunk_compressed_offset  INT,
+                chunk_uncompressed_offset  INT
+            )",
+            [],
+        )?;
+        Ok(())
+    }
+
+    fn insert_data_into_table(conn: &Connection, chunk_table: &ChunkTable) -> Result<()> {
+        conn.execute(
+            "INSERT INTO chunk(chunk_blob_id,chunk_digest,chunk_compressed_size,
+                chunk_uncompressed_size,chunk_compressed_offset,chunk_uncompressed_offset)
+            VALUES (?1, ?2, ?3, ?4, ?5, ?6);
+            ",
+            params![
+                chunk_table.chunk_blob_id,
+                chunk_table.chunk_digest,
+                chunk_table.chunk_compressed_size,
+                chunk_table.chunk_uncompressed_size,
+                chunk_table.chunk_compressed_offset,
+                chunk_table.chunk_uncompressed_offset
+            ],
+        )?;
+
+        Ok(())
+    }
+
+    fn get_data_from_table(conn: &Connection) -> Result<Vec<ChunkTable>> {
+        let mut stmt = conn.prepare(
+            "SELECT id, chunk_blob_id, chunk_digest,chunk_compressed_size,
+        chunk_uncompressed_size, chunk_compressed_offset, chunk_uncompressed_offset from chunk",
+        )?;
+        let chunk_iterator = stmt.query_map([], |row| {
+            Ok(ChunkTable {
+                id: row.get(0)?,
+                chunk_blob_id: row.get(1)?,
+                chunk_digest: row.get(2)?,
+                chunk_compressed_size: row.get(3)?,
+                chunk_uncompressed_size: row.get(4)?,
+                chunk_compressed_offset: row.get(5)?,
+                chunk_uncompressed_offset: row.get(6)?,
+            })
+        })?;
+        let mut chunks = Vec::new();
+        for chunk in chunk_iterator {
+            chunks.push(chunk?);
+        }
+        Ok(chunks)
+    }
+}
+
+#[derive(Debug)]
+#[allow(dead_code)]
+pub struct BlobTable {
+    // id: i32,
+    blob_id: String,
+    blob_size: String,
+    image_name: String,
+}
+
+impl Table for BlobTable {
+    fn clear(conn: Connection) -> Result<()> {
+        let _ = conn.execute("DROP TABLE blob", [])?;
+        Ok(())
+    }
+
+    fn creat_table(conn: &Connection) -> Result<()> {
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS blob (
+                blob_id             TEXT PRIMARY KEY ,
+                blob_size           TEXT NOT NULL,
+                image_name          TEXT
+            )",
+            [],
+        )?;
+        Ok(())
+    }
+
+    fn insert_data_into_table(conn: &Connection, blob_table: &BlobTable) -> Result<()> {
+        conn.execute(
+            "INSERT INTO blob (blob_id, blob_size, image_name)
+            SELECT ?1, ?2, ?3
+            WHERE NOT EXISTS (
+                SELECT blob_id
+                FROM blob
+                WHERE blob_id = ?4
+            ) limit 1
+            ;
+            ",
+            params![
+                blob_table.blob_id,
+                blob_table.blob_size,
+                blob_table.image_name,
+                blob_table.blob_id
+            ],
+        )?;
+
+        Ok(())
+    }
+
+    fn get_data_from_table(conn: &Connection) -> Result<Vec<BlobTable>> {
+        let mut stmt = conn.prepare("SELECT blob_id,blob_size,image_name from blob")?;
+        let blob_iterator = stmt.query_map([], |row| {
+            Ok(BlobTable {
+                blob_id: row.get(0)?,
+                blob_size: row.get(1)?,
+                image_name: row.get(2)?,
+            })
+        })?;
+        let mut blobs = Vec::new();
+        for blob in blob_iterator {
+            blobs.push(blob?);
+        }
+        Ok(blobs)
+    }
+}

--- a/src/bin/nydus-image/main.rs
+++ b/src/bin/nydus-image/main.rs
@@ -44,6 +44,7 @@ use nydus_utils::{
 };
 use serde::{Deserialize, Serialize};
 
+use crate::deduplicate::Deduplicate;
 use crate::unpack::{OCIUnpacker, Unpacker};
 use crate::validator::Validator;
 
@@ -52,6 +53,7 @@ use nydus_service::ServiceArgs;
 #[cfg(target_os = "linux")]
 use std::str::FromStr;
 
+mod deduplicate;
 mod inspect;
 mod stat;
 mod unpack;
@@ -347,6 +349,47 @@ fn prepare_cmd_args(bti_string: &'static str) -> App {
                     arg_output_json.clone(),
                 )
         );
+
+    let app = app.subcommand(
+        App::new("chunkdict")
+            .about("deduplicate RAFS filesystem metadata")
+            .subcommand(
+                App::new("save")
+                    .about("Save chunk info to a database")
+                    .arg(
+                        Arg::new("BOOTSTRAP")
+                            .help("File path of RAFS metadata")
+                            .required_unless_present("bootstrap"),
+                    )
+                    .arg(
+                        Arg::new("bootstrap")
+                            .short('B')
+                            .long("bootstrap")
+                            .help("[Deprecated] File path of RAFS meta blob/bootstrap")
+                            .conflicts_with("BOOTSTRAP")
+                            .required(false),
+                    )
+                    .arg(
+                        Arg::new("blob-dir")
+                            .long("blob-dir")
+                            .short('D')
+                            .conflicts_with("config")
+                            .help(
+                                "Directory for localfs storage backend, hosting data blobs and cache files",
+                            ),
+                    )
+                    .arg(arg_config.clone())
+                    .arg(
+                        Arg::new("verbose")
+                            .long("verbose")
+                            .short('v')
+                            .help("Output message in verbose mode")
+                            .action(ArgAction::SetTrue)
+                            .required(false),
+                    )
+                    .arg(arg_output_json.clone())
+            )
+    );
 
     let app = app.subcommand(
         App::new("merge")
@@ -691,6 +734,13 @@ fn main() -> Result<()> {
 
     if let Some(matches) = cmd.subcommand_matches("create") {
         Command::create(matches, &build_info)
+    } else if let Some(matches) = cmd.subcommand_matches("chunkdict") {
+        if let Some(sub_matches) = matches.subcommand_matches("save") {
+            Command::chunkdict_save(sub_matches)
+        } else {
+            println!("{}", usage);
+            Ok(())
+        }
     } else if let Some(matches) = cmd.subcommand_matches("merge") {
         Command::merge(matches, &build_info)
     } else if let Some(matches) = cmd.subcommand_matches("check") {
@@ -1036,6 +1086,36 @@ impl Command {
         event_tracer!("egid", "{}", getegid());
         info!("successfully built RAFS filesystem: \n{}", build_output);
         OutputSerializer::dump(matches, build_output, build_info)
+    }
+
+    fn chunkdict_save(matches: &ArgMatches) -> Result<()> {
+        let bootstrap_path = Self::get_bootstrap(matches)?;
+        let config = Self::get_configuration(matches)?;
+        // For backward compatibility with v2.1
+        config
+            .internal
+            .set_blob_accessible(matches.get_one::<String>("bootstrap").is_none());
+
+        let mut deduplicate = Deduplicate::new(bootstrap_path, Arc::clone(&config))?;
+        let blobs = deduplicate
+            .save_metadata_to_database()
+            .with_context(|| format!("failed to check bootstrap {:?}", bootstrap_path))?;
+        println!("RAFS filesystem metadata is saved.");
+        let mut blob_ids = Vec::new();
+        for (idx, blob) in blobs.iter().enumerate() {
+            println!(
+                "\t {}: {}, compressed data size 0x{:x}, compressed file size 0x{:x}, uncompressed file size 0x{:x}, chunks: 0x{:x}, features: {}",
+                idx,
+                blob.blob_id(),
+                blob.compressed_data_size(),
+                blob.compressed_size(),
+                blob.uncompressed_size(),
+                blob.chunk_count(),
+                format_blob_features(blob.features()),
+            );
+            blob_ids.push(blob.blob_id().to_string());
+        }
+        Ok(())
     }
 
     fn merge(matches: &ArgMatches, build_info: &BuildTimeInfo) -> Result<()> {


### PR DESCRIPTION
## Relevant Issue (if applicable)

_N/A_

## Details

These commits introduce the following changes:

Background: In high-density deployment scenarios, the issue of redundant storage and distribution of chunks in Nydus images poses significant challenges. This problem leads to inefficient utilization of storage space and excessive consumption of bandwidth resources. To address this problem, it is crucial to design an effective chunk deduplication mechanism. This entails conducting in-depth research on chunk deduplication algorithms and developing solutions that enable deduplication across different business contexts, within the same business, across different layers, and within the same layer. By implementing comprehensive chunk deduplication strategies, we can significantly optimize storage utilization and enhance bandwidth efficiency in high-density deployment environments.

1. Commit: "cargo: Add rusqlite package to dependencies"
    
    - Adds the 'rusqlite' package to the project's dependencies.
    - Updates the 'cargo.toml' and 'cargo.lock' files to include the 'rusqlite' package.
    - Enables interaction with SQLite databases in the project.
2. Commit: "nydus-image: Store chunk and blob metadata"
    
    - Adds functionality to store chunk and blob metadata from nydus source images.
    - Introduces the 'nydus-image chunkdict save' command.
    - Allows storing metadata by using the '--bootstrap' option followed by the path to the nydus bootstrap file (e.g., '~/output/nydus_bootstrap').

## Types of changes

What types of changes do your commits introduce? Put an `x` in all the boxes that apply:

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [x]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to change)
- [ ]  Documentation Update (if none of the other choices apply)

## Checklist

Go over all the following points, and put an `x` in all the boxes that apply:

- [x]  I have updated the documentation accordingly.
- [ ]  I have added tests to cover my changes.