### PR TITLE
[backport] rafs: avoid a debug_assert related to v5 amplify io

### DIFF
--- a/rafs/src/metadata/md_v5.rs
+++ b/rafs/src/metadata/md_v5.rs
@@ -172,12 +172,12 @@ impl RafsSuper {
             if let Ok(ni) = self.get_inode(next_ino, false) {
                 if ni.is_reg() {
                     let next_size = ni.size();
-                    let next_size = if next_size < window_size {
+                    let next_size = if next_size == 0 {
+                        continue;
+                    } else if next_size < window_size {
                         next_size
                     } else if window_size >= self.meta.chunk_size as u64 {
                         window_size / self.meta.chunk_size as u64 * self.meta.chunk_size as u64
-                    } else if next_size == 0 {
-                        continue;
                     } else {
                         break;
                     };


### PR DESCRIPTION
backport master commit 
```
commit 251730990ebc4a008b231d46c2315e1fc372f889
Author: Jiang Liu <gerry@linux.alibaba.com>
Date:   Sun Apr 30 17:10:00 2023 +0800

    rafs: avoid a debug_assert related to v5 amplify io

    In function RafsSuper::amplify_io(), is the next inode `ni` is
    zero-sized, the debug assertion in function calculate_bio_chunk_index()
    (rafs/src/metadata/layout/v5.rs) will get triggered. So zero-sized
    file should be skipped by amplify_io().

    Signed-off-by: Jiang Liu <gerry@linux.alibaba.com>
```
## Relevant Issue (if applicable)
_If there are Issues related to this PullRequest, please list it._

## Details
_Please describe the details of PullRequest._

## Types of changes

_What types of changes does your PullRequest introduce? Put an `x` in all the boxes that apply:_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Go over all the following points, and put an `x` in all the boxes that apply._

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.