### PR TITLE
feat: implement `takeover` for nydusd fusedev daemon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,6 +121,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a4ddaa51a5bc52a6948f74c06d20aaaddb71924eab79b8c97a8c556e942d6a"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -235,7 +244,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.98",
 ]
 
 [[package]]
@@ -316,6 +325,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc64"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55626594feae15d266d52440b26ff77de0e22230cf0c113abe619084c1ddc910"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -349,7 +364,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "scratch",
- "syn",
+ "syn 1.0.98",
 ]
 
 [[package]]
@@ -366,7 +381,7 @@ checksum = "81bbeb29798b407ccd82a3324ade1a7286e0d29851475990b612670f6f5124d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.98",
 ]
 
 [[package]]
@@ -524,8 +539,7 @@ dependencies = [
 [[package]]
 name = "fuse-backend-rs"
 version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f85357722be4bf3d0b7548bedf7499686c77628c2c61cb99c6519463f7a9e5f0"
+source = "git+https://github.com/loheagn/fuse-backend-rs.git?branch=vfs-persist#be366463fa66e2e675e32e79b3a5500e58f153d1"
 dependencies = [
  "arc-swap",
  "bitflags 1.3.2",
@@ -536,6 +550,9 @@ dependencies = [
  "log",
  "mio",
  "nix",
+ "snapshot",
+ "versionize",
+ "versionize_derive",
  "vhost",
  "virtio-queue",
  "vm-memory",
@@ -571,7 +588,7 @@ checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.98",
 ]
 
 [[package]]
@@ -1276,6 +1293,7 @@ dependencies = [
  "nydus-api",
  "nydus-rafs",
  "nydus-storage",
+ "nydus-upgrade",
  "nydus-utils",
  "rust-fsm",
  "serde",
@@ -1284,6 +1302,8 @@ dependencies = [
  "time",
  "tokio",
  "tokio-uring",
+ "versionize",
+ "versionize_derive",
  "vhost",
  "vhost-user-backend",
  "virtio-bindings",
@@ -1326,6 +1346,17 @@ dependencies = [
  "url",
  "vm-memory",
  "vmm-sys-util",
+]
+
+[[package]]
+name = "nydus-upgrade"
+version = "0.1.0"
+dependencies = [
+ "sendfd",
+ "snapshot",
+ "thiserror",
+ "versionize",
+ "versionize_derive",
 ]
 
 [[package]]
@@ -1391,7 +1422,7 @@ checksum = "b501e44f11665960c7e7fcf062c7d96a14ade4aa98116c004b2e37b5be7d736c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.98",
 ]
 
 [[package]]
@@ -1480,7 +1511,7 @@ checksum = "069bdb1e05adc7a8990dce9cc75370895fbe4e3d58b9b73bf1aee56359344a55"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.98",
 ]
 
 [[package]]
@@ -1510,7 +1541,7 @@ dependencies = [
  "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.98",
  "version_check",
 ]
 
@@ -1527,18 +1558,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.47"
+version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ea3d908b0e36316caf9e9e2c4625cdde190a7e6f440d794667ed17a1855e725"
+checksum = "3d433d9f1a3e8c1263d9456598b16fec66f4acc9a74dacffd35c7bb09b3a1328"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.20"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3bcdf212e9776fbcb2d23ab029360416bb1706b1aea2d1a5ba002727cbcab804"
+checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
 dependencies = [
  "proc-macro2",
 ]
@@ -1645,7 +1676,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44237c429621e3606374941c3061fe95686bdaddb9b4f6524e4edc2d21da9c58"
 dependencies = [
  "quote",
- "syn",
+ "syn 1.0.98",
 ]
 
 [[package]]
@@ -1725,6 +1756,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sendfd"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "604b71b8fc267e13bb3023a2c901126c8f349393666a6d98ac1ae5729b701798"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.139"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1741,7 +1781,7 @@ checksum = "dc1d3230c1de7932af58ad8ffbe1d784bd55efd5a9d84ac24f69c72d83543dfb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.98",
 ]
 
 [[package]]
@@ -1805,6 +1845,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd0db749597d91ff862fd1d55ea87f7855a744a8425a64695b6fca237d1dad1"
 
 [[package]]
+name = "snapshot"
+version = "0.1.0"
+source = "git+https://github.com/firecracker-microvm/firecracker?tag=v1.4.1#02dd0328589c59ae11b7ad13eaf412410f8e72e1"
+dependencies = [
+ "libc",
+ "thiserror",
+ "versionize",
+ "versionize_derive",
+]
+
+[[package]]
 name = "socket2"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1831,6 +1882,17 @@ name = "syn"
 version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c50aef8a904de4c23c788f104b7dddc7d6f79c647c7c8ce4cc8f73eb0ca773dd"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "2.0.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7303ef2c05cd654186cb250d29049a24840ca25d2747c25c0381c8d9e2f582e8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1872,22 +1934,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.31"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd829fe32373d27f76265620b5309d0340cb8550f523c1dda251d6298069069a"
+checksum = "9d6d7a740b8a666a7e828dd00da9c0dc290dff53154ea77ac109281de90589b7"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.31"
+version = "1.0.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0396bc89e626244658bef819e22d0cc459e795a5ebe878e6ec336d1674a8d79a"
+checksum = "49922ecae66cc8a249b77e68d1d0623c1b2c514f0060c27cdc68bd62a1219d35"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.37",
 ]
 
 [[package]]
