### PR TITLE
tests: chang assertr of test_worker_mgr_rate_limiter

### DIFF
--- a/storage/src/cache/worker.rs
+++ b/storage/src/cache/worker.rs
@@ -507,8 +507,8 @@ mod tests {
         assert!(mgr
             .send_prefetch_message(AsyncPrefetchMessage::RateLimiter(u64::MAX))
             .is_ok());
-        assert_eq!(mgr.prefetch_inflight.load(Ordering::Acquire), 3);
-        thread::sleep(Duration::from_secs(1));
+        assert!(mgr.prefetch_inflight.load(Ordering::Acquire) <= 3);
+        thread::sleep(Duration::from_secs(2));
         assert!(mgr.prefetch_inflight.load(Ordering::Acquire) <= 2);
         assert!(mgr.prefetch_inflight.load(Ordering::Acquire) >= 1);
         thread::sleep(Duration::from_secs(3));


### PR DESCRIPTION
## Relevant Issue (if applicable)
![image](https://github.com/user-attachments/assets/ae6835a3-4ee0-49bc-ac62-2aa6200788e3)

![image](https://github.com/user-attachments/assets/3a9e844f-8290-4961-af02-8fd6d2efa3b4)

## Details
assert_eq!(mgr.prefetch_inflight.load(Ordering::Acquire), 3); and assert!(mgr.prefetch_inflight.load(Ordering::Acquire) <= 2); sometimes failed.
The reason is the worker threads may have already started processing the requests and decreased the counter before the main thread checks it.

- change assert!(mgr.prefetch_inflight.load(Ordering::Acquire) = 3); to assert!(mgr.prefetch_inflight.load(Ordering::Acquire) <= 3);
-  thread::sleep(Duration::from_secs(1)); to thread::sleep(Duration::from_secs(2));

## Types of changes

_What types of changes does your PullRequest introduce? Put an `x` in all the boxes that apply:_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Go over all the following points, and put an `x` in all the boxes that apply._

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.