### PR TITLE
builder: optimize tarfs building speed by skipping file content

### DIFF
--- a/utils/src/reader.rs
+++ b/utils/src/reader.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::fs::File;
-use std::io::{BufReader, Read};
+use std::io::{BufReader, Read, Seek, SeekFrom};
 use std::marker::PhantomData;
 use std::os::unix::io::{AsRawFd, RawFd};
 use std::sync::{Arc, Mutex};
@@ -95,6 +95,15 @@ impl<R: Read> Read for BufReaderInfo<R> {
             }
             v
         })
+    }
+}
+
+impl<R: Read + Seek> Seek for BufReaderInfo<R> {
+    fn seek(&mut self, pos: SeekFrom) -> std::io::Result<u64> {
+        let mut state = self.state.lock().unwrap();
+        let pos = state.reader.seek(pos)?;
+        state.pos = pos;
+        Ok(pos)
     }
 }
 


### PR DESCRIPTION
The tarfs crate provides seekable reader to iterate entries in tar file, so optimize tarfs building speed by skipping file content.

## Types of changes

_What types of changes does your PullRequest introduce? Put an `x` in all the boxes that apply:_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Go over all the following points, and put an `x` in all the boxes that apply._

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.