### PR TITLE
tests: add go module unit coverage statistics in Codecov

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -169,7 +169,7 @@ jobs:
         CARGO_BIN=$(which cargo)
         sudo -E CARGO=${CARGO_BIN} make ut-nextest
 
-  contrib-unit-test:
+  contrib-unit-test-coverage:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
@@ -183,6 +183,12 @@ jobs:
       run: |
         curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sudo sh -s -- -b /usr/bin v1.54.2
         make -e DOCKER=false contrib-test
+    - name: Upload contrib coverage file
+      uses: actions/upload-artifact@master
+      with:
+        name: contrib-test-coverage-artifact
+        path: |
+          contrib/nydusify/coverage.txt
 
   nydus-unit-test-coverage:
     runs-on: ubuntu-latest
@@ -205,11 +211,31 @@ jobs:
           CARGO_HOME=${HOME}/.cargo
           CARGO_BIN=$(which cargo)
           sudo -E CARGO=${CARGO_BIN} make coverage-codecov
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+      - name: Upload nydus coverage file
+        uses: actions/upload-artifact@master
         with:
-          files: codecov.json
-          fail_ci_if_error: true
+          name: nydus-test-coverage-artifact
+          path: |
+            codecov.json
+
+  upload-coverage-to-codecov:
+    runs-on: ubuntu-latest
+    needs: [contrib-unit-test-coverage, nydus-unit-test-coverage]
+    steps:
+    - uses: actions/checkout@v3
+    - name: Download nydus coverage file
+      uses: actions/download-artifact@master
+      with:
+        name: nydus-test-coverage-artifact
+    - name: Download contrib coverage file
+      uses: actions/download-artifact@master
+      with:
+        name: contrib-test-coverage-artifact
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v3
+      with:
+        files: ./codecov.json,./coverage.txt
+        fail_ci_if_error: true
 
   nydus-cargo-deny:
     name: cargo-deny

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -30,9 +30,7 @@ jobs:
         cache-dependency-path: "**/*.sum"
     - name: Build Contrib
       run: |
-        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sudo sh -s -- -b /usr/bin v1.54.2
         make -e DOCKER=false nydusify-release
-        make -e DOCKER=false contrib-test
     - name: Upload Nydusify
       uses: actions/upload-artifact@master
       with:
@@ -170,6 +168,21 @@ jobs:
         CARGO_HOME=${HOME}/.cargo
         CARGO_BIN=$(which cargo)
         sudo -E CARGO=${CARGO_BIN} make ut-nextest
+
+  contrib-unit-test:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Setup Golang
+      uses: actions/setup-go@v4
+      with:
+        go-version-file: 'go.work'
+        cache-dependency-path: "**/*.sum"
+    - name: Unit Test
+      run: |
+        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sudo sh -s -- -b /usr/bin v1.54.2
+        make -e DOCKER=false contrib-test
 
   nydus-unit-test-coverage:
     runs-on: ubuntu-latest

--- a/contrib/nydusify/.gitignore
+++ b/contrib/nydusify/.gitignore
@@ -3,3 +3,4 @@ tmp
 cmd/nydusify
 output
 nydus-hook-plugin
+coverage.out

--- a/contrib/nydusify/.gitignore
+++ b/contrib/nydusify/.gitignore
@@ -3,4 +3,4 @@ tmp
 cmd/nydusify
 output
 nydus-hook-plugin
-coverage.out
+coverage.txt

--- a/contrib/nydusify/Makefile
+++ b/contrib/nydusify/Makefile
@@ -29,7 +29,7 @@ plugin:
 test: build
 	@go vet $(PACKAGES)
 	golangci-lint run
-	@go test -covermode=atomic -coverprofile=coverage.out -count=1 -v -timeout 20m -race ${PACKAGES}
+	@go test -covermode=atomic -coverprofile=coverage.txt -count=1 -v -timeout 20m -race ${PACKAGES}
 
 coverage: test
 	@go tool cover -func=coverage.out

--- a/contrib/nydusify/Makefile
+++ b/contrib/nydusify/Makefile
@@ -29,7 +29,7 @@ plugin:
 test: build
 	@go vet $(PACKAGES)
 	golangci-lint run
-	@go test -covermode=atomic -coverprofile=coverage.out -count=1 -v -timeout 20m -race ./pkg/... ./cmd/...
+	@go test -covermode=atomic -coverprofile=coverage.out -count=1 -v -timeout 20m -race ${PACKAGES}
 
 coverage: test
 	@go tool cover -func=coverage.out


### PR DESCRIPTION
## Relevant Issue (if applicable)
resolve https://github.com/dragonflyoss/nydus/issues/1518.

## Details
1. Add `contrib-unit-test-coverage` job to test the Golang modules in contrib.
2. Upload both rust and golang coverage files to Codecov.

## Types of changes

_What types of changes does your PullRequest introduce? Put an `x` in all the boxes that apply:_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Go over all the following points, and put an `x` in all the boxes that apply._

- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.