### PR TITLE
nydusify: fix unnecessary manifest index when copy one platform image

### DIFF
--- a/contrib/nydusify/pkg/copier/copier.go
+++ b/contrib/nydusify/pkg/copier/copier.go
@@ -364,8 +364,8 @@ func Copy(ctx context.Context, opt Opt) error {
 		return errors.Wrap(err, "push image manifests")
 	}
 
-	if sourceImage.MediaType == ocispec.MediaTypeImageIndex ||
-		sourceImage.MediaType == images.MediaTypeDockerSchema2ManifestList {
+	if len(targetDescs) > 1 && (sourceImage.MediaType == ocispec.MediaTypeImageIndex ||
+		sourceImage.MediaType == images.MediaTypeDockerSchema2ManifestList) {
 		targetIndex := ocispec.Index{}
 		if _, err := utils.ReadJSON(ctx, pvd.ContentStore(), &targetIndex, *sourceImage); err != nil {
 			return errors.Wrap(err, "read source manifest list")


### PR DESCRIPTION
When use the command to copy the image with specified one platform:

```
nydusify copy --platform linux/amd64 --source nginx --target localhost:5000/nginx
```

We found the target image is a manifest index format like:

```
{
  "schemaVersion": 2,
  "mediaType": "application/vnd.docker.distribution.manifest.list.v2+json",
  "manifests": [
    {
      "mediaType": "application/vnd.docker.distribution.manifest.v2+json",
      "digest": "sha256:d2e65182b5fd330470eca9b8e23e8a1a0d87cc9b820eb1fb3f034bf8248d37ee",
      "size": 1778,
      "platform": {
        "architecture": "amd64",
        "os": "linux"
      }
    }
  ]
}
```

This can be a bit strange, in fact just the manifest is enough, the patch improves this.

## Relevant Issue (if applicable)
_If there are Issues related to this PullRequest, please list it._

## Details
_Please describe the details of PullRequest._

## Types of changes

_What types of changes does your PullRequest introduce? Put an `x` in all the boxes that apply:_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Go over all the following points, and put an `x` in all the boxes that apply._

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.