### PR TITLE
nydusify: small improvements for mount & check subcommands

### DIFF
--- a/contrib/nydusify/cmd/nydusify.go
+++ b/contrib/nydusify/cmd/nydusify.go
@@ -24,7 +24,6 @@ import (
 	"github.com/urfave/cli/v2"
 
 	"github.com/dragonflyoss/nydus/contrib/nydusify/pkg/checker"
-	"github.com/dragonflyoss/nydus/contrib/nydusify/pkg/checker/rule"
 	"github.com/dragonflyoss/nydus/contrib/nydusify/pkg/chunkdict/generator"
 	"github.com/dragonflyoss/nydus/contrib/nydusify/pkg/committer"
 	"github.com/dragonflyoss/nydus/contrib/nydusify/pkg/converter"
@@ -796,7 +795,12 @@ func main() {
 					Usage:     "Json configuration file for storage backend",
 					EnvVars:   []string{"BACKEND_CONFIG_FILE"},
 				},
-
+				&cli.BoolFlag{
+					Name:    "prefetch",
+					Value:   false,
+					Usage:   "Enable full image data prefetch",
+					EnvVars: []string{"PREFETCH"},
+				},
 				&cli.StringFlag{
 					Name:    "mount-path",
 					Value:   "./image-fs",
@@ -836,12 +840,10 @@ func main() {
 						return err
 					}
 
-					backendConfigStruct, err := rule.NewRegistryBackendConfig(parsed)
+					backendConfigStruct, err := utils.NewRegistryBackendConfig(parsed, c.Bool("target-insecure"))
 					if err != nil {
 						return errors.Wrap(err, "parse registry backend configuration")
 					}
-
-					backendConfigStruct.SkipVerify = c.Bool("target-insecure")
 
 					bytes, err := json.Marshal(backendConfigStruct)
 					if err != nil {
@@ -865,6 +867,7 @@ func main() {
 					BackendType:    backendType,
 					BackendConfig:  backendConfig,
 					ExpectedArch:   arch,
+					Prefetch:       c.Bool("prefetch"),
 				})
 				if err != nil {
 					return err

--- a/contrib/nydusify/pkg/checker/checker.go
+++ b/contrib/nydusify/pkg/checker/checker.go
@@ -168,6 +168,7 @@ func (checker *Checker) check(ctx context.Context) error {
 			TargetInsecure:  checker.TargetInsecure,
 			PlainHTTP:       checker.targetParser.Remote.IsWithHTTP(),
 			NydusdConfig: tool.NydusdConfig{
+				EnablePrefetch: true,
 				NydusdPath:     checker.NydusdPath,
 				BackendType:    checker.BackendType,
 				BackendConfig:  checker.BackendConfig,

--- a/contrib/nydusify/pkg/checker/tool/nydusd.go
+++ b/contrib/nydusify/pkg/checker/tool/nydusd.go
@@ -76,12 +76,10 @@ func makeConfig(conf NydusdConfig) error {
 	if conf.BackendType == "" {
 		conf.BackendType = "localfs"
 		conf.BackendConfig = `{"dir": "/fake"}`
-		conf.EnablePrefetch = false
 	} else {
 		if conf.BackendConfig == "" {
 			return errors.Errorf("empty backend configuration string")
 		}
-		conf.EnablePrefetch = true
 	}
 	if err := tpl.Execute(&ret, conf); err != nil {
 		return errors.New("failed to prepare configuration file for Nydusd")
@@ -176,7 +174,7 @@ func (nydusd *Nydusd) Mount() error {
 		"--apisock",
 		nydusd.APISockPath,
 		"--log-level",
-		"error",
+		"warn",
 	}
 
 	cmd := exec.Command(nydusd.NydusdPath, args...)

--- a/contrib/nydusify/pkg/utils/backend.go
+++ b/contrib/nydusify/pkg/utils/backend.go
@@ -1,0 +1,57 @@
+package utils
+
+import (
+	"encoding/base64"
+	"fmt"
+	"os"
+
+	"github.com/distribution/reference"
+	dockerconfig "github.com/docker/cli/cli/config"
+	"github.com/pkg/errors"
+)
+
+type RegistryBackendConfig struct {
+	Scheme     string             `json:"scheme"`
+	Host       string             `json:"host"`
+	Repo       string             `json:"repo"`
+	Auth       string             `json:"auth,omitempty"`
+	SkipVerify bool               `json:"skip_verify,omitempty"`
+	Proxy      BackendProxyConfig `json:"proxy"`
+}
+
+type BackendProxyConfig struct {
+	URL      string `json:"url"`
+	Fallback bool   `json:"fallback"`
+	PingURL  string `json:"ping_url"`
+}
+
+func NewRegistryBackendConfig(parsed reference.Named, insecure bool) (RegistryBackendConfig, error) {
+	proxyURL := os.Getenv("HTTP_PROXY")
+	if proxyURL == "" {
+		proxyURL = os.Getenv("HTTPS_PROXY")
+	}
+
+	backendConfig := RegistryBackendConfig{
+		Scheme:     "https",
+		Host:       reference.Domain(parsed),
+		Repo:       reference.Path(parsed),
+		SkipVerify: insecure,
+		Proxy: BackendProxyConfig{
+			URL:      proxyURL,
+			Fallback: true,
+		},
+	}
+
+	config := dockerconfig.LoadDefaultConfigFile(os.Stderr)
+	authConfig, err := config.GetAuthConfig(backendConfig.Host)
+	if err != nil {
+		return backendConfig, errors.Wrap(err, "get docker registry auth config")
+	}
+	var auth string
+	if authConfig.Username != "" && authConfig.Password != "" {
+		auth = base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", authConfig.Username, authConfig.Password)))
+	}
+	backendConfig.Auth = auth
+
+	return backendConfig, nil
+}

--- a/contrib/nydusify/pkg/viewer/viewer.go
+++ b/contrib/nydusify/pkg/viewer/viewer.go
@@ -37,6 +37,7 @@ type Opt struct {
 	BackendConfig string
 	ExpectedArch  string
 	FsVersion     string
+	Prefetch      bool
 }
 
 // fsViewer provides complete view of file system in nydus image
@@ -63,15 +64,16 @@ func New(opt Opt) (*FsViewer, error) {
 	mode := "cached"
 
 	nydusdConfig := tool.NydusdConfig{
-		NydusdPath:    opt.NydusdPath,
-		BackendType:   opt.BackendType,
-		BackendConfig: opt.BackendConfig,
-		BootstrapPath: filepath.Join(opt.WorkDir, "nydus_bootstrap"),
-		ConfigPath:    filepath.Join(opt.WorkDir, "fs/nydusd_config.json"),
-		BlobCacheDir:  filepath.Join(opt.WorkDir, "fs/nydus_blobs"),
-		MountPath:     opt.MountPath,
-		APISockPath:   filepath.Join(opt.WorkDir, "fs/nydus_api.sock"),
-		Mode:          mode,
+		EnablePrefetch: opt.Prefetch,
+		NydusdPath:     opt.NydusdPath,
+		BackendType:    opt.BackendType,
+		BackendConfig:  opt.BackendConfig,
+		BootstrapPath:  filepath.Join(opt.WorkDir, "nydus_bootstrap"),
+		ConfigPath:     filepath.Join(opt.WorkDir, "fs/nydusd_config.json"),
+		BlobCacheDir:   filepath.Join(opt.WorkDir, "fs/nydus_blobs"),
+		MountPath:      opt.MountPath,
+		APISockPath:    filepath.Join(opt.WorkDir, "fs/nydus_api.sock"),
+		Mode:           mode,
 	}
 
 	fsViewer := &FsViewer{


### PR DESCRIPTION
- Add `--prefetch` option for enabling full image data prefetch.
- Support `HTTP_PROXY` / `HTTPS_PROXY` env for enabling proxy for nydusd.
- Change nydusd log level to `warn` for mount & check subcommands.

## Relevant Issue (if applicable)
_If there are Issues related to this PullRequest, please list it._

## Details
_Please describe the details of PullRequest._

## Types of changes

_What types of changes does your PullRequest introduce? Put an `x` in all the boxes that apply:_

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Go over all the following points, and put an `x` in all the boxes that apply._

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.