### PR TITLE
overlay: add overlay implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -448,6 +448,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "endian-type"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34f04666d835ff5d62e058c3995147c06f42fe86ff053337632bca83e42702d"
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -568,9 +574,9 @@ dependencies = [
 
 [[package]]
 name = "fuse-backend-rs"
-version = "0.11.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e5a63a89f40ec26a0a1434e89de3f4ee939a920eae15d641053ee09ee6ed44b"
+checksum = "e1663480cae165243a6c7f75abecfb868c16d17346afc74faf61a2febcadd11b"
 dependencies = [
  "arc-swap",
  "bitflags 1.3.2",
@@ -582,6 +588,7 @@ dependencies = [
  "log",
  "mio",
  "nix",
+ "radix_trie",
  "versionize",
  "versionize_derive",
  "vhost",
@@ -1154,6 +1161,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "nibble_vec"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
 name = "nix"
 version = "0.24.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1656,6 +1672,16 @@ dependencies = [
  "r2d2",
  "rusqlite",
  "uuid",
+]
+
+[[package]]
+name = "radix_trie"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c069c179fcdc6a2fe24d8d18305cf085fdbd4f922c041943e203685d6a1c58fd"
+dependencies = [
+ "endian-type",
+ "nibble_vec",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ path = "src/lib.rs"
 anyhow = "1"
 clap = { version = "4.0.18", features = ["derive", "cargo"] }
 flexi_logger = { version = "0.25", features = ["compress"] }
-fuse-backend-rs = "^0.11.0"
+fuse-backend-rs = "^0.12.0"
 hex = "0.4.3"
 hyper = "0.14.11"
 hyperlocal = "0.8.0"

--- a/api/src/config.rs
+++ b/api/src/config.rs
@@ -29,6 +29,8 @@ pub struct ConfigV2 {
     pub cache: Option<CacheConfigV2>,
     /// Configuration information for RAFS filesystem.
     pub rafs: Option<RafsConfigV2>,
+    /// Overlay configuration information for the instance.
+    pub overlay: Option<OverlayConfig>,
     /// Internal runtime configuration.
     #[serde(skip)]
     pub internal: ConfigV2Internal,
@@ -42,6 +44,7 @@ impl Default for ConfigV2 {
             backend: None,
             cache: None,
             rafs: None,
+            overlay: None,
             internal: ConfigV2Internal::default(),
         }
     }
@@ -56,6 +59,7 @@ impl ConfigV2 {
             backend: None,
             cache: None,
             rafs: None,
+            overlay: None,
             internal: ConfigV2Internal::default(),
         }
     }
@@ -1024,6 +1028,7 @@ impl From<&BlobCacheEntryConfigV2> for ConfigV2 {
             backend: Some(c.backend.clone()),
             cache: Some(c.cache.clone()),
             rafs: None,
+            overlay: None,
             internal: ConfigV2Internal::default(),
         }
     }
@@ -1395,6 +1400,7 @@ impl TryFrom<RafsConfig> for ConfigV2 {
             backend: Some(backend),
             cache: Some(cache),
             rafs: Some(rafs),
+            overlay: None,
             internal: ConfigV2Internal::default(),
         })
     }
@@ -1521,6 +1527,15 @@ impl TryFrom<&BlobCacheEntryConfig> for BlobCacheEntryConfigV2 {
             metadata_path: v.metadata_path.clone(),
         })
     }
+}
+
+/// Configuration information for Overlay filesystem.
+/// OverlayConfig is used to configure the writable layer(upper layer),
+/// The filesystem will be writable when OverlayConfig is set.
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+pub struct OverlayConfig {
+    pub upper_dir: String,
+    pub work_dir: String,
 }
 
 #[cfg(test)]

--- a/builder/src/core/context.rs
+++ b/builder/src/core/context.rs
@@ -1516,6 +1516,7 @@ mod tests {
             id: "id".to_owned(),
             cache: None,
             rafs: None,
+            overlay: None,
             internal: ConfigV2Internal {
                 blob_accessible: Arc::new(AtomicBool::new(true)),
             },

--- a/clib/Cargo.toml
+++ b/clib/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "staticlib"]
 [dependencies]
 libc = "0.2.137"
 log = "0.4.17"
-fuse-backend-rs = "^0.11.0"
+fuse-backend-rs = "^0.12.0"
 nydus-api = { version = "0.3", path = "../api" }
 nydus-rafs = { version = "0.3.1", path = "../rafs" }
 nydus-storage = { version = "0.6.3", path = "../storage" }

--- a/docs/nydus-overlayfs.md
+++ b/docs/nydus-overlayfs.md
@@ -39,3 +39,4 @@ mount -t overlay overlay ./foo/merged -o lowerdir=./foo/lower2:./foo/lower1,uppe
 Meanwhile, when containerd passes the `nydus-snapshotter` mount slice to `containerd-shim-kata-v2`, it can parse the mount slice and pass the `extraoption` to `nydusd`, to support nydus image format natively.
 
 So in summary, `containerd` and `containerd-shim-runc-v2` rely on the `nydus-overlay` mount helper to handle the mount slice returned by `nydus-snapshotter`, while `containerd-shim-kata-v2` can parse and handle it on its own.
