### PR TITLE
backport  #1311 # 1348

### DIFF
--- a/rafs/src/fs.rs
+++ b/rafs/src/fs.rs
@@ -797,7 +797,7 @@ impl FileSystem for Rafs {
             let r = self.device.read_to(w, desc)?;
             result += r;
             recorder.mark_success(r);
-            if r as u32 != desc.bi_size {
+            if r as u64 != desc.bi_size {
                 break;
             }
         }

--- a/rafs/src/metadata/direct_v6.rs
+++ b/rafs/src/metadata/direct_v6.rs
@@ -1287,7 +1287,7 @@ impl RafsInode for OndiskInodeWrapper {
 
         let mut descs = BlobIoVec::new();
         descs.bi_vec.push(desc);
-        descs.bi_size += content_len;
+        descs.bi_size += content_len as u64;
         left -= content_len;
 
         if left != 0 {
@@ -1311,7 +1311,7 @@ impl RafsInode for OndiskInodeWrapper {
                 }
 
                 descs.bi_vec.push(desc);
-                descs.bi_size += content_len;
+                descs.bi_size += content_len as u64;
                 left -= content_len;
                 if left == 0 {
                     break;

--- a/rafs/src/metadata/layout/v5.rs
+++ b/rafs/src/metadata/layout/v5.rs
@@ -1324,7 +1324,7 @@ fn add_chunk_to_bio_desc(
         (chunk_end - chunk_start) as u32,
         user_io,
     );
-    desc.bi_size += bio.size;
+    desc.bi_size += bio.size as u64;
     desc.bi_vec.push(bio);
 
     true

--- a/storage/src/cache/worker.rs
+++ b/storage/src/cache/worker.rs
@@ -186,9 +186,9 @@ impl AsyncWorkerMgr {
     }
 
     /// Consume network bandwidth budget for prefetching.
-    pub fn consume_prefetch_budget(&self, size: u32) {
+    pub fn consume_prefetch_budget(&self, size: u64) {
         if self.prefetch_inflight.load(Ordering::Relaxed) > 0 {
-            if let Some(v) = NonZeroU32::new(size) {
+            if let Some(v) = NonZeroU32::new(size as u32) {
                 // Try to consume budget but ignore result.
                 if let Some(limiter) = self.prefetch_limiter.as_ref() {
                     let _ = limiter.check_n(v);

--- a/storage/src/device.rs
+++ b/storage/src/device.rs
@@ -543,7 +543,7 @@ pub struct BlobIoVec {
     /// Blob IO flags.
     pub bi_flags: u32,
     /// Total size of blob IOs to be performed.
-    pub bi_size: u32,
+    pub bi_size: u64,
     /// Array of blob IOs, these IOs should executed sequentially.
     // TODO: As bi_vec must stay within the same blob, move BlobInfo out here?
     pub bi_vec: Vec<BlobIoDesc>,
@@ -560,7 +560,7 @@ impl BlobIoVec {
     /// Append another blob io vector to current one.
     pub fn append(&mut self, mut desc: BlobIoVec) {
         self.bi_vec.append(desc.bi_vec.as_mut());
-        self.bi_size += desc.bi_size;
+        self.bi_size += desc.bi_size as u64;
         debug_assert!(self.validate());
     }
 


### PR DESCRIPTION
## backport

fix: amplify io is too large to hold in fuse buffer https://github.com/dragonflyoss/image-service/pull/1311
fix: large files broke prefetch https://github.com/dragonflyoss/image-service/pull/1348
