### PR TITLE
storage: simplify mirror implementation

### DIFF
--- a/api/src/config.rs
+++ b/api/src/config.rs
@@ -917,12 +917,6 @@ pub struct MirrorConfig {
     /// HTTP request headers to be passed to mirror server.
     #[serde(default)]
     pub headers: HashMap<String, String>,
-    /// Whether the authorization process is through mirror, default to false.
-    /// true: authorization through mirror, e.g. Using normal registry as mirror.
-    /// false: authorization through original registry,
-    /// e.g. when using Dragonfly server as mirror, authorization through it may affect performance.
-    #[serde(default)]
-    pub auth_through: bool,
     /// Interval for mirror health checking, in seconds.
     #[serde(default = "default_check_interval")]
     pub health_check_interval: u64,
@@ -936,7 +930,6 @@ impl Default for MirrorConfig {
         Self {
             host: String::new(),
             headers: HashMap::new(),
-            auth_through: false,
             health_check_interval: 5,
             failure_limit: 5,
             ping_url: String::new(),
@@ -1825,7 +1818,6 @@ mod tests {
         [[backend.oss.mirrors]]
         host = "http://127.0.0.1:65001"
         ping_url = "http://127.0.0.1:65001/ping"
-        auth_through = true
         health_check_interval = 10
         failure_limit = 10
         "#;
@@ -1859,7 +1851,6 @@ mod tests {
         let mirror = &oss.mirrors[0];
         assert_eq!(mirror.host, "http://127.0.0.1:65001");
         assert_eq!(mirror.ping_url, "http://127.0.0.1:65001/ping");
-        assert!(mirror.auth_through);
         assert!(mirror.headers.is_empty());
         assert_eq!(mirror.health_check_interval, 10);
         assert_eq!(mirror.failure_limit, 10);
@@ -1891,7 +1882,6 @@ mod tests {
         [[backend.registry.mirrors]]
         host = "http://127.0.0.1:65001"
         ping_url = "http://127.0.0.1:65001/ping"
-        auth_through = true
         health_check_interval = 10
         failure_limit = 10
         "#;
@@ -1927,7 +1917,6 @@ mod tests {
         let mirror = &registry.mirrors[0];
         assert_eq!(mirror.host, "http://127.0.0.1:65001");
         assert_eq!(mirror.ping_url, "http://127.0.0.1:65001/ping");
-        assert!(mirror.auth_through);
         assert!(mirror.headers.is_empty());
         assert_eq!(mirror.health_check_interval, 10);
         assert_eq!(mirror.failure_limit, 10);

--- a/docs/nydusd.md
+++ b/docs/nydusd.md
@@ -297,9 +297,6 @@ Currently, the mirror mode is only tested in the registry backend, and in theory
           {
             // Mirror server URL (including scheme), e.g. Dragonfly dfdaemon server URL
             "host": "http://dragonfly1.io:65001",
-            // true: Send the authorization request to the mirror e.g. another docker registry.
-            // false: Authorization request won't be relayed by the mirror e.g. Dragonfly.
-            "auth_through": false,
             // Headers for mirror server
             "headers": {
               // For Dragonfly dfdaemon server URL, we need to specify "X-Dragonfly-Registry" (including scheme).

--- a/misc/configs/nydusd-blob-cache-entry-configuration-v2.toml
+++ b/misc/configs/nydusd-blob-cache-entry-configuration-v2.toml
@@ -57,8 +57,6 @@ host = "http://127.0.0.1:65001"
 ping_url = "http://127.0.0.1:65001/ping"
 # HTTP request headers to be passed to mirror server.
 # headers =
-# Whether the authorization process is through mirror, default to false.
-auth_through = true
 # Interval for mirror health checking, in seconds.
 health_check_interval = 5
 # Maximum number of failures before marking a mirror as unusable.
@@ -108,8 +106,6 @@ host = "http://127.0.0.1:65001"
 ping_url = "http://127.0.0.1:65001/ping"
 # HTTP request headers to be passed to mirror server.
 # headers =
-# Whether the authorization process is through mirror, default to false.
-auth_through = true
 # Interval for mirror health checking, in seconds.
 health_check_interval = 5
 # Maximum number of failures before marking a mirror as unusable.

--- a/misc/configs/nydusd-blob-cache-entry.toml
+++ b/misc/configs/nydusd-blob-cache-entry.toml
@@ -62,8 +62,6 @@ host = "http://127.0.0.1:65001"
 ping_url = "http://127.0.0.1:65001/ping"
 # HTTP request headers to be passed to mirror server.
 # headers =
-# Whether the authorization process is through mirror, default to false.
-auth_through = true
 # Interval for mirror health checking, in seconds.
 health_check_interval = 5
 # Maximum number of failures before marking a mirror as unusable.
@@ -113,8 +111,6 @@ host = "http://127.0.0.1:65001"
 ping_url = "http://127.0.0.1:65001/ping"
 # HTTP request headers to be passed to mirror server.
 # headers =
-# Whether the authorization process is through mirror, default to false.
-auth_through = true
 # Interval for mirror health checking, in seconds.
 health_check_interval = 5
 # Maximum number of failures before marking a mirror as unusable.

--- a/misc/configs/nydusd-config-v2.toml
+++ b/misc/configs/nydusd-config-v2.toml
@@ -55,8 +55,6 @@ host = "http://127.0.0.1:65001"
 ping_url = "http://127.0.0.1:65001/ping"
 # HTTP request headers to be passed to mirror server.
 # headers =
-# Whether the authorization process is through mirror, default to false.
-auth_through = true
 # Interval for mirror health checking, in seconds.
 health_check_interval = 5
 # Maximum number of failures before marking a mirror as unusable.
@@ -106,8 +104,6 @@ host = "http://127.0.0.1:65001"
 ping_url = "http://127.0.0.1:65001/ping"
 # HTTP request headers to be passed to mirror server.
 # headers =
-# Whether the authorization process is through mirror, default to false.
-auth_through = true
 # Interval for mirror health checking, in seconds.
 health_check_interval = 5
 # Maximum number of failures before marking a mirror as unusable.

--- a/storage/src/backend/http_proxy.rs
+++ b/storage/src/backend/http_proxy.rs
@@ -214,7 +214,6 @@ impl BlobReader for HttpProxyReader {
                         None,
                         &mut HeaderMap::new(),
                         true,
-                        false,
                     )
                     .map(|resp| resp.headers().to_owned())
                     .map_err(|e| HttpProxyError::RemoteRequest(e).into())
@@ -255,15 +254,7 @@ impl BlobReader for HttpProxyReader {
                         .map_err(|e| HttpProxyError::ConstructHeader(format!("{}", e)))?,
                 );
                 let mut resp = connection
-                    .call::<&[u8]>(
-                        Method::GET,
-                        uri.as_str(),
-                        None,
-                        None,
-                        &mut headers,
-                        true,
-                        false,
-                    )
+                    .call::<&[u8]>(Method::GET, uri.as_str(), None, None, &mut headers, true)
                     .map_err(HttpProxyError::RemoteRequest)?;
 
                 Ok(resp

--- a/storage/src/backend/object_storage.rs
+++ b/storage/src/backend/object_storage.rs
@@ -89,15 +89,7 @@ where
 
         let resp = self
             .connection
-            .call::<&[u8]>(
-                Method::HEAD,
-                url.as_str(),
-                None,
-                None,
-                &mut headers,
-                true,
-                false,
-            )
+            .call::<&[u8]>(Method::HEAD, url.as_str(), None, None, &mut headers, true)
             .map_err(ObjectStorageError::Request)?;
         let content_length = resp
             .headers()
@@ -136,15 +128,7 @@ where
         // Safe because the the call() is a synchronous operation.
         let mut resp = self
             .connection
-            .call::<&[u8]>(
-                Method::GET,
-                url.as_str(),
-                None,
-                None,
-                &mut headers,
-                true,
-                false,
-            )
+            .call::<&[u8]>(Method::GET, url.as_str(), None, None, &mut headers, true)
             .map_err(ObjectStorageError::Request)?;
         Ok(resp
             .copy_to(&mut buf)


### PR DESCRIPTION
```
Nydusd uses a registry backend which generates a surge of blob requests without
auth tokens on initial startup. This caused mirror backends (e.g. dragonfly)
to process very slowly, the commit fixes this problem.

It implements waiting for the first blob request to complete before making other
blob requests, this ensures the first request caches a valid registry auth token,
and subsequent concurrent blob requests can reuse the cached token.

This change is worthwhile to reduce concurrent token requests, it also makes the
behavior consistent with containerd, which first requests the image manifest and
caches the token before concurrently requesting blobs.
```

## Relevant Issue (if applicable)
_If there are Issues related to this PullRequest, please list it._

## Details
_Please describe the details of PullRequest._

## Types of changes

_What types of changes does your PullRequest introduce? Put an `x` in all the boxes that apply:_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Go over all the following points, and put an `x` in all the boxes that apply._

- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.