+

--- a/rafs/Cargo.toml
+++ b/rafs/Cargo.toml
@@ -19,7 +19,7 @@ nix = "0.24"
 serde = { version = "1.0.110", features = ["serde_derive", "rc"] }
 serde_json = "1.0.53"
 vm-memory = "0.10"
-fuse-backend-rs = "^0.11.0"
+fuse-backend-rs = "^0.12.0"
 thiserror = "1"
 
 nydus-api = { version = "0.3", path = "../api" }

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 [dependencies]
 bytes = { version = "1", optional = true }
 dbs-allocator = { version = "0.1.1", optional = true }
-fuse-backend-rs = { version = "^0.11.0", features = ["persist"] }
+fuse-backend-rs = { version = "^0.12.0", features = ["persist"] }
 libc = "0.2"
 log = "0.4.8"
 mio = { version = "0.8", features = ["os-poll", "os-ext"] }

--- a/smoke/tests/overlay_fs_test.go
+++ b/smoke/tests/overlay_fs_test.go
@@ -1,0 +1,110 @@
+// Copyright 2023 Nydus Developers. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package tests
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/containerd/log"
+	"github.com/containerd/nydus-snapshotter/pkg/converter"
+	"github.com/dragonflyoss/nydus/smoke/tests/texture"
+	"github.com/dragonflyoss/nydus/smoke/tests/tool"
+	"github.com/dragonflyoss/nydus/smoke/tests/tool/test"
+	"github.com/opencontainers/go-digest"
+	"github.com/stretchr/testify/require"
+)
+
+type OverlayFsTestSuite struct {
+	t *testing.T
+}
+
+func (ts *OverlayFsTestSuite) prepareTestEnv(t *testing.T) *tool.Context {
+	ctx := tool.DefaultContext(t)
+	ctx.PrepareWorkDir(t)
+
+	packOption := converter.PackOption{
+		BuilderPath: ctx.Binary.Builder,
+		Compressor:  ctx.Build.Compressor,
+		FsVersion:   ctx.Build.FSVersion,
+		ChunkSize:   ctx.Build.ChunkSize,
+	}
+
+	lowerLayer := texture.MakeLowerLayer(t, filepath.Join(ctx.Env.WorkDir, "lower"))
+	lowerBlobDigest := lowerLayer.Pack(t, packOption, ctx.Env.BlobDir)
+	mergeOption := converter.MergeOption{
+		BuilderPath:   ctx.Binary.Builder,
+		ChunkDictPath: "",
+		OCIRef:        true,
+	}
+	actualDigests, lowerBootstrap := tool.MergeLayers(t, *ctx, mergeOption, []converter.Layer{
+		{
+			Digest: lowerBlobDigest,
+		},
+	})
+	require.Equal(t, []digest.Digest{lowerBlobDigest}, actualDigests)
+
+	// Verify lower layer mounted by nydusd
+	ctx.Env.BootstrapPath = lowerBootstrap
+	tool.Verify(t, *ctx, lowerLayer.FileTree)
+	return ctx
+}
+
+func (ts *OverlayFsTestSuite) TestSimpleOverlayFs(t *testing.T) {
+	ctx := ts.prepareTestEnv(t)
+	fmt.Printf("Workdir is %v\n", ctx.Env.WorkDir)
+	defer ctx.Destroy(t)
+
+	nydusd, err := tool.NewNydusdWithOverlay(tool.NydusdConfig{
+		NydusdPath:      ctx.Binary.Nydusd,
+		BootstrapPath:   ctx.Env.BootstrapPath,
+		ConfigPath:      filepath.Join(ctx.Env.WorkDir, "nydusd-config.fusedev.json"),
+		MountPath:       ctx.Env.MountDir,
+		APISockPath:     filepath.Join(ctx.Env.WorkDir, "nydusd-api.sock"),
+		BackendType:     "localfs",
+		BackendConfig:   fmt.Sprintf(`{"dir": "%s"}`, ctx.Env.BlobDir),
+		EnablePrefetch:  ctx.Runtime.EnablePrefetch,
+		BlobCacheDir:    ctx.Env.CacheDir,
+		CacheType:       ctx.Runtime.CacheType,
+		CacheCompressed: ctx.Runtime.CacheCompressed,
+		RafsMode:        ctx.Runtime.RafsMode,
+		OvlUpperDir:     ctx.Env.OvlUpperDir,
+		OvlWorkDir:      ctx.Env.OvlWorkDir,
+		DigestValidate:  false,
+		Writable:        true,
+	})
+	require.NoError(t, err)
+
+	err = nydusd.Mount()
+	require.NoError(t, err)
+	defer func() {
+		if err := nydusd.Umount(); err != nil {
+			log.L.WithError(err).Errorf("umount")
+		}
+	}()
+
+	// Write some file under mounted dir.
+	mountedDir := ctx.Env.MountDir
+	file := filepath.Join(mountedDir, "test.txt")
+	err = os.WriteFile(file, []byte("hello world"), 0644)
+	require.NoError(t, err)
+
+	// Read it back
+	data, err := os.ReadFile(file)
+	require.NoError(t, err)
+	require.Equal(t, "hello world", string(data))
+
+	// Try to read from upper dir.
+	upperFile := filepath.Join(ctx.Env.OvlUpperDir, "test.txt")
+	data, err = os.ReadFile(upperFile)
+	require.NoError(t, err)
+	require.Equal(t, "hello world", string(data))
+}
+
+func TestOverlayFs(t *testing.T) {
+	test.Run(t, &OverlayFsTestSuite{t: t})
+}