@@ -1943,7 +2005,7 @@ checksum = "d266c00fde287f55d3f1c3e96c500c362a2b8c695076ec180f27918820bc6df8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.98",
 ]
 
 [[package]]
@@ -2019,7 +2081,7 @@ checksum = "11c75893af559bc8e10716548bdef5cb2b983f8e637db9d0e15126b61b484ee2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.98",
 ]
 
 [[package]]
@@ -2102,6 +2164,34 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "versionize"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dca4b7062e7e6d685901e815c35f9671e059de97c1c0905eeff8592f3fff442f"
+dependencies = [
+ "bincode",
+ "crc64",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_derive",
+ "syn 1.0.98",
+ "versionize_derive",
+ "vmm-sys-util",
+]
+
+[[package]]
+name = "versionize_derive"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c4971c07ef708cd51003222e509aaed8eae14aeb2907706b01578843195e03a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.98",
+]
 
 [[package]]
 name = "vhost"
@@ -2206,7 +2296,7 @@ dependencies = [
  "log",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.98",
  "wasm-bindgen-shared",
 ]
 
@@ -2240,7 +2330,7 @@ checksum = "7d94ac45fcf608c1f45ef53e748d35660f168490c10b23704c7779ab8f5c3048"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 1.0.98",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ path = "src/lib.rs"
 anyhow = "1"
 clap = { version = "4.0.18", features = ["derive", "cargo"] }
 flexi_logger = { version = "0.25", features = ["compress"] }
-fuse-backend-rs = "^0.10.4"
+fuse-backend-rs = { git = "https://github.com/loheagn/fuse-backend-rs.git", branch = "vfs-persist" }
 hex = "0.4.3"
 hyper = "0.14.11"
 hyperlocal = "0.8.0"
@@ -57,16 +57,25 @@ openssl = { version = "0.10.55", features = ["vendored"] }
 # pin openssl-src to bring in fix for https://rustsec.org/advisories/RUSTSEC-2022-0032
 #openssl-src = { version = "111.22" }
 
-nydus-api = { version = "0.3.0", path = "api", features = ["error-backtrace", "handler"] }
+nydus-api = { version = "0.3.0", path = "api", features = [
+    "error-backtrace",
+    "handler",
+] }
 nydus-builder = { version = "0.1.0", path = "builder" }
 nydus-rafs = { version = "0.3.1", path = "rafs" }
-nydus-service = { version = "0.3.0", path = "service", features = ["block-device"] }
-nydus-storage = { version = "0.6.3", path = "storage", features = ["prefetch-rate-limit"] }
+nydus-service = { version = "0.3.0", path = "service", features = [
+    "block-device",
+] }
+nydus-storage = { version = "0.6.3", path = "storage", features = [
+    "prefetch-rate-limit",
+] }
 nydus-utils = { version = "0.4.2", path = "utils" }
 
 vhost = { version = "0.6.0", features = ["vhost-user-slave"], optional = true }
 vhost-user-backend = { version = "0.8.0", optional = true }
-virtio-bindings = { version = "0.1", features = ["virtio-v5_0_0"], optional = true }
+virtio-bindings = { version = "0.1", features = [
+    "virtio-v5_0_0",
+], optional = true }
 virtio-queue = { version = "0.7.0", optional = true }
 vm-memory = { version = "0.10.0", features = ["backend-mmap"], optional = true }
 vmm-sys-util = { version = "0.11.0", optional = true }
@@ -96,15 +105,25 @@ virtiofs = [
     "vm-memory",
     "vmm-sys-util",
 ]
-block-nbd = [
-    "nydus-service/block-nbd"
-]
+block-nbd = ["nydus-service/block-nbd"]
 
 backend-http-proxy = ["nydus-storage/backend-http-proxy"]
-backend-localdisk = ["nydus-storage/backend-localdisk", "nydus-storage/backend-localdisk-gpt"]
+backend-localdisk = [
+    "nydus-storage/backend-localdisk",
+    "nydus-storage/backend-localdisk-gpt",
+]
 backend-oss = ["nydus-storage/backend-oss"]
 backend-registry = ["nydus-storage/backend-registry"]
 backend-s3 = ["nydus-storage/backend-s3"]
 
 [workspace]
-members = ["api", "builder", "clib", "rafs", "storage", "service", "utils"]
+members = [
+    "api",
+    "builder",
+    "clib",
+    "rafs",
+    "storage",
+    "service",
+    "upgrade",
+    "utils",
+]

--- a/api/src/http.rs
+++ b/api/src/http.rs
@@ -131,7 +131,7 @@ pub enum DaemonErrorKind {
     /// Unexpected event type.
     UnexpectedEvent(String),
     /// Can't upgrade the daemon.
-    UpgradeManager,
+    UpgradeManager(String),
     /// Unsupported requests.
     Unsupported,
 }

