### PR TITLE
Always use blob id as the name of the filecache when use separate blob

### DIFF
--- a/storage/src/cache/filecache/mod.rs
+++ b/storage/src/cache/filecache/mod.rs
@@ -229,7 +229,7 @@ impl FileCacheEntry {
                 Arc::new(BlobStateMap::from(NoopChunkMap::new(true))) as Arc<dyn ChunkMap>;
             (file, None, chunk_map, true, true, false)
         } else {
-            let blob_file_path = format!("{}/{}", mgr.work_dir, blob_meta_id);
+            let blob_file_path = format!("{}/{}", mgr.work_dir, blob_id);
             let (chunk_map, is_direct_chunkmap) =
                 Self::create_chunk_map(mgr, &blob_info, &blob_file_path)?;
             // Validation is supported by RAFS v5 (which has no meta_ci) or v6 with chunk digest array.


### PR DESCRIPTION
## Details
Before we only has one blob, called a data blob, so when generating a filecache, we always used the id of this blob as the name of the filecache, and later after supporting separate blobs, we has two blobs, one is a data blob, the other is a meta blob, in order to maintain compatibility, we should always use the data blob id as the filecache name, not the meta blob id.

## Types of changes

_What types of changes does your PullRequest introduce? Put an `x` in all the boxes that apply:_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)
