### PR TITLE
feat: notifying  incosistent fs version problem with exit code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1217,6 +1217,7 @@ dependencies = [
  "nydus-utils",
  "serde",
  "serde_json",
+ "thiserror",
  "vm-memory",
  "vmm-sys-util",
 ]

--- a/rafs/Cargo.toml
+++ b/rafs/Cargo.toml
@@ -20,6 +20,7 @@ serde = { version = "1.0.110", features = ["serde_derive", "rc"] }
 serde_json = "1.0.53"
 vm-memory = "0.10"
 fuse-backend-rs = "^0.10.3"
+thiserror = "1"
 
 nydus-api = { version = "0.3", path = "../api" }
 nydus-storage = { version = "0.6", path = "../storage", features = ["backend-localfs"] }


### PR DESCRIPTION
If acceld converts with different fs version cache, leading to an inconsistent fs version problem when merging into boostrap layer. So we need to notify acceld that an inconsistent version occured and handle this error.

## Relevant Issue (if applicable)
_If there are Issues related to this PullRequest, please list it._

## Details
Define `InconsistentFsVersion` with `thiserror` and check error type after merge, if is fs version inconsistent problem, just return status code 2.

## Types of changes

_What types of changes does your PullRequest introduce? Put an `x` in all the boxes that apply:_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Go over all the following points, and put an `x` in all the boxes that apply._

- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.