--- a/clib/Cargo.toml
+++ b/clib/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "staticlib"]
 [dependencies]
 libc = "0.2.137"
 log = "0.4.17"
-fuse-backend-rs = "^0.10.3"
+fuse-backend-rs = { git = "https://github.com/loheagn/fuse-backend-rs.git", branch = "vfs-persist" }
 nydus-api = { version = "0.3", path = "../api" }
 nydus-rafs = { version = "0.3.1", path = "../rafs" }
 nydus-storage = { version = "0.6.3", path = "../storage" }

--- a/rafs/Cargo.toml
+++ b/rafs/Cargo.toml
@@ -19,11 +19,13 @@ nix = "0.24"
 serde = { version = "1.0.110", features = ["serde_derive", "rc"] }
 serde_json = "1.0.53"
 vm-memory = "0.10"
-fuse-backend-rs = "^0.10.3"
+fuse-backend-rs = { git = "https://github.com/loheagn/fuse-backend-rs.git", branch = "vfs-persist" }
 thiserror = "1"
 
 nydus-api = { version = "0.3", path = "../api" }
-nydus-storage = { version = "0.6", path = "../storage", features = ["backend-localfs"] }
+nydus-storage = { version = "0.6", path = "../storage", features = [
+    "backend-localfs",
+] }
 nydus-utils = { version = "0.4", path = "../utils" }
 
 [dev-dependencies]
@@ -37,4 +39,8 @@ vhost-user-fs = ["fuse-backend-rs/vhost-user-fs"]
 
 [package.metadata.docs.rs]
 all-features = true
-targets = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu", "aarch64-apple-darwin"]
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "aarch64-unknown-linux-gnu",
+    "aarch64-apple-darwin",
+]

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -12,7 +12,9 @@ resolver = "2"
 [dependencies]
 bytes = { version = "1", optional = true }
 dbs-allocator = { version = "0.1.1", optional = true }
-fuse-backend-rs = "^0.10.3"
+fuse-backend-rs = { git = "https://github.com/loheagn/fuse-backend-rs.git", branch = "vfs-persist", features = [
+    "persist",
+] }
 libc = "0.2"
 log = "0.4.8"
 mio = { version = "0.8", features = ["os-poll", "os-ext"] }
@@ -23,15 +25,20 @@ serde_json = "1.0.51"
 thiserror = "1.0"
 time = { version = "0.3.14", features = ["serde-human-readable"] }
 tokio = { version = "1.24", features = ["macros"] }
+versionize_derive = "0.1.6"
+versionize = "0.1.10"
 
-nydus-api = { version = "0.3.0", path = "../api"}
+nydus-api = { version = "0.3.0", path = "../api" }
 nydus-rafs = { version = "0.3.1", path = "../rafs" }
 nydus-storage = { version = "0.6.3", path = "../storage" }
+nydus-upgrade = { version = "0.1.0", path = "../upgrade" }
 nydus-utils = { version = "0.4.2", path = "../utils" }
 
 vhost = { version = "0.6.0", features = ["vhost-user-slave"], optional = true }
 vhost-user-backend = { version = "0.8.0", optional = true }
-virtio-bindings = { version = "0.1", features = ["virtio-v5_0_0"], optional = true }
+virtio-bindings = { version = "0.1", features = [
+    "virtio-v5_0_0",
+], optional = true }
 virtio-queue = { version = "0.7.0", optional = true }
 vm-memory = { version = "0.10.0", features = ["backend-mmap"], optional = true }
 
@@ -52,10 +59,7 @@ virtiofs = [
     "virtio-bindings",
 ]
 
-block-device = [ "dbs-allocator", "tokio/fs"]
+block-device = ["dbs-allocator", "tokio/fs"]
 block-nbd = ["block-device", "bytes"]
 
-coco = [
-    "fuse-backend-rs/fusedev",
-    "nydus-storage/backend-registry",
-]
+coco = ["fuse-backend-rs/fusedev", "nydus-storage/backend-registry"]

--- a/service/src/fusedev.rs
+++ b/service/src/fusedev.rs
@@ -145,10 +145,9 @@ impl FuseServer {
     }
 }
 
