### PR TITLE
bats test: change rust docker image to Debian 11 bullseye version

### DIFF
--- a/tests/bats/common_tests.sh
+++ b/tests/bats/common_tests.sh
@@ -38,7 +38,7 @@ generate_rust_golang_dockerfile() {
   local dockerfile=${1:-"/tmp/rust_golang_dockerfile"}
   local rust_version=${2:-"${rust_toolchain}"}
   cat > $dockerfile <<EOF
-FROM rust:${rust_version}
+FROM rust:${rust_version}-bullseye
 
 RUN apt-get update -y \
     && apt-get install -y cmake g++ pkg-config jq libcurl4-openssl-dev libelf-dev libdw-dev binutils-dev libiberty-dev musl-tools \

--- a/tests/bats/common_tests.sh
+++ b/tests/bats/common_tests.sh
@@ -46,9 +46,9 @@ RUN apt-get update -y \
     && rm -rf /var/lib/apt/lists/*
 
 # install golang env
-Run wget https://go.dev/dl/go1.19.linux-amd64.tar.gz \
-    && tar -C /usr/local -xzf go1.19.linux-amd64.tar.gz \
-    && rm -rf go1.19.linux-amd64.tar.gz
+Run wget https://go.dev/dl/go1.21.5.linux-amd64.tar.gz \
+    && tar -C /usr/local -xzf go1.21.5.linux-amd64.tar.gz \
+    && rm -rf go1.21.5.linux-amd64.tar.gz
 
 ENV PATH \$PATH:/usr/local/go/bin
 RUN go env -w GO111MODULE=on


### PR DESCRIPTION
## Relevant Issue (if applicable)
```
time="2024-01-02T08:35:55.227978686+08:00" level=info msg="Start nydus-snapshotter. Version: v0.13.1-43-g47d4311, PID: 3816076, FsDriver: fscache, DaemonMode: shared"
time="2024-01-02T08:35:55.251926930+08:00" level=info msg="Trying to translate bucket records..."
time="2024-01-02T08:35:55.251964327+08:00" level=info msg="Trying to update bucket records from v1.0 to v1.1 ..."
time="2024-01-02T08:35:55.254677837+08:00" level=info msg="Run daemons monitor..."
time="2024-01-02T08:35:55.254810535+08:00" level=info msg="initializing shared nydus daemon for fscache"
time="2024-01-02T08:35:55.255910957+08:00" level=info msg="nydusd command: /usr/local/bin/nydusd singleton --fscache /var/lib/containerd/io.containerd.snapshotter.v1.nydus/cache --apisock /var/lib/containerd/io.containerd.snapshotter.v1.nydus/socket/cm9lkqq3cngfi05gk0mg/api.sock --log-level info --log-rotation-size 100"
/usr/local/bin/nydusd: /lib64/libc.so.6: version `GLIBC_2.34' not found (required by /usr/local/bin/nydusd)
/usr/local/bin/nydusd: /lib64/libc.so.6: version `GLIBC_2.33' not found (required by /usr/local/bin/nydusd)
```

## Details
The rust:1.72.1 image is based on the Debian 12 bookworm, and requires an excessively high version of glibc, resulting in the inability to find the glibc version to run the compiled nydus program on some old operating systems.

## Types of changes

_What types of changes does your PullRequest introduce? Put an `x` in all the boxes that apply:_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Go over all the following points, and put an `x` in all the boxes that apply._

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.