### PR TITLE
[WIP] nydus-image: fix unpack from specify blob dir

### DIFF
--- a/rafs/src/metadata/cached_v5.rs
+++ b/rafs/src/metadata/cached_v5.rs
@@ -461,6 +461,26 @@ impl RafsInode for CachedInodeV5 {
     }
 
     #[inline]
+    fn is_blkdev(&self) -> bool {
+        self.i_mode & libc::S_IFMT as u32 == libc::S_IFBLK as u32
+    }
+
+    #[inline]
+    fn is_chrdev(&self) -> bool {
+        self.i_mode & libc::S_IFMT as u32 == libc::S_IFCHR as u32
+    }
+
+    #[inline]
+    fn is_sock(&self) -> bool {
+        self.i_mode & libc::S_IFMT as u32 == libc::S_IFSOCK as u32
+    }
+
+    #[inline]
+    fn is_fifo(&self) -> bool {
+        self.i_mode & libc::S_IFMT as u32 == libc::S_IFIFO as u32
+    }
+
+    #[inline]
     fn is_dir(&self) -> bool {
         self.i_mode & libc::S_IFMT as u32 == libc::S_IFDIR as u32
     }

--- a/rafs/src/metadata/direct_v5.rs
+++ b/rafs/src/metadata/direct_v5.rs
@@ -714,6 +714,10 @@ impl RafsInode for OndiskInodeWrapper {
         self
     }
 
+    impl_inode_wrapper!(is_blkdev, bool);
+    impl_inode_wrapper!(is_chrdev, bool);
+    impl_inode_wrapper!(is_sock, bool);
+    impl_inode_wrapper!(is_fifo, bool);
     impl_inode_wrapper!(is_dir, bool);
     impl_inode_wrapper!(is_reg, bool);
     impl_inode_wrapper!(is_symlink, bool);

--- a/rafs/src/metadata/direct_v6.rs
+++ b/rafs/src/metadata/direct_v6.rs
@@ -937,6 +937,26 @@ impl RafsInode for OndiskInodeWrapper {
         0
     }
 
+    #[inline]
+    fn is_blkdev(&self) -> bool {
+        self.mode_format_bits() == libc::S_IFBLK as u32
+    }
+
+    #[inline]
+    fn is_chrdev(&self) -> bool {
+        self.mode_format_bits() == libc::S_IFCHR as u32
+    }
+
+    #[inline]
+    fn is_sock(&self) -> bool {
+        self.mode_format_bits() == libc::S_IFSOCK as u32
+    }
+
+    #[inline]
+    fn is_fifo(&self) -> bool {
+        self.mode_format_bits() == libc::S_IFIFO as u32
+    }
+
     fn is_dir(&self) -> bool {
         self.mode_format_bits() == libc::S_IFDIR as u32
     }

--- a/rafs/src/metadata/inode.rs
+++ b/rafs/src/metadata/inode.rs
@@ -156,7 +156,7 @@ impl InodeWrapper {
         match self {
             InodeWrapper::V5(i) => i.is_chrdev(),
             InodeWrapper::V6(i) => i.is_chrdev(),
-            InodeWrapper::Ref(_i) => unimplemented!(),
+            InodeWrapper::Ref(i) => i.as_inode().is_chrdev(),
         }
     }
 
@@ -183,7 +183,7 @@ impl InodeWrapper {
         match self {
             InodeWrapper::V5(i) => i.is_sock(),
             InodeWrapper::V6(i) => i.is_sock(),
-            InodeWrapper::Ref(_i) => unimplemented!(),
+            InodeWrapper::Ref(i) => i.as_inode().is_dir(),
         }
     }
 
@@ -322,7 +322,7 @@ impl InodeWrapper {
         match self {
             InodeWrapper::V5(i) => i.i_uid,
             InodeWrapper::V6(i) => i.i_uid,
-            InodeWrapper::Ref(_i) => unimplemented!(),
+            InodeWrapper::Ref(i) => i.as_inode().get_attr().uid,
         }
     }
 
