### PR TITLE
Fix no export subcmd panic on mac

### DIFF
--- a/src/bin/nydus-image/main.rs
+++ b/src/bin/nydus-image/main.rs
@@ -762,8 +762,6 @@ fn main() -> Result<()> {
         Command::merge(matches, &build_info)
     } else if let Some(matches) = cmd.subcommand_matches("check") {
         Command::check(matches, &build_info)
-    } else if let Some(matches) = cmd.subcommand_matches("export") {
-        Command::export(&cmd, matches, &build_info)
     } else if let Some(matches) = cmd.subcommand_matches("inspect") {
         Command::inspect(matches)
     } else if let Some(matches) = cmd.subcommand_matches("stat") {
@@ -773,8 +771,18 @@ fn main() -> Result<()> {
     } else if let Some(matches) = cmd.subcommand_matches("unpack") {
         Command::unpack(matches)
     } else {
-        println!("{}", usage);
-        Ok(())
+        #[cfg(target_os = "linux")]
+        if let Some(matches) = cmd.subcommand_matches("export") {
+            Command::export(&cmd, matches, &build_info)
+        } else {
+            println!("{}", usage);
+            Ok(())
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            println!("{}", usage);
+            Ok(())
+        }
     }
 }
 
@@ -1726,17 +1734,6 @@ impl Command {
             path.as_ref()
         );
         Ok(())
-    }
-}
-
-#[cfg(not(target_os = "linux"))]
-impl Command {
-    fn export(
-        _args: &ArgMatches,
-        _subargs: &ArgMatches,
-        _build_info: &BuildTimeInfo,
-    ) -> Result<()> {
-        unimplemented!()
     }
 }
 


### PR DESCRIPTION
## Relevant Issue (if applicable)
_If there are Issues related to this PullRequest, please list it._

Fix panic caused by no `export` subcmd on mac in issue #1340 

## Details
_Please describe the details of PullRequest._

## Types of changes

_What types of changes does your PullRequest introduce? Put an `x` in all the boxes that apply:_

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Go over all the following points, and put an `x` in all the boxes that apply._

- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.