### PR TITLE
U2.2 backport - #1229 #1311 # 1348

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -479,9 +479,9 @@ dependencies = [
 
 [[package]]
 name = "fuse-backend-rs"
-version = "0.10.1"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91aa2575daf333bef77ad5026d28d5ebdb04ec8e5d7a4ac9b1bb03976c2d673a"
+checksum = "dc24820b14267bec37fa87f5c2a32b5f1c5405b8c60cc3aa77afd481bd2628a6"
 dependencies = [
  "arc-swap",
  "bitflags",
@@ -1211,6 +1211,7 @@ dependencies = [
  "anyhow",
  "base64",
  "clap",
+ "flexi_logger",
  "fuse-backend-rs",
  "hex",
  "hyper",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,8 @@ path = "src/lib.rs"
 anyhow = "1"
 base64 = "0.21"
 clap = { version = "4.0.18", features = ["derive", "cargo"] }
-fuse-backend-rs = "0.10.1"
+flexi_logger = { version = "0.25", features = ["compress"] }
+fuse-backend-rs = "^0.10.4"
 hex = "0.4.3"
 hyper = "0.14.11"
 hyperlocal = "0.8.0"

--- a/rafs/src/fs.rs
+++ b/rafs/src/fs.rs
@@ -621,19 +621,20 @@ impl FileSystem for Rafs {
         assert!(!io_vecs.is_empty() && !io_vecs[0].is_empty());
 
         // Try to amplify user io for Rafs v5, to improve performance.
-        if self.sb.meta.is_v5() && size < self.amplify_io {
+        let amplify_io = cmp::min(self.amplify_io as usize, w.available_bytes()) as u32;
+        if self.sb.meta.is_v5() && size < amplify_io {
             let all_chunks_ready = self.device.all_chunks_ready(&io_vecs);
             if !all_chunks_ready {
                 let chunk_mask = self.metadata().chunk_size as u64 - 1;
                 let next_chunk_base = (offset + (size as u64) + chunk_mask) & !chunk_mask;
                 let window_base = cmp::min(next_chunk_base, inode_size);
                 let actual_size = window_base - (offset & !chunk_mask);
-                if actual_size < self.amplify_io as u64 {
-                    let window_size = self.amplify_io as u64 - actual_size;
+                if actual_size < amplify_io as u64 {
+                    let window_size = amplify_io as u64 - actual_size;
                     let orig_cnt = io_vecs.iter().fold(0, |s, d| s + d.len());
                     self.sb.amplify_io(
                         &self.device,
-                        self.amplify_io,
+                        amplify_io,
                         &mut io_vecs,
                         &inode,
                         window_base,

--- a/smoke/Makefile
+++ b/smoke/Makefile
@@ -19,7 +19,7 @@ lint:
 # NYDUS_NYDUSIFY=/path/to/latest/nydusify \
 # make test
 test: build lint
-	sudo -E ./smoke.test -test.v -test.timeout 10m -test.parallel=8 -test.run=$(TESTS)
+	sudo -E ./smoke.test -test.v -test.timeout 10m -test.parallel=16 -test.run=$(TESTS)
 
 # WORK_DIR=/tmp \
 # NYDUS_BUILDER=/path/to/latest/nydus-image \

--- a/smoke/tests/api_test.go
+++ b/smoke/tests/api_test.go
@@ -195,7 +195,7 @@ func (a *APIV1TestSuite) TestPrefetch(t *testing.T) {
 	config.RafsMode = ctx.Runtime.RafsMode
 	err = nydusd.MountByAPI(config)
 	require.NoError(t, err)
-	time.Sleep(time.Millisecond * 10)
+	time.Sleep(time.Millisecond * 15)
 
 	bcm, err := nydusd.GetBlobCacheMetrics("")
 	require.NoError(t, err)

--- a/smoke/tests/api_test.go
+++ b/smoke/tests/api_test.go
@@ -159,7 +159,10 @@ func (a *APIV1TestSuite) TestPrefetch(t *testing.T) {
 	ctx.PrepareWorkDir(t)
 	defer ctx.Destroy(t)
 
-	rootFs := texture.MakeLowerLayer(t, filepath.Join(ctx.Env.WorkDir, "root-fs"))
+	rootFs := texture.MakeLowerLayer(
+		t,
+		filepath.Join(ctx.Env.WorkDir, "root-fs"),
+		texture.LargerFileMaker("large-blob.bin", 5))
 
 	rafs := a.rootFsToRafs(t, ctx, rootFs)
 

--- a/smoke/tests/image_test.go
+++ b/smoke/tests/image_test.go
@@ -15,7 +15,8 @@ import (
 )
 
 const (
-	paramZran = "zran"
+	paramZran      = "zran"
+	paramAmplifyIO = "amplify_io"
 )
 
 type ImageTestSuite struct {

--- a/smoke/tests/texture/layer.go
+++ b/smoke/tests/texture/layer.go
@@ -22,6 +22,11 @@ func MakeChunkDictLayer(t *testing.T, workDir string) *tool.Layer {
 	layer.CreateFile(t, "chunk-dict-file-3", []byte("dir-1/file-1"))
 	layer.CreateFile(t, "chunk-dict-file-4", []byte("dir-2/file-1"))
 	layer.CreateFile(t, "chunk-dict-file-5", []byte("dir-1/file-2"))
+	layer.CreateFile(t, "chunk-dict-file-6", []byte("This is poetry"))
+	layer.CreateFile(t, "chunk-dict-file-7", []byte("My name is long"))
+	layer.CreateLargeFile(t, "chunk-dict-file-8", 13)
+	layer.CreateHoledFile(t, "chunk-dict-file-9", []byte("hello world"), 1024, 1024*1024)
+	layer.CreateFile(t, "chunk-dict-file-10", []byte(""))
 
 	return layer
 }
@@ -51,6 +56,24 @@ func MakeLowerLayer(t *testing.T, workDir string) *tool.Layer {
 	layer.CreateSpecialFile(t, "char-1", syscall.S_IFCHR)
 	layer.CreateSpecialFile(t, "block-1", syscall.S_IFBLK)
 	layer.CreateSpecialFile(t, "fifo-1", syscall.S_IFIFO)
+
+	// Create file with chinese name
+	layer.CreateFile(t, "唐诗三百首", []byte("This is poetry"))
+
+	// Create file with long name
+	layer.CreateFile(t, "/test-😉-name.test-😉-name.test-😉-name.test-😉-name.test-😉-name.test-😉-name.test-😉-name.test-😉-name.test-😉-name.test-😉-name.test-😉-name.test-😉-name.test-😉-name.test-😉-name.test-😉-name.test-😉-name.test-😉-name.", []byte("My name is long"))
+
+	// Create symlink with non-existed source file
+	layer.CreateSymlink(t, "dir-1/file-deleted-symlink", "dir-1/file-deleted")
+
+	// Create large file
+	layer.CreateLargeFile(t, "large-blob.bin", 13)
+
+	// Create holed file
+	layer.CreateHoledFile(t, "file-hole-1", []byte("hello world"), 1024, 1024*1024)
+
+	// Create empty file
+	layer.CreateFile(t, "empty.txt", []byte(""))
 
 	layer.CreateFile(t, "dir-1/file-2", []byte("dir-1/file-2"))
 	// Set file xattr (only `security.capability` xattr is supported in OCI layer)

--- a/smoke/tests/tool/context.go
+++ b/smoke/tests/tool/context.go
@@ -37,6 +37,7 @@ type RuntimeContext struct {
 	CacheCompressed bool
 	RafsMode        string
 	EnablePrefetch  bool
+	AmplifyIO       uint64
 }
 
 type EnvContext struct {
@@ -73,6 +74,7 @@ func DefaultContext(t *testing.T) *Context {
 			CacheCompressed: false,
 			RafsMode:        "direct",
 			EnablePrefetch:  true,
+			AmplifyIO:       uint64(0x100000),
 		},
 	}
 }

--- a/smoke/tests/tool/file.go
+++ b/smoke/tests/tool/file.go
@@ -30,10 +30,10 @@ type File struct {
 
 func GetXattrs(t *testing.T, path string) map[string]string {
 	xattrs := map[string]string{}
-	names, err := xattr.List(path)
+	names, err := xattr.LList(path)
 	require.NoError(t, err)
 	for _, name := range names {
-		data, err := xattr.Get(path, name)
+		data, err := xattr.LGet(path, name)
 		require.NoError(t, err)
 		xattrs[name] = string(data)
 	}
@@ -41,7 +41,7 @@ func GetXattrs(t *testing.T, path string) map[string]string {
 }
 
 func NewFile(t *testing.T, path, target string) *File {
-	stat, err := os.Stat(path)
+	stat, err := os.Lstat(path)
 	require.NoError(t, err)
 
 	xattrs := GetXattrs(t, path)

--- a/smoke/tests/tool/iterator.go
+++ b/smoke/tests/tool/iterator.go
@@ -47,6 +47,10 @@ func (d *DescartesItem) Str() string {
 	return sb.String()
 }
 
+func (d *DescartesItem) GetUInt64(name string) uint64 {
+	return d.vals[name].(uint64)
+}
+
 // Generator of Cartesian product.
 //
 // An example is below:

--- a/smoke/tests/tool/layer.go
+++ b/smoke/tests/tool/layer.go
@@ -44,6 +44,33 @@ func (l *Layer) CreateFile(t *testing.T, name string, data []byte) {
 	require.NoError(t, err)
 }
 
+func (l *Layer) CreateLargeFile(t *testing.T, name string, sizeMB int) {
+	f, err := os.Create(filepath.Join(l.workDir, name))
+	require.NoError(t, err)
+	defer func() {
+		f.Close()
+	}()
+
+	for b := 1; b <= sizeMB; b++ {
+		_, err := f.Write(bytes.Repeat([]byte{byte(b)}, 1024*1024))
+		require.NoError(t, err)
+	}
+}
+
+func (l *Layer) CreateHoledFile(t *testing.T, name string, data []byte, offset, fileSize int64) {
+	f, err := os.Create(filepath.Join(l.workDir, name))
+	require.NoError(t, err)
+	defer func() {
+		f.Close()
+	}()
+
+	err = f.Truncate(fileSize)
+	require.NoError(t, err)
+
+	_, err = f.WriteAt(data, offset)
+	require.NoError(t, err)
+}
+
 func (l *Layer) CreateDir(t *testing.T, name string) {
 	err := os.MkdirAll(filepath.Join(l.workDir, name), 0755)
 	require.NoError(t, err)

--- a/smoke/tests/tool/nydusd.go
+++ b/smoke/tests/tool/nydusd.go
@@ -69,6 +69,7 @@ type NydusdConfig struct {
 	LatestReadFiles bool
 	AccessPattern   bool
 	PrefetchFiles   []string
+	AmplifyIO       uint64
 }
 
 type Nydusd struct {
@@ -104,7 +105,8 @@ var configTpl = `
 	 "digest_validate": {{.DigestValidate}},
 	 "enable_xattr": true,
      "latest_read_files": {{.LatestReadFiles}},
-     "access_pattern": {{.AccessPattern}}
+     "access_pattern": {{.AccessPattern}},
+     "amplify_io": {{.AmplifyIO}}
  }
  `
 

--- a/smoke/tests/tool/verify.go
+++ b/smoke/tests/tool/verify.go
@@ -29,6 +29,7 @@ func Verify(t *testing.T, ctx Context, expectedFiles map[string]*File) {
 		CacheCompressed: ctx.Runtime.CacheCompressed,
 		RafsMode:        ctx.Runtime.RafsMode,
 		DigestValidate:  false,
+		AmplifyIO:       ctx.Runtime.AmplifyIO,
 	}
 
 	nydusd, err := NewNydusd(config)

--- a/storage/src/cache/worker.rs
+++ b/storage/src/cache/worker.rs
@@ -184,7 +184,7 @@ impl AsyncWorkerMgr {
     }
 
     /// Consume network bandwidth budget for prefetching.
-    pub fn consume_prefetch_budget(&self, size: u32) {
+    pub fn consume_prefetch_budget(&self, size: u64) {
         if self.prefetch_inflight.load(Ordering::Relaxed) > 0 {
             self.prefetch_consumed
                 .fetch_add(size as usize, Ordering::AcqRel);


### PR DESCRIPTION
## Backport

feat: add more types of file to smoke #1229
fix: amplify io is too large to hold in fuse buffer #1311
fix: large files broke prefetch #1348
