### PR TITLE
contrib: upgrade to go 1.20

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Setup Golang
       uses: actions/setup-go@v3
       with:
-        go-version: ~1.18
+        go-version: ~1.20
     - name: Golang Cache
       uses: actions/cache@v3
       with:

--- a/.github/workflows/convert.yml
+++ b/.github/workflows/convert.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Setup Golang
       uses: actions/setup-go@v3
       with:
-        go-version: ~1.18
+        go-version: ~1.20
     - name: Golang Cache
       uses: actions/cache@v3
       with:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v3
         with:
-          go-version: 1.18
+          go-version: 1.20
       - name: Setup pytest
         run: |
           sudo apt-get update

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,7 +94,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v3
       with:
-        go-version: '1.18'
+        go-version: '1.20'
     - name: cache go mod
       uses: actions/cache@v3
       with:

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Setup Golang
       uses: actions/setup-go@v3
       with:
-        go-version: ~1.18
+        go-version: ~1.20
     - name: Golang Cache
       uses: actions/cache@v3
       with:
@@ -58,7 +58,7 @@ jobs:
     - name: Setup Golang
       uses: actions/setup-go@v3
       with:
-        go-version: ~1.18
+        go-version: ~1.20
     - name: Golang Cache
       uses: actions/cache@v3
       with:

