### PR TITLE
bats test: add a backup image to avoid network errors

### DIFF
--- a/tests/bats/run_container_with_rafs_and_compile_linux.bats
+++ b/tests/bats/run_container_with_rafs_and_compile_linux.bats
@@ -1,15 +1,22 @@
 load "${BATS_TEST_DIRNAME}/common_tests.sh"
 
 setup() {
-	nydus_rafs_image="ghcr.io/dragonflyoss/image-service/bldlinux:v0.1-rafs-v6-lz4"
+	nydus_rafs_image="docker.io/openanolis/bldlinux:v0.1-rafs-v6-lz4"
+	nydus_rafs_image_bak="ghcr.io/dragonflyoss/image-service/bldlinux:v0.1-rafs-v6-lz4"
 	run_nydus_snapshotter
 	config_containerd_for_nydus
 	ctr images ls | grep -q "${nydus_rafs_image}" && ctr images rm $nydus_rafs_image
-	ctr-remote images rpull $nydus_rafs_image
+	nerdctl pull --snapshotter=nydus $nydus_rafs_image
+	ctr images ls | grep -q "${nydus_rafs_image_bak}" && ctr images rm $nydus_rafs_image_bak
+	nerdctl pull --snapshotter=nydus $nydus_rafs_image_bak
 }
 
 @test "run container with rafs and compile linux" {
 	nerdctl run --rm --net=host --snapshotter=nydus $nydus_rafs_image /bin/bash -c 'cd /linux-5.10.87; make defconfig; make -j8'
+	if [ $? -ne 0 ]; then
+		nydus_rafs_image=${nydus_rafs_image_bak}
+		nerdctl run --rm --net=host --snapshotter=nydus $nydus_rafs_image /bin/bash -c 'cd /linux-5.10.87; make defconfig; make -j8'
+	fi
 	echo "drop cache and compile linux in container again"
 	echo 3 > /proc/sys/vm/drop_caches
 	nerdctl run --rm --net=host --snapshotter=nydus $nydus_rafs_image /bin/bash -c 'cd /linux-5.10.87; make defconfig; make -j8'


### PR DESCRIPTION
## Relevant Issue (if applicable)
In some cases, the image source provided by ghcr.io is not very stable and may cause the test to fail.

## Details
This patch adds a backup image to avoid network errors. When the test fails, the backup image is retried.

Test passed in: https://tone.openanolis.cn/ws/nrh4nnio/test_result/117548?tab=1
![test](https://github.com/dragonflyoss/nydus/assets/29459113/ffd04d8f-de69-43ab-8d43-dda3175711e3)

## Types of changes

_What types of changes does your PullRequest introduce? Put an `x` in all the boxes that apply:_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Go over all the following points, and put an `x` in all the boxes that apply._

- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.