### PR TITLE
deps: update tar-rs to handle very large uid/gid in image unpack

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1759,9 +1759,8 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.38"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b55807c0344e1e6c04d7c965f5289c39a8d94ae23ed5c0b57aabac549f871c6"
+version = "0.4.39"
+source = "git+https://github.com/nydusaccelerator/tar-rs.git#17f97d22c66d0d6137665844ac8f8ef5a007255c"
 dependencies = [
  "filetime",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,3 +107,7 @@ backend-s3 = ["nydus-storage/backend-s3"]
 
 [workspace]
 members = ["api", "builder", "clib", "rafs", "storage", "service", "utils"]
+
+[patch.crates-io]
+# Due to the slow processing of PR by the upstream, temporarily fork tar-rs for this project
+tar = { git = "https://github.com/nydusaccelerator/tar-rs.git" }

--- a/misc/top_images/image_list.txt
+++ b/misc/top_images/image_list.txt
@@ -43,3 +43,4 @@ kong
 solr
 sentry
 zookeeper
+ghcr.io/dragonflyoss/image-service/pax-uid-test


### PR DESCRIPTION
## Relevant Issue (if applicable)
https://github.com/alexcrichton/tar-rs/issues/332

## Details
update tar-rs to support read large uid/gid from PAX extensions to fix very large UIDs/GIDs (>=2097151, limit of USTAR tar) lost in PAX style tar during unpack.

## Types of changes

_What types of changes does your PullRequest introduce? Put an `x` in all the boxes that apply:_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Go over all the following points, and put an `x` in all the boxes that apply._

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.