### PR TITLE
[WIP] Nydusd: introduce runtime streaming prefetching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -592,53 +592,53 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.21"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
+checksum = "eac8f7d7865dcb88bd4373ab671c8cf4508703796caa2b1985a9ca867b3fcb78"
 dependencies = [
  "futures-core",
 ]
 
 [[package]]
 name = "futures-core"
-version = "0.3.21"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
+checksum = "dfc6580bb841c5a68e9ef15c77ccc837b40a7504914d52e47b8b0e9bbda25a1d"
 
 [[package]]
 name = "futures-io"
-version = "0.3.21"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
+checksum = "a44623e20b9681a318efdd71c299b6b222ed6f231972bfe2f224ebad6311f0c1"
 
 [[package]]
 name = "futures-macro"
-version = "0.3.21"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33c1e13800337f4d4d7a316bf45a567dbcb6ffe087f16424852d97e97a91f512"
+checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.98",
+ "syn 2.0.37",
 ]
 
 [[package]]
 name = "futures-sink"
-version = "0.3.21"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21163e139fa306126e6eedaf49ecdb4588f939600f0b1e770f4205ee4b7fa868"
+checksum = "9fb8e00e87438d937621c1c6269e53f536c14d3fbd6a042bb24879e57d474fb5"
 
 [[package]]
 name = "futures-task"
-version = "0.3.21"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
+checksum = "38d84fa142264698cdce1a9f9172cf383a0c82de1bddcf3092901442c4097004"
 
 [[package]]
 name = "futures-util"