@@ -341,7 +341,7 @@ impl InodeWrapper {
         match self {
             InodeWrapper::V5(i) => i.i_gid,
             InodeWrapper::V6(i) => i.i_gid,
-            InodeWrapper::Ref(_i) => unimplemented!(),
+            InodeWrapper::Ref(i) => i.as_inode().get_attr().gid,
         }
     }
 

--- a/rafs/src/metadata/mod.rs
+++ b/rafs/src/metadata/mod.rs
@@ -176,6 +176,18 @@ pub trait RafsInode: Any {
     /// Posix: get project id associated with the inode.
     fn projid(&self) -> u32;
 
+    /// Mode: check whether the inode is a block device.
+    fn is_blkdev(&self) -> bool;
+
+    /// Mode: check whether the inode is a char device.
+    fn is_chrdev(&self) -> bool;
+
+    /// Mode: check whether the inode is a sock.
+    fn is_sock(&self) -> bool;
+
+    /// Mode: check whether the inode is a fifo.
+    fn is_fifo(&self) -> bool;
+
     /// Mode: check whether the inode is a directory.
     fn is_dir(&self) -> bool;
 

--- a/rafs/src/mock/mock_inode.rs
+++ b/rafs/src/mock/mock_inode.rs
@@ -175,6 +175,26 @@ impl RafsInode for MockInode {
             .collect::<Vec<XattrName>>())
     }
 
+    #[inline]
+    fn is_blkdev(&self) -> bool {
+        self.i_mode & libc::S_IFMT as u32 == libc::S_IFBLK as u32
+    }
+
+    #[inline]
+    fn is_chrdev(&self) -> bool {
+        self.i_mode & libc::S_IFMT as u32 == libc::S_IFCHR as u32
+    }
+
+    #[inline]
+    fn is_sock(&self) -> bool {
+        self.i_mode & libc::S_IFMT as u32 == libc::S_IFSOCK as u32
+    }
+
+    #[inline]
+    fn is_fifo(&self) -> bool {
+        self.i_mode & libc::S_IFMT as u32 == libc::S_IFIFO as u32
+    }
+
     fn is_dir(&self) -> bool {
         self.i_mode & libc::S_IFMT as u32 == libc::S_IFDIR as u32
     }

--- a/src/bin/nydus-image/main.rs
+++ b/src/bin/nydus-image/main.rs
@@ -1172,7 +1172,13 @@ impl Command {
 
                 Some(Arc::new(local_fs))
             }
-            None => Self::get_backend(matches, "unpacker").ok(),
+            None => {
+                Some(BlobFactory::new_backend(
+                    config.backend.as_ref().unwrap(),
+                    "unpacker",
+                )?)
+                // Self::get_backend(matches, "unpacker").ok()
+            }
         };
 
         OCIUnpacker::new(bootstrap, backend, output)

--- a/src/bin/nydus-image/unpack/mod.rs
+++ b/src/bin/nydus-image/unpack/mod.rs
@@ -184,7 +184,7 @@ impl OCITarBuilderFactory {
                     .as_deref()
                     .with_context(|| "both blob path or blob backend config are not specified")?;
                 let reader = blob_backend
-                    .get_reader("unpacker")
+                    .get_reader(blob.blob_id().as_str())
                     .map_err(|err| anyhow!("fail to get reader, error {:?}", err))?;
 
                 let compressor = blob.compressor();


### PR DESCRIPTION
Fix the panic when user specify `--blob-dir` on unpack:

```
$ nydus-image unpack --bootstrap /path/to/bootstrap \
    --blob-dir /path/to/blobs \
    --output /path/to/oci.tar

Error: fail to unpack

Caused by:
    both blob path or blob backend config are not specified
```

## Relevant Issue (if applicable)
_If there are Issues related to this PullRequest, please list it._

## Details
_Please describe the details of PullRequest._

## Types of changes

_What types of changes does your PullRequest introduce? Put an `x` in all the boxes that apply:_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Go over all the following points, and put an `x` in all the boxes that apply._

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.