### PR TITLE
[WIP]nydus-image: enhance unpack command to support extracting files to dir

### DIFF
--- a/src/bin/nydus-image/main.rs
+++ b/src/bin/nydus-image/main.rs
@@ -720,8 +720,16 @@ fn prepare_cmd_args(bti_string: &'static str) -> App {
             .arg(
                 Arg::new("output")
                     .long("output")
-                    .help("path for output tar file")
-                    .required(true),
+                    .default_value("/dev/stdout")
+                    .help("Path for output tar file, if not configured, it will default to STDOUT.")
+                    .required(false),
+            )
+            .arg(
+                Arg::new("untar")
+                    .long("untar")
+                    .action(ArgAction::SetTrue)
+                    .help("Untar all files to the output dir, creating dir if it does not exist.")
+                    .required(false),
             ),
     )
 }
@@ -1363,11 +1371,12 @@ impl Command {
                 }
             }
         };
+        let untar = matches.get_flag("untar");
 
-        OCIUnpacker::new(bootstrap, backend, output)
-            .with_context(|| "fail to create unpacker")?
+        OCIUnpacker::new(bootstrap, backend, output, untar)
+            .with_context(|| "failed to create unpacker")?
             .unpack(config)
-            .with_context(|| "fail to unpack")
+            .with_context(|| format!("failed to unpack image to: {}", output))
     }
 
     fn check(matches: &ArgMatches, build_info: &BuildTimeInfo) -> Result<()> {


### PR DESCRIPTION
## Relevant Issue (if applicable)
N/A

## Details
When --output is specified as a directory, the nydus-image unpack command will return an error, which is not convenient for users.

This patch enhances this command in the following 3 aspects:
1. Allow --output to be passed as a directory. In this case, the tar file will be output to this subdirectory.
2. Added --untar flag to support decompressing this tar file into the directory specified by --output.
3. When --output is not specified, the default output is to /dev/stdout

## Types of changes

_What types of changes does your PullRequest introduce? Put an `x` in all the boxes that apply:_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Go over all the following points, and put an `x` in all the boxes that apply._

- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.