### PR TITLE
deps: change tar-rs to upstream version 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -874,9 +874,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.139"
+version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "201de327520df007757c1f0adce6e827fe8562fbc28bfd9c15571c66ca1f5f79"
+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "libz-sys"
@@ -1758,8 +1758,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.39"
-source = "git+https://github.com/nydusaccelerator/tar-rs.git#17f97d22c66d0d6137665844ac8f8ef5a007255c"
+version = "0.4.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b16afcea1f22891c49a00c751c7b63b2233284064f11a200fc624137c51e2ddb"
 dependencies = [
  "filetime",
  "libc",
@@ -2278,9 +2279,9 @@ dependencies = [
 
 [[package]]
 name = "xattr"
-version = "0.2.3"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d1526bbe5aaeb5eb06885f4d987bcdfa5e23187055de9b83fe00156a821fabc"
+checksum = "f4686009f71ff3e5c4dbcf1a282d0a44db3f021ba69350cd42086b3e5f1c6985"
 dependencies = [
  "libc",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1083,7 +1083,7 @@ dependencies = [
 
 [[package]]
 name = "nydus-api"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "backtrace",
  "dbs-uhttp",
@@ -1136,7 +1136,7 @@ dependencies = [
 
 [[package]]
 name = "nydus-rafs"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -1227,7 +1227,7 @@ dependencies = [
 
 [[package]]
 name = "nydus-storage"
-version = "0.6.3"
+version = "0.6.4"
 dependencies = [
  "arc-swap",
  "base64",
@@ -1263,7 +1263,7 @@ dependencies = [
 
 [[package]]
 name = "nydus-utils"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "blake3",
  "flate2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ nix = "0.24.0"
 rlimit = "0.9.0"
 serde = { version = "1.0.110", features = ["serde_derive", "rc"] }
 serde_json = "1.0.51"
-tar = "0.4.38"
+tar = "0.4.40"
 tokio = { version = "1.24", features = ["macros"] }
 
 # Build static linked openssl library
@@ -74,7 +74,7 @@ vmm-sys-util = { version = "0.11.0", optional = true }
 time = { version = "0.3.14", features = ["formatting"] }
 
 [dev-dependencies]
-xattr = "0.2.3"
+xattr = "1.0.1"
 vmm-sys-util = "0.11.0"
 
 [features]
@@ -107,7 +107,3 @@ backend-s3 = ["nydus-storage/backend-s3"]
 
 [workspace]
 members = ["api", "builder", "clib", "rafs", "storage", "service", "utils"]
-
-[patch.crates-io]
-# Due to the slow processing of PR by the upstream, temporarily fork tar-rs for this project
-tar = { git = "https://github.com/nydusaccelerator/tar-rs.git" }

--- a/builder/Cargo.toml
+++ b/builder/Cargo.toml
@@ -19,9 +19,9 @@ nix = "0.24"
 serde = { version = "1.0.110", features = ["serde_derive", "rc"] }
 serde_json = "1.0.53"
 sha2 = "0.10.2"
-tar = "0.4.38"
+tar = "0.4.40"
 vmm-sys-util = "0.11.0"
-xattr = "0.2.3"
+xattr = "1.0.1"
 
 nydus-api = { version = "0.3", path = "../api" }
 nydus-rafs = { version = "0.3", path = "../rafs" }

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -28,7 +28,7 @@ serde = { version = "1.0.110", features = ["serde_derive", "rc"] }
 serde_json = "1.0.53"
 sha1 = { version = "0.10.5", optional = true }
 sha2 = { version = "0.10.2", optional = true }
-tar = "0.4.38"
+tar = "0.4.40"
 time = { version = "0.3.14", features = ["formatting"], optional = true }
 tokio = { version = "1.19.0", features = ["macros", "rt", "rt-multi-thread", "sync", "time"] }
 url = { version = "2.1.1", optional = true }
@@ -41,7 +41,7 @@ nydus-utils = { version = "0.4", path = "../utils", features = ["encryption", "z
 
 [dev-dependencies]
 vmm-sys-util = "0.11"
-tar = "0.4.38"
+tar = "0.4.40"
 regex = "1.7.0"
 
 [features]

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -36,7 +36,7 @@ flate2 = { version = "1.0.17", features = ["zlib-ng-compat"], default-features =
 
 [dev-dependencies]
 vmm-sys-util = "0.11.0"
-tar = "0.4.38"
+tar = "0.4.40"
 
 [features]
 zran = ["libz-sys"]


### PR DESCRIPTION
## Relevant Issue (if applicable)
#1387 #1391

## Details
Since upstream tar-rs merged our fix for reading large uids/gids from
the PAX extension, so change tar-rs back to the upstream version.

Update tar-rs dependency xattr to 1.0.1 as well.

## Types of changes

_What types of changes does your PullRequest introduce? Put an `x` in all the boxes that apply:_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Go over all the following points, and put an `x` in all the boxes that apply._

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.