### PR TITLE
WIP: test MountByAPI

### DIFF
--- a/smoke/tests/tool/verify.go
+++ b/smoke/tests/tool/verify.go
@@ -37,7 +37,7 @@ func Verify(t *testing.T, ctx Context, expectedFiles map[string]*File) {
 
 	config.EnablePrefetch = ctx.Runtime.EnablePrefetch
 	config.BootstrapPath = ctx.Env.BootstrapPath
-	config.MountPath = "/pseudo_fs_1"
+	config.MountPath = "/"
 	config.BackendType = "localfs"
 	config.BackendConfig = fmt.Sprintf(`{"dir": "%s"}`, ctx.Env.BlobDir)
 	config.BlobCacheDir = ctx.Env.CacheDir


### PR DESCRIPTION

## Details
 Currently working on testing the MountByAPI functionality. The configuration is being mounted in two stages: initially using the mount(), followed by the MountByAPI()