-version = "0.3.21"
+version = "0.3.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
+checksum = "3d6401deb83407ab3da39eba7e33987a73c3df0c82b4bb5813ee871c19c41d48"
 dependencies = [
  "futures-core",
  "futures-io",
@@ -1378,6 +1378,7 @@ dependencies = [
  "httpdate",
  "hyper",
  "hyperlocal",
+ "indexmap 1.9.1",
  "lazy_static",
  "leaky-bucket",
  "libc",

--- a/rafs/src/metadata/direct_v6.rs
+++ b/rafs/src/metadata/direct_v6.rs
@@ -847,6 +847,7 @@ impl RafsInode for OndiskInodeWrapper {
                         curr_chunk_index == tail_chunk_index,
                     )
                     .ok_or_else(|| einval!("failed to get chunk information"))?;
+                //TODO:这里应该考虑某个中间的chunk的blob_index不同的情况
                 if desc.blob.blob_index() != descs.blob_index() {
                     vec.push(descs);
                     descs = BlobIoVec::new(desc.blob.clone());

--- a/rafs/src/metadata/md_v6.rs
+++ b/rafs/src/metadata/md_v6.rs
@@ -178,7 +178,7 @@ impl RafsSuper {
         // debug!("prefetch table contents {:?}", prefetch_table);
 
         let mut hardlinks: HashSet<u64> = HashSet::new();
-        let mut fetched_ranges: HashMap<u32, HashSet<u64>> = HashMap::new();
+        let mut fetched_ranges: HashMap<u32, HashSet<u32>> = HashMap::new();
         let blob_ccis = device.get_all_blob_cci();
 
         let mut found_root_inode = false;

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -18,6 +18,7 @@ http = { version = "0.2.8", optional = true }
 httpdate = { version = "1.0", optional = true }
 hyper = { version = "0.14.11", optional = true }
 hyperlocal = { version = "0.8.0", optional = true }
+indexmap = "1"
 lazy_static = "1.4.0"
 leaky-bucket = { version = "0.12.1", optional = true }
 libc = "0.2"

--- a/storage/src/cache/cachedfile.rs
+++ b/storage/src/cache/cachedfile.rs
@@ -846,7 +846,7 @@ impl StreamChunkIter {
             chunks: Vec::new(),
             p_cur: 0,
             l_cur: 0,
-            ext_end: 0,
+            ext_end: f_offset,
             entry,
             meta,
             min_pending_size,
@@ -869,12 +869,7 @@ impl StreamChunkIter {
 
         let mut chunks_new = self
             .meta
-            .get_chunks_compressed(
-                self.f_offset + self.ext_end,
-                size_to_extend,
-                0,
-                self.prefetch,
-            )
+            .get_chunks_compressed(self.ext_end, size_to_extend, 0, self.prefetch)
             .unwrap();
 
         self.chunks.append(&mut chunks_new);

--- a/storage/src/cache/dummycache.rs
+++ b/storage/src/cache/dummycache.rs
@@ -31,7 +31,7 @@ use crate::backend::{BlobBackend, BlobReader};
 use crate::cache::state::{ChunkMap, NoopChunkMap};
 use crate::cache::{BlobCache, BlobCacheMgr};
 use crate::device::{
-    BlobChunkInfo, BlobFeatures, BlobInfo, BlobIoDesc, BlobIoVec, BlobPrefetchRequest,
+    BlobChunkInfo, BlobFeatures, BlobInfo, BlobIoDesc, BlobIoVec, BlobPrefetchRequest, BlobRange,
 };
 use crate::utils::{alloc_buf, copyv};
 use crate::{StorageError, StorageResult};
@@ -104,6 +104,8 @@ impl BlobCache for DummyCache {
         Ok(())
     }
 
+    fn init_stream_prefetch(&self, _blobs: Vec<Arc<dyn BlobCache>>) {}
+
     fn stop_prefetch(&self) -> StorageResult<()> {
         Ok(())
     }
@@ -119,6 +121,14 @@ impl BlobCache for DummyCache {
         _bios: &[BlobIoDesc],
     ) -> StorageResult<usize> {
         Err(StorageError::Unsupported)
+    }
+
+    fn add_stream_prefetch_range(&self, _range: BlobRange) -> Result<()> {
+        unimplemented!()
+    }
+
+    fn flush_stream_prefetch(&self) -> Result<()> {
+        unimplemented!()
     }
 
     fn read(&self, iovec: &mut BlobIoVec, bufs: &[FileVolatileSlice]) -> Result<usize> {
@@ -163,6 +173,15 @@ impl BlobCache for DummyCache {
         )
         .map(|(n, _)| n)
         .map_err(|e| eother!(e))
+    }
+
+    fn fetch_range_compressed_stream(
+        self: Arc<Self>,
+        _offset: u64,
+        _size: u64,
+        _prefetch: bool,
+    ) -> std::io::Result<()> {
+        unimplemented!();
     }
 }
 

--- a/storage/src/cache/state/mod.rs
+++ b/storage/src/cache/state/mod.rs
@@ -74,7 +74,7 @@ pub trait ChunkMap: Any + Send + Sync {
     ///
     /// The function returns:
     /// - `Err(Timeout)` waiting for inflight backend IO timeouts.
-    /// - `Ok(true)` if the the chunk is ready.
+    /// - `Ok(true)` if the chunk is ready.
     /// - `Ok(false)` marks the chunk as pending, either set_ready_and_clear_pending() or
     ///   clear_pending() must be called to clear the pending state.
     fn check_ready_and_mark_pending(&self, _chunk: &dyn BlobChunkInfo) -> StorageResult<bool> {
@@ -83,7 +83,16 @@ pub trait ChunkMap: Any + Send + Sync {
 
     /// Set the chunk to ready for use and clear the pending state.
     fn set_ready_and_clear_pending(&self, _chunk: &dyn BlobChunkInfo) -> Result<()> {
-        panic!("no support of check_ready_and_mark_pending()");
+        panic!("no support of set_ready_and_clear_pending()");
+    }
+
+    /// Try to mark the chunk to pending if the chunk is not ready or pending yet.
+    ///
+    /// The function returns:
+    /// - `Ok(true)` if the chunk is successfully turned into pending.
+    /// - `Ok(false)` if the chunk is pending or ready already.
+    fn try_mark_pending(&self, _chunk: &dyn BlobChunkInfo) -> StorageResult<bool> {
+        panic!("no support of try_mark_pending()");
     }
 
     /// Clear the pending state of the chunk.

--- a/storage/src/cache/streaming.rs
+++ b/storage/src/cache/streaming.rs
@@ -1,8 +1,8 @@
 use crate::cache::BlobCache;
 use crate::device::BlobRange;
-use indexmap::IndexMap;
 use nydus_utils::async_helper::with_runtime;
 use nydus_utils::mpmc::Channel;
+use std::collections::BTreeMap;
 use std::io::Result;
 use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::{Arc, Mutex};
@@ -33,12 +33,17 @@ static MIN_TASK_SIZE: u64 = 0x100000;
 // 最小任务阈值: 512KB
 static MIN_SUBMITTALBE_TASK_SIZE: u64 = 0x80000;
 
+// 最大合并阈值：512KB
+// 两个不连续的任务，如果中间间隔小于MAX_MERGE_GAP，那么可以合并
+static MAX_MERGE_GAP: u64 = 0x80000;
+
 struct PrefetchBuffer {
     // 用于计算预取任务的
-    // 最后更新的任务（大概率是最新的任务）的start_offset
+    // 最后更新的任务（大概率是最新的任务）的end_offset
+    // 允许指向0或者已经被remove的任务
     last_modified: u64,
     // 正在等待用于计算的任务队列
-    buf: IndexMap<u64, BlobRange>,
+    buf: BTreeMap<u64, BlobRange>,
     // 目前为止总共计算了多少预取数据
     total_processed: u64,
     blobs: Vec<Arc<dyn BlobCache>>,
@@ -62,7 +67,7 @@ impl StreamPrefetchMgr {
             active: AtomicBool::new(false),
             waiting: Mutex::new(PrefetchBuffer {
                 last_modified: 0,
-                buf: IndexMap::new(),
+                buf: BTreeMap::new(),
                 total_processed: 0,
                 blobs: Vec::new(),
             }),
@@ -83,74 +88,77 @@ impl StreamPrefetchMgr {
         waiting.blobs = blobs;
     }
 
-    // 要求append是合法的，这里不检查合法性
-    fn extend_range(
-        &self,
-        start_processed: u64,
-        r_new: BlobRange,
-        waiting: &mut PrefetchBuffer,
-    ) -> Result<()> {
-        let r = waiting.buf.get_mut(&start_processed).unwrap();
-        let r_new_size = r_new.end - r_new.offset;
-        // TODO:判断数据债是否超过阈值
-        // 全局已处理的数据量-任务发起前全局已处理的数据量 > 任务目前的长度 + MAX_DEPT
-        // 而且，任务不能太小
-        if waiting.total_processed - start_processed > r.end - r.offset + MAX_DEBT
-            && r.end - r.offset < MIN_SUBMITTALBE_TASK_SIZE
-        {
-            // 数据债是否超过阈值，所以要提交该任务
-            if let Some(r) = waiting.buf.remove(&start_processed) {
-                // 将该任务弹出并加入到任务队列
-                self.send_msg(r, &waiting.blobs)?;
-                // 将新任务添加到末尾
-                waiting.buf.insert(waiting.total_processed, r_new);
-                waiting.last_modified = waiting.total_processed;
-            } else {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    "append_range: waiting_queue remove failed",
-                ));
+    // 尝试将需要提交的range提交
+    fn submit_ranges(&self, waiting: &mut PrefetchBuffer) -> Result<()> {
+        // 从后往前遍历，找到第一个不超过阈值的任务
+        let mut not_exceeded_offset = u64::MAX;
+        for end_offset in waiting.buf.keys() {
+            if waiting.total_processed - end_offset < MAX_DEBT {
+                not_exceeded_offset = *end_offset;
+                break;
             }
-        } else {
-            // 数据债未超阈值，
-            r.end = r_new.end;
         }
 
-        // 为两种情况均更新current_offset
-        waiting.total_processed += r_new_size;
+        // 弹出需要被提交的任务
+        let to_keep = waiting.buf.split_off(&not_exceeded_offset);
+        let to_submit = std::mem::take(&mut waiting.buf);
+        waiting.buf = to_keep;
+
+        // 提交任务
+        for (end_offset, r) in to_submit {
+            // 将太小的任务放回
+            if r.end - r.offset < MIN_SUBMITTALBE_TASK_SIZE {
+                waiting.buf.insert(end_offset, r);
+            } else {
+                self.send_msg(&r, &waiting.blobs)?;
+            }
+        }
         Ok(())
     }
 
     pub fn add_prefetch_range(&self, r_new: BlobRange) -> Result<()> {
         let mut waiting = self.waiting.lock().unwrap();
 
-        // 这里处理了self.last_modified初始值问题，if==false
-        if let Some(r_recent) = waiting.buf.get(&waiting.last_modified) {
-            // TODO:完善这里对于is_countinous的判断
-            if r_recent.blob_idx == r_new.blob_idx && r_recent.end == r_new.offset {
-                self.extend_range(waiting.last_modified, r_new, &mut waiting)?;
-                return Ok(());
+        //1. 尝试merge到现有任务中
+        // 先判断last_modified，允许last_modified指向不存在的key
+        let mut merged = false;
+
+        let last_modified = waiting.buf.get_key_value(&waiting.last_modified);
+        for (end_offset, r_old) in last_modified.into_iter().chain(waiting.buf.iter()) {
+            if let Some((added_size, r_merged)) = r_old.try_merge(&r_new, MAX_MERGE_GAP) {
+                merged = true;
+
+                // remove old and add merged
+                let end_offset = *end_offset;
+                waiting.buf.remove(&end_offset);
+                // 在原先的end_processed基础上增加
+                let new_end_offset = end_offset + added_size;
+                waiting.buf.insert(new_end_offset, r_merged);
+                waiting.last_modified = new_end_offset;
+                waiting.total_processed += added_size;
+
+                break;
             }
         }
-        //针对非连续的任务，需要判断任务列表了
-        //1. 尝试extend到现有任务中
-        for (start_offset, r) in waiting.buf.iter() {
-            if r.blob_idx == r_new.blob_idx && r.end == r_new.offset {
-                self.extend_range(*start_offset, r_new, &mut waiting)?;
-                return Ok(());
-            }
-        }
+
+        // 3. 检查旧任务是否需要提交
+        self.submit_ranges(&mut waiting)?;
+
         // 2.append为新任务
-        let r_new_size = r_new.end - r_new.offset;
-        let p = waiting.total_processed;
-        waiting.buf.insert(p, r_new);
-        waiting.last_modified = waiting.total_processed;
-        waiting.total_processed += r_new_size;
+        if !merged {
+            let r_new_size = r_new.end - r_new.offset;
+            waiting.total_processed += r_new_size;
+            waiting.last_modified = waiting.total_processed;
+
+            let p = waiting.total_processed;
+            waiting.buf.insert(p, r_new);
+        }
+
         Ok(())
     }
 
     #[inline]
-    fn send_msg(&self, r: BlobRange, blobs: &[Arc<dyn BlobCache>]) -> Result<()> {
+    fn send_msg(&self, r: &BlobRange, blobs: &[Arc<dyn BlobCache>]) -> Result<()> {
         let msg = StreamingPrefetchMessage::new_blob_prefetch(
             blobs[r.blob_idx as usize].clone(),
             r.offset,
@@ -171,13 +179,15 @@ impl StreamPrefetchMgr {
         })
     }
 
+    // 清空等待队列，提交全部任务
     pub fn flush_waiting_queue(&self) -> Result<()> {
         let mut waiting = self.waiting.lock().unwrap();
         let mut buf = std::mem::take(&mut waiting.buf);
 
-        for (_, r) in buf.drain(..) {
+        for r in buf.values() {
             self.send_msg(r, &waiting.blobs)?;
         }
+        buf.clear();
 
         Ok(())
     }

--- a/storage/src/cache/streaming.rs
+++ b/storage/src/cache/streaming.rs
@@ -1,0 +1,272 @@
+use crate::cache::BlobCache;
+use crate::device::BlobRange;
+use indexmap::IndexMap;
+use nydus_utils::async_helper::with_runtime;
+use nydus_utils::mpmc::Channel;
+use std::io::Result;
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread;
+use tokio::runtime::Runtime;
+
+use super::worker::AsyncPrefetchConfig;
+
+/// Asynchronous service request message.
+pub enum StreamingPrefetchMessage {
+    /// Asynchronous blob layer prefetch request with (offset, size) of blob on storage backend.
+    BlobPrefetch(Arc<dyn BlobCache>, u64, u64),
+}
+
+impl StreamingPrefetchMessage {
+    /// Create a new asynchronous blob prefetch request message.
+    pub fn new_blob_prefetch(blob_cache: Arc<dyn BlobCache>, offset: u64, size: u64) -> Self {
+        StreamingPrefetchMessage::BlobPrefetch(blob_cache, offset, size)
+    }
+}
+
+// 最大负债4MB
+static MAX_DEBT: u64 = 0x400000;
+// 小任务判断标准：<1MB
+#[allow(unused)]
+static MIN_TASK_SIZE: u64 = 0x100000;
+
+// 最小任务阈值: 512KB
+static MIN_SUBMITTALBE_TASK_SIZE: u64 = 0x80000;
+
+struct PrefetchBuffer {
+    // 用于计算预取任务的
+    // 最后更新的任务（大概率是最新的任务）的start_offset
+    last_modified: u64,
+    // 正在等待用于计算的任务队列
+    buf: IndexMap<u64, BlobRange>,
+    // 目前为止总共计算了多少预取数据
+    total_processed: u64,
+    blobs: Vec<Arc<dyn BlobCache>>,
+}
+pub(crate) struct StreamPrefetchMgr {
+    workers: AtomicU32,
+    threads_count: u32,
+    active: AtomicBool,
+    waiting: Mutex<PrefetchBuffer>,
+    // 保存任务的队列
+    new_channel: Arc<Channel<StreamingPrefetchMessage>>,
+    // 保存小任务的队列
+    new_channel_small: Arc<Channel<StreamingPrefetchMessage>>,
+}
+
+impl StreamPrefetchMgr {
+    pub fn new(prefetch_config: Arc<AsyncPrefetchConfig>) -> Self {
+        Self {
+            threads_count: prefetch_config.threads_count as u32,
+            workers: AtomicU32::new(0),
+            active: AtomicBool::new(false),
+            waiting: Mutex::new(PrefetchBuffer {
+                last_modified: 0,
+                buf: IndexMap::new(),
+                total_processed: 0,
+                blobs: Vec::new(),
+            }),
+            new_channel: Arc::new(Channel::new()),
+            new_channel_small: Arc::new(Channel::new()),
+        }
+    }
+
+    /// Create working threads and start the event loop.
+    pub fn start(mgr: Arc<Self>) -> Result<()> {
+        Self::start_prefetch_workers(mgr)?;
+
+        Ok(())
+    }
+
+    pub fn init_blobs(&self, blobs: Vec<Arc<dyn BlobCache>>) {
+        let mut waiting = self.waiting.lock().unwrap();
+        waiting.blobs = blobs;
+    }
+
+    // 要求append是合法的，这里不检查合法性
+    fn extend_range(
+        &self,
+        start_processed: u64,
+        r_new: BlobRange,
+        waiting: &mut PrefetchBuffer,
+    ) -> Result<()> {
+        let r = waiting.buf.get_mut(&start_processed).unwrap();
+        let r_new_size = r_new.end - r_new.offset;
+        // TODO:判断数据债是否超过阈值
+        // 全局已处理的数据量-任务发起前全局已处理的数据量 > 任务目前的长度 + MAX_DEPT
+        // 而且，任务不能太小
+        if waiting.total_processed - start_processed > r.end - r.offset + MAX_DEBT
+            && r.end - r.offset < MIN_SUBMITTALBE_TASK_SIZE
+        {
+            // 数据债是否超过阈值，所以要提交该任务
+            if let Some(r) = waiting.buf.remove(&start_processed) {
+                // 将该任务弹出并加入到任务队列
+                self.send_msg(r, &waiting.blobs)?;
+                // 将新任务添加到末尾
+                waiting.buf.insert(waiting.total_processed, r_new);
+                waiting.last_modified = waiting.total_processed;
+            } else {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    "append_range: waiting_queue remove failed",
+                ));
+            }
+        } else {
+            // 数据债未超阈值，
+            r.end = r_new.end;
+        }
+
+        // 为两种情况均更新current_offset
+        waiting.total_processed += r_new_size;
+        Ok(())
+    }
+
+    pub fn add_prefetch_range(&self, r_new: BlobRange) -> Result<()> {
+        let mut waiting = self.waiting.lock().unwrap();
+
+        // 这里处理了self.last_modified初始值问题，if==false
+        if let Some(r_recent) = waiting.buf.get(&waiting.last_modified) {
+            // TODO:完善这里对于is_countinous的判断
+            if r_recent.blob_idx == r_new.blob_idx && r_recent.end == r_new.offset {
+                self.extend_range(waiting.last_modified, r_new, &mut waiting)?;
+                return Ok(());
+            }
+        }
+        //针对非连续的任务，需要判断任务列表了
+        //1. 尝试extend到现有任务中
+        for (start_offset, r) in waiting.buf.iter() {
+            if r.blob_idx == r_new.blob_idx && r.end == r_new.offset {
+                self.extend_range(*start_offset, r_new, &mut waiting)?;
+                return Ok(());
+            }
+        }
+        // 2.append为新任务
+        let r_new_size = r_new.end - r_new.offset;
+        let p = waiting.total_processed;
+        waiting.buf.insert(p, r_new);
+        waiting.last_modified = waiting.total_processed;
+        waiting.total_processed += r_new_size;
+        Ok(())
+    }
+
+    #[inline]
+    fn send_msg(&self, r: BlobRange, blobs: &[Arc<dyn BlobCache>]) -> Result<()> {
+        let msg = StreamingPrefetchMessage::new_blob_prefetch(
+            blobs[r.blob_idx as usize].clone(),
+            r.offset,
+            r.end - r.offset,
+        );
+        let channel = if r.end - r.offset < MIN_TASK_SIZE {
+            &self.new_channel_small
+        } else {
+            &self.new_channel
+        };
+        debug!(
+            "CMDebug: send_msg, offset: {}, size: {}",
+            r.offset,
+            r.end - r.offset
+        );
+        channel.send(msg).map_err(|_| {
+            std::io::Error::new(std::io::ErrorKind::Other, "Send prefetch message failed")
+        })
+    }
+
+    pub fn flush_waiting_queue(&self) -> Result<()> {
+        let mut waiting = self.waiting.lock().unwrap();
+        let mut buf = std::mem::take(&mut waiting.buf);
+
+        for (_, r) in buf.drain(..) {
+            self.send_msg(r, &waiting.blobs)?;
+        }
+
+        Ok(())
+    }
+
+    fn start_prefetch_workers(mgr: Arc<Self>) -> Result<()> {
+        for num in 0..mgr.threads_count + 1 {
+            let mgr2 = mgr.clone();
+            let res = thread::Builder::new()
+                .name(format!("nydus_storage_worker_{}", num))
+                .spawn(move || {
+                    mgr2.grow_n(1);
+                    debug!("CMDebug: start_prefetch_workers, {}", num);
+
+                    with_runtime(|rt| {
+                        if num == 0 {
+                            rt.block_on(Self::handle_prefetch_requests_small(mgr2.clone(), rt));
+                        } else {
+                            rt.block_on(Self::handle_prefetch_requests(mgr2.clone(), rt));
+                        }
+                    });
+
+                    mgr2.shrink_n(1);
+                    info!("storage: worker thread {} exits.", num)
+                });
+
+            if let Err(e) = res {
+                error!("storage: failed to create worker thread, {:?}", e);
+                return Err(e);
+            }
+        }
+        mgr.active.store(true, Ordering::Release);
+        Ok(())
+    }
+
+    async fn handle_prefetch_requests(mgr: Arc<Self>, rt: &Runtime) {
+        loop {
+            let msg;
+            tokio::select! {
+                Ok(m) = mgr.new_channel.recv() => msg = m,
+                Ok(m) = mgr.new_channel_small.recv() => msg = m,
+                else => break,
+            }
+            match msg {
+                StreamingPrefetchMessage::BlobPrefetch(blob_cache, offset, size) => {
+                    rt.spawn_blocking(move || {
+                        let _ = Self::handle_blob_prefetch_request(blob_cache, offset, size);
+                    });
+                }
+            }
+        }
+    }
+
+    // 专门处理小blob
+    async fn handle_prefetch_requests_small(mgr: Arc<Self>, rt: &Runtime) {
+        while let Ok(msg) = mgr.new_channel_small.recv().await {
+            match msg {
+                StreamingPrefetchMessage::BlobPrefetch(blob_cache, offset, size) => {
+                    rt.spawn_blocking(move || {
+                        let _ = Self::handle_blob_prefetch_request(blob_cache, offset, size);
+                    });
+                }
+            }
+        }
+    }
+
+    fn handle_blob_prefetch_request(
+        cache: Arc<dyn BlobCache>,
+        offset: u64,
+        size: u64,
+    ) -> Result<()> {
+        debug!(
+            "CMDebug: storage: prefetch blob {} offset {} size {}",
+            cache.blob_id(),
+            offset,
+            size
+        );
+        if size == 0 {
+            return Ok(());
+        }
+
+        cache.fetch_range_compressed_stream(offset, size, true)?;
+
+        Ok(())
+    }
+
+    fn shrink_n(&self, n: u32) {
+        self.workers.fetch_sub(n, Ordering::Relaxed);
+    }
+    fn grow_n(&self, n: u32) {
+        self.workers.fetch_add(n, Ordering::Relaxed);
+    }
+}

--- a/storage/src/meta/chunk_info_v1.rs
+++ b/storage/src/meta/chunk_info_v1.rs
@@ -54,6 +54,10 @@ impl BlobMetaChunkInfo for BlobChunkInfoV1Ondisk {
         self.comp_info = u64::to_le(size_low | size_high | offset);
     }
 
+    fn compressed_size_batch(&self, _state: &BlobCompressionContext) -> u32 {
+        self.compressed_size()
+    }
+
     fn uncompressed_offset(&self) -> u64 {
         u64::from_le(self.uncomp_info) & BLOB_CC_V1_CHUNK_UNCOMP_OFFSET_MASK
     }

--- a/storage/src/meta/chunk_info_v2.rs
+++ b/storage/src/meta/chunk_info_v2.rs
@@ -129,6 +129,15 @@ impl BlobMetaChunkInfo for BlobChunkInfoV2Ondisk {
         self.comp_info |= u64::to_le(size << CHUNK_V2_COMP_SIZE_SHIFT);
     }
 
+    fn compressed_size_batch(&self, meta: &BlobCompressionContext) -> u32 {
+        if self.is_batch() {
+            let batch_idx = self.get_batch_index().unwrap() as usize;
+            meta.get_batch_context(batch_idx).unwrap().compressed_size()
+        } else {
+            self.compressed_size()
+        }
+    }
+
     fn uncompressed_offset(&self) -> u64 {
         (u64::from_le(self.uncomp_info) & CHUNK_V2_UNCOMP_OFFSET_MASK)
             << CHUNK_V2_UNCOMP_OFFSET_SHIFT


### PR DESCRIPTION
## Relevant Issue (if applicable)
_If there are Issues related to this PullRequest, please list it._

## Details
Streaming prefetching allows to prefetch a blob by a single prefetching request, where the request is streaming processed the partially fetched data is processed immediately.

As a result, the number of requests for starting a Wordpress container can be reduced from~115 requests to ~36 requests.

It requires build-time prefetching to pre-organize the chunks.

Still working in progress.

## Types of changes

_What types of changes does your PullRequest introduce? Put an `x` in all the boxes that apply:_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Go over all the following points, and put an `x` in all the boxes that apply._

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.