### PR TITLE
change a new nydus image for ci test

### DIFF
--- a/tests/bats/run_container_with_rafs_and_compile_linux.bats
+++ b/tests/bats/run_container_with_rafs_and_compile_linux.bats
@@ -1,7 +1,7 @@
 load "${BATS_TEST_DIRNAME}/common_tests.sh"
 
 setup() {
-	nydus_rafs_image="nydus-anolis-registry.cn-hangzhou.cr.aliyuncs.com/nydus_test/bldlinux:v0.1-rafs-v6-lz4"
+	nydus_rafs_image="ghcr.io/dragonflyoss/image-service/bldlinux:v0.1-rafs-v6-lz4"
 	run_nydus_snapshotter
 	config_containerd_for_nydus
 	ctr images ls | grep -q "${nydus_rafs_image}" && ctr images rm $nydus_rafs_image


### PR DESCRIPTION
The network is not stable when pulling the old image, which may result in ci test failure, so use the new image instead.

## Relevant Issue (if applicable)
_If there are Issues related to this PullRequest, please list it._

## Details
_Please describe the details of PullRequest._

## Types of changes

_What types of changes does your PullRequest introduce? Put an `x` in all the boxes that apply:_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Go over all the following points, and put an `x` in all the boxes that apply._

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.