### PR TITLE
action: use same golang cache

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -123,15 +123,11 @@ jobs:
           sudo tar xzf nydus-static-$version_arch.tgz -C nydus-$version
           sudo cp -r nydus-$version/nydus-static/* /usr/bin/nydus-$version/
         done
-    - name: Golang Cache
-      uses: actions/cache@v3
+    - name: Setup Golang
+      uses: actions/setup-go@v4
       with:
-        path: |
-          ~/.cache/go-build
-          ~/go/pkg/mod
-        key: ${{ runner.os }}-golang-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-golang-
+        go-version-file: 'go.work'
+        cache-dependency-path: "**/*.sum"
     - name: Integration Test
       run: |
         sudo mkdir -p /usr/bin/nydus-latest /home/runner/work/workdir


### PR DESCRIPTION
## Relevant Issue (if applicable)
N/A

## Details
`setup-go@v4` uses the cache name of `setup-go-Linux-ubuntu22-go-1.20.11-${hash}`. `actions/cache@v3` restores the same content, so just restore the same cache.
![image](https://github.com/dragonflyoss/nydus/assets/59167816/810f5426-d58e-41d4-a48d-bfde4f0b0063)
![image](https://github.com/dragonflyoss/nydus/assets/59167816/d0ff5121-e9a7-4b6a-98ba-d0a2c8ce7ad1)
After changes, `nydus-integration-test` will restore the same cache.
![image](https://github.com/dragonflyoss/nydus/assets/59167816/17a1146a-4dfc-4933-8071-b172a908469f)


## Types of changes

_What types of changes does your PullRequest introduce? Put an `x` in all the boxes that apply:_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Go over all the following points, and put an `x` in all the boxes that apply._

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.