### PR TITLE
service: print more error message

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -287,6 +287,12 @@ $ cat localfs.json
       "config": {
         "dir": "/<YOUR-WORK-PATH>/nydus-image/blobs"
       }
+    },
+    "cache": {
+      "type": "blobcache",
+      "config": {
+        "work_dir": "/var/lib/nydus/cache"
+      }
     }
   },
   "mode": "direct"

--- a/service/src/fusedev.rs
+++ b/service/src/fusedev.rs
@@ -591,7 +591,10 @@ pub fn create_fuse_daemon(
         || api_sock.is_none()
     {
         if let Some(cmd) = mount_cmd {
-            daemon.service.mount(cmd)?;
+            daemon.service.mount(cmd).map_err(|e| {
+                error!("service mount error: {}", &e);
+                eother!(e)
+            })?;
         }
         daemon
             .service
@@ -599,7 +602,10 @@ pub fn create_fuse_daemon(
             .lock()
             .unwrap()
             .mount()
-            .map_err(|e| eother!(e))?;
+            .map_err(|e| {
+                error!("service session mount error: {}", &e);
+                eother!(e)
+            })?;
         daemon
             .on_event(DaemonStateMachineInput::Mount)
             .map_err(|e| eother!(e))?;


### PR DESCRIPTION
Some error messages were swallowed which makes user confused, for example, for RAFSv6, we need to set blobcache config in `localfs.json` (following docs tutorial), before modification, the error message indicates nothing:

```
ERROR [src/bin/nydusd/main.rs:525] Failed in starting daemon: Invalid
argument (os error 22)
```

After this modification, we get clearer error message:

```
ERROR [/src/fusedev.rs:595] service mount error: RAFS failed to handle
request, Configure("Rafs v6 must have local blobcache configured")
```

## Relevant Issue (if applicable)

## Details
_Please describe the details of PullRequest._

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.