### PR TITLE
chore: change nydus snapshotter work dir

### DIFF
--- a/api/src/config.rs
+++ b/api/src/config.rs
@@ -2127,7 +2127,7 @@ mod tests {
                     "type": "blobcache",
                     "compressed": true,
                     "config": {
-                        "work_dir": "/var/lib/containerd-nydus/cache",
+                        "work_dir": "/var/lib/containerd/io.containerd.snapshotter.v1.nydus/cache",
                         "disable_indexed_map": false
                     }
                 }

--- a/docs/containerd-env-setup.md
+++ b/docs/containerd-env-setup.md
@@ -90,7 +90,7 @@ Please refer to the nydusd [doc](./nydusd.md) to learn more options.
 Make sure the default nydus snapshotter root directory is clear.
 
 ```
-sudo rm -rf /var/lib/containerd-nydus
+sudo rm -rf /var/lib/containerd/io.containerd.snapshotter.v1.nydus
 ```
 
 3. Start `containerd-nydus-grpc` (nydus snapshotter):

--- a/docs/nydus-fscache.md
+++ b/docs/nydus-fscache.md
@@ -134,7 +134,7 @@ make
 
 ```
 # make sure the directory exists.
-mkdir -p /var/lib/containerd-nydus
+mkdir -p /var/lib/containerd/io.containerd.snapshotter.v1.nydus
 
 ./bin/containerd-nydus-grpc \
  --nydusd-config /etc/nydus/nydusd-config.fscache.json \

--- a/misc/performance/nydusd_config.json
+++ b/misc/performance/nydusd_config.json
@@ -14,7 +14,7 @@
         "cache": {
             "type": "blobcache",
             "config": {
-                "work_dir": "/var/lib/containerd-nydus/cache"
+                "work_dir": "/var/lib/containerd/io.containerd.snapshotter.v1.nydus/cache"
             }
         }
     },

--- a/misc/performance/snapshotter_config.toml
+++ b/misc/performance/snapshotter_config.toml
@@ -1,6 +1,6 @@
 version = 1
 # Snapshotter's own home directory where it stores and creates necessary resources
-root = "/var/lib/containerd-nydus"
+root = "/var/lib/containerd/io.containerd.snapshotter.v1.nydus"
 # The snapshotter's GRPC server socket, containerd will connect to plugin on this socket
 address = "/run/containerd-nydus/containerd-nydus-grpc.sock"
 daemon_mode = "dedicated"

--- a/misc/prepare.sh
+++ b/misc/prepare.sh
@@ -5,7 +5,7 @@ if [ "$1" == "takeover_test" ]; then
     SNAPSHOTTER_CONFIG="misc/takeover/snapshotter_config.toml"
 fi
 
-readonly SNAPSHOTTER_VERSION=0.13.13
+readonly SNAPSHOTTER_VERSION=0.14.0
 readonly NERDCTL_VERSION=1.7.6
 readonly CNI_PLUGINS_VERSION=1.5.0
 

--- a/misc/takeover/snapshotter_config.toml
+++ b/misc/takeover/snapshotter_config.toml
@@ -1,6 +1,6 @@
 version = 1
 # Snapshotter's own home directory where it stores and creates necessary resources
-root = "/var/lib/containerd-nydus"
+root = "/var/lib/containerd/io.containerd.snapshotter.v1.nydus"
 # The snapshotter's GRPC server socket, containerd will connect to plugin on this socket
 address = "/run/containerd-nydus/containerd-nydus-grpc.sock"
 daemon_mode = "dedicated"

--- a/smoke/tests/tool/container.go
+++ b/smoke/tests/tool/container.go
@@ -256,11 +256,11 @@ func getContainerBackendMetrics(t *testing.T) (*ContainerMetrics, error) {
 	return &info, nil
 }
 
-// searchAPISockPath search sock filepath in nydusd work dir, default in "/var/lib/containerd-nydus/socket"
+// searchAPISockPath search sock filepath in nydusd work dir, default in "/var/lib/containerd/io.containerd.snapshotter.v1.nydus/socket"
 func searchAPISockPath(t *testing.T) string {
 	var apiSockPath string
 
-	err := filepath.Walk("/var/lib/containerd-nydus/socket", func(path string, info os.FileInfo, err error) error {
+	err := filepath.Walk("/var/lib/containerd/io.containerd.snapshotter.v1.nydus/socket", func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Relevant Issue (if applicable)
_If there are Issues related to this PullRequest, please list it._

## Details
- use `/var/lib/containerd/io.containerd.snapshotter.v1.nydus` as nydus sanpshotter work dir.
- bump nydus snapshotter to v1.14.0

## Types of changes

_What types of changes does your PullRequest introduce? Put an `x` in all the boxes that apply:_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Go over all the following points, and put an `x` in all the boxes that apply._

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.