### PR TITLE
Nydusify-fix(stable/v2.1): fix some bug about the subcommand mount of nydusify

### DIFF
--- a/contrib/nydusify/cmd/nydusify.go
+++ b/contrib/nydusify/cmd/nydusify.go
@@ -9,6 +9,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -17,11 +18,13 @@ import (
 	"strings"
 
 	"github.com/containerd/containerd/reference/docker"
+	"github.com/docker/distribution/reference"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
 
 	"github.com/dragonflyoss/image-service/contrib/nydusify/pkg/checker"
+	"github.com/dragonflyoss/image-service/contrib/nydusify/pkg/checker/rule"
 	"github.com/dragonflyoss/image-service/contrib/nydusify/pkg/converter"
 	"github.com/dragonflyoss/image-service/contrib/nydusify/pkg/converter/provider"
 	"github.com/dragonflyoss/image-service/contrib/nydusify/pkg/metrics"
@@ -629,7 +632,7 @@ func main() {
 				&cli.StringFlag{
 					Name:     "backend-type",
 					Value:    "",
-					Required: true,
+					Required: false,
 					Usage:    "Type of storage backend, possible values: 'registry', 'oss'",
 					EnvVars:  []string{"BACKEND_TYPE"},
 				},
@@ -679,8 +682,26 @@ func main() {
 				if err != nil {
 					return err
 				} else if backendConfig == "" {
-					// TODO get auth from docker configuration file
-					return errors.Errorf("backend configuration is empty, please specify option '--backend-config'")
+
+					backendType = "registry"
+					parsed, err := reference.ParseNormalizedNamed(c.String("target"))
+					if err != nil {
+						return err
+					}
+
+					backendConfigStruct, err := rule.NewRegistryBackendConfig(parsed)
+					if err != nil {
+						return errors.Wrap(err, "parse registry backend configuration")
+					}
+
+					backendConfigStruct.SkipVerify = c.Bool("target-insecure")
+
+					bytes, err := json.Marshal(backendConfigStruct)
+					if err != nil {
+						return errors.Wrap(err, "marshal registry backend configuration")
+					}
+					backendConfig = string(bytes)
+
 				}
 
 				_, arch, err := provider.ExtractOsArch(c.String("platform"))


### PR DESCRIPTION
## Relevant Issue (if applicable)
this is the solution of issue https://github.com/dragonflyoss/image-service/issues/1306.(#1306) 


## Details
we fix the bug, the nydusify `mount` subcommand will not need the `--backend-type`  and  `--backend-config` options when  the blobs of target image are all stored in the registry,



## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist
- [x] I have added tests to cover my changes.