### PR TITLE
[backport v2.1] deps: update tar-rs to handle very large uid/gid in image unpack 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -803,9 +803,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.142"
+version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a987beff54b60ffa6d51982e1aa1146bc42f19bd26be28b0586f252fccf5317"
+checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1686,9 +1686,9 @@ dependencies = [
 
 [[package]]
 name = "tar"
-version = "0.4.38"
+version = "0.4.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b55807c0344e1e6c04d7c965f5289c39a8d94ae23ed5c0b57aabac549f871c6"
+checksum = "b16afcea1f22891c49a00c751c7b63b2233284064f11a200fc624137c51e2ddb"
 dependencies = [
  "filetime",
  "libc",
@@ -2322,9 +2322,9 @@ dependencies = [
 
 [[package]]
 name = "xattr"
-version = "0.2.3"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d1526bbe5aaeb5eb06885f4d987bcdfa5e23187055de9b83fe00156a821fabc"
+checksum = "f4686009f71ff3e5c4dbcf1a282d0a44db3f021ba69350cd42086b3e5f1c6985"
 dependencies = [
  "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ serde_json = "1.0.51"
 sha2 = "0.10.2"
 time = { version = "0.3.14", features = ["serde-human-readable"] }
 lazy_static = "1.4.0"
-xattr = "0.2.2"
+xattr = "1.0.1"
 nix = "0.24.0"
 anyhow = "1.0.35"
 base64 = "0.13.0"
@@ -48,7 +48,7 @@ tokio = { version = "1.18.2", features = ["macros"] }
 hyper = "0.14.11"
 # pin rand_core to bring in fix for https://rustsec.org/advisories/RUSTSEC-2021-0023
 rand_core = "0.6.2"
-tar = "0.4.38"
+tar = "0.4.40"
 mio = { version = "0.8", features = ["os-poll", "os-ext"] }
 
 fuse-backend-rs = { version = "0.9" }


### PR DESCRIPTION
## Relevant Issue (if applicable)
#1387 #1391

## Details
Update tar-rs to support read large uid/gid from PAX extensions to
fix very large UIDs/GIDs (>=2097151, limit of USTAR tar) lost in
PAX style tar during unpack.

Update tar-rs dependency xattr to 1.0.1 as well.

## Types of changes

_What types of changes does your PullRequest introduce? Put an `x` in all the boxes that apply:_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Go over all the following points, and put an `x` in all the boxes that apply._

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.