--- a/smoke/tests/tool/context.go
+++ b/smoke/tests/tool/context.go
@@ -47,6 +47,8 @@ type EnvContext struct {
 	CacheDir      string
 	MountDir      string
 	BootstrapPath string
+	OvlUpperDir   string
+	OvlWorkDir    string
 }
 
 type Context struct {
@@ -98,11 +100,21 @@ func (ctx *Context) PrepareWorkDir(t *testing.T) {
 	err = os.MkdirAll(mountDir, 0755)
 	require.NoError(t, err)
 
+	// For overlay fs
+	ovlUpperDir := filepath.Join(workDir, "upper")
+	err = os.MkdirAll(ovlUpperDir, 0755)
+	require.NoError(t, err)
+	ovlWorkDir := filepath.Join(workDir, "work")
+	err = os.MkdirAll(ovlWorkDir, 0755)
+	require.NoError(t, err)
+
 	ctx.Env = EnvContext{
-		WorkDir:  workDir,
-		BlobDir:  blobDir,
-		CacheDir: cacheDir,
-		MountDir: mountDir,
+		WorkDir:     workDir,
+		BlobDir:     blobDir,
+		CacheDir:    cacheDir,
+		MountDir:    mountDir,
+		OvlUpperDir: ovlUpperDir,
+		OvlWorkDir:  ovlWorkDir,
 	}
 }
 

--- a/smoke/tests/tool/layer.go
+++ b/smoke/tests/tool/layer.go
@@ -230,7 +230,7 @@ func (l *Layer) Overlay(_ *testing.T, upper *Layer) *Layer {
 
 func (l *Layer) recordFileTree(t *testing.T) {
 	l.FileTree = map[string]*File{}
-	filepath.Walk(l.workDir, func(path string, fi os.FileInfo, err error) error {
+	filepath.Walk(l.workDir, func(path string, _ os.FileInfo, _ error) error {
 		targetPath := l.TargetPath(t, path)
 		l.FileTree[targetPath] = NewFile(t, path, targetPath)
 		return nil

--- a/smoke/tests/tool/verify.go
+++ b/smoke/tests/tool/verify.go
@@ -43,7 +43,7 @@ func Verify(t *testing.T, ctx Context, expectedFiles map[string]*File) {
 	}()
 
 	actualFiles := map[string]*File{}
-	err = filepath.WalkDir(ctx.Env.MountDir, func(path string, entry fs.DirEntry, err error) error {
+	err = filepath.WalkDir(ctx.Env.MountDir, func(path string, _ fs.DirEntry, err error) error {
 		require.Nil(t, err)
 
 		targetPath, err := filepath.Rel(ctx.Env.MountDir, path)

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -42,7 +42,7 @@ tokio = { version = "1.19.0", features = [
 ] }
 url = { version = "2.1.1", optional = true }
 vm-memory = "0.10"
-fuse-backend-rs = "^0.11.0"
+fuse-backend-rs = "^0.12.0"
 gpt = { version = "3.1.0", optional = true }
 
 nydus-api = { version = "0.3", path = "../api" }

--- a/storage/src/device.rs
+++ b/storage/src/device.rs
@@ -1338,12 +1338,9 @@ impl FileReadWriteVolatile for BlobDeviceIoVec<'_> {
         unimplemented!();
     }
 
-    fn read_at_volatile(
-        &mut self,
-        _slice: FileVolatileSlice,
-        _offset: u64,
-    ) -> Result<usize, Error> {
-        unimplemented!();
+    fn read_at_volatile(&mut self, slice: FileVolatileSlice, offset: u64) -> Result<usize, Error> {
+        let buffers = [slice];
+        self.read_vectored_at_volatile(&buffers, offset)
     }
 
     // The default read_vectored_at_volatile only read to the first slice, so we have to overload it.


### PR DESCRIPTION
With help of newly introduced Overlay FileSystem in `fuse-backend-rs` library, now we can create writable rootfs in Nydus. Implementation of writable rootfs is based on one passthrough FS(as upper layer) over one readonly rafs(as lower layer).

To do so, configuration is extended with some Overlay options.

## Details
An userspace overlay filesystem is usable for control of user data, with this implementation, Nydus can have stronger control on container rootfs.

## Types of changes

_What types of changes does your PullRequest introduce? Put an `x` in all the boxes that apply:_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Go over all the following points, and put an `x` in all the boxes that apply._

- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.