### PR TITLE
docs: add containerd runtime-level snapshotter usage for nydus

### DIFF
--- a/docs/containerd-env-setup.md
+++ b/docs/containerd-env-setup.md
@@ -124,7 +124,7 @@ sudo systemctl restart containerd
 ```
 
 ### Using Runtime-level Snapshotter in Container for Nydus
-Containerd (version >= v1.7.0) has supported developers configuring ```runtime-level snapshotter```. Following these two steps, we can use different snapshotter for different runtime.
+How about: Containerd (>= v1.7.0) supports configuring the ```runtime-level``` snapshotter. By following the steps below, we can declare runtimes that use different snapshotters:
 #### Step 1: Configure Containerd
 ```toml
 [plugins."io.containerd.grpc.v1.cri".containerd]
@@ -147,10 +147,9 @@ linux:
     namespace_options:
       network: 2
 annotations:
-  "io.containerd.osfeature": "nydus.remoteimage.v1"
   "io.containerd.cri.runtime-handler": "nydus-runc"
 ```
-As above two steps configured, if we set annotation ```"io.containerd.cri.runtime-handler": "nydus-runc"``` in sandbox spec, the ```nydus snapshotter``` will be used. Conversely (i.e. not setting the annotation), the ```overlayfs``` snapshotter will be used.
+As shown above, the sandbox is declared with ```"io.containerd.cri.runtime-handler": "nydus-runc"``` annotation will use the ```nydus``` snapshotter, while others will use the default ```overlayfs``` snapshotter.
 
 ## Start a Local Registry Container
 

--- a/docs/containerd-env-setup.md
+++ b/docs/containerd-env-setup.md
@@ -124,7 +124,7 @@ sudo systemctl restart containerd
 ```
 
 ### Using Runtime-level Snapshotter in Container for Nydus
-How about: Containerd (>= v1.7.0) supports configuring the ```runtime-level``` snapshotter. By following the steps below, we can declare runtimes that use different snapshotters:
+Containerd (>= v1.7.0) supports configuring the ```runtime-level``` snapshotter. By following the steps below, we can declare runtimes that use different snapshotters:
 #### Step 1: Configure Containerd
 ```toml
 [plugins."io.containerd.grpc.v1.cri".containerd]


### PR DESCRIPTION
## Relevant Issue (if applicable)
#1296 

## Details
Containerd (version >= 1.7.0) has supported runtime-level snapshotter. Developers can using different snapshotter with different runtime in the same environment. I think this feature is very important and necessary for Nydus that is used in production environment. The brief content of this PR is about how to use runtime-level snapshotter.

cc @adamqqqplay @zyfjeff

## Types of changes

_What types of changes does your PullRequest introduce? Put an `x` in all the boxes that apply:_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Go over all the following points, and put an `x` in all the boxes that apply._

- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.