### PR TITLE
api: fix unsupported dummy cache type

### DIFF
--- a/api/src/config.rs
+++ b/api/src/config.rs
@@ -1312,7 +1312,7 @@ impl TryFrom<&CacheConfig> for CacheConfigV2 {
             "fscache" => {
                 config.fs_cache = Some(serde_json::from_value(v.cache_config.clone())?);
             }
-            "" => {}
+            "" | "dummycache" => {}
             t => {
                 return Err(Error::new(
                     ErrorKind::InvalidInput,


### PR DESCRIPTION
The dummycache type is missed to handle in config validation:

```
ERROR [/src/fusedev.rs:595] service mount error: RAFS failed to handle request, Failed to load config: failed to parse configuration information`
ERROR [/src/error.rs:18] Stack:
   0: backtrace::backtrace::trace
   1: backtrace::capture::Backtrace::new

ERROR [/src/error.rs:19] Error:
        Rafs(LoadConfig(Custom { kind: InvalidInput, error: "failed to parse configuration information" }))
        at service/src/fusedev.rs:596
ERROR [src/bin/nydusd/main.rs:525] Failed in starting daemon:
Error: Custom { kind: Other, error: "" }
```

Fix https://github.com/dragonflyoss/nydus/issues/1456

## Relevant Issue (if applicable)
_If there are Issues related to this PullRequest, please list it._

## Details
_Please describe the details of PullRequest._

## Types of changes

_What types of changes does your PullRequest introduce? Put an `x` in all the boxes that apply:_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Go over all the following points, and put an `x` in all the boxes that apply._

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.