### PR TITLE
fix: amplify io is too large to hold in fuse buffer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ path = "src/lib.rs"
 anyhow = "1"
 clap = { version = "4.0.18", features = ["derive", "cargo"] }
 flexi_logger = { version = "0.25", features = ["compress"] }
-fuse-backend-rs = "^0.10.3"
+fuse-backend-rs = "^0.10.4"
 hex = "0.4.3"
 hyper = "0.14.11"
 hyperlocal = "0.8.0"

--- a/rafs/src/fs.rs
+++ b/rafs/src/fs.rs
@@ -631,7 +631,7 @@ impl FileSystem for Rafs {
                 let actual_size = window_base - (offset & !chunk_mask);
                 if actual_size < amplify_io as u64 {
                     let window_size = amplify_io as u64 - actual_size;
-                    let orig_cnt = descs.iter().fold(0, |s, d| s + d.len());
+                    let orig_cnt = io_vecs.iter().fold(0, |s, d| s + d.len());
                     self.sb.amplify_io(
                         &self.device,
                         amplify_io,

--- a/smoke/Makefile
+++ b/smoke/Makefile
@@ -15,7 +15,7 @@ build:
 # NYDUS_NYDUSIFY=/path/to/latest/nydusify \
 # make test
 test: build
-	sudo -E ./smoke.test -test.v -test.timeout 10m -test.parallel=8 -test.run=$(TESTS)
+	sudo -E ./smoke.test -test.v -test.timeout 10m -test.parallel=16 -test.run=$(TESTS)
 
 # WORK_DIR=/tmp \
 # NYDUS_BUILDER=/path/to/latest/nydus-image \

--- a/smoke/tests/api_test.go
+++ b/smoke/tests/api_test.go
@@ -195,7 +195,7 @@ func (a *APIV1TestSuite) TestPrefetch(t *testing.T) {
 	config.RafsMode = ctx.Runtime.RafsMode
 	err = nydusd.MountByAPI(config)
 	require.NoError(t, err)
-	time.Sleep(time.Millisecond * 10)
+	time.Sleep(time.Millisecond * 15)
 
 	bcm, err := nydusd.GetBlobCacheMetrics("")
 	require.NoError(t, err)

--- a/smoke/tests/image_test.go
+++ b/smoke/tests/image_test.go
@@ -15,9 +15,10 @@ import (
 )
 
 const (
-	paramZran    = "zran"
-	paramBatch   = "batch"
-	paramEncrypt = "encrypt"
+	paramZran      = "zran"
+	paramBatch     = "batch"
+	paramEncrypt   = "encrypt"
+	paramAmplifyIO = "amplify_io"
 )
 
 type ImageTestSuite struct {

--- a/smoke/tests/native_layer_test.go
+++ b/smoke/tests/native_layer_test.go
@@ -43,6 +43,7 @@ func (n *NativeLayerTestSuite) TestMakeLayers() test.Generator {
 		Dimension(paramEnablePrefetch, []interface{}{false, true}).
 		Dimension(paramBatch, []interface{}{"0", "0x100000"}).
 		Dimension(paramEncrypt, []interface{}{false, true}).
+		Dimension(paramAmplifyIO, []interface{}{uint64(0x100000)}).
 		Skip(func(param *tool.DescartesItem) bool {
 
 			// rafs v6 not support cached mode nor dummy cache
@@ -77,6 +78,67 @@ func (n *NativeLayerTestSuite) TestMakeLayers() test.Generator {
 		ctx.Runtime.CacheCompressed = scenario.GetBool(paramCacheCompressed)
 		ctx.Runtime.RafsMode = scenario.GetString(paramRafsMode)
 		ctx.Runtime.EnablePrefetch = scenario.GetBool(paramEnablePrefetch)
+		ctx.Runtime.AmplifyIO = scenario.GetUInt64(paramAmplifyIO)
+
+		return scenario.Str(), func(t *testing.T) {
+			n.testMakeLayers(*ctx, t)
+		}
+	}
+}
+
+func (n *NativeLayerTestSuite) TestAmplifyIO() test.Generator {
+
+	scenarios := tool.DescartesIterator{}
+	scenarios.
+
+		/* Common params */
+		Dimension(paramCompressor, []interface{}{"lz4_block"}).
+		Dimension(paramFSVersion, []interface{}{"5", "6"}).
+		Dimension(paramChunkSize, []interface{}{"0x100000"}).
+		Dimension(paramCacheType, []interface{}{"blobcache"}).
+		Dimension(paramCacheCompressed, []interface{}{false}).
+		Dimension(paramRafsMode, []interface{}{"direct"}).
+		Dimension(paramEnablePrefetch, []interface{}{true}).
+		Dimension(paramBatch, []interface{}{"0x100000"}).
+		Dimension(paramEncrypt, []interface{}{false}).
+
+		/* Amplify io - target param */
+		Dimension(paramAmplifyIO, []interface{}{uint64(0x0), uint64(0x100000), uint64(0x10000000)}).
+		Skip(func(param *tool.DescartesItem) bool {
+
+			// Rafs v6 not support cached mode nor dummy cache
+			if param.GetString(paramFSVersion) == "6" {
+				return param.GetString(paramRafsMode) == "cached" || param.GetString(paramCacheType) == ""
+			}
+
+			// Dummy cache not support prefetch
+			if param.GetString(paramCacheType) == "" && param.GetBool(paramEnablePrefetch) {
+				return true
+			}
+
+			// Batch or encrypt not work with rafs v5.
+			if param.GetString(paramFSVersion) == "5" && (param.GetString(paramBatch) != "0" || param.GetBool(paramEncrypt)) {
+				return true
+			}
+
+			return false
+		})
+
+	return func() (name string, testCase test.Case) {
+		if !scenarios.HasNext() {
+			return
+		}
+		scenario := scenarios.Next()
+
+		ctx := tool.DefaultContext(n.t)
+		ctx.Build.Compressor = scenario.GetString(paramCompressor)
+		ctx.Build.FSVersion = scenario.GetString(paramFSVersion)
+		ctx.Build.ChunkSize = scenario.GetString(paramChunkSize)
+		ctx.Runtime.CacheType = scenario.GetString(paramCacheType)
+		ctx.Runtime.CacheCompressed = scenario.GetBool(paramCacheCompressed)
+		ctx.Runtime.RafsMode = scenario.GetString(paramRafsMode)
+		ctx.Runtime.EnablePrefetch = scenario.GetBool(paramEnablePrefetch)
+		ctx.Runtime.AmplifyIO = scenario.GetUInt64(paramAmplifyIO)
 
 		return scenario.Str(), func(t *testing.T) {
 			n.testMakeLayers(*ctx, t)

--- a/smoke/tests/tool/context.go
+++ b/smoke/tests/tool/context.go
@@ -39,6 +39,7 @@ type RuntimeContext struct {
 	CacheCompressed bool
 	RafsMode        string
 	EnablePrefetch  bool
+	AmplifyIO       uint64
 }
 
 type EnvContext struct {
@@ -75,6 +76,7 @@ func DefaultContext(t *testing.T) *Context {
 			CacheCompressed: false,
 			RafsMode:        "direct",
 			EnablePrefetch:  true,
+			AmplifyIO:       uint64(0x100000),
 		},
 	}
 }

--- a/smoke/tests/tool/iterator.go
+++ b/smoke/tests/tool/iterator.go
@@ -47,6 +47,10 @@ func (d *DescartesItem) Str() string {
 	return sb.String()
 }
 
+func (d *DescartesItem) GetUInt64(name string) uint64 {
+	return d.vals[name].(uint64)
+}
+
 // Generator of Cartesian product.
 //
 // An example is below:

--- a/smoke/tests/tool/nydusd.go
+++ b/smoke/tests/tool/nydusd.go
@@ -69,6 +69,7 @@ type NydusdConfig struct {
 	LatestReadFiles bool
 	AccessPattern   bool
 	PrefetchFiles   []string
+	AmplifyIO       uint64
 }
 
 type Nydusd struct {
@@ -104,7 +105,8 @@ var configTpl = `
 	 "digest_validate": {{.DigestValidate}},
 	 "enable_xattr": true,
      "latest_read_files": {{.LatestReadFiles}},
-     "access_pattern": {{.AccessPattern}}
+     "access_pattern": {{.AccessPattern}},
+     "amplify_io": {{.AmplifyIO}}
  }
  `
 

--- a/smoke/tests/tool/verify.go
+++ b/smoke/tests/tool/verify.go
@@ -29,6 +29,7 @@ func Verify(t *testing.T, ctx Context, expectedFiles map[string]*File) {
 		CacheCompressed: ctx.Runtime.CacheCompressed,
 		RafsMode:        ctx.Runtime.RafsMode,
 		DigestValidate:  false,
+		AmplifyIO:       ctx.Runtime.AmplifyIO,
 	}
 
 	nydusd, err := NewNydusd(config)


### PR DESCRIPTION
Fuse request buffer is fixed by `FUSE_KERN_BUF_SIZE * pagesize() + FUSE_HEADER_ SIZE`. When amplify io is larger than it, FuseDevWriter suffers from smaller buffer. As a result, invalid data error is returned.

##  Reproduction
    run nydusd with 3MB amplify_io
    error from random io:
        reply error header OutHeader { len: 16, error: -5, unique: 108 }, error Custom { kind: InvalidData, error: "data out of range, available 1052656 requested 1250066" }

## Details
    size of fuse buffer = 1052656 + 16 (size of inner header) = 256(FUSE_KERN_BUF_SIZE) * 4096(page size) + 4096(fuse header)
    let amplify_io = min(user_specified, fuseWriter.available_bytes())

## Resolution
   Evalucation of amplify_io will be replaced with [ZeroCopyWriter.available_bytes()]("https://github.com/cloud-hypervisor/fuse-backend-rs/pull/135").

## Relevant Issue
#1270
ci: https://github.com/dragonflyoss/image-service/actions/runs/4931748472/jobs/8814099799
#1312 