### PR TITLE
smoke: add image conversion time in benchmark 

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -318,16 +318,16 @@ jobs:
         esac
         cd benchmark-result
         metric_files=(
+          "${{ matrix.image }}-oci.json"
           "${{ matrix.image }}-fsversion-v5.json"
           "${{ matrix.image }}-fsversion-v6.json"
           "${{ matrix.image }}-zran.json"
-          "${{ matrix.image }}-oci.json"
         )
-        echo "| bench-result | e2e-time(s) | read-count | read-amount(MB) | image-size(MB) |" >> $GITHUB_STEP_SUMMARY
-        echo "|:-------------|:----------:|:----------:|:---------------:|:--------:|" >> $GITHUB_STEP_SUMMARY
+        echo "| bench-result | e2e-time(s) | read-count | read-amount(MB) | image-size(MB) |convert-time(s)|" >> $GITHUB_STEP_SUMMARY
+        echo "|:-------------|:-----------:|:----------:|:---------------:|:--------------:|:-------------:|" >> $GITHUB_STEP_SUMMARY
         for file in "${metric_files[@]}"; do
             name=$(basename "$file" .json | sed 's/^[^-]*-\(.*\)$/\1/')
-            data=$(jq -r '. | "\(.e2e_time / 1e9) \(.read_count) \(.read_amount_total / (1024 * 1024)) \(.image_size / (1024 * 1024))"' "$file" | \
-              awk '{ printf "%.2f | %.0f | %.2f | %.2f", $1, $2, $3, $4 }')
+            data=$(jq -r '. | "\(.e2e_time / 1e9) \(.read_count) \(.read_amount_total / (1024 * 1024)) \(.image_size / (1024 * 1024)) \(.conversion_elapsed / 1e9)"' "$file" | \
+              awk '{ printf "%.2f | %.0f | %.2f | %.2f | %.2f", $1, $2, $3, $4, $5 }')
             echo "| $name | $data |" >> $GITHUB_STEP_SUMMARY
         done

--- a/smoke/tests/tool/container.go
+++ b/smoke/tests/tool/container.go
@@ -20,10 +20,11 @@ import (
 )
 
 type ContainerMetrics struct {
-	E2ETime         time.Duration `json:"e2e_time"`
-	ReadCount       uint64        `json:"read_count"`
-	ReadAmountTotal uint64        `json:"read_amount_total"`
-	ImageSize       int64         `json:"image_size"`
+	E2ETime           time.Duration `json:"e2e_time"`
+	ConversionElapsed time.Duration `json:"conversion_elapsed"`
+	ReadCount         uint64        `json:"read_count"`
+	ReadAmountTotal   uint64        `json:"read_amount_total"`
+	ImageSize         int64         `json:"image_size"`
 }
 
 type RunArgs struct {


### PR DESCRIPTION
## Relevant Issue (if applicable)
#1460

## Details
Add `ConversionElapsed` in `benchmark`. `ConversionElapsed` can express the performance of nydus image conversion.


## Types of changes

_What types of changes does your PullRequest introduce? Put an `x` in all the boxes that apply:_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Go over all the following points, and put an `x` in all the boxes that apply._

- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.