### PR TITLE
Define new feature flags to control crate dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,12 +99,6 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
 version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
@@ -1111,7 +1105,7 @@ name = "nydus-builder"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "base64 0.13.1",
+ "base64",
  "hex",
  "indexmap",
  "libc",
@@ -1237,7 +1231,7 @@ name = "nydus-storage"
 version = "0.6.3"
 dependencies = [
  "arc-swap",
- "base64 0.13.1",
+ "base64",
  "bitflags",
  "fuse-backend-rs",
  "gpt",
@@ -1515,7 +1509,7 @@ version = "0.11.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b71749df584b7f4cac2c426c127a7c785a5106cc98f7a8feb044115f0fa254"
 dependencies = [
- "base64 0.21.0",
+ "base64",
  "bytes",
  "encoding_rs",
  "futures-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ nydus-api = { version = "0.3.0", path = "api", features = ["error-backtrace", "h
 nydus-builder = { version = "0.1.0", path = "builder" }
 nydus-rafs = { version = "0.3.1", path = "rafs" }
 nydus-service = { version = "0.3.0", path = "service", features = ["block-device"] }
-nydus-storage = { version = "0.6.3", path = "storage" }
+nydus-storage = { version = "0.6.3", path = "storage", features = ["prefetch-rate-limit"] }
 nydus-utils = { version = "0.4.2", path = "utils" }
 
 vhost = { version = "0.5.0", features = ["vhost-user-slave"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ openssl = { version = "0.10.55", features = ["vendored"] }
 # pin openssl-src to bring in fix for https://rustsec.org/advisories/RUSTSEC-2022-0032
 #openssl-src = { version = "111.22" }
 
-nydus-api = { version = "0.3.0", path = "api", features = ["handler"] }
+nydus-api = { version = "0.3.0", path = "api", features = ["error-backtrace", "handler"] }
 nydus-builder = { version = "0.1.0", path = "builder" }
 nydus-rafs = { version = "0.3.1", path = "rafs" }
 nydus-service = { version = "0.3.0", path = "service", features = ["block-device"] }

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -9,20 +9,22 @@ repository = "https://github.com/dragonflyoss/image-service"
 edition = "2018"
 
 [dependencies]
-backtrace = "0.3"
+libc = "0.2"
+log = "0.4.8"
+serde_json = "1.0.53"
+toml = "0.5"
+
+backtrace = { version = "0.3", optional = true }
 dbs-uhttp = { version = "0.3.0", optional = true }
 http = { version = "0.2.1", optional = true }
 lazy_static = { version = "1.4.0", optional = true }
-libc = "0.2"
-log = "0.4.8"
 mio = { version = "0.8", features = ["os-poll", "os-ext"], optional = true }
 serde = { version = "1.0.110", features = ["rc", "serde_derive"] }
-serde_json = "1.0.53"
-toml = "0.5"
 url = { version = "2.1.1", optional = true }
 
 [dev-dependencies]
 vmm-sys-util = { version = "0.10" }
 
 [features]
+error-backtrace = ["backtrace"]
 handler = ["dbs-uhttp", "http", "lazy_static", "mio", "url"]

--- a/builder/Cargo.toml
+++ b/builder/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 
 [dependencies]
 anyhow = "1.0.35"
-base64 = "0.13.0"
+base64 = "0.21"
 hex = "0.4.3"
 indexmap = "1"
 libc = "0.2"

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 
 [dependencies]
 arc-swap = "1.5"
-base64 = { version = "0.13.1", optional = true }
+base64 = { version = "0.21", optional = true }
 bitflags = "1.2.1"
 hex = "0.4.3"
 hmac = { version = "0.12.1", optional = true }

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -10,22 +10,23 @@ edition = "2018"
 
 [dependencies]
 arc-swap = "1.5"
-base64 = { version = "0.13.0", optional = true }
+base64 = { version = "0.13.1", optional = true }
 bitflags = "1.2.1"
 hex = "0.4.3"
 hmac = { version = "0.12.1", optional = true }
 http = { version = "0.2.8", optional = true }
 httpdate = { version = "1.0", optional = true }
-hyper = {version = "0.14.11", optional =  true}
-hyperlocal = {version = "0.8.0", optional = true}
+hyper = {version = "0.14.11", optional =  true }
+hyperlocal = {version = "0.8.0", optional = true }
 lazy_static = "1.4.0"
-leaky-bucket = "0.12.1"
+leaky-bucket = { version = "0.12.1", optional = true }
 libc = "0.2"
 log = "0.4.8"
 nix = "0.24"
 reqwest = { version = "0.11.14", features = ["blocking", "json"], optional = true }
 serde = { version = "1.0.110", features = ["serde_derive", "rc"] }
 serde_json = "1.0.53"
+sha1 = { version = "0.10.5", optional = true }
 sha2 = { version = "0.10.2", optional = true }
 tar = "0.4.38"
 time = { version = "0.3.14", features = ["formatting"], optional = true }
@@ -37,7 +38,6 @@ gpt = { version = "3.0.0", optional = true }
 
 nydus-api = { version = "0.3", path = "../api" }
 nydus-utils = { version = "0.4", path = "../utils", features = ["encryption", "zran"] }
-sha1 = { version = "0.10.5", optional = true }
 
 [dev-dependencies]
 vmm-sys-util = "0.10"
@@ -51,6 +51,7 @@ backend-oss = ["base64", "httpdate", "hmac", "sha1", "reqwest", "url"]
 backend-registry = ["base64", "reqwest", "url"]
 backend-s3 = ["base64", "hmac", "http", "reqwest", "sha2", "time", "url"]
 backend-http-proxy = ["hyper", "hyperlocal", "http", "reqwest", "url"]
+prefetch-rate-limit = ["leaky-bucket"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/storage/src/backend/oss.rs
+++ b/storage/src/backend/oss.rs
@@ -8,6 +8,7 @@ use std::io::Result;
 use std::sync::Arc;
 use std::time::SystemTime;
 
+use base64::Engine;
 use hmac::{Hmac, Mac};
 use reqwest::header::HeaderMap;
 use reqwest::Method;
@@ -99,7 +100,7 @@ impl ObjectStorageState for OssState {
             .chain_update(data.as_bytes())
             .finalize()
             .into_bytes();
-        let signature = base64::encode(&hmac);
+        let signature = base64::engine::general_purpose::STANDARD.encode(&hmac);
 
         let authorization = format!("OSS {}:{}", self.access_key_id, signature);
 

--- a/storage/src/backend/registry.rs
+++ b/storage/src/backend/registry.rs
@@ -12,6 +12,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use std::{fmt, thread};
 
 use arc_swap::ArcSwapOption;
+use base64::Engine;
 use reqwest::blocking::Response;
 pub use reqwest::header::HeaderMap;
 use reqwest::header::{HeaderValue, CONTENT_LENGTH};
@@ -765,12 +766,14 @@ impl Registry {
 
     fn get_authorization_info(auth: &Option<String>) -> Result<(String, String)> {
         if let Some(auth) = &auth {
-            let auth: Vec<u8> = base64::decode(auth.as_bytes()).map_err(|e| {
-                einval!(format!(
-                    "Invalid base64 encoded registry auth config: {:?}",
-                    e
-                ))
-            })?;
+            let auth: Vec<u8> = base64::engine::general_purpose::STANDARD
+                .decode(auth.as_bytes())
+                .map_err(|e| {
+                    einval!(format!(
+                        "Invalid base64 encoded registry auth config: {:?}",
+                        e
+                    ))
+                })?;
             let auth = std::str::from_utf8(&auth).map_err(|e| {
                 einval!(format!(
                     "Invalid utf-8 encoded registry auth config: {:?}",


### PR DESCRIPTION
## Details
Refine crate dependencies:
- introduce `error-backtrace` to nydus-api
- introduce `prefetch-rate-limit to nydus-storage
- upgrade base64 to 0.20

