### PR TITLE
nydus-image: refactor unpack/compact cli interface

### DIFF
--- a/docs/nydus-image.md
+++ b/docs/nydus-image.md
@@ -182,6 +182,29 @@ data blobs: ["9e50ae5ac02b2ef6ffb86075720e49d95d8240eed4717dd8ac9c68cadba00762"]
 -rw-r--r-- 1 root root 20480 3月  29 17:02 df01f389850b79cd5a6ca6db98495bb457aa0821b0558351c55537551322fb96
 ```
 
+## Unpack Nydus Image
+`nydus-image` tool supports to unpack Nydus image to a tar file.
+```shell
+# use --blob to specify RAFS data blob
+nydus-image unpack --blob image/blob1 image/bootstrap --output tmp.tar
+
+# use --blob-dir to specify the directory containing RAFS data blobs
+nydus-image unpack --blob-dir=image/ image/bootstrap --output tmp.tar
+
+# example-oss.config
+{
+  "endpoint": "region.aliyuncs.com",
+  "scheme": "https",
+  "access_key_id": "",
+  "access_key_secret": "",
+  "bucket_name": "",
+  "object_prefix": "image/"
+}
+
+# use backend config file to specify remote storage for RAFS data blobs
+nydus-image unpack --backend-type oss --backend-config-file example-oss.config image/bootstrap --output tmp.tar
+```
+
 ## Compact Nydus Image
 `nydus-image` tool supports to compact Nydus image for
 1. reduce number of blobs

--- a/smoke/tests/main_test.go
+++ b/smoke/tests/main_test.go
@@ -22,10 +22,16 @@ func TestMain(m *testing.M) {
 		registryPort = "5077"
 		os.Setenv("REGISTRY_PORT", registryPort)
 	}
+
+	var reg *tool.Registry = nil
 	if os.Getenv("DISABLE_REGISTRY") == "" {
-		reg := tool.NewRegistry()
-		defer reg.Destroy()
+		reg = tool.NewRegistry()
 	}
+
 	code := m.Run()
+
+	if reg != nil {
+		reg.Destroy()
+	}
 	os.Exit(code)
 }

--- a/smoke/tests/main_test.go
+++ b/smoke/tests/main_test.go
@@ -23,7 +23,7 @@ func TestMain(m *testing.M) {
 		os.Setenv("REGISTRY_PORT", registryPort)
 	}
 
-	var reg *tool.Registry = nil
+	var reg *tool.Registry
 	if os.Getenv("DISABLE_REGISTRY") == "" {
 		reg = tool.NewRegistry()
 	}


### PR DESCRIPTION
Since unpack and compact subcommands does not need the entire nydusd configuration file, let's refactor their cli interface and directly take backend configuration file.

Specifically, we introduce `--backend-type`, `--backend-config` and `--backend-config-file` options to specify the backend type and remove `--config` option.

Fixes: #1602

## Relevant Issue (if applicable)
#1602 

## Details
Introduce  `--backend-type`, `--backend-config` and `--backend-config-file` options for `unpack` and `compact` subcommands in nydus-image.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.