### PR TITLE
[backport v2.2] deps: Bump dependent crate versions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -479,9 +479,9 @@ dependencies = [
 
 [[package]]
 name = "fuse-backend-rs"
-version = "0.10.4"
+version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc24820b14267bec37fa87f5c2a32b5f1c5405b8c60cc3aa77afd481bd2628a6"
+checksum = "f85357722be4bf3d0b7548bedf7499686c77628c2c61cb99c6519463f7a9e5f0"
 dependencies = [
  "arc-swap",
  "bitflags",
@@ -492,10 +492,9 @@ dependencies = [
  "log",
  "mio",
  "nix",
- "tokio-uring",
  "vhost",
  "virtio-queue",
- "vm-memory",
+ "vm-memory 0.10.0",
  "vmm-sys-util",
 ]
 
@@ -837,16 +836,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "io-uring"
-version = "0.5.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba34abb5175052fc1a2227a10d2275b7386c9990167de9786c0b88d8b062330"
-dependencies = [
- "bitflags",
- "libc",
-]
-
-[[package]]
 name = "ipnet"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1149,7 +1138,7 @@ dependencies = [
  "nydus-storage",
  "serde",
  "serde_json",
- "vm-memory",
+ "vm-memory 0.9.0",
 ]
 
 [[package]]
@@ -1200,7 +1189,7 @@ dependencies = [
  "serde",
  "serde_json",
  "spmc",
- "vm-memory",
+ "vm-memory 0.10.0",
  "vmm-sys-util",
 ]
 
@@ -1240,7 +1229,7 @@ dependencies = [
  "vhost-user-backend",
  "virtio-bindings",
  "virtio-queue",
- "vm-memory",
+ "vm-memory 0.10.0",
  "vmm-sys-util",
  "xattr",
 ]
@@ -1269,7 +1258,7 @@ dependencies = [
  "vhost-user-backend",
  "virtio-bindings",
  "virtio-queue",
- "vm-memory",
+ "vm-memory 0.10.0",
  "vmm-sys-util",
 ]
 
@@ -1306,7 +1295,7 @@ dependencies = [
  "time",
  "tokio",
  "url",
- "vm-memory",
+ "vm-memory 0.10.0",
  "vmm-sys-util",
 ]
 
@@ -1651,12 +1640,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "scoped-tls"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea6a9290e3c9cf0f18145ef7ffa62d68ee0bf5fcd651017e586dc7fd5da448c2"
-
-[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1930,20 +1913,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-uring"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d5e02bb137e030b3a547c65a3bd2f1836d66a97369fdcc69034002b10e155ef"
-dependencies = [
- "io-uring",
- "libc",
- "scoped-tls",
- "slab",
- "socket2",
- "tokio",
-]
-
-[[package]]
 name = "tokio-util"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2078,28 +2047,28 @@ checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "vhost"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79243657c76e5c90dcbf60187c842614f6dfc7123972c55bb3bcc446792aca93"
+checksum = "c9b791c5b0717a0558888a4cf7240cea836f39a99cb342e12ce633dcaa078072"
 dependencies = [
  "bitflags",
  "libc",
- "vm-memory",
+ "vm-memory 0.10.0",
  "vmm-sys-util",
 ]
 
 [[package]]
 name = "vhost-user-backend"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a0fc7d5f8e2943cd9f2ecd58be3f2078add863a49573d14dd9d64e1ab26544c"
+checksum = "9f237b91db4ac339d639fb43398b52d785fa51e3c7760ac9425148863c1f4303"
 dependencies = [
  "libc",
  "log",
  "vhost",
  "virtio-bindings",
  "virtio-queue",
- "vm-memory",
+ "vm-memory 0.10.0",
  "vmm-sys-util",
 ]
 
@@ -2111,13 +2080,13 @@ checksum = "3ff512178285488516ed85f15b5d0113a7cdb89e9e8a760b269ae4f02b84bd6b"
 
 [[package]]
 name = "virtio-queue"
-version = "0.6.1"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435dd49c7b38419729afd43675850c7b5dc4728f2fabd70c7a9079a331e4f8c6"
+checksum = "3ba81e2bcc21c0d2fc5e6683e79367e26ad219197423a498df801d79d5ba77bd"
 dependencies = [
  "log",
  "virtio-bindings",
- "vm-memory",
+ "vm-memory 0.10.0",
  "vmm-sys-util",
 ]
 
@@ -2127,6 +2096,16 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "583f213899e8a5eea23d9c507252d4bed5bc88f0ecbe0783262f80034630744b"
 dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "vm-memory"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "688a70366615b45575a424d9c665561c1b5ab2224d494f706b6a6812911a827c"
+dependencies = [
  "arc-swap",
  "libc",
  "winapi",
@@ -2134,9 +2113,9 @@ dependencies = [
 
 [[package]]
 name = "vmm-sys-util"
-version = "0.10.0"
+version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08604d7be03eb26e33b3cee3ed4aef2bf550b305d1cca60e84da5d28d3790b62"
+checksum = "dd64fe09d8e880e600c324e7d664760a17f56e9672b7495a86381b49e4f72f46"
 dependencies = [
  "bitflags",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ serde_json = "1.0.51"
 sha2 = "0.10.2"
 tar = "0.4.38"
 tokio = { version = "1.24", features = ["macros"] }
-vmm-sys-util = "0.10.0"
+vmm-sys-util = "0.11.0"
 xattr = "0.2.3"
 
 # Build static linked openssl library
@@ -66,11 +66,11 @@ nydus-service = { version = "0.2.0", path = "service" }
 nydus-storage = { version = "0.6.2", path = "storage" }
 nydus-utils = { version = "0.4.1", path = "utils" }
 
-vhost = { version = "0.5.0", features = ["vhost-user-slave"], optional = true }
-vhost-user-backend = { version = "0.7.0", optional = true }
+vhost = { version = "0.6.0", features = ["vhost-user-slave"], optional = true }
+vhost-user-backend = { version = "0.8.0", optional = true }
 virtio-bindings = { version = "0.1", features = ["virtio-v5_0_0"], optional = true }
-virtio-queue = { version = "0.6.0", optional = true }
-vm-memory = { version = "0.9.0", features = ["backend-mmap"], optional = true }
+virtio-queue = { version = "0.7.0", optional = true }
+vm-memory = { version = "0.10.0", features = ["backend-mmap"], optional = true }
 
 [features]
 default = [

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -23,7 +23,7 @@ url = { version = "2.1.1", optional = true }
 nydus-error = { version = "0.2", path = "../error" }
 
 [dev-dependencies]
-vmm-sys-util = { version = "0.10" }
+vmm-sys-util = { version = "0.11" }
 
 [features]
 handler = ["dbs-uhttp", "http", "lazy_static", "mio", "url"]

--- a/rafs/Cargo.toml
+++ b/rafs/Cargo.toml
@@ -23,8 +23,8 @@ nix = "0.24"
 serde = { version = "1.0.110", features = ["serde_derive", "rc"] }
 serde_json = "1.0.53"
 spmc = "0.3.0"
-vm-memory = "0.9"
-fuse-backend-rs = "0.10"
+vm-memory = "0.10"
+fuse-backend-rs = "0.10.5"
 
 nydus-api = { version = "0.2", path = "../api" }
 nydus-error = { version = "0.2", path = "../error" }
@@ -32,7 +32,7 @@ nydus-storage = { version = "0.6", path = "../storage", features = ["backend-loc
 nydus-utils = { version = "0.4", path = "../utils" }
 
 [dev-dependencies]
-vmm-sys-util = "0.10"
+vmm-sys-util = "0.11"
 assert_matches = "1.5.0"
 
 [features]

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 resolver = "2"
 
 [dependencies]
-fuse-backend-rs = "0.10.1"
+fuse-backend-rs = "0.10.5"
 libc = "0.2"
 log = "0.4.8"
 mio = { version = "0.8", features = ["os-poll", "os-ext"] }
@@ -28,14 +28,14 @@ nydus-rafs = { version = "0.2.2", path = "../rafs" }
 nydus-storage = { version = "0.6.2", path = "../storage" }
 nydus-utils = { version = "0.4.1", path = "../utils" }
 
-vhost = { version = "0.5.0", features = ["vhost-user-slave"], optional = true }
-vhost-user-backend = { version = "0.7.0", optional = true }
+vhost = { version = "0.6.0", features = ["vhost-user-slave"], optional = true }
+vhost-user-backend = { version = "0.8.0", optional = true }
 virtio-bindings = { version = "0.1", features = ["virtio-v5_0_0"], optional = true }
-virtio-queue = { version = "0.6.0", optional = true }
-vm-memory = { version = "0.9.0", features = ["backend-mmap"], optional = true }
+virtio-queue = { version = "0.7.0", optional = true }
+vm-memory = { version = "0.10.0", features = ["backend-mmap"], optional = true }
 
 [dev-dependencies]
-vmm-sys-util = "0.10.0"
+vmm-sys-util = "0.11.0"
 
 [features]
 default = ["fuse-backend-rs/fusedev"]

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -40,8 +40,8 @@ tokio = { version = "1.19.0", features = [
   "time",
 ] }
 url = { version = "2.1.1", optional = true }
-vm-memory = "0.9"
-fuse-backend-rs = "0.10"
+vm-memory = "0.10"
+fuse-backend-rs = "0.10.5"
 gpt = { version = "3.0.0", optional = true }
 
 nydus-api = { version = "0.2", path = "../api" }
@@ -50,7 +50,7 @@ nydus-error = { version = "0.2", path = "../error" }
 sha1 = { version = "0.10.5", optional = true }
 
 [dev-dependencies]
-vmm-sys-util = "0.10"
+vmm-sys-util = "0.11"
 tar = "0.4.38"
 regex = "1.7.0"
 

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -34,7 +34,7 @@ libz-sys = { version = "1.1.8", features = ["zlib-ng"], default-features = false
 flate2 = { version = "1.0.17", features = ["zlib-ng-compat"], default-features = false }
 
 [dev-dependencies]
-vmm-sys-util = "0.10.0"
+vmm-sys-util = "0.11.0"
 tar = "0.4.38"
 
 [features]


### PR DESCRIPTION
## Relevant Issue (if applicable)
_If there are Issues related to this PullRequest, please list it._

## Details

This pull request is mainly for updating vm-memory and vmm-sys-util.

The affacted crates include:

- vm-memory: from 0.9.0 to 0.10.0
- vmm-sys-util: from 0.10.0 to 0.11.0
- vhost: from 0.5.0 to 0.6.0
- virtio-queue: from 0.6.0 to 0.7.0
- fuse-backend-rs: from 0.10.4 to 0.10.5
- vhost-user-backend: from 0.7.0 to 0.8.0

## Types of changes

_What types of changes does your PullRequest introduce? Put an `x` in all the boxes that apply:_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Go over all the following points, and put an `x` in all the boxes that apply._

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.