### PR TITLE
Enhance localdisk storage backend to manually add blob objects

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,7 +100,7 @@ block-nbd = [
 ]
 
 backend-http-proxy = ["nydus-storage/backend-http-proxy"]
-backend-localdisk = ["nydus-storage/backend-localdisk"]
+backend-localdisk = ["nydus-storage/backend-localdisk", "nydus-storage/backend-localdisk-gpt"]
 backend-oss = ["nydus-storage/backend-oss"]
 backend-registry = ["nydus-storage/backend-registry"]
 backend-s3 = ["nydus-storage/backend-s3"]

--- a/api/src/config.rs
+++ b/api/src/config.rs
@@ -443,6 +443,9 @@ pub struct LocalDiskConfig {
     /// Mounted block device path or original localdisk image file path.
     #[serde(default)]
     pub device_path: String,
+    /// Disable discover blob objects by scanning GPT table.
+    #[serde(default)]
+    pub disable_gpt: bool,
 }
 
 /// Configuration information for localfs storage backend.

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -45,7 +45,8 @@ tar = "0.4.38"
 regex = "1.7.0"
 
 [features]
-backend-localdisk = ["gpt"]
+backend-localdisk = []
+backend-localdisk-gpt = ["gpt", "backend-localdisk"]
 backend-localfs = []
 backend-oss = ["base64", "httpdate", "hmac", "sha1", "reqwest", "url"]
 backend-registry = ["base64", "reqwest", "url"]

--- a/storage/src/cache/worker.rs
+++ b/storage/src/cache/worker.rs
@@ -52,7 +52,7 @@ pub(crate) enum AsyncPrefetchMessage {
     #[cfg_attr(not(test), allow(unused))]
     /// Ping for test.
     Ping,
-    #[cfg_attr(not(test), allow(unused))]
+    #[allow(unused)]
     RateLimiter(u64),
 }
 


### PR DESCRIPTION
## Relevant Issue (if applicable)
_If there are Issues related to this PullRequest, please list it._

## Details
    Enhance the localdisk storage backend, so we can manually add blob
    objects in the disk, in addition to discovering blob objects by
    scanning GPT partition table.

## Types of changes

_What types of changes does your PullRequest introduce? Put an `x` in all the boxes that apply:_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Go over all the following points, and put an `x` in all the boxes that apply._

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.