### PR TITLE
Add --blob-cache-dir arg use to generate raw blob cache and meta

### DIFF
--- a/builder/src/compact.rs
+++ b/builder/src/compact.rs
@@ -21,6 +21,8 @@ use nydus_utils::{digest, try_round_up_4k};
 use serde::{Deserialize, Serialize};
 use sha2::Digest;
 
+use crate::core::context::Artifact;
+
 use super::core::blob::Blob;
 use super::core::bootstrap::Bootstrap;
 use super::{

--- a/smoke/tests/blobcache_test.go
+++ b/smoke/tests/blobcache_test.go
@@ -1,0 +1,222 @@
+package tests
+
+import (
+	"fmt"
+	"io"
+	"io/fs"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/containerd/containerd/log"
+	"github.com/dragonflyoss/image-service/smoke/tests/texture"
+	"github.com/dragonflyoss/image-service/smoke/tests/tool"
+	"github.com/dragonflyoss/image-service/smoke/tests/tool/test"
+	"github.com/opencontainers/go-digest"
+	"github.com/stretchr/testify/require"
+)
+
+type BlobCacheTestSuite struct {
+	T *testing.T
+}
+
+func (a *BlobCacheTestSuite) compareTwoFiles(t *testing.T, left, right string) {
+
+	lf, err := os.Open(left)
+	require.NoError(t, err)
+	defer lf.Close()
+	leftDigester, err := digest.FromReader(lf)
+	require.NoError(t, err)
+
+	rf, err := os.Open(right)
+	require.NoError(t, err)
+	defer rf.Close()
+	rightDigester, err := digest.FromReader(rf)
+	require.NoError(t, err)
+
+	require.Equal(t, leftDigester, rightDigester)
+}
+
+func (a *BlobCacheTestSuite) prepareTestEnv(t *testing.T) (*tool.Context, string, digest.Digest) {
+	ctx := tool.DefaultContext(t)
+	ctx.PrepareWorkDir(t)
+
+	rootFs := texture.MakeLowerLayer(t, filepath.Join(ctx.Env.WorkDir, "root-fs"))
+
+	rootfsReader := rootFs.ToOCITar(t)
+
+	ociBlobDigester := digest.Canonical.Digester()
+	ociBlob, err := ioutil.TempFile(ctx.Env.BlobDir, "oci-blob-")
+	require.NoError(t, err)
+
+	_, err = io.Copy(io.MultiWriter(ociBlobDigester.Hash(), ociBlob), rootfsReader)
+	require.NoError(t, err)
+
+	ociBlobDigest := ociBlobDigester.Digest()
+	err = os.Rename(ociBlob.Name(), filepath.Join(ctx.Env.BlobDir, ociBlobDigest.Hex()))
+	require.NoError(t, err)
+
+	// use to generate blob.data and blob.meta
+	blobcacheDir := filepath.Join(ctx.Env.WorkDir, "blobcache")
+	err = os.MkdirAll(blobcacheDir, 0755)
+	require.NoError(t, err)
+
+	ctx.Env.BootstrapPath = filepath.Join(ctx.Env.WorkDir, "bootstrap")
+	return ctx, blobcacheDir, ociBlobDigest
+}
+
+func (a *BlobCacheTestSuite) TestCommandFlags(t *testing.T) {
+	ctx, blobcacheDir, ociBlobDigest := a.prepareTestEnv(t)
+	defer ctx.Destroy(t)
+
+	testCases := []struct {
+		name           string
+		conversionType string
+		bootstrap      string
+		testArgs       string
+		success        bool
+		expectedOutput string
+	}{
+		{
+			name:           "conflict with --blob-dir",
+			conversionType: "targz-ref",
+			bootstrap:      fmt.Sprintf("--bootstrap %s", ctx.Env.BootstrapPath),
+			testArgs:       fmt.Sprintf("--blob-dir %s --blob-cache-dir %s", ctx.Env.BlobDir, blobcacheDir),
+			success:        false,
+			expectedOutput: "The argument '--blob-dir <blob-dir>' cannot be used with '--blob-cache-dir <blob-cache-dir>'",
+		},
+		{
+			name:           "conflict with --blob",
+			conversionType: "targz-ref",
+			bootstrap:      fmt.Sprintf("--bootstrap %s", ctx.Env.BootstrapPath),
+			testArgs:       fmt.Sprintf("--blob %s --blob-cache-dir %s", "xxxxxx", blobcacheDir),
+			success:        false,
+			expectedOutput: "The argument '--blob <blob>' cannot be used with '--blob-cache-dir <blob-cache-dir>'",
+		},
+		{
+			name:           "conflict with --blob-inline-meta",
+			conversionType: "targz-ref",
+			bootstrap:      "",
+			testArgs:       fmt.Sprintf("--blob-inline-meta --blob-cache-dir %s", blobcacheDir),
+			success:        false,
+			expectedOutput: "The argument '--blob-inline-meta' cannot be used with '--blob-cache-dir <blob-cache-dir>'",
+		},
+		{
+			name:           "conflict with --compressor",
+			conversionType: "targz-ref",
+			bootstrap:      fmt.Sprintf("--bootstrap %s", ctx.Env.BootstrapPath),
+			testArgs:       fmt.Sprintf("--compressor zstd --blob-cache-dir %s", blobcacheDir),
+			success:        false,
+			expectedOutput: "The argument '--compressor <compressor>' cannot be used with '--blob-cache-dir <blob-cache-dir>'",
+		},
+
+		{
+			name:           "conflict with tar-tarfs conversion type",
+			conversionType: "tar-tarfs",
+			bootstrap:      fmt.Sprintf("--bootstrap %s", ctx.Env.BootstrapPath),
+			testArgs:       fmt.Sprintf("--blob-cache-dir %s", blobcacheDir),
+			success:        false,
+			expectedOutput: "conversion type `tar-tarfs` conflicts with `--blob-cache-dir`",
+		},
+
+		{
+			name:           "conflict with estargztoc-ref conversion type",
+			conversionType: "estargztoc-ref",
+			bootstrap:      fmt.Sprintf("--bootstrap %s", ctx.Env.BootstrapPath),
+			testArgs:       fmt.Sprintf("--blob-id %s --blob-cache-dir %s", "xxxx", blobcacheDir),
+			success:        false,
+			expectedOutput: "conversion type `estargztoc-ref` conflicts with `--blob-cache-dir`",
+		},
+
+		{
+			name:           "conflict with estargz-rafs conversion type",
+			conversionType: "estargz-rafs",
+			bootstrap:      fmt.Sprintf("--bootstrap %s", ctx.Env.BootstrapPath),
+			testArgs:       fmt.Sprintf("--blob-cache-dir %s", blobcacheDir),
+			success:        false,
+			expectedOutput: "conversion type `estargz-rafs` conflicts with `--blob-cache-dir`",
+		},
+
+		{
+			name:           "conflict with estargz-ref conversion type",
+			conversionType: "estargz-ref",
+			bootstrap:      fmt.Sprintf("--bootstrap %s", ctx.Env.BootstrapPath),
+			testArgs:       fmt.Sprintf("--blob-cache-dir %s", blobcacheDir),
+			success:        false,
+			expectedOutput: "conversion type `estargz-ref` conflicts with `--blob-cache-dir`",
+		},
+	}
+
+	for _, tc := range testCases {
+		output, err := tool.RunWithCombinedOutput(fmt.Sprintf("%s  create -t %s %s %s %s",
+			ctx.Binary.Builder, tc.conversionType, tc.bootstrap, tc.testArgs,
+			filepath.Join(ctx.Env.BlobDir, ociBlobDigest.Hex())))
+
+		if tc.success {
+			require.NoError(t, err)
+		} else {
+			require.NotEqual(t, err, nil)
+		}
+
+		require.Contains(t, output, tc.expectedOutput)
+	}
+}
+
+func (a *BlobCacheTestSuite) TestGenerateBlobcache(t *testing.T) {
+	ctx, blobcacheDir, ociBlobDigest := a.prepareTestEnv(t)
+	defer ctx.Destroy(t)
+
+	tool.Run(t, fmt.Sprintf("%s  create -t targz-ref --bootstrap %s --blob-dir %s %s",
+		ctx.Binary.Builder, ctx.Env.BootstrapPath, ctx.Env.BlobDir,
+		filepath.Join(ctx.Env.BlobDir, ociBlobDigest.Hex())))
+
+	nydusd, err := tool.NewNydusd(tool.NydusdConfig{
+		NydusdPath:      ctx.Binary.Nydusd,
+		BootstrapPath:   ctx.Env.BootstrapPath,
+		ConfigPath:      filepath.Join(ctx.Env.WorkDir, "nydusd-config.fusedev.json"),
+		MountPath:       ctx.Env.MountDir,
+		APISockPath:     filepath.Join(ctx.Env.WorkDir, "nydusd-api.sock"),
+		BackendType:     "localfs",
+		BackendConfig:   fmt.Sprintf(`{"dir": "%s"}`, ctx.Env.BlobDir),
+		EnablePrefetch:  ctx.Runtime.EnablePrefetch,
+		BlobCacheDir:    ctx.Env.CacheDir,
+		CacheType:       ctx.Runtime.CacheType,
+		CacheCompressed: ctx.Runtime.CacheCompressed,
+		RafsMode:        ctx.Runtime.RafsMode,
+		DigestValidate:  false,
+	})
+	require.NoError(t, err)
+
+	err = nydusd.Mount()
+	require.NoError(t, err)
+	defer func() {
+		if err := nydusd.Umount(); err != nil {
+			log.L.WithError(err).Errorf("umount")
+		}
+	}()
+
+	// make sure blobcache ready
+	err = filepath.WalkDir(ctx.Env.MountDir, func(path string, entry fs.DirEntry, err error) error {
+		require.Nil(t, err)
+		if entry.Type().IsRegular() {
+			targetPath, err := filepath.Rel(ctx.Env.MountDir, path)
+			require.NoError(t, err)
+			_, _ = os.ReadFile(targetPath)
+		}
+		return nil
+	})
+	require.NoError(t, err)
+
+	// Generate blobcache
+	tool.Run(t, fmt.Sprintf("%s create -t targz-ref --bootstrap %s --blob-cache-dir %s %s",
+		ctx.Binary.Builder, ctx.Env.BootstrapPath, blobcacheDir,
+		filepath.Join(ctx.Env.BlobDir, ociBlobDigest.Hex())))
+
+	a.compareTwoFiles(t, filepath.Join(blobcacheDir, fmt.Sprintf("%s.blob.data", ociBlobDigest.Hex())), filepath.Join(ctx.Env.CacheDir, fmt.Sprintf("%s.blob.data", ociBlobDigest.Hex())))
+	a.compareTwoFiles(t, filepath.Join(blobcacheDir, fmt.Sprintf("%s.blob.meta", ociBlobDigest.Hex())), filepath.Join(ctx.Env.CacheDir, fmt.Sprintf("%s.blob.meta", ociBlobDigest.Hex())))
+}
+
+func TestBlobCache(t *testing.T) {
+	test.Run(t, &BlobCacheTestSuite{T: t})
+}

--- a/smoke/tests/tool/layer.go
+++ b/smoke/tests/tool/layer.go
@@ -116,7 +116,7 @@ func (l *Layer) TargetPath(t *testing.T, path string) string {
 
 func (l *Layer) Pack(t *testing.T, packOption converter.PackOption, blobDir string) digest.Digest {
 	// Output OCI tar stream
-	ociTar := l.toOCITar(t)
+	ociTar := l.ToOCITar(t)
 	defer ociTar.Close()
 	l.recordFileTree(t)
 
@@ -141,7 +141,7 @@ func (l *Layer) Pack(t *testing.T, packOption converter.PackOption, blobDir stri
 
 func (l *Layer) PackRef(t *testing.T, ctx Context, blobDir string, compress bool) (digest.Digest, digest.Digest) {
 	// Output OCI tar stream
-	ociTar := l.toOCITar(t)
+	ociTar := l.ToOCITar(t)
 	defer ociTar.Close()
 	l.recordFileTree(t)
 
@@ -238,7 +238,7 @@ func (l *Layer) recordFileTree(t *testing.T) {
 	})
 }
 
-func (l *Layer) toOCITar(t *testing.T) io.ReadCloser {
+func (l *Layer) ToOCITar(t *testing.T) io.ReadCloser {
 	return archive.Diff(context.Background(), "", l.workDir)
 }
 

--- a/smoke/tests/tool/util.go
+++ b/smoke/tests/tool/util.go
@@ -21,6 +21,13 @@ var defaultBinary = map[string]string{
 	"NYDUS_NYDUSIFY": "nydusify",
 }
 
+func RunWithCombinedOutput(cmd string) (string, error) {
+	_cmd := exec.Command("sh", "-c", cmd)
+	output, err := _cmd.CombinedOutput()
+
+	return string(output), err
+}
+
 func Run(t *testing.T, cmd string) {
 	_cmd := exec.Command("sh", "-c", cmd)
 	_cmd.Stdout = os.Stdout


### PR DESCRIPTION
## Relevant Issue (if applicable)
#1415 

## Details
generate blob cache and blob meta through the —-blob-cache-dir parameters,
so that nydusd can be started directly from these two files without
going to the backend to download. this can improve the performance
of data loading in localfs mode.

## Types of changes

_What types of changes does your PullRequest introduce? Put an `x` in all the boxes that apply:_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Go over all the following points, and put an `x` in all the boxes that apply._

- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.