### PR TITLE
Backport/v2.2 parse image pull auth from env

### DIFF
--- a/api/src/config.rs
+++ b/api/src/config.rs
@@ -1906,4 +1906,48 @@ mod tests {
         assert_eq!(&config.id, "id1");
         assert_eq!(config.backend.as_ref().unwrap().backend_type, "localfs");
     }
+
+    #[test]
+    fn test_update_registry_auth_info() {
+        let config = r#"
+        {
+            "device": {
+              "id": "test",
+              "backend": {
+                "type": "registry",
+                "config": {
+                    "readahead": false,
+                    "host": "docker.io",
+                    "repo": "library/nginx",
+                    "scheme": "https",
+                    "proxy": {
+                        "fallback": false
+                    },
+                    "timeout": 5,
+                    "connect_timeout": 5,
+                    "retry_limit": 8
+                }
+              }
+            },
+            "mode": "direct",
+            "digest_validate": false,
+            "enable_xattr": true,
+            "fs_prefetch": {
+              "enable": true,
+              "threads_count": 10,
+              "merging_size": 131072,
+              "bandwidth_rate": 10485760
+            }
+          }"#;
+
+        let mut rafs_config = ConfigV2::from_str(&config).unwrap();
+        let test_auth = "test_auth".to_string();
+
+        rafs_config.update_registry_auth_info(&Some(test_auth.clone()));
+
+        let backend = rafs_config.backend.unwrap();
+        let registry = backend.registry.unwrap();
+        let auth = registry.auth.unwrap();
+        assert_eq!(auth, test_auth);
+    }
 }

--- a/api/src/config.rs
+++ b/api/src/config.rs
@@ -202,6 +202,17 @@ impl ConfigV2 {
             false
         }
     }
+
+    /// Fill authorization for registry backend.
+    pub fn update_registry_auth_info(&mut self, auth: &Option<String>) {
+        if let Some(auth) = auth {
+            if let Some(backend) = self.backend.as_mut() {
+                if let Some(registry) = backend.registry.as_mut() {
+                    registry.auth = Some(auth.to_string());
+                }
+            }
+        }
+    }
 }
 
 impl FromStr for ConfigV2 {

--- a/docs/nydusd.md
+++ b/docs/nydusd.md
@@ -34,6 +34,8 @@ sudo nydusd \
   --log-level info
 ```
 
+For registry backend, we can set authorization with environment variable `IMAGE_PULL_AUTH` to avoid loading `auth` from nydusd configuration file.
+
 ### Run With Virtio-FS
 If no `/path/to/bootstrap` is available, please refer to [nydus-image.md](https://github.com/dragonflyoss/image-service/blob/master/docs/nydus-image.md) for more details.
 
@@ -227,7 +229,8 @@ Document located at: https://github.com/adamqqqplay/nydus-localdisk/blob/master/
   },
   ...
 }
-```
+``` 
+Note: The value of `device.backend.config.auth` will be overwrite if running the nydusd with environment variable `IMAGE_PULL_AUTH`.
 
 ##### Enable P2P Proxy for Storage Backend
 


### PR DESCRIPTION
## Details
This commit attempts to avoid loading auth from the nydusd configuration file, which is insecure for users. The auth loaded from env will overwrite the auth loaded from file if it is not null.

Related to #1382 

## Types of changes

_What types of changes does your PullRequest introduce? Put an `x` in all the boxes that apply:_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Go over all the following points, and put an `x` in all the boxes that apply._

- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.