### PR TITLE
refactor: fixed the unnecessary mutex lock operation

### DIFF
--- a/builder/src/chunkdict_generator.rs
+++ b/builder/src/chunkdict_generator.rs
@@ -93,7 +93,7 @@ impl Generator {
     /// Validate tree.
     fn validate_tree(tree: &Tree) -> Result<()> {
         let pre = &mut |t: &Tree| -> Result<()> {
-            let node = t.lock_node();
+            let node = t.borrow_mut_node();
             debug!("chunkdict tree: ");
             debug!("inode: {}", node);
             for chunk in &node.chunks {
@@ -208,7 +208,7 @@ impl Generator {
         node.inode.set_child_count(node.chunks.len() as u32);
         let child = Tree::new(node);
         child
-            .lock_node()
+            .borrow_mut_node()
             .v5_set_dir_size(ctx.fs_version, &child.children);
         Ok(child)
     }

--- a/builder/src/compact.rs
+++ b/builder/src/compact.rs
@@ -304,7 +304,7 @@ impl BlobCompactor {
         let chunk_dict = self.get_chunk_dict();
 
         let cb = &mut |n: &Tree| -> Result<()> {
-            let mut node = n.lock_node();
+            let mut node = n.borrow_mut_node();
             for chunk_idx in 0..node.chunks.len() {
                 let chunk = &mut node.chunks[chunk_idx];
                 let chunk_key = ChunkKey::from(&chunk.inner);
@@ -367,7 +367,7 @@ impl BlobCompactor {
     fn apply_blob_move(&mut self, from: u32, to: u32) -> Result<()> {
         if let Some(idx_list) = self.b2nodes.get(&from) {
             for (n, chunk_idx) in idx_list.iter() {
-                let mut node = n.lock().unwrap();
+                let mut node = n.borrow_mut();
                 ensure!(
                     node.chunks[*chunk_idx].inner.blob_index() == from,
                     "unexpected blob_index of chunk"
@@ -381,7 +381,7 @@ impl BlobCompactor {
     fn apply_chunk_change(&mut self, c: &(ChunkWrapper, ChunkWrapper)) -> Result<()> {
         if let Some(chunks) = self.c2nodes.get(&ChunkKey::from(&c.0)) {
             for (n, chunk_idx) in chunks.iter() {
-                let mut node = n.lock().unwrap();
+                let mut node = n.borrow_mut();
                 let chunk = &mut node.chunks[*chunk_idx];
                 let mut chunk_inner = chunk.inner.deref().clone();
                 apply_chunk_change(&c.1, &mut chunk_inner)?;

--- a/builder/src/core/blob.rs
+++ b/builder/src/core/blob.rs
@@ -33,7 +33,7 @@ impl Blob {
                 let mut chunk_data_buf = vec![0u8; RAFS_MAX_CHUNK_SIZE as usize];
                 let (inodes, prefetch_entries) = BlobLayout::layout_blob_simple(&ctx.prefetch)?;
                 for (idx, node) in inodes.iter().enumerate() {
-                    let mut node = node.lock().unwrap();
+                    let mut node = node.borrow_mut();
                     let size = node
                         .dump_node_data(ctx, blob_mgr, blob_writer, &mut chunk_data_buf)
                         .context("failed to dump blob chunks")?;

--- a/builder/src/core/layout.rs
+++ b/builder/src/core/layout.rs
@@ -16,11 +16,11 @@ impl BlobLayout {
         let (pre, non_pre) = prefetch.get_file_nodes();
         let mut inodes: Vec<TreeNode> = pre
             .into_iter()
-            .filter(|x| Self::should_dump_node(x.lock().unwrap().deref()))
+            .filter(|x| Self::should_dump_node(x.borrow().deref()))
             .collect();
         let mut non_prefetch_inodes: Vec<TreeNode> = non_pre
             .into_iter()
-            .filter(|x| Self::should_dump_node(x.lock().unwrap().deref()))
+            .filter(|x| Self::should_dump_node(x.borrow().deref()))
             .collect();
 
         let prefetch_entries = inodes.len();
@@ -53,7 +53,7 @@ mod tests {
         let tree = Tree::new(node1);
 
         let mut prefetch = Prefetch::default();
-        prefetch.insert(&tree.node, tree.node.lock().unwrap().deref());
+        prefetch.insert(&tree.node, tree.node.borrow().deref());
 
         let (inodes, prefetch_entries) = BlobLayout::layout_blob_simple(&prefetch).unwrap();
         assert_eq!(inodes.len(), 1);

--- a/builder/src/core/v6.rs
+++ b/builder/src/core/v6.rs
@@ -576,7 +576,7 @@ impl BuildContext {
 
 impl Bootstrap {
     pub(crate) fn v6_update_dirents(parent: &Tree, parent_offset: u64) {
-        let mut node = parent.lock_node();
+        let mut node = parent.borrow_mut_node();
         let node_offset = node.v6_offset;
         if !node.is_dir() {
             return;
@@ -596,7 +596,7 @@ impl Bootstrap {
 
         let mut dirs: Vec<&Tree> = Vec::new();
         for child in parent.children.iter() {
-            let child_node = child.lock_node();
+            let child_node = child.borrow_mut_node();
             let entry = (
                 child_node.v6_offset,
                 OsStr::from_bytes(child.name()).to_owned(),
@@ -670,7 +670,7 @@ impl Bootstrap {
         // When using nid 0 as root nid,
         // the root directory will not be shown by glibc's getdents/readdir.
         // Because in some OS, ino == 0 represents corresponding file is deleted.
-        let root_node_offset = self.tree.lock_node().v6_offset;
+        let root_node_offset = self.tree.borrow_mut_node().v6_offset;
         let orig_meta_addr = root_node_offset - EROFS_BLOCK_SIZE_4096;
         let meta_addr = if blob_table_size > 0 {
             align_offset(
@@ -704,7 +704,7 @@ impl Bootstrap {
         timing_tracer!(
             {
                 self.tree.walk_bfs(true, &mut |n| {
-                    n.lock_node().dump_bootstrap_v6(
+                    n.borrow_mut_node().dump_bootstrap_v6(
                         ctx,
                         bootstrap_ctx.writer.as_mut(),
                         orig_meta_addr,

--- a/builder/src/directory.rs
+++ b/builder/src/directory.rs
@@ -34,7 +34,7 @@ impl FilesystemTreeBuilder {
         layer_idx: u16,
     ) -> Result<Vec<Tree>> {
         let mut result = Vec::new();
-        let parent = parent.lock().unwrap();
+        let parent = parent.borrow();
         if !parent.is_dir() {
             return Ok(result);
         }
@@ -70,7 +70,7 @@ impl FilesystemTreeBuilder {
             let mut child = Tree::new(child);
             child.children = self.load_children(ctx, bootstrap_ctx, &child.node, layer_idx)?;
             child
-                .lock_node()
+                .borrow_mut_node()
                 .v5_set_dir_size(ctx.fs_version, &child.children);
             result.push(child);
         }
@@ -112,7 +112,7 @@ impl DirectoryBuilder {
             { tree_builder.load_children(ctx, bootstrap_ctx, &tree.node, layer_idx) },
             "load_from_directory"
         )?;
-        tree.lock_node()
+        tree.borrow_mut_node()
             .v5_set_dir_size(ctx.fs_version, &tree.children);
 
         Ok(tree)

--- a/builder/src/merge.rs
+++ b/builder/src/merge.rs
@@ -257,7 +257,7 @@ impl Merger {
 
             let upper = Tree::from_bootstrap(&rs, &mut ())?;
             upper.walk_bfs(true, &mut |n| {
-                let mut node = n.lock_node();
+                let mut node = n.borrow_mut_node();
                 for chunk in &mut node.chunks {
                     let origin_blob_index = chunk.inner.blob_index() as usize;
                     let blob_ctx = blobs[origin_blob_index].as_ref();

--- a/builder/src/stargz.rs
+++ b/builder/src/stargz.rs
@@ -601,7 +601,7 @@ impl StargzBuilder {
                 }
             }
 
-            let mut tmp_node = tmp_tree.lock_node();
+            let mut tmp_node = tmp_tree.borrow_mut_node();
             if !tmp_node.is_reg() {
                 bail!(
                     "stargz: target {} for hardlink {} is not a regular file",
@@ -788,7 +788,7 @@ impl StargzBuilder {
         bootstrap
             .tree
             .walk_bfs(true, &mut |n| {
-                let mut node = n.lock_node();
+                let mut node = n.borrow_mut_node();
                 let node_path = node.path();
                 if let Some((size, ref mut chunks)) = self.file_chunk_map.get_mut(node_path) {
                     node.inode.set_size(*size);
@@ -802,9 +802,9 @@ impl StargzBuilder {
 
         for (k, v) in self.hardlink_map.iter() {
             match bootstrap.tree.get_node(k) {
-                Some(n) => {
-                    let mut node = n.lock_node();
-                    let target = v.lock().unwrap();
+                Some(t) => {
+                    let mut node = t.borrow_mut_node();
+                    let target = v.borrow();
                     node.inode.set_size(target.inode.size());
                     node.inode.set_child_count(target.inode.child_count());
                     node.chunks = target.chunks.clone();

--- a/builder/src/tarball.rs
+++ b/builder/src/tarball.rs
@@ -349,7 +349,7 @@ impl<'a> TarballTreeBuilder<'a> {
                     }
                 }
             }
-            let mut tmp_node = tmp_tree.lock_node();
+            let mut tmp_node = tmp_tree.borrow_mut_node();
             if !tmp_node.is_reg() {
                 bail!(
                     "tarball: target {} for hardlink {} is not a regular file",
@@ -452,7 +452,7 @@ impl<'a> TarballTreeBuilder<'a> {
         // Tar hardlink header has zero file size and no file data associated, so copy value from
         // the associated regular file.
         if let Some(t) = hardlink_target {
-            let n = t.lock_node();
+            let n = t.borrow_mut_node();
             if n.inode.is_v5() {
                 node.inode.set_digest(n.inode.digest().to_owned());
             }
@@ -540,7 +540,7 @@ impl<'a> TarballTreeBuilder<'a> {
         for c in &mut tree.children {
             Self::set_v5_dir_size(c);
         }
-        let mut node = tree.lock_node();
+        let mut node = tree.borrow_mut_node();
         node.v5_set_dir_size(RafsVersion::V5, &tree.children);
     }
 

--- a/src/bin/nydus-image/deduplicate.rs
+++ b/src/bin/nydus-image/deduplicate.rs
@@ -271,7 +271,7 @@ impl Deduplicate<SqliteDatabase> {
         version: String,
     ) -> anyhow::Result<()> {
         let process_chunk = &mut |t: &Tree| -> Result<()> {
-            let node = t.lock_node();
+            let node = t.borrow_mut_node();
             for chunk in &node.chunks {
                 let index = chunk.inner.blob_index();
                 let chunk_blob_id = blob_infos[index as usize].blob_id();

--- a/src/bin/nydus-image/stat.rs
+++ b/src/bin/nydus-image/stat.rs
@@ -171,7 +171,7 @@ impl ImageStat {
         };
 
         let pre = &mut |t: &Tree| -> Result<()> {
-            let node = t.lock_node();
+            let node = t.borrow_mut_node();
             if node.is_reg() {
                 image.files += 1;
                 if node.is_hardlink() {

--- a/src/bin/nydus-image/validator.rs
+++ b/src/bin/nydus-image/validator.rs
@@ -33,7 +33,7 @@ impl Validator {
         let tree = Tree::from_bootstrap(&self.sb, &mut ()).context(err)?;
 
         let pre = &mut |t: &Tree| -> Result<()> {
-            let node = t.lock_node();
+            let node = t.borrow_mut_node();
             if verbosity {
                 println!("inode: {}", node);
                 for chunk in &node.chunks {


### PR DESCRIPTION
## Relevant Issue (if applicable)
_If there are Issues related to this PullRequest, please list it._

## Details

This PR is a preliminary proposal, and I welcome friendly discussions on this issue.

Due to `Rc` is neither `Send` or `Sync`, it cannot be sent between threads safely. Rust cannot send an `Rc` to another thread, then you have to construct the value on the thread that will use it, or send the value to that thread before wrapping it in an `Rc`. So rustc's mechanism will not exploit the `Mutex`'s protection.

IMHO, for the most part, we should use `Rc<RefCell<T>>` for single thread or `Arc<Mutex<T>>` for exclusive access (until compiler complain about our code need Send or Sync).

Thank you for your time!

## Types of changes

_What types of changes does your PullRequest introduce? Put an `x` in all the boxes that apply:_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Go over all the following points, and put an `x` in all the boxes that apply._

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.