### PR TITLE
misc: rename vault to hashicorp/vault

### DIFF
--- a/misc/top_images/image_list.txt
+++ b/misc/top_images/image_list.txt
@@ -31,7 +31,7 @@ php
 bash
 caddy
 telegraf
-vault
+hashicorp/vault
 couchdb
 eclipse-mosquitto
 cassandra


### PR DESCRIPTION
In convert ci, v5/v6 failed with vault. Actually vault had move to hashicorp/vault.
![image](https://github.com/dragonflyoss/image-service/assets/59167816/b65b3962-2d07-419a-aede-a18c9e4ce105)

## Types of changes

_What types of changes does your PullRequest introduce? Put an `x` in all the boxes that apply:_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)