-struct FusedevFsService {
+pub struct FusedevFsService {
     /// Fuse connection ID which usually equals to `st_dev`
     pub conn: AtomicU64,
-    #[allow(dead_code)]
     pub failover_policy: FailoverPolicy,
     pub session: Mutex<FuseSession>,
 
@@ -254,7 +253,7 @@ pub struct FusedevDaemon {
     result_receiver: Mutex<Receiver<NydusResult<()>>>,
     service: Arc<FusedevFsService>,
     state: AtomicI32,
-    supervisor: Option<String>,
+    pub supervisor: Option<String>,
     threads_cnt: u32,
     state_machine_thread: Mutex<Option<JoinHandle<Result<()>>>>,
     fuse_service_threads: Mutex<Vec<JoinHandle<Result<()>>>>,

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -29,6 +29,8 @@ use nydus_api::{ConfigV2, DaemonErrorKind};
 use nydus_rafs::RafsError;
 use serde::{Deserialize, Serialize};
 use serde_json::Error as SerdeError;
+use versionize::{VersionMap, Versionize, VersionizeError, VersionizeResult};
+use versionize_derive::Versionize;
 
 pub mod daemon;
 mod fs_service;
@@ -79,7 +81,7 @@ pub enum Error {
     ChannelSend(#[from] SendError<crate::daemon::DaemonStateMachineInput>),
     #[error("failed to receive message from channel, {0}")]
     ChannelReceive(#[from] RecvError),
-    #[error(transparent)]
+    #[error("failed to upgrade nydusd daemon, {0}")]
     UpgradeManager(upgrade::UpgradeMgrError),
     #[error("failed to start service, {0}")]
     StartService(String),
@@ -140,7 +142,7 @@ impl From<Error> for DaemonErrorKind {
     fn from(e: Error) -> Self {
         use Error::*;
         match e {
-            UpgradeManager(_) => DaemonErrorKind::UpgradeManager,
+            UpgradeManager(e) => DaemonErrorKind::UpgradeManager(format!("{:?}", e)),
             NotReady => DaemonErrorKind::NotReady,
             Unsupported => DaemonErrorKind::Unsupported,
             Serde(e) => DaemonErrorKind::Serde(e),
@@ -154,7 +156,7 @@ impl From<Error> for DaemonErrorKind {
 pub type Result<T> = std::result::Result<T, Error>;
 
 /// Type of supported backend filesystems.
-#[derive(Clone, Debug, Serialize, PartialEq, Deserialize)]
+#[derive(Clone, Debug, Serialize, PartialEq, Deserialize, Versionize)]
 pub enum FsBackendType {
     /// Registry Accelerated File System
     Rafs,

--- a/service/src/upgrade.rs
+++ b/service/src/upgrade.rs
@@ -4,15 +4,40 @@
 
 //! Online upgrade manager for Nydus daemons and filesystems.
 
+use std::any::TypeId;
+use std::collections::HashMap;
 use std::convert::{TryFrom, TryInto};
+use std::io;
+use std::os::fd::RawFd;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use nydus_upgrade::backend::unix_domain_socket::UdsStorageBackend;
+use nydus_upgrade::backend::{StorageBackend, StorageBackendErr};
 
 use crate::fs_service::{FsBackendMountCmd, FsBackendUmountCmd};
-use crate::Result;
+use crate::{Error, Result};
 
 /// Error codes related to upgrade manager.
 #[derive(thiserror::Error, Debug)]
-pub enum UpgradeMgrError {}
+pub enum UpgradeMgrError {
+    #[error("missing supervisor path")]
+    MissingSupervisorPath,
+
+    #[error("failed to save/restore data via the backend, {0}")]
+    StorageBackendError(StorageBackendErr),
+
+    #[error("failed to serialize, {0}")]
+    Serialize(io::Error),
+    #[error("failed to deserialize, {0}")]
+    Deserialize(io::Error),
+}
+
+impl From<UpgradeMgrError> for Error {
+    fn from(e: UpgradeMgrError) -> Self {
+        Error::UpgradeManager(e)
+    }
+}
 
 /// FUSE fail-over policies.
 #[derive(PartialEq, Eq)]
@@ -43,46 +68,255 @@ impl TryFrom<&String> for FailoverPolicy {
     }
 }
 
+const MAX_STATE_DATA_LENGTH: usize = 1024 * 32;
+
 /// Online upgrade manager.
-pub struct UpgradeManager {}
+pub struct UpgradeManager {
+    // backend_mount_cmd_map records the mount command of each backend filesystem.
+    // the structure is: mountpoint -> (FsBackendMountCmd, vfs_index)
+    backend_mount_cmd_map: HashMap<String, (FsBackendMountCmd, u8)>,
+    fds: Vec<RawFd>,
+    backend: Box<dyn StorageBackend>,
+
+    disabled: AtomicBool,
+}
 
 impl UpgradeManager {
     /// Create a new instance of [UpgradeManager].
-    pub fn new(_: PathBuf) -> Self {
-        UpgradeManager {}
+    pub fn new(socket_path: PathBuf) -> Self {
+        UpgradeManager {
+            backend_mount_cmd_map: HashMap::new(),
+            backend: Box::new(UdsStorageBackend::new(socket_path)),
+            fds: Vec::new(),
+            disabled: AtomicBool::new(false),
+        }
     }
 
     /// Add a filesystem instance into the upgrade manager.
-    pub fn add_mounts_state(&mut self, _cmd: FsBackendMountCmd, _vfs_index: u8) -> Result<()> {
+    pub fn add_mounts_state(&mut self, cmd: FsBackendMountCmd, vfs_index: u8) -> Result<()> {
+        if self.disabled.load(Ordering::Acquire) {
+            return Err(Error::Unsupported);
+        }
+
+        let cmd_map = &mut self.backend_mount_cmd_map;
+        if cmd_map.contains_key(&cmd.mountpoint) {
+            return Err(Error::AlreadyExists);
+        }
+
+        cmd_map.insert(cmd.mountpoint.clone(), (cmd, vfs_index));
         Ok(())
     }
 
     /// Update a filesystem instance in the upgrade manager.
-    pub fn update_mounts_state(&mut self, _cmd: FsBackendMountCmd) -> Result<()> {
-        Ok(())
+    pub fn update_mounts_state(&mut self, cmd: FsBackendMountCmd) -> Result<()> {
+        if self.disabled.load(Ordering::Acquire) {
+            return Err(Error::Unsupported);
+        }
+
+        let cmd_map = &mut self.backend_mount_cmd_map;
+        match cmd_map.get_mut(&cmd.mountpoint) {
+            Some(cmd_with_vfs_idx) => {
+                cmd_with_vfs_idx.0 = cmd;
+                Ok(())
+            }
+            None => Err(Error::NotFound),
+        }
     }
 
     /// Remove a filesystem instance from the upgrade manager.
-    pub fn remove_mounts_state(&mut self, _cmd: FsBackendUmountCmd) -> Result<()> {
-        Ok(())
+    pub fn remove_mounts_state(&mut self, cmd: FsBackendUmountCmd) -> Result<()> {
+        if self.disabled.load(Ordering::Acquire) {
+            return Err(Error::Unsupported);
+        }
+
+        let cmd_map = &mut self.backend_mount_cmd_map;
+        match cmd_map.get_mut(&cmd.mountpoint) {
+            Some(_) => {
+                cmd_map.remove(&cmd.mountpoint);
+                Ok(())
+            }
+            None => Err(Error::NotFound),
+        }
     }
 
     /// Disable online upgrade capability.
-    pub fn disable_upgrade(&mut self) {}
+    pub fn disable_upgrade(&mut self) {
+        self.disabled.store(true, Ordering::Release);
+    }
+
+    /// Save the fuse fds and fuse state data for online upgrade.
+    fn save(&mut self, data: &Vec<u8>) -> Result<()> {
+        self.backend
+            .save(&self.fds, data)
+            .map_err(UpgradeMgrError::StorageBackendError)?;
+        Ok(())
+    }
+
+    /// Restore the fuse fds and fuse state data for online upgrade.
+    fn restore(&mut self) -> Result<Vec<u8>> {
+        let mut fds = vec![0 as RawFd; 8];
+        let mut state_data = vec![0u8; MAX_STATE_DATA_LENGTH];
+        let (state_data_len, fds_len) = self
+            .backend
+            .restore(&mut fds, &mut state_data)
+            .map_err(UpgradeMgrError::StorageBackendError)?;
+        fds.truncate(fds_len);
+        state_data.truncate(state_data_len);
+
+        self.fds = fds;
+        Ok(state_data)
+    }
+
+    fn add_fd(&mut self, fd: RawFd) {
+        self.fds.push(fd);
+    }
 }
 
 /// Online upgrade utilities for FUSE daemon.
 pub mod fusedev_upgrade {
+    use std::fs::File;
+    use std::os::fd::{FromRawFd, RawFd};
+    use std::os::unix::io::AsRawFd;
+    use std::sync::atomic::Ordering;
+
+    use nydus_upgrade::persist::Snapshotter;
+    use versionize::{VersionMap, Versionize, VersionizeResult};
+    use versionize_derive::Versionize;
+
     use super::*;
-    use crate::fusedev::FusedevDaemon;
+    use crate::daemon::NydusDaemon;
+    use crate::fusedev::{FusedevDaemon, FusedevFsService};
+
+    #[derive(Versionize, Clone, Default)]
+    struct FusedevState {
+        backend_fs_mount_cmd_list: Vec<(FsBackendMountCmd, u8)>,
+        vfs_state_data: Vec<u8>,
+        fuse_conn_id: u64,
+    }
+
+    impl Snapshotter for FusedevState {
+        fn get_versions() -> Vec<HashMap<TypeId, u16>> {
+            vec![
+                // version 1
+                HashMap::from([(FusedevState::type_id(), 1)]),
+                // more versions for the future
+            ]
+        }
+    }
 
     /// Save state information for a FUSE daemon.
-    pub fn save(_daemon: &FusedevDaemon) -> Result<()> {
+    pub fn save(daemon: &FusedevDaemon) -> Result<()> {
+        let svc = daemon.get_default_fs_service().ok_or(Error::NotFound)?;
+
+        if !svc.get_vfs().initialized() {
+            return Err(Error::NotReady);
+        }
+
+        let mut mgr = svc.upgrade_mgr().unwrap();
+
+        // set fd
+        let fd = svc
+            .as_ref()
+            .as_any()
+            .downcast_ref::<FusedevFsService>()
+            .unwrap()
+            .session
+            .lock()
+            .unwrap()
+            .get_fuse_file()
+            .unwrap()
+            .as_raw_fd();
+        mgr.add_fd(fd);
+
+        // save vfs state
+        let vfs_state_data = svc.get_vfs().save_to_bytes().map_err(|e| {
+            let io_err = io::Error::new(
+                io::ErrorKind::Other,
+                format!("Failed to save vfs state: {:?}", e),
+            );
+            UpgradeMgrError::Serialize(io_err)
+        })?;
+
+        let backend_fs_mount_cmd_list = mgr
+            .backend_mount_cmd_map
+            .iter()
+            .map(|(_, (cmd, vfs_idx))| (cmd.clone(), *vfs_idx))
+            .collect();
+
+        let fuse_conn_id = svc
+            .as_any()
+            .downcast_ref::<FusedevFsService>()
+            .unwrap()
+            .conn
+            .load(Ordering::Acquire);
+
+        let state = FusedevState {
+            backend_fs_mount_cmd_list,
+            vfs_state_data,
+            fuse_conn_id,
+        };
+        let state = state.save().map_err(UpgradeMgrError::Serialize)?;
+
+        // save the mgr state via the backend in the mgr
+        mgr.save(&state)?;
+
         Ok(())
     }
 
     /// Restore state information for a FUSE daemon.
-    pub fn restore(_daemon: &FusedevDaemon) -> Result<()> {
+    pub fn restore(daemon: &FusedevDaemon) -> Result<()> {
+        if daemon.supervisor.is_none() {
+            return Err(UpgradeMgrError::MissingSupervisorPath.into());
+        }
+
+        let svc = daemon.get_default_fs_service().ok_or(Error::NotFound)?;
+
+        let mut mgr = svc.upgrade_mgr().unwrap();
+
+        // restore the mgr state via the backend in the mgr
+        let mut state_data = mgr.restore()?;
+
+        let mut state =
+            FusedevState::restore(&mut state_data).map_err(UpgradeMgrError::Deserialize)?;
+
+        // restore the backend fs mount cmd map
+        state
+            .backend_fs_mount_cmd_list
+            .iter()
+            .for_each(|(cmd, vfs_idx)| {
+                mgr.backend_mount_cmd_map
+                    .insert(cmd.mountpoint.clone(), (cmd.clone(), *vfs_idx));
+            });
+
+        // restore the fuse daemon
+        svc.as_any()
+            .downcast_ref::<FusedevFsService>()
+            .unwrap()
+            .conn
+            .store(state.fuse_conn_id, Ordering::Release);
+
+        // restore fuse fd
+        svc.as_any()
+            .downcast_ref::<FusedevFsService>()
+            .unwrap()
+            .session
+            .lock()
+            .unwrap()
+            .set_fuse_file(unsafe { File::from_raw_fd(mgr.fds[0] as RawFd) });
+
+        // restore vfs
+        svc.get_vfs()
+            .restore_from_bytes(&mut state.vfs_state_data)?;
+        state
+            .backend_fs_mount_cmd_list
+            .iter()
+            .try_for_each(|(cmd, vfs_idx)| -> Result<()> {
+                svc.restore_mount(cmd, *vfs_idx)?;
+                // as we are in upgrade stage and obtain the lock, `unwrap` is safe here
+                mgr.add_mounts_state(cmd.clone(), *vfs_idx).unwrap();
+                Ok(())
+            })?;
+
         Ok(())
     }
 }

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -16,28 +16,40 @@ hex = "0.4.3"
 hmac = { version = "0.12.1", optional = true }
 http = { version = "0.2.8", optional = true }
 httpdate = { version = "1.0", optional = true }
-hyper = {version = "0.14.11", optional =  true }
-hyperlocal = {version = "0.8.0", optional = true }
+hyper = { version = "0.14.11", optional = true }
+hyperlocal = { version = "0.8.0", optional = true }
 lazy_static = "1.4.0"
 leaky-bucket = { version = "0.12.1", optional = true }
 libc = "0.2"
 log = "0.4.8"
 nix = "0.24"
-reqwest = { version = "0.11.14", features = ["blocking", "json"], optional = true }
+reqwest = { version = "0.11.14", features = [
+    "blocking",
+    "json",
+], optional = true }
 serde = { version = "1.0.110", features = ["serde_derive", "rc"] }
 serde_json = "1.0.53"
 sha1 = { version = "0.10.5", optional = true }
 sha2 = { version = "0.10.2", optional = true }
 tar = "0.4.40"
 time = { version = "0.3.14", features = ["formatting"], optional = true }
-tokio = { version = "1.19.0", features = ["macros", "rt", "rt-multi-thread", "sync", "time"] }
+tokio = { version = "1.19.0", features = [
+    "macros",
+    "rt",
+    "rt-multi-thread",
+    "sync",
+    "time",
+] }
 url = { version = "2.1.1", optional = true }
 vm-memory = "0.10"
-fuse-backend-rs = "^0.10.3"
+fuse-backend-rs = { git = "https://github.com/loheagn/fuse-backend-rs.git", branch = "vfs-persist" }
 gpt = { version = "3.0.0", optional = true }
 
 nydus-api = { version = "0.3", path = "../api" }
-nydus-utils = { version = "0.4", path = "../utils", features = ["encryption", "zran"] }
+nydus-utils = { version = "0.4", path = "../utils", features = [
+    "encryption",
+    "zran",
+] }
 
 [dev-dependencies]
 vmm-sys-util = "0.11"
@@ -56,4 +68,8 @@ prefetch-rate-limit = ["leaky-bucket"]
 
 [package.metadata.docs.rs]
 all-features = true
-targets = ["x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu", "aarch64-apple-darwin"]
+targets = [
+    "x86_64-unknown-linux-gnu",
+    "aarch64-unknown-linux-gnu",
+    "aarch64-apple-darwin",
+]

--- a/upgrade/Cargo.toml
+++ b/upgrade/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "nydus-upgrade"
+version = "0.1.0"
+description = "Nydus Daemon Upgrade"
+authors = ["The Nydus Developers"]
+license = "Apache-2.0"
+homepage = "https://nydus.dev/"
+repository = "https://github.com/dragonflyoss/image-service"
+edition = "2021"
+
+[dependencies]
+sendfd = "0.4.3"
+snapshot = { git = "https://github.com/firecracker-microvm/firecracker", tag = "v1.4.1" }
+thiserror = "1"
+versionize_derive = "0.1.6"
+versionize = "0.1.10"

--- a/upgrade/src/backend/mod.rs
+++ b/upgrade/src/backend/mod.rs
@@ -1,0 +1,93 @@
+use std::{io, os::fd::RawFd};
+
+pub mod unix_domain_socket;
+
+#[derive(thiserror::Error, Debug)]
+pub enum StorageBackendErr {
+    #[error("failed to create UnixStream, {0}")]
+    CreateUnixStream(io::Error),
+    #[error("failed to send fd over UnixStream, {0}")]
+    SendFd(io::Error),
+    #[error("failed to receive fd over UnixStream, {0}")]
+    RecvFd(io::Error),
+    #[error("no enough fds")]
+    NoEnoughFds,
+}
+
+pub type Result<T> = std::result::Result<T, StorageBackendErr>;
+
+/// StorageBackend trait is used to save and restore the fuse fds and fuse state data for online upgrade.
+pub trait StorageBackend: Send + Sync {
+    /// Save the fuse fds and fuse state data for online upgrade.
+    /// Returns the length of bytes of fuse state data.
+    fn save(&mut self, fds: &[RawFd], data: &[u8]) -> Result<usize>;
+
+    /// Restore the fuse fds and fuse state data for online upgrade.
+    /// Returns the length of bytes of fuse state data and the length of fds.
+    fn restore(&mut self, fds: &mut Vec<RawFd>, data: &mut Vec<u8>) -> Result<(usize, usize)>;
+}
+
+#[cfg(test)]
+mod test {
+
+    #[test]
+    fn test_storage_backend() {
+        use std::os::fd::RawFd;
+
+        use crate::backend::{Result, StorageBackend};
+
+        #[derive(Default)]
+        struct TestStorageBackend {
+            fds: Vec<RawFd>,
+            data: Vec<u8>,
+        }
+
+        impl StorageBackend for TestStorageBackend {
+            fn save(&mut self, fds: &[RawFd], data: &[u8]) -> Result<usize> {
+                self.fds = Vec::new();
+                fds.iter().for_each(|fd| self.fds.push(*fd));
+
+                self.data = vec![0u8; data.len()];
+                self.data.clone_from_slice(data);
+
+                Ok(self.data.len())
+            }
+
+            fn restore(
+                &mut self,
+                fds: &mut Vec<RawFd>,
+                data: &mut Vec<u8>,
+            ) -> Result<(usize, usize)> {
+                fds.truncate(self.fds.len());
+                fds.copy_from_slice(&self.fds);
+
+                data.truncate(self.data.len());
+                data.copy_from_slice(&self.data);
+
+                Ok((data.len(), fds.len()))
+            }
+        }
+
+        const FDS_LEN: usize = 10;
+        const DATA_LEN: usize = 5;
+        let fds = [5 as RawFd; FDS_LEN];
+        let data: [u8; DATA_LEN] = [7, 8, 9, 10, 12];
+
+        let mut backend: Box<dyn StorageBackend> = Box::new(TestStorageBackend::default());
+        let saved_data_len = backend.save(&fds, &data).unwrap();
+        assert_eq!(saved_data_len, DATA_LEN);
+
+        let mut restored_fds = vec![0 as RawFd; 100];
+        let mut restored_data = vec![0 as u8; 100];
+        let (restored_data_len, restored_fds_len) = backend
+            .restore(&mut restored_fds, &mut restored_data)
+            .unwrap();
+        assert_eq!(restored_data_len, DATA_LEN);
+        assert_eq!(restored_fds_len, FDS_LEN);
+
+        restored_data.truncate(restored_data_len);
+        restored_fds.truncate(restored_fds_len);
+        assert_eq!(restored_data, data);
+        assert_eq!(restored_fds, fds);
+    }
+}

--- a/upgrade/src/backend/unix_domain_socket.rs
+++ b/upgrade/src/backend/unix_domain_socket.rs
@@ -1,0 +1,52 @@
+// Copyright 2023 Nydus Developers. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{
+    os::{fd::RawFd, unix::net::UnixStream},
+    path::PathBuf,
+};
+
+use sendfd::{RecvWithFd, SendWithFd};
+
+use super::{Result, StorageBackend, StorageBackendErr};
+
+pub struct UdsStorageBackend {
+    socket_path: PathBuf,
+}
+
+impl UdsStorageBackend {
+    pub fn new(socket_path: PathBuf) -> Self {
+        UdsStorageBackend { socket_path }
+    }
+}
+
+impl StorageBackend for UdsStorageBackend {
+    fn save(&mut self, fds: &[RawFd], data: &[u8]) -> Result<usize> {
+        if fds.len() < 1 {
+            return Err(StorageBackendErr::NoEnoughFds);
+        }
+
+        let socket =
+            UnixStream::connect(&self.socket_path).map_err(StorageBackendErr::CreateUnixStream)?;
+        let len = socket
+            .send_with_fd(data, fds)
+            .map_err(StorageBackendErr::SendFd)?;
+
+        Ok(len)
+    }
+
+    fn restore(&mut self, fds: &mut Vec<RawFd>, data: &mut Vec<u8>) -> Result<(usize, usize)> {
+        let socket =
+            UnixStream::connect(&self.socket_path).map_err(StorageBackendErr::CreateUnixStream)?;
+        let len_pair = socket
+            .recv_with_fd(data, fds)
+            .map_err(StorageBackendErr::RecvFd)?;
+
+        if fds.len() < 1 {
+            return Err(StorageBackendErr::NoEnoughFds);
+        }
+
+        Ok(len_pair)
+    }
+}

--- a/upgrade/src/lib.rs
+++ b/upgrade/src/lib.rs
@@ -1,0 +1,6 @@
+// Copyright 2023 Nydus Developers. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod backend;
+pub mod persist;

--- a/upgrade/src/persist.rs
+++ b/upgrade/src/persist.rs
@@ -1,0 +1,65 @@
+// Copyright 2023 Nydus Developers. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use std::io::{Error as IoError, ErrorKind, Result};
+use std::{any::TypeId, collections::HashMap};
+
+use snapshot::Snapshot;
+use versionize::{VersionMap, Versionize};
+
+/// A list of versions.
+type Versions = Vec<HashMap<TypeId, u16>>;
+
+/// A trait for snapshotting.
+/// This trait is used to save and restore a struct
+/// which implements `versionize::Versionize`.
+pub trait Snapshotter: Versionize + Sized {
+    /// Returns a list of versions.
+    fn get_versions() -> Versions;
+
+    /// Returns a `VersionMap` with the versions defined by `get_versions`.
+    fn new_version_map() -> VersionMap {
+        let mut version_map = VersionMap::new();
+        for (idx, map) in Self::get_versions().into_iter().enumerate() {
+            if idx > 0 {
+                version_map.new_version();
+            }
+            for (type_id, version) in map {
+                version_map.set_type_version(type_id, version);
+            }
+        }
+        version_map
+    }
+
+    /// Returns a new `Snapshot` with the versions defined by `get_versions`.
+    fn new_snapshot() -> Snapshot {
+        let vm = Self::new_version_map();
+        let target_version = vm.latest_version();
+        Snapshot::new(vm, target_version)
+    }
+
+    /// Saves the struct to a `Vec<u8>`.
+    fn save(&self) -> Result<Vec<u8>> {
+        let mut buf = Vec::new();
+        let mut snapshot = Self::new_snapshot();
+        snapshot.save(&mut buf, self).map_err(|e| {
+            IoError::new(
+                ErrorKind::Other,
+                format!("Failed to save snapshot: {:?}", e),
+            )
+        })?;
+
+        Ok(buf)
+    }
+
+    /// Restores the struct from a `Vec<u8>`.
+    fn restore(buf: &mut Vec<u8>) -> Result<Self> {
+        Snapshot::load(&mut buf.as_slice(), buf.len(), Self::new_version_map()).map_err(|e| {
+            IoError::new(
+                ErrorKind::Other,
+                format!("Failed to load snapshot: {:?}", e),
+            )
+        })
+    }
+}


### PR DESCRIPTION
## Relevant Issue (if applicable)

#1421 

## Details

This patch implements the `save` and `restore` functions in the `fusedev_upgrade` in the service crate. 

To do this,
- This patch adds a new crate named `nydus-upgrade` into the workspace. The `nydus-upgrade` crate has some util functions help to do serialization and deserialization for the rust structs using the [versionize](https://github.com/firecracker-microvm/versionize) and [snapshot](https://github.com/firecracker-microvm/firecracker/tree/main/src/snapshot) crates. The crate also has a trait named `StorageBackend` which can be used to store and restore fuse session fds and state data for the upgrade action, and there's also an implementation named `UdsStorageBackend` which uses unix domain socket to do this.
- as we have to use the same fuse session connection, backend file system mount commands, Vfs to re-mount the rafs for the new daemon (created for "hot upgrade" or failover), this patch add a new struct named `FusedevState` to hold these information. The `FusedevState` is serialized and stored into the `UdsStorageBackend` (which happens in the `save` function in the `fusedev_upgrade` module) before the new daemon is created, and the `FusedevState` is deserialized and restored from the `UdsStorageBackend` (which happens in the `restore` function in the `fusedev_upgrade` module) when the new daemon is triggered by `takeover`.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Go over all the following points, and put an `x` in all the boxes that apply._

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.