### PR TITLE
builder: set the default compression algorithm for meta ci to lz4

### DIFF
--- a/rafs/src/builder/core/blob.rs
+++ b/rafs/src/builder/core/blob.rs
@@ -184,7 +184,11 @@ impl Blob {
             header.set_separate_blob(true);
         };
 
-        let mut compressor = compress::Algorithm::Zstd;
+        let mut compressor = if ctx.conversion_type.is_to_ref() {
+            compress::Algorithm::Zstd
+        } else {
+            ctx.compressor
+        };
         let (compressed_data, compressed) = compress::compress(ci_data, compressor)
             .with_context(|| "failed to compress blob chunk info array".to_string())?;
         if !compressed {


### PR DESCRIPTION
We set the compression algorithm of meta ci to zstd by default, but there is no option for nydus-image to configure it.

This could cause compatibility problems on the nydus version that does not support zstd. Let's reset it to lz4 by default.

## Relevant Issue (if applicable)
_If there are Issues related to this PullRequest, please list it._

## Details
_Please describe the details of PullRequest._

## Types of changes

_What types of changes does your PullRequest introduce? Put an `x` in all the boxes that apply:_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Go over all the following points, and put an `x` in all the boxes that apply._

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.