### PR TITLE
feat: skip proxy health check if connection is not active

### DIFF
--- a/api/src/config.rs
+++ b/api/src/config.rs
@@ -907,6 +907,9 @@ pub struct ProxyConfig {
     /// Replace URL to http to request source registry with proxy, and allow fallback to https if the proxy is unhealthy.
     #[serde(default)]
     pub use_http: bool,
+    /// Elapsed time to pause proxy health check when the request is inactive, in seconds.
+    #[serde(default = "default_check_pause_elapsed")]
+    pub check_pause_elapsed: u64,
 }
 
 impl Default for ProxyConfig {
@@ -917,6 +920,7 @@ impl Default for ProxyConfig {
             fallback: true,
             check_interval: 5,
             use_http: false,
+            check_pause_elapsed: 300,
         }
     }
 }
@@ -938,6 +942,9 @@ pub struct MirrorConfig {
     /// Maximum number of failures before marking a mirror as unusable.
     #[serde(default = "default_failure_limit")]
     pub failure_limit: u8,
+    /// Elapsed time to pause mirror health check when the request is inactive, in seconds.
+    #[serde(default = "default_check_pause_elapsed")]
+    pub check_pause_elapsed: u64,
 }
 
 impl Default for MirrorConfig {
@@ -948,6 +955,7 @@ impl Default for MirrorConfig {
             health_check_interval: 5,
             failure_limit: 5,
             ping_url: String::new(),
+            check_pause_elapsed: 300,
         }
     }
 }
@@ -1189,6 +1197,10 @@ fn default_http_timeout() -> u32 {
 
 fn default_check_interval() -> u64 {
     5
+}
+
+fn default_check_pause_elapsed() -> u64 {
+    300
 }
 
 fn default_failure_limit() -> u8 {

--- a/api/src/config.rs
+++ b/api/src/config.rs
@@ -944,7 +944,7 @@ pub struct MirrorConfig {
     pub failure_limit: u8,
     /// Elapsed time to pause mirror health check when the request is inactive, in seconds.
     #[serde(default = "default_check_pause_elapsed")]
-    pub check_pause_elapsed: u64,
+    pub health_check_pause_elapsed: u64,
 }
 
 impl Default for MirrorConfig {
@@ -955,7 +955,7 @@ impl Default for MirrorConfig {
             health_check_interval: 5,
             failure_limit: 5,
             ping_url: String::new(),
-            check_pause_elapsed: 300,
+            health_check_pause_elapsed: 300,
         }
     }
 }

--- a/docs/nydusd.md
+++ b/docs/nydusd.md
@@ -324,7 +324,7 @@ The `HttpProxy` backend also supports the `Proxy` and `Mirrors` configurations f
 
 ##### Enable Mirrors for Storage Backend (Recommend)
 
-Nydus is deeply integrated with [Dragonfly](https://d7y.io/) P2P mirror mode, please refer the [doc](https://d7y.io/docs/setup/integration/nydus) to learn how configuring Nydus to use Dragonfly.
+Nydus is deeply integrated with [Dragonfly](https://d7y.io/) P2P mirror mode, please refer the [doc](https://d7y.io/docs/next/operations/integrations/container-runtime/nydus/) to learn how configuring Nydus to use Dragonfly.
 
 Add `device.backend.config.mirrors` field to enable mirrors for storage backend. The mirror can be a P2P distribution server or registry. If the request to mirror server failed, it will fall back to the original registry.
 Currently, the mirror mode is only tested in the registry backend, and in theory, the OSS backend also supports it.
@@ -356,6 +356,9 @@ Currently, the mirror mode is only tested in the registry backend, and in theory
             "health_check_interval": 5,
             // Failure counts before disabling this mirror. Use 5 as default if left empty.
             "failure_limit": 5,
+            // Elapsed time to pause mirror health check when the request is inactive, in seconds.
+            // Use 300 as default if left empty.
+            "check_pause_elapsed": 300,
           },
           {
             "host": "http://dragonfly2.io:65001",
@@ -393,6 +396,9 @@ Add `device.backend.config.proxy` field to enable HTTP proxy for storage backend
           "ping_url": "http://p2p-proxy:40901/server/ping",
           // Interval of P2P proxy health checking, in seconds
           "check_interval": 5
+          // Elapsed time to pause proxy health check when the request is inactive, in seconds.
+          // Use 300 as default if left empty.
+          "check_pause_elapsed": 300,
         },
         ...
       }

--- a/docs/nydusd.md
+++ b/docs/nydusd.md
@@ -358,7 +358,7 @@ Currently, the mirror mode is only tested in the registry backend, and in theory
             "failure_limit": 5,
             // Elapsed time to pause mirror health check when the request is inactive, in seconds.
             // Use 300 as default if left empty.
-            "check_pause_elapsed": 300,
+            "health_check_pause_elapsed": 300,
           },
           {
             "host": "http://dragonfly2.io:65001",

--- a/storage/src/backend/connection.rs
+++ b/storage/src/backend/connection.rs
@@ -443,7 +443,7 @@ impl Connection {
                         .as_secs()
                         - last_active.load(Ordering::Relaxed);
                     // If the connection is not active for a set time, skip mirror health check.
-                    if elapsed <= mirror_cloned.config.check_pause_elapsed {
+                    if elapsed <= mirror_cloned.config.health_check_pause_elapsed {
                         // Try to recover the mirror server when it is unavailable.
                         if !mirror_cloned.status.load(Ordering::Relaxed) {
                             info!(


### PR DESCRIPTION
## Relevant Issue (if applicable)

Fixes #1588 

## Details

1. Add `last_active` field for `Connection`. When `Connection.call()` is called, `last_active`  is updated to current timestamp.
2. Add `check_pause_elapsed` field for `ProxyConfig` and `MirrorConfig`. Connection is considered to be inactive if the current time to the `last_active` time exceeds `check_pause_elapsed`.
3. In proxy and mirror's health checking thread's loop, if the connection is not active (exceeds `check_pause_elapsed`), this round of health check is skipped.
4. Update the document.

## Types of changes

_What types of changes does your PullRequest introduce? Put an `x` in all the boxes that apply:_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Go over all the following points, and put an `x` in all the boxes that apply._

- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.