### PR TITLE
storage: fix compatibility on fetching token for registry backend

### DIFF
--- a/api/src/error.rs
+++ b/api/src/error.rs
@@ -11,16 +11,16 @@ pub fn make_error(
     _file: &str,
     _line: u32,
 ) -> std::io::Error {
-    #[cfg(all(debug_assertions, feature = "error-backtrace"))]
+    #[cfg(all(feature = "error-backtrace"))]
     {
         if let Ok(val) = std::env::var("RUST_BACKTRACE") {
             if val.trim() != "0" {
-                log::error!("Stack:\n{:?}", backtrace::Backtrace::new());
-                log::error!("Error:\n\t{:?}\n\tat {}:{}", _raw, _file, _line);
+                error!("Stack:\n{:?}", backtrace::Backtrace::new());
+                error!("Error:\n\t{:?}\n\tat {}:{}", _raw, _file, _line);
                 return err;
             }
         }
-        log::error!(
+        error!(
             "Error:\n\t{:?}\n\tat {}:{}\n\tnote: enable `RUST_BACKTRACE=1` env to display a backtrace",
             _raw, _file, _line
         );


### PR DESCRIPTION
## Details

The registry backend received an unauthorized error from Harbor registry
when fetching registry token by HTTP GET method, the bug is introduced
from https://github.com/dragonflyoss/image-service/pull/1425/files#diff-f7ce8f265a570c66eae48c85e0f5b6f29fdaec9cf2ee2eded95810fe320d80e1L263.

We should insert the basic auth header to ensure the compatibility of
fetching token by HTTP GET method.

This refers to containerd implementation: https://github.com/containerd/containerd/blob/dc7dba9c20f7210c38e8255487fc0ee12692149d/remotes/docker/auth/fetch.go#L187

The change has been tested for Harbor v2.9.

## Types of changes

_What types of changes does your PullRequest introduce? Put an `x` in all the boxes that apply:_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Go over all the following points, and put an `x` in all the boxes that apply._

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.