### PR TITLE
nydus-overlayfs: filter option "io.katacontainers.volume"

### DIFF
--- a/contrib/nydus-overlayfs/cmd/main.go
+++ b/contrib/nydus-overlayfs/cmd/main.go
@@ -13,7 +13,11 @@ import (
 )
 
 const (
+	// Extra mount option to pass Nydus specific information from snapshotter to runtime through containerd.
 	extraOptionKey = "extraoption="
+	// Kata virtual volume infmation passed from snapshotter to runtime through containerd, superset of `extraOptionKey`.
+	// Please refer to `KataVirtualVolume` in https://github.com/kata-containers/kata-containers/blob/main/src/libs/kata-types/src/mount.rs
+	kataVolumeOptionKey = "io.katacontainers.volume="
 )
 
 var (
@@ -44,7 +48,7 @@ func parseArgs(args []string) (*mountArgs, error) {
 	}
 	if args[2] == "-o" && len(args[3]) != 0 {
 		for _, opt := range strings.Split(args[3], ",") {
-			if strings.HasPrefix(opt, extraOptionKey) {
+			if strings.HasPrefix(opt, extraOptionKey) || strings.HasPrefix(opt, kataVolumeOptionKey) {
 				// filter extraoption
 				continue
 			}


### PR DESCRIPTION
Filter mount option "io.katacontainers.volume", which is a superset of "extraoptions".


## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Go over all the following points, and put an `x` in all the boxes that apply._

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.