### PR TITLE
builder: correctly generate nid for v6 inodes

### DIFF
--- a/rafs/src/builder/core/bootstrap.rs
+++ b/rafs/src/builder/core/bootstrap.rs
@@ -52,8 +52,8 @@ impl Bootstrap {
 
         Self::build_rafs(ctx, bootstrap_ctx, &mut self.tree)?;
         if ctx.fs_version.is_v6() {
-            // Sort directory entries to keep them ordered.
-            Self::v6_update_dirents(&self.tree, bootstrap_ctx.offset);
+            let root_offset = self.tree.node.lock().unwrap().v6_offset;
+            Self::v6_update_dirents(&self.tree, root_offset);
         }
 
         Ok(())

--- a/rafs/src/builder/core/v6.rs
+++ b/rafs/src/builder/core/v6.rs
@@ -64,6 +64,8 @@ impl Node {
         if self.is_dir() || self.is_symlink() {
             self.v6_dirents_offset += meta_offset;
         }
+        let nid = calculate_nid(self.v6_offset, meta_addr);
+        self.inode.set_ino(nid);
 
         if self.is_dir() {
             self.v6_dump_dir(ctx, f_bootstrap, meta_addr, meta_offset, &mut inode)?;

--- a/rafs/src/builder/stargz.rs
+++ b/rafs/src/builder/stargz.rs
@@ -246,7 +246,7 @@ impl TocEntry {
             mode |= libc::S_IFIFO;
         }
 
-        self.mode & !libc::S_IFMT | mode as u32
+        self.mode & !libc::S_IFMT as u32 | mode as u32
     }
 
     /// Get real device id associated with the `TocEntry`.


### PR DESCRIPTION
The `nid` is not actually used yet, but we should still generate it with correct value.

## Relevant Issue (if applicable)
_If there are Issues related to this PullRequest, please list it._

## Details
_Please describe the details of PullRequest._

## Types of changes

_What types of changes does your PullRequest introduce? Put an `x` in all the boxes that apply:_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Go over all the following points, and put an `x` in all the boxes that apply._

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.