--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ dind_cache_mount := $(if $(DIND_CACHE_DIR),-v $(DIND_CACHE_DIR):/var/lib/docker,
 define build_golang
 	echo "Building target $@ by invoking: $(2)"
 	if [ $(DOCKER) = "true" ]; then \
-		docker run --rm -v ${go_path}:/go -v ${current_dir}:/nydus-rs --workdir /nydus-rs/$(1) golang:1.18 $(2) ;\
+		docker run --rm -v ${go_path}:/go -v ${current_dir}:/nydus-rs --workdir /nydus-rs/$(1) golang:1.20 $(2) ;\
 	else \
 		$(2) -C $(1); \
 	fi

--- a/contrib/ctr-remote/go.mod
+++ b/contrib/ctr-remote/go.mod
@@ -1,6 +1,6 @@
 module github.com/dragonflyoss/image-service/contrib/ctr-remote
 
-go 1.18
+go 1.20
 
 require (
 	github.com/containerd/containerd v1.7.0

--- a/contrib/nydus-overlayfs/go.mod
+++ b/contrib/nydus-overlayfs/go.mod
@@ -1,6 +1,6 @@
 module github.com/dragonflyoss/image-service/contrib/nydus-overlayfs
 
-go 1.18
+go 1.20
 
 require (
 	github.com/pkg/errors v0.9.1

--- a/contrib/nydus-test/misc/containerize/Dockerfile
+++ b/contrib/nydus-test/misc/containerize/Dockerfile
@@ -25,8 +25,8 @@ RUN wget https://github.com/opencontainers/runc/releases/download/v1.1.2/runc.am
 RUN chmod +x /usr/bin/*; chmod +x /usr/bin/runc
 
 # Install golang
-RUN wget https://go.dev/dl/go1.18.1.linux-amd64.tar.gz -O /home/go1.18.1.linux-amd64.tar.gz
-RUN tar -C /usr/local -xzf /home/go1.18.1.linux-amd64.tar.gz
+RUN wget https://go.dev/dl/go1.20.10.linux-amd64.tar.gz -O /home/go1.20.10.linux-amd64.tar.gz
+RUN tar -C /usr/local -xzf /home/go1.20.10.linux-amd64.tar.gz
 ENV PATH $PATH:/usr/local/go/bin
 RUN mkdir /root/go
 RUN rm -rf /home/*

--- a/contrib/nydusify/cmd/nydusify_test.go
+++ b/contrib/nydusify/cmd/nydusify_test.go
@@ -6,7 +6,6 @@ package main
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -50,7 +49,7 @@ func TestParseBackendConfig(t *testing.T) {
 	}`
 	require.True(t, json.Valid([]byte(configJSON)))
 
-	file, err := ioutil.TempFile("", "nydusify-backend-config-test.json")
+	file, err := os.CreateTemp("", "nydusify-backend-config-test.json")
 	require.NoError(t, err)
 	defer os.RemoveAll(file.Name())
 

--- a/contrib/nydusify/go.mod
+++ b/contrib/nydusify/go.mod
@@ -1,6 +1,6 @@
 module github.com/dragonflyoss/image-service/contrib/nydusify
 
-go 1.18
+go 1.20
 
 require (
 	github.com/aliyun/aliyun-oss-go-sdk v2.2.6+incompatible

--- a/smoke/go.mod
+++ b/smoke/go.mod
@@ -1,6 +1,6 @@
 module github.com/dragonflyoss/image-service/smoke
 
-go 1.18
+go 1.20
 
 require (
 	github.com/containerd/containerd v1.7.0

--- a/smoke/tests/api_test.go
+++ b/smoke/tests/api_test.go
@@ -7,7 +7,7 @@ package tests
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -231,7 +231,7 @@ func (a *APIV1TestSuite) visit(path string) error {
 	}
 	defer f.Close()
 
-	ioutil.ReadAll(f)
+	io.ReadAll(f)
 
 	return nil
 }

--- a/smoke/tests/blobcache_test.go
+++ b/smoke/tests/blobcache_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -47,7 +46,7 @@ func (a *BlobCacheTestSuite) prepareTestEnv(t *testing.T) (*tool.Context, string
 	rootfsReader := rootFs.ToOCITar(t)
 
 	ociBlobDigester := digest.Canonical.Digester()
-	ociBlob, err := ioutil.TempFile(ctx.Env.BlobDir, "oci-blob-")
+	ociBlob, err := os.CreateTemp(ctx.Env.BlobDir, "oci-blob-")
 	require.NoError(t, err)
 
 	_, err = io.Copy(io.MultiWriter(ociBlobDigester.Hash(), ociBlob), rootfsReader)

--- a/smoke/tests/tool/context.go
+++ b/smoke/tests/tool/context.go
@@ -5,7 +5,6 @@
 package tool
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -86,7 +85,7 @@ func (ctx *Context) PrepareWorkDir(t *testing.T) {
 	if tempDir == "" {
 		tempDir = os.TempDir()
 	}
-	workDir, err := ioutil.TempDir(tempDir, "nydus-smoke-")
+	workDir, err := os.MkdirTemp(tempDir, "nydus-smoke-")
 	require.NoError(t, err)
 
 	blobDir := filepath.Join(workDir, "blobs")

--- a/smoke/tests/tool/layer.go
+++ b/smoke/tests/tool/layer.go
@@ -10,7 +10,6 @@ import (
 	"context"
 	"crypto/rand"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -121,7 +120,7 @@ func (l *Layer) Pack(t *testing.T, packOption converter.PackOption, blobDir stri
 	l.recordFileTree(t)
 
 	// Pack OCI tar to nydus native blob
-	blob, err := ioutil.TempFile(blobDir, "blob-")
+	blob, err := os.CreateTemp(blobDir, "blob-")
 	require.NoError(t, err)
 	defer blob.Close()
 	blobDigester := digest.Canonical.Digester()
@@ -160,7 +159,7 @@ func (l *Layer) PackRef(t *testing.T, ctx Context, blobDir string, compress bool
 	}
 
 	// Pack OCI blob to nydus zran blob
-	rafsBlob, err := ioutil.TempFile(blobDir, "rafs-blob-")
+	rafsBlob, err := os.CreateTemp(blobDir, "rafs-blob-")
 	require.NoError(t, err)
 	defer rafsBlob.Close()
 	rafsBlobDigester := digest.Canonical.Digester()
@@ -172,7 +171,7 @@ func (l *Layer) PackRef(t *testing.T, ctx Context, blobDir string, compress bool
 	require.NoError(t, err)
 
 	ociBlobDigester := digest.Canonical.Digester()
-	ociBlob, err := ioutil.TempFile(blobDir, "oci-blob-")
+	ociBlob, err := os.CreateTemp(blobDir, "oci-blob-")
 	require.NoError(t, err)
 
 	_, err = io.Copy(io.MultiWriter(twc, ociBlobDigester.Hash(), ociBlob), ociBlobReader)
@@ -250,7 +249,7 @@ func MergeLayers(t *testing.T, ctx Context, mergeOption converter.MergeOption, l
 		layers[idx].ReaderAt = ra
 	}
 
-	bootstrap, err := ioutil.TempFile(ctx.Env.WorkDir, "bootstrap-")
+	bootstrap, err := os.CreateTemp(ctx.Env.WorkDir, "bootstrap-")
 	require.NoError(t, err)
 	defer bootstrap.Close()
 	actualDigests, err := converter.Merge(context.Background(), layers, bootstrap, mergeOption)

--- a/smoke/tests/tool/nydusd.go
+++ b/smoke/tests/tool/nydusd.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -246,7 +245,7 @@ func (nydusd *Nydusd) MountByAPI(config NydusdConfig) error {
 		return err
 	}
 	defer f.Close()
-	rafsConfig, err := ioutil.ReadAll(f)
+	rafsConfig, err := io.ReadAll(f)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Relevant Issue (if applicable)
#1453 CI fails due to lower Go version.

## Details
Keep consistent with other components in container ecosystem, for example containerd is using go 1.20.

## Types of changes

_What types of changes does your PullRequest introduce? Put an `x` in all the boxes that apply:_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Go over all the following points, and put an `x` in all the boxes that apply._

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.