### PR TITLE
fixup nydusctl umount argument usage

### DIFF
--- a/builder/src/core/v5.rs
+++ b/builder/src/core/v5.rs
@@ -37,6 +37,7 @@ impl Node {
         ctx: &mut BuildContext,
         f_bootstrap: &mut dyn RafsIoWrite,
     ) -> Result<()> {
+        trace!("[{}]\t{}", self.overlay, self);
         if let InodeWrapper::V5(raw_inode) = &self.inode {
             // Dump inode info
             let name = self.name();

--- a/src/bin/nydusctl/main.rs
+++ b/src/bin/nydusctl/main.rs
@@ -134,8 +134,7 @@ async fn main() -> Result<()> {
                     Arg::new("mountpoint")
                         .help("Mountpoint of the filesystem instance")
                         .short('m')
-                        .required(true)
-                        .index(1),
+                        .required(true),
                 ),
         );
 


### PR DESCRIPTION
## Details
- per [clap document](https://docs.rs/clap/4.3.15/clap/struct.Arg.html#method.index) Arg::index() shouldn’t to be used with [Arg::short](https://docs.rs/clap/4.3.15/clap/struct.Arg.html#method.short) or [Arg::long](https://docs.rs/clap/4.3.15/clap/struct.Arg.html#method.long).
- v5 rafs builder log only chunk info, I guess we miss the inode info.

## Types of changes


- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist


- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.