### PR TITLE
fix: deprecated docker field leads to failure of nydusify check

### DIFF
--- a/contrib/nydusify/pkg/checker/rule/manifest.go
+++ b/contrib/nydusify/pkg/checker/rule/manifest.go
@@ -80,6 +80,20 @@ func (rule *ManifestRule) Validate() error {
 
 	// Check Nydus image config with OCI image
 	if rule.SourceParsed.OCIImage != nil {
+
+		//nolint:staticcheck
+		// ignore static check SA1019 here. We have to assign deprecated field.
+		//
+		// Skip ArgsEscaped's Check
+		//
+		//   This field is present only for legacy compatibility with Docker and
+		// should not be used by new image builders. Nydusify (1.6 and above)
+		// ignores it, which is an expected behavior.
+		//   Also ignore it in check.
+		//
+		//   Addition: [ArgsEscaped in spec](https://github.com/opencontainers/image-spec/pull/892)
+		rule.TargetParsed.NydusImage.Config.Config.ArgsEscaped = rule.SourceParsed.OCIImage.Config.Config.ArgsEscaped
+
 		ociConfig, err := json.Marshal(rule.SourceParsed.OCIImage.Config.Config)
 		if err != nil {
 			return errors.New("marshal oci image config")

--- a/contrib/nydusify/pkg/checker/rule/manifest_test.go
+++ b/contrib/nydusify/pkg/checker/rule/manifest_test.go
@@ -1,0 +1,38 @@
+package rule
+
+import (
+	"testing"
+
+	"github.com/dragonflyoss/image-service/contrib/nydusify/pkg/parser"
+	"github.com/stretchr/testify/assert"
+
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+func TestManifestRuleValidate_IgnoreDeprecatedField(t *testing.T) {
+	source := &parser.Parsed{
+		NydusImage: &parser.Image{
+			Config: v1.Image{
+				Config: v1.ImageConfig{
+					ArgsEscaped: true, // deprecated field
+				},
+			},
+		},
+	}
+	target := &parser.Parsed{
+		NydusImage: &parser.Image{
+			Config: v1.Image{
+				Config: v1.ImageConfig{
+					ArgsEscaped: false,
+				},
+			},
+		},
+	}
+
+	rule := ManifestRule{
+		SourceParsed: source,
+		TargetParsed: target,
+	}
+
+	assert.Nil(t, rule.Validate())
+}


### PR DESCRIPTION
## Details

`NydusImage.Config.Config.ArgsEscaped` is present only for legacy compatibility with Docker and should not be used by new image builders. Nydusify (1.6 and above) ignores it, which is an expected behavior.

This pr ignores comparision of it in nydusify checking, which leads to failure.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Go over all the following points, and put an `x` in all the boxes that apply._

- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.

## Spec

[image-spec](https://github.com/opencontainers/image-spec/pull/892)