### PR TITLE
nydusd: add the config support of `amplify_io`

### DIFF
--- a/api/src/config.rs
+++ b/api/src/config.rs
@@ -819,8 +819,8 @@ pub struct RafsConfigV2 {
     /// Filesystem metadata cache mode.
     #[serde(default = "default_rafs_mode")]
     pub mode: String,
-    /// Batch size to read data from storage cache layer.
-    #[serde(rename = "batch_size", default = "default_batch_size")]
+    /// Amplified user IO request batch size to read data from remote storage backend / local cache.
+    #[serde(rename = "batch_size", default = "default_user_io_batch_size")]
     pub user_io_batch_size: usize,
     /// Whether to validate data digest.
     #[serde(default)]
@@ -874,7 +874,7 @@ pub struct PrefetchConfigV2 {
     /// Number of data prefetching working threads.
     #[serde(rename = "threads", default = "default_prefetch_threads_count")]
     pub threads_count: usize,
-    /// The batch size to prefetch data from backend.
+    /// The amplify batch size to prefetch data from backend.
     #[serde(default = "default_prefetch_batch_size")]
     pub batch_size: usize,
     /// Network bandwidth rate limit in unit of Bytes and Zero means no limit.
@@ -1194,11 +1194,11 @@ fn default_work_dir() -> String {
     ".".to_string()
 }
 
-pub fn default_batch_size() -> usize {
-    128 * 1024
+pub fn default_user_io_batch_size() -> usize {
+    1024 * 1024
 }
 
-fn default_prefetch_batch_size() -> usize {
+pub fn default_prefetch_batch_size() -> usize {
     1024 * 1024
 }
 
@@ -1363,8 +1363,9 @@ struct RafsConfig {
     /// Record file name if file access trace log.
     #[serde(default)]
     pub latest_read_files: bool,
+    // Amplified user IO request batch size to read data from remote storage backend / local cache.
     // ZERO value means, amplifying user io is not enabled.
-    #[serde(rename = "amplify_io", default = "default_batch_size")]
+    #[serde(rename = "amplify_io", default = "default_user_io_batch_size")]
     pub user_io_batch_size: usize,
 }
 
@@ -1410,8 +1411,8 @@ struct FsPrefetchControl {
     #[serde(default = "default_prefetch_threads_count")]
     pub threads_count: usize,
 
-    /// Window size in unit of bytes to merge request to backend.
-    #[serde(rename = "merging_size", default = "default_batch_size")]
+    /// The amplify batch size to prefetch data from backend.
+    #[serde(rename = "merging_size", default = "default_prefetch_batch_size")]
     pub batch_size: usize,
 
     /// Network bandwidth limitation for prefetching.
@@ -1449,7 +1450,7 @@ struct BlobPrefetchConfig {
     pub enable: bool,
     /// Number of data prefetching working threads.
     pub threads_count: usize,
-    /// The maximum size of a merged IO request.
+    /// The amplify batch size to prefetch data from backend.
     #[serde(rename = "merging_size")]
     pub batch_size: usize,
     /// Network bandwidth rate limit in unit of Bytes and Zero means no limit.

--- a/docs/nydusd.md
+++ b/docs/nydusd.md
@@ -130,6 +130,9 @@ We are working on enabling cloud-hypervisor support for nydus.
   "iostats_files": true,
   // Enable support of fs extended attributes
   "enable_xattr": false,
+  // Amplified user IO request batch size to read data from remote storage backend / local cache
+  // in unit of Bytes, valid values: 0-268435456, default: 1048576
+  "amplify_io": 1048576,
   "fs_prefetch": {
     // Enable blob prefetch
     "enable": false,

--- a/misc/configs/nydusd-config-v2.toml
+++ b/misc/configs/nydusd-config-v2.toml
@@ -142,7 +142,8 @@ bandwidth_limit = 10000000
 [rafs]
 # Filesystem metadata cache mode, "direct" or "cached". "direct" is almost what you want.
 mode = "direct"
-# Batch size to read data from storage cache layer, valid values: 0-0x10000000
+# Amplified user IO request batch size to read data from remote storage backend / local cache,
+# valid values: 0-0x10000000
 batch_size = 1000000
 # Whether to validate data digest.
 validate = true

--- a/rafs/src/metadata/md_v5.rs
+++ b/rafs/src/metadata/md_v5.rs
@@ -128,7 +128,7 @@ impl RafsSuper {
     // not overlap user IO's chunk.
     // V5 rafs tries to amplify user IO by expanding more chunks to user IO and
     // expect that those chunks are likely to be continuous with user IO's chunks.
-    pub(crate) fn amplify_io(
+    pub(crate) fn amplify_user_io(
         &self,
         device: &BlobDevice,
         max_uncomp_size: u32,

--- a/service/src/fs_cache.rs
+++ b/service/src/fs_cache.rs
@@ -518,8 +518,8 @@ impl FsCacheHandler {
             .map_err(|e| eother!(format!("failed to start prefetch worker, {}", e)))?;
 
         let size = match cache_cfg.prefetch.batch_size.checked_next_power_of_two() {
-            None => nydus_api::default_batch_size() as u64,
-            Some(1) => nydus_api::default_batch_size() as u64,
+            None => nydus_api::default_prefetch_batch_size() as u64,
+            Some(1) => nydus_api::default_prefetch_batch_size() as u64,
             Some(s) => s as u64,
         };
         let size = std::cmp::max(0x4_0000u64, size);

--- a/storage/src/cache/cachedfile.rs
+++ b/storage/src/cache/cachedfile.rs
@@ -301,10 +301,10 @@ impl FileCacheEntry {
     }
 
     fn prefetch_batch_size(&self) -> u64 {
-        if self.prefetch_config.merging_size < 0x2_0000 {
+        if self.prefetch_config.batch_size < 0x2_0000 {
             0x2_0000
         } else {
-            self.prefetch_config.merging_size as u64
+            self.prefetch_config.batch_size as u64
         }
     }
 

--- a/storage/src/cache/worker.rs
+++ b/storage/src/cache/worker.rs
@@ -25,7 +25,7 @@ pub(crate) struct AsyncPrefetchConfig {
     pub enable: bool,
     /// Number of working threads.
     pub threads_count: usize,
-    /// Window size to merge/amplify requests.
+    /// The amplify batch size to prefetch data from backend.
     pub batch_size: usize,
     /// Network bandwidth for prefetch, in unit of Bytes and Zero means no rate limit is set.
     #[allow(unused)]


### PR DESCRIPTION
## Relevant Issue (if applicable)
_If there are Issues related to this PullRequest, please list it._

## Details
_Please describe the details of PullRequest._

The first commit is to rename the variables with similar usages into same names.

i.e.,

**`prefetch.batch_size`/`prefetch.merging_size` -> `batch_size` (filed name)/`prefetch_batch_size`(function name) (newly changed)**

`threads`/`threads_count` -> `threads_count`

`batch_size`/`amplify_io` ->`user_io_batch_size`

`bandwidth_rate`/`bandwidth_limit` -> `bandwidth_limit`

This change is only for the variables in nydusd runtime, and does not affect the filed names in the config file.

The second commit adds the support of `amplify_io` in the config file of nydusd to restrict read amplification.

## Types of changes

_What types of changes does your PullRequest introduce? Put an `x` in all the boxes that apply:_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Go over all the following points, and put an `x` in all the boxes that apply._

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.