### PR TITLE
Backport/v2.1 parse image pull auth from env

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1179,9 +1179,9 @@ checksum = "18a6dbe30758c9f83eb00cbea4ac95966305f5a7772f3f42ebfc7fc7eddbd8e1"
 
 [[package]]
 name = "openssl"
-version = "0.10.52"
+version = "0.10.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01b8574602df80f7b85fdfc5392fa884a4e3b3f4f35402c070ab34c3d3f78d56"
+checksum = "345df152bc43501c5eb9e4654ff05f794effb78d4efe3d53abc158baddc0703d"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1220,9 +1220,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.87"
+version = "0.9.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e17f59264b2809d77ae94f0e1ebabc434773f370d6ca667bd223ea10e06cc7e"
+checksum = "374533b0e45f3a7ced10fcaeccca020e66656bc03dac384f852e4e5a7a8104a6"
 dependencies = [
  "cc",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,9 +40,9 @@ anyhow = "1.0.35"
 base64 = "0.13.0"
 rust-fsm = "0.6.0"
 vm-memory = { version = "0.9.0", features = ["backend-mmap"], optional = true }
-openssl = { version = "0.10.48", features = ["vendored"] }
+openssl = { version = "0.10.55", features = ["vendored"] }
 # pin openssl-src to bring in fix for https://rustsec.org/advisories/RUSTSEC-2022-0032
-openssl-src = { version = "=111.25.0" }
+openssl-src = { version = "111.25.0" }
 hyperlocal = "0.8.0"
 tokio = { version = "1.18.2", features = ["macros"] }
 hyper = "0.14.11"

--- a/docs/nydusd.md
+++ b/docs/nydusd.md
@@ -34,6 +34,8 @@ sudo nydusd \
   --log-level info
 ```
 
+For registry backend, we can set authorization with environment variable `IMAGE_PULL_AUTH` to avoid loading `auth` from nydusd configuration file.
+
 ### Run With Virtio-FS
 If no `/path/to/bootstrap` is available, please refer to [nydus-image.md](https://github.com/dragonflyoss/image-service/blob/master/docs/nydus-image.md) for more details.
 
@@ -202,7 +204,8 @@ We are working on enabling cloud-hypervisor support for nydus.
   },
   ...
 }
-```
+``` 
+Note: The value of `device.backend.config.auth` will be overwrite if running the nydusd with environment variable `IMAGE_PULL_AUTH`.
 
 ##### Enable P2P Proxy for Storage Backend
 

--- a/src/bin/nydusd/fs_service.rs
+++ b/src/bin/nydusd/fs_service.rs
@@ -53,6 +53,7 @@ impl FsBackendCollection {
             FsBackendType::Rafs => {
                 let mut config: serde_json::Value =
                     serde_json::from_str(&cmd.config).map_err(DaemonError::Serde)?;
+
                 trim_backend_config!(
                     config,
                     "access_key_id",


### PR DESCRIPTION
This commit attempts to avoid loading auth from the nydusd configuration file, which is insecure for users. The auth loaded from env will overwrite the auth loaded from file if it is not null.

## Relevant Issue (if applicable)
_If there are Issues related to this PullRequest, please list it._

## Details
_Please describe the details of PullRequest._

## Types of changes

_What types of changes does your PullRequest introduce? Put an `x` in all the boxes that apply:_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Go over all the following points, and put an `x` in all the boxes that apply._

- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.