### PR TITLE
fix: upload-artifact@v4 breake in release and RUSTSEC-2024-0003

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,7 +140,7 @@ jobs:
     - name: store-artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: nydus-release-tarball
+        name: nydus-release-tarball-${{ matrix.os }}-${{ matrix.arch }}
         path: |
           ${{ env.tarball }}
           ${{ env.tarball_shasum }}
@@ -173,7 +173,7 @@ jobs:
     - name: store-artifacts
       uses: actions/upload-artifact@v4
       with:
-        name: nydus-release-tarball
+        name: nydus-release-tarball-${{ matrix.os }}-${{ matrix.arch }}
         path: |
           ${{ env.tarball }}
           ${{ env.tarball_shasum }}
@@ -185,7 +185,8 @@ jobs:
     - name: download artifacts
       uses: actions/download-artifact@v4
       with:
-        name: nydus-release-tarball
+        pattern: nydus-release-tarball-*
+        merge-multiple: true
         path: nydus-tarball
     - name: prepare release env
       run: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -448,6 +448,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
 name = "errno"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -691,9 +697,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.18"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17f8a914c2987b688368b5138aa05321db91f4090cf26118185672ad588bce21"
+checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
 dependencies = [
  "bytes",
  "fnv",
@@ -701,7 +707,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap",
+ "indexmap 2.0.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -890,6 +896,16 @@ checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad227c3af19d4914570ad36d30409928b75967c298feb9ea1969db3a610bb14e"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.0",
 ]
 
 [[package]]
@@ -1223,7 +1239,7 @@ dependencies = [
  "anyhow",
  "base64",
  "hex",
- "indexmap",
+ "indexmap 1.9.1",
  "libc",
  "log",
  "nix",


### PR DESCRIPTION
## Relevant Issue (if applicable)
https://github.com/dragonflyoss/nydus/actions/runs/7562390653
```
Error:
Failed to CreateArtifact: Received non-retryable error: Failed request: (409) Conflict: an artifact with this name already exists on the workflow run
```
https://github.com/dragonflyoss/nydus/actions/runs/7564593915/job/20599129930
```
 /github/workspace/Cargo.lock:74:1
   │
74 │ h2 0.3.18 registry+https://github.com/rust-lang/crates.io-index
   │ --------------------------------------------------------------- security vulnerability detected
   │
   = ID: RUSTSEC-2024-0003
   = Advisory: https://rustsec.org/advisories/RUSTSEC-2024-0003
   = An attacker with an HTTP/2 connection to an affected endpoint can send a steady stream of invalid frames to force the
     generation of reset frames on the victim endpoint.
     By closing their recv window, the attacker could then force these resets to be queued in an unbounded fashion,
     resulting in Out Of Memory (OOM) and high CPU usage.
```
## Details
1. fix error in release upload action https://github.com/actions/upload-artifact/issues/478#issuecomment-1885470013
2. fix RUSTSEC-2024-0003  https://github.com/hyperium/h2/pull/737
## Types of changes

_What types of changes does your PullRequest introduce? Put an `x` in all the boxes that apply:_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Go over all the following points, and put an `x` in all the boxes that apply._

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.