### PR TITLE
nydusify: fix copy race issue

### DIFF
--- a/contrib/nydusify/pkg/copier/copier.go
+++ b/contrib/nydusify/pkg/copier/copier.go
@@ -16,6 +16,7 @@ import (
 	"github.com/containerd/containerd/content"
 	containerdErrdefs "github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/platforms"
 	"github.com/containerd/containerd/reference/docker"
 	"github.com/containerd/nydus-snapshotter/pkg/converter"
@@ -151,7 +152,7 @@ func pushBlobFromBackend(
 	for idx := range blobIDs {
 		func(idx int) {
 			eg.Go(func() error {
-				sem.Acquire(ctx, 1)
+				sem.Acquire(context.Background(), 1)
 				defer sem.Release(1)
 
 				blobID := blobIDs[idx]
@@ -244,6 +245,9 @@ func getPlatform(platform *ocispec.Platform) string {
 }
 
 func Copy(ctx context.Context, opt Opt) error {
+	// Containerd image fetch requires a namespace context.
+	ctx = namespaces.WithNamespace(ctx, "nydusify")
+
 	platformMC, err := platformutil.ParsePlatforms(opt.AllPlatforms, opt.Platforms)
 	if err != nil {
 		return err
@@ -319,7 +323,7 @@ func Copy(ctx context.Context, opt Opt) error {
 	for idx := range sourceDescs {
 		func(idx int) {
 			eg.Go(func() error {
-				sem.Acquire(ctx, 1)
+				sem.Acquire(context.Background(), 1)
 				defer sem.Release(1)
 
 				sourceDesc := sourceDescs[idx]

--- a/smoke/tests/compatibility_test.go
+++ b/smoke/tests/compatibility_test.go
@@ -86,7 +86,7 @@ func (c *CompatibilityTestSuite) TestConvertImages() test.Generator {
 		image := c.prepareImage(c.t, scenario.GetString(paramImage))
 		return scenario.Str(), func(t *testing.T) {
 			imageTest := &ImageTestSuite{T: t}
-			imageTest.TestConvertImage(t, *ctx, image)
+			imageTest.TestConvertAndCopyImage(t, *ctx, image, false)
 		}
 	}
 }

--- a/smoke/tests/image_test.go
+++ b/smoke/tests/image_test.go
@@ -63,12 +63,12 @@ func (i *ImageTestSuite) TestConvertImages() test.Generator {
 
 		image := i.prepareImage(i.T, scenario.GetString(paramImage))
 		return scenario.Str(), func(t *testing.T) {
-			i.TestConvertImage(t, *ctx, image)
+			i.TestConvertAndCopyImage(t, *ctx, image, true)
 		}
 	}
 }
 
-func (i *ImageTestSuite) TestConvertImage(t *testing.T, ctx tool.Context, source string) {
+func (i *ImageTestSuite) TestConvertAndCopyImage(t *testing.T, ctx tool.Context, source string, testCopy bool) {
 
 	// Prepare work directory
 	ctx.PrepareWorkDir(t)
@@ -117,6 +117,25 @@ func (i *ImageTestSuite) TestConvertImage(t *testing.T, ctx tool.Context, source
 	checkCmd := fmt.Sprintf(
 		"%s %s check --source %s --target %s --nydus-image %s --nydusd %s --work-dir %s",
 		nydusifyPath, logLevel, source, target, ctx.Binary.Builder, ctx.Binary.Nydusd, filepath.Join(ctx.Env.WorkDir, "check"),
+	)
+	tool.RunWithoutOutput(t, checkCmd)
+
+	if !testCopy {
+		return
+	}
+
+	// Copy image
+	targetCopied := fmt.Sprintf("%s_copied", target)
+	copyCmd := fmt.Sprintf(
+		"%s %s copy --source %s --target %s --nydus-image %s --work-dir %s",
+		ctx.Binary.Nydusify, logLevel, target, targetCopied, ctx.Binary.Builder, ctx.Env.WorkDir,
+	)
+	tool.RunWithoutOutput(t, copyCmd)
+
+	// Check copied image
+	checkCmd = fmt.Sprintf(
+		"%s %s check --source %s --target %s --nydus-image %s --nydusd %s --work-dir %s",
+		nydusifyPath, logLevel, source, targetCopied, ctx.Binary.Builder, ctx.Binary.Nydusd, filepath.Join(ctx.Env.WorkDir, "check"),
 	)
 	tool.RunWithoutOutput(t, checkCmd)
 }


### PR DESCRIPTION
## Relevant Issue (if applicable)
_If there are Issues related to this PullRequest, please list it._

## Details

1. Fix lost namespace on containerd image pull context:

```
pull source image: namespace is required: failed precondition
```

The bug is introduced from https://github.com/dragonflyoss/nydus/pull/1446.

2. Fix possible semaphore Acquire race on the same one context:

```
panic: semaphore: released more than held
```

## Types of changes

_What types of changes does your PullRequest introduce? Put an `x` in all the boxes that apply:_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Go over all the following points, and put an `x` in all the boxes that apply._

- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.