### PR TITLE
builder: align file dump order with prefetch list, fix #1488

### DIFF
--- a/builder/src/core/blob.rs
+++ b/builder/src/core/blob.rs
@@ -16,7 +16,7 @@ use sha2::digest::Digest;
 use super::layout::BlobLayout;
 use super::node::Node;
 use crate::core::context::Artifact;
-use crate::{BlobContext, BlobManager, BuildContext, ConversionType, Feature, Tree};
+use crate::{BlobContext, BlobManager, BuildContext, ConversionType, Feature};
 
 /// Generator for RAFS data blob.
 pub(crate) struct Blob {}
@@ -25,15 +25,13 @@ impl Blob {
     /// Dump blob file and generate chunks
     pub(crate) fn dump(
         ctx: &BuildContext,
-        tree: &Tree,
         blob_mgr: &mut BlobManager,
         blob_writer: &mut dyn Artifact,
     ) -> Result<()> {
         match ctx.conversion_type {
             ConversionType::DirectoryToRafs => {
                 let mut chunk_data_buf = vec![0u8; RAFS_MAX_CHUNK_SIZE as usize];
-                let (inodes, prefetch_entries) =
-                    BlobLayout::layout_blob_simple(&ctx.prefetch, tree)?;
+                let (inodes, prefetch_entries) = BlobLayout::layout_blob_simple(&ctx.prefetch)?;
                 for (idx, node) in inodes.iter().enumerate() {
                     let mut node = node.lock().unwrap();
                     let size = node

--- a/builder/src/core/bootstrap.rs
+++ b/builder/src/core/bootstrap.rs
@@ -37,8 +37,7 @@ impl Bootstrap {
         assert_eq!(index, RAFS_V5_ROOT_INODE);
         root_node.index = index;
         root_node.inode.set_ino(index);
-        ctx.prefetch
-            .insert_if_need(&self.tree.node, root_node.deref());
+        ctx.prefetch.insert(&self.tree.node, root_node.deref());
         bootstrap_ctx.inode_map.insert(
             (
                 root_node.layer_idx,
@@ -160,7 +159,7 @@ impl Bootstrap {
             if !child_node.is_dir() && ctx.fs_version.is_v6() {
                 child_node.v6_set_offset(bootstrap_ctx, v6_hardlink_offset, block_size)?;
             }
-            ctx.prefetch.insert_if_need(&child.node, child_node.deref());
+            ctx.prefetch.insert(&child.node, child_node.deref());
             if child_node.is_dir() {
                 dirs.push(child);
             }

--- a/builder/src/directory.rs
+++ b/builder/src/directory.rs
@@ -148,7 +148,7 @@ impl Builder for DirectoryBuilder {
 
         // Dump blob file
         timing_tracer!(
-            { Blob::dump(ctx, &bootstrap.tree, blob_mgr, blob_writer.as_mut(),) },
+            { Blob::dump(ctx, blob_mgr, blob_writer.as_mut()) },
             "dump_blob"
         )?;
 

--- a/builder/src/stargz.rs
+++ b/builder/src/stargz.rs
@@ -860,7 +860,7 @@ impl Builder for StargzBuilder {
 
         // Dump blob file
         timing_tracer!(
-            { Blob::dump(ctx, &bootstrap.tree, blob_mgr, blob_writer.as_mut()) },
+            { Blob::dump(ctx, blob_mgr, blob_writer.as_mut()) },
             "dump_blob"
         )?;
 

--- a/builder/src/tarball.rs
+++ b/builder/src/tarball.rs
@@ -615,7 +615,7 @@ impl Builder for TarballBuilder {
 
         // Dump blob file
         timing_tracer!(
-            { Blob::dump(ctx, &bootstrap.tree, blob_mgr, blob_writer.as_mut()) },
+            { Blob::dump(ctx, blob_mgr, blob_writer.as_mut()) },
             "dump_blob"
         )?;
 


### PR DESCRIPTION
## Relevant Issue (if applicable)
_If there are Issues related to this PullRequest, please list it._

Fix #1488

## Details
_Please describe the details of PullRequest._

1. The dump order for prefetch files does not match the order specified in prefetch list, so let's fix it, by recording the index of matched prefetch pattern, and then sort the prefetch files by indexes before dump.

Master:
![image](https://github.com/dragonflyoss/nydus/assets/22473909/95dc4d02-d2d1-498c-ab6f-b62a176cc7ec)

Patch:
![image](https://github.com/dragonflyoss/nydus/assets/22473909/1b45313b-db13-46cf-9ecf-1dbb9d9cbe0f)

2. The construction of `Prefetch` is slow due to inefficient matching of prefetch patterns.
For the build of patterns, `generate_patterns()`, the check whether current pattern is existed or covered by existing patterns in `prefetch.patterns`, is changed from iterating every pattern to check whether the parent path have been recorded.
For the build of `prefetch.files`, the rootfs tree is iterated in BFS only once in `build_rafs()`, and then cached in `Prefetch` to aviod duplicate BFS iteration in `layout_blob_simple()`.

3. Unit tests for prefetch are added.

Thus the build time prefetching is accelerated. For the `nydusify convert` time of a single layer Wordpress image with a total of 14,916 files, out of which 3,205 are prefetching files,

Master:
DirectoryToRafs: **19.13s**
TarToRafs: **17.43s**

Patch:
DirectoryToRafs: **7.08s**
TarToRafs: **5.33s**

## Types of changes

_What types of changes does your PullRequest introduce? Put an `x` in all the boxes that apply:_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Go over all the following points, and put an `x` in all the boxes that apply._

- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.