### PR TITLE
Rafs: Add missing prefix of hex

### DIFF
--- a/rafs/src/metadata/md_v5.rs
+++ b/rafs/src/metadata/md_v5.rs
@@ -27,7 +27,7 @@ impl RafsSuper {
         self.meta.sb_size = sb.sb_size();
         self.meta.chunk_size = sb.block_size();
         self.meta.flags = RafsSuperFlags::from_bits(sb.flags())
-            .ok_or_else(|| einval!(format!("invalid super flags {:x}", sb.flags())))?;
+            .ok_or_else(|| einval!(format!("invalid super flags 0x{:x}", sb.flags())))?;
         info!("RAFS v5 super block features: {}", self.meta.flags);
 
         self.meta.inodes_count = sb.inodes_count();

--- a/rafs/src/metadata/md_v6.rs
+++ b/rafs/src/metadata/md_v6.rs
@@ -47,7 +47,7 @@ impl RafsSuper {
         self.meta.inodes_count = sb.inodes_count();
 
         self.meta.flags = RafsSuperFlags::from_bits(ext_sb.flags())
-            .ok_or_else(|| einval!(format!("invalid RAFS flags {:x}", ext_sb.flags())))?;
+            .ok_or_else(|| einval!(format!("invalid RAFS flags 0x{:x}", ext_sb.flags())))?;
         info!("RAFS features: {}", self.meta.flags);
 
         self.meta.prefetch_table_entries = ext_sb.prefetch_table_size() / size_of::<u32>() as u32;


### PR DESCRIPTION

## Relevant Issue (if applicable)
_If there are Issues related to this PullRequest, please list it._

## Details

Without hex prefix, it confuses me a little bit when debugging flags problems.

## Types of changes

_What types of changes does your PullRequest introduce? Put an `x` in all the boxes that apply:_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Go over all the following points, and put an `x` in all the boxes that apply._

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.