### PR TITLE
Fix nydusify

### DIFF
--- a/contrib/nydusify/cmd/nydusify.go
+++ b/contrib/nydusify/cmd/nydusify.go
@@ -741,18 +741,15 @@ func main() {
 						skipVerify = true
 					}
 					scheme := "http"
-					// if rule.PlainHTTP {
-					// 	scheme = "http"
-					// }
 
-					backendConfig_struct := RegistryBackendConfig{scheme, host, repo, auth, skipVerify}
+
+					backendConfigStruct := RegistryBackendConfig{scheme, host, repo, auth, skipVerify}
 					bytes, err := json.Marshal(backendConfig_struct)
 					if err != nil {
 						return errors.Wrap(err, "parse registry backend config")
 					}
 					backendConfig = string(bytes)
 
-					//return errors.Errorf("backend configuration is empty, please specify option '--backend-config'")
 				}
 
 				_, arch, err := provider.ExtractOsArch(c.String("platform"))

--- a/contrib/nydusify/cmd/nydusify.go
+++ b/contrib/nydusify/cmd/nydusify.go
@@ -713,8 +713,6 @@ func main() {
 				if err != nil {
 					return err
 				} else if backendConfig == "" {
-					// TODO get auth from docker configuration file
-					// parsed, err := reference.ParseNormalizedNamed(rule.Target)
 
 					backendType = "registry"
 					parsed, err := reference.ParseNormalizedNamed(c.String("target"))

--- a/contrib/nydusify/pkg/viewer/viewer.go
+++ b/contrib/nydusify/pkg/viewer/viewer.go
@@ -61,11 +61,29 @@ func New(opt Opt) (*FsViewer, error) {
 	}
 
 	mode := "cached"
-	digestValidate := true
+	digestValidate := false
 	if opt.FsVersion == "6" {
 		mode = "direct"
 		digestValidate = false
 	}
+	// targetParsed, err := targetParser.Parse()
+	// if err != nil {
+	// 	return errors.Wrap(err, "parse Nydus image")
+	// }
+
+	// digestValidate := false
+	// if targetParsed.NydusImage != nil {
+	// 	nydusManifest := parser.FindNydusBootstrapDesc(&targetParsed.NydusImage.Manifest)
+	// 	if nydusManifest != nil {
+	// 		v := utils.GetNydusFsVersionOrDefault(nydusManifest.Annotations, utils.V5)
+	// 		if v == utils.V5 {
+	// 			// Digest validate is not currently supported for v6,
+	// 			// but v5 supports it. In order to make the check more sufficient,
+	// 			// this validate needs to be turned on for v5.
+	// 			digestValidate = true
+	// 		}
+	// 	}
+	// }
 
 	nydusdConfig := tool.NydusdConfig{
 		NydusdPath:     opt.NydusdPath,
@@ -157,6 +175,18 @@ func (fsViewer *FsViewer) MountImage() error {
 // It includes two steps, pull the boostrap of the image, and mount the
 // image under specified path.
 func (fsViewer *FsViewer) View(ctx context.Context) error {
+	if err := fsViewer.view(ctx); err != nil {
+		if utils.RetryWithHTTP(err) {
+			fsViewer.Parser.Remote.MaybeWithHTTP(err)
+			return fsViewer.view(ctx)
+		}
+		return err
+
+	}
+	return nil
+}
+
+func (fsViewer *FsViewer) view(ctx context.Context) error {
 	// Pull bootstrap
 	targetParsed, err := fsViewer.Parser.Parse(ctx)
 	if err != nil {
@@ -165,6 +195,18 @@ func (fsViewer *FsViewer) View(ctx context.Context) error {
 	err = fsViewer.PullBootstrap(ctx, targetParsed)
 	if err != nil {
 		return errors.Wrap(err, "failed to pull Nydus image bootstrap")
+	}
+
+	//Adjust nydused parameters(DigestValidate) according to rafs format
+	nydusManifest := parser.FindNydusBootstrapDesc(&targetParsed.NydusImage.Manifest)
+	if nydusManifest != nil {
+		v := utils.GetNydusFsVersionOrDefault(nydusManifest.Annotations, utils.V5)
+		if v == utils.V5 {
+			// Digest validate is not currently supported for v6,
+			// but v5 supports it. In order to make the check more sufficient,
+			// this validate needs to be turned on for v5.
+			fsViewer.NydusdConfig.DigestValidate = true
+		}
 	}
 
 	err = fsViewer.MountImage()


### PR DESCRIPTION
## Relevant Issue (if applicable)
this is the solution of issue https://github.com/dragonflyoss/image-service/issues/1306.(#1306) 


## Details
we fix the bug, the nydusify `mount` subcommand will not need the `--backend-type`  and  `--backend-config` options when  the blobs of target image are all stored in the registry,



## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist
- [x] I have added tests to cover my changes.