### PR TITLE
Makefile: allow to build debug version nydusd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-all: build
+all: release
 
 all-build: build contrib-build
 
@@ -91,7 +91,7 @@ endef
 	@${CARGO} clean --target ${RUST_TARGET_STATIC} --release -p libz-sys
 
 # Targets that are exposed to developers and users.
-build: .format .release_version
+build: .format
 	${CARGO} build $(CARGO_COMMON) $(CARGO_BUILD_FLAGS)
 	# Cargo will skip checking if it is already checked
 	${CARGO} clippy --workspace $(EXCLUDE_PACKAGES) $(CARGO_COMMON) $(CARGO_BUILD_FLAGS) --bins --tests -- -Dwarnings --allow clippy::unnecessary_cast --allow clippy::needless_borrow


### PR DESCRIPTION

## Relevant Issue (if applicable)
none.

## Details
We still build the release version by default, but make sure that `make build` only generates a debug version nydusd.

## Types of changes

_What types of changes does your PullRequest introduce? Put an `x` in all the boxes that apply:_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.