### PR TITLE
support generating separate blob for prefetched files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2795,10 +2795,10 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.1+zstd.1.5.2"
+version = "2.0.13+zstd.1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fd07cbbc53846d9145dbffdf6dd09a7a0aa52be46741825f5c97bdd4f73f12b"
+checksum = "38ff0f21cfee8f97d94cef41359e0c89aa6113028ab0291aa8ca0038995a95aa"
 dependencies = [
  "cc",
- "libc",
+ "pkg-config",
 ]

--- a/builder/src/chunkdict_generator.rs
+++ b/builder/src/chunkdict_generator.rs
@@ -18,18 +18,20 @@ use super::core::node::{ChunkSource, NodeInfo};
 use super::{BlobManager, Bootstrap, BootstrapManager, BuildContext, BuildOutput, Tree};
 use crate::core::node::Node;
 use crate::NodeChunk;
-use anyhow::Result;
+use crate::OsString;
+use anyhow::{Ok, Result};
 use nydus_rafs::metadata::chunk::ChunkWrapper;
 use nydus_rafs::metadata::inode::InodeWrapper;
 use nydus_rafs::metadata::layout::RafsXAttrs;
 use nydus_storage::meta::BlobChunkInfoV1Ondisk;
 use nydus_utils::compress::Algorithm;
 use nydus_utils::digest::RafsDigest;
-use std::ffi::OsString;
+
 use std::mem::size_of;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
+use std::u32;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct ChunkdictChunkInfo {

--- a/builder/src/core/blob.rs
+++ b/builder/src/core/blob.rs
@@ -94,7 +94,7 @@ impl Blob {
         Ok(())
     }
 
-    fn finalize_blob_data(
+    pub fn finalize_blob_data(
         ctx: &BuildContext,
         blob_mgr: &mut BlobManager,
         blob_writer: &mut dyn Artifact,

--- a/builder/src/core/context.rs
+++ b/builder/src/core/context.rs
@@ -13,6 +13,7 @@ use std::io::{BufWriter, Cursor, Read, Seek, Write};
 use std::mem::size_of;
 use std::os::unix::fs::FileTypeExt;
 use std::path::{Display, Path, PathBuf};
+use std::result::Result::Ok;
 use std::str::FromStr;
 use std::sync::{Arc, Mutex};
 use std::{fmt, fs};
@@ -459,6 +460,7 @@ impl BlobCacheGenerator {
     }
 }
 
+#[derive(Clone)]
 /// BlobContext is used to hold the blob information of a layer during build.
 pub struct BlobContext {
     /// Blob id (user specified or sha256(blob)).
@@ -896,6 +898,11 @@ impl BlobManager {
             global_chunk_dict: Arc::new(()),
             layered_chunk_dict: HashChunkDict::new(digester),
         }
+    }
+
+    /// Set current blob index
+    pub fn set_current_blob_index(&mut self, index: usize) {
+        self.current_blob_index = Some(index as u32)
     }
 
     fn new_blob_ctx(ctx: &BuildContext) -> Result<BlobContext> {

--- a/builder/src/core/overlay.rs
+++ b/builder/src/core/overlay.rs
@@ -71,6 +71,16 @@ pub enum WhiteoutSpec {
     None,
 }
 
+impl fmt::Display for WhiteoutSpec {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            WhiteoutSpec::Oci => write!(f, "oci"),
+            WhiteoutSpec::Overlayfs => write!(f, "overlayfs"),
+            WhiteoutSpec::None => write!(f, "none"),
+        }
+    }
+}
+
 impl Default for WhiteoutSpec {
     fn default() -> Self {
         Self::Oci

--- a/builder/src/core/tree.rs
+++ b/builder/src/core/tree.rs
@@ -174,6 +174,30 @@ impl Tree {
         Some(tree)
     }
 
+    /// Get the mutable tree node corresponding to the path.
+    pub fn get_node_mut(&mut self, path: &Path) -> Option<&mut Tree> {
+        let target_vec = Node::generate_target_vec(path);
+        assert!(!target_vec.is_empty());
+        let mut tree = self;
+
+        let last_idx = target_vec.len() - 1;
+        for name in &target_vec[1..last_idx] {
+            match tree.get_child_idx(name.as_bytes()) {
+                Some(idx) => tree = &mut tree.children[idx],
+                None => return None,
+            }
+        }
+
+        if let Some(last_name) = target_vec.last() {
+            match tree.get_child_idx(last_name.as_bytes()) {
+                Some(idx) => Some(&mut tree.children[idx]),
+                None => None,
+            }
+        } else {
+            Some(tree)
+        }
+    }
+
     /// Merge the upper layer tree into the lower layer tree, applying whiteout rules.
     pub fn merge_overaly(&mut self, ctx: &BuildContext, upper: Tree) -> Result<()> {
         assert_eq!(self.name, "/".as_bytes());

--- a/builder/src/lib.rs
+++ b/builder/src/lib.rs
@@ -41,6 +41,8 @@ pub use self::core::prefetch::{Prefetch, PrefetchPolicy};
 pub use self::core::tree::{MetadataTreeBuilder, Tree, TreeNode};
 pub use self::directory::DirectoryBuilder;
 pub use self::merge::Merger;
+pub use self::optimize_prefetch::update_ctx_from_bootstrap;
+pub use self::optimize_prefetch::OptimizePrefetch;
 pub use self::stargz::StargzBuilder;
 pub use self::tarball::TarballBuilder;
 
@@ -49,6 +51,7 @@ mod compact;
 mod core;
 mod directory;
 mod merge;
+mod optimize_prefetch;
 mod stargz;
 mod tarball;
 
@@ -249,7 +252,6 @@ fn finalize_blob(
             blob_cache.finalize(&blob_ctx.blob_id)?;
         }
     }
-
     Ok(())
 }
 

--- a/builder/src/optimize_prefetch.rs
+++ b/builder/src/optimize_prefetch.rs
@@ -1,0 +1,273 @@
+use crate::anyhow;
+use crate::core::blob::Blob;
+use crate::finalize_blob;
+use crate::Artifact;
+use crate::ArtifactWriter;
+use crate::BlobContext;
+use crate::BlobManager;
+use crate::Bootstrap;
+use crate::BootstrapManager;
+use crate::BuildContext;
+use crate::ChunkSource;
+use crate::ConversionType;
+use crate::NodeChunk;
+use crate::Path;
+use crate::PathBuf;
+use crate::Tree;
+use crate::TreeNode;
+use anyhow::Context;
+use anyhow::{Ok, Result};
+use nydus_api::ConfigV2;
+use nydus_rafs::metadata::layout::v6::RafsV6BlobTable;
+use nydus_rafs::metadata::layout::RafsBlobTable;
+use nydus_rafs::metadata::RafsSuper;
+use nydus_rafs::metadata::RafsVersion;
+use nydus_storage::device::BlobInfo;
+use nydus_storage::meta::BatchContextGenerator;
+use nydus_storage::meta::BlobChunkInfoV1Ondisk;
+use nydus_utils::compress;
+use sha2::Digest;
+use std::fs::File;
+use std::io::Read;
+use std::io::Seek;
+use std::mem::size_of;
+use std::sync::Arc;
+pub struct OptimizePrefetch {}
+
+struct PrefetchBlobState {
+    blob_info: BlobInfo,
+    blob_ctx: BlobContext,
+    blob_writer: Box<dyn Artifact>,
+}
+
+impl PrefetchBlobState {
+    fn new(ctx: &BuildContext, blob_layer_num: u32, blobs_dir_path: &Path) -> Result<Self> {
+        let mut blob_info = BlobInfo::new(
+            blob_layer_num,
+            String::from("prefetch-blob"),
+            0,
+            0,
+            ctx.chunk_size,
+            u32::MAX,
+            ctx.blob_features,
+        );
+        blob_info.set_compressor(ctx.compressor);
+        let mut blob_ctx = BlobContext::from(ctx, &blob_info, ChunkSource::Build)?;
+        blob_ctx.blob_meta_info_enabled = true;
+        let blob_writer = ArtifactWriter::new(crate::ArtifactStorage::FileDir(
+            blobs_dir_path.to_path_buf(),
+        ))
+        .map(|writer| Box::new(writer) as Box<dyn Artifact>)?;
+        Ok(Self {
+            blob_info,
+            blob_ctx,
+            blob_writer,
+        })
+    }
+}
+
+impl OptimizePrefetch {
+    /// Generate a new bootstrap for prefetch.
+    pub fn generate_prefetch(
+        tree: &mut Tree,
+        ctx: &mut BuildContext,
+        bootstrap_mgr: &mut BootstrapManager,
+        blob_table: &mut RafsV6BlobTable,
+        blobs_dir_path: PathBuf,
+        prefetch_nodes: Vec<TreeNode>,
+    ) -> Result<()> {
+        // create a new blob for prefetch layer
+        let blob_layer_num = blob_table.entries.len();
+
+        let mut blob_state = PrefetchBlobState::new(&ctx, blob_layer_num as u32, &blobs_dir_path)?;
+        let mut batch = BatchContextGenerator::new(0)?;
+        for node in &prefetch_nodes {
+            Self::process_prefetch_node(
+                tree,
+                &node,
+                &mut blob_state,
+                &mut batch,
+                blob_table,
+                &blobs_dir_path,
+            )?;
+        }
+
+        Self::dump_blob(ctx, blob_table, &mut blob_state)?;
+
+        debug!("prefetch blob id: {}", ctx.blob_id);
+
+        Self::build_dump_bootstrap(tree, ctx, bootstrap_mgr, blob_table)?;
+        Ok(())
+    }
+
+    fn build_dump_bootstrap(
+        tree: &mut Tree,
+        ctx: &mut BuildContext,
+        bootstrap_mgr: &mut BootstrapManager,
+        blob_table: &mut RafsV6BlobTable,
+    ) -> Result<()> {
+        let mut bootstrap_ctx = bootstrap_mgr.create_ctx()?;
+        let mut bootstrap = Bootstrap::new(tree.clone())?;
+
+        // Build bootstrap
+        bootstrap.build(ctx, &mut bootstrap_ctx)?;
+
+        // Verify and update prefetch blob
+        assert!(
+            blob_table
+                .entries
+                .iter()
+                .filter(|blob| blob.blob_id() == "prefetch-blob")
+                .count()
+                == 1,
+            "Expected exactly one prefetch-blob"
+        );
+
+        // Rewrite prefetch blob id
+        blob_table
+            .entries
+            .iter_mut()
+            .filter(|blob| blob.blob_id() == "prefetch-blob")
+            .for_each(|blob| {
+                let mut info = (**blob).clone();
+                info.set_blob_id(ctx.blob_id.clone());
+                *blob = Arc::new(info);
+            });
+
+        // Dump bootstrap
+        let blob_table_withprefetch = RafsBlobTable::V6(blob_table.clone());
+        bootstrap.dump(
+            ctx,
+            &mut bootstrap_mgr.bootstrap_storage,
+            &mut bootstrap_ctx,
+            &blob_table_withprefetch,
+        )?;
+
+        Ok(())
+    }
+
+    fn dump_blob(
+        ctx: &mut BuildContext,
+        blob_table: &mut RafsV6BlobTable,
+        blob_state: &mut PrefetchBlobState,
+    ) -> Result<()> {
+        blob_table.entries.push(blob_state.blob_info.clone().into());
+        let mut blob_mgr = BlobManager::new(ctx.digester);
+        blob_mgr.add_blob(blob_state.blob_ctx.clone());
+        blob_mgr.set_current_blob_index(0);
+        Blob::finalize_blob_data(&ctx, &mut blob_mgr, blob_state.blob_writer.as_mut())?;
+        if let Some((_, blob_ctx)) = blob_mgr.get_current_blob() {
+            Blob::dump_meta_data(&ctx, blob_ctx, blob_state.blob_writer.as_mut()).unwrap();
+        };
+        ctx.blob_id = String::from("");
+        blob_mgr.get_current_blob().unwrap().1.blob_id = String::from("");
+        finalize_blob(ctx, &mut blob_mgr, blob_state.blob_writer.as_mut())?;
+        ctx.blob_id = blob_mgr
+            .get_current_blob()
+            .ok_or(anyhow!("failed to get current blob"))?
+            .1
+            .blob_id
+            .clone();
+        Ok(())
+    }
+
+    fn process_prefetch_node(
+        tree: &mut Tree,
+        node: &TreeNode,
+        prefetch_state: &mut PrefetchBlobState,
+        batch: &mut BatchContextGenerator,
+        blob_table: &RafsV6BlobTable,
+        blobs_dir_path: &Path,
+    ) -> Result<()> {
+        let tree_node = tree
+            .get_node_mut(&node.borrow().path())
+            .ok_or(anyhow!("failed to get node"))?
+            .node
+            .as_ref();
+        let blob_id = tree_node
+            .borrow()
+            .chunks
+            .first()
+            .and_then(|chunk| blob_table.entries.get(chunk.inner.blob_index() as usize))
+            .map(|entry| entry.blob_id())
+            .ok_or(anyhow!("failed to get blob id"))?;
+
+        let mut blob_file = Arc::new(File::open(blobs_dir_path.join(blob_id))?);
+
+        tree_node.borrow_mut().layer_idx = prefetch_state.blob_info.blob_index() as u16;
+
+        let mut child = tree_node.borrow_mut();
+        let chunks: &mut Vec<NodeChunk> = child.chunks.as_mut();
+        let blob_ctx = &mut prefetch_state.blob_ctx;
+        let blob_info = &mut prefetch_state.blob_info;
+        let encrypted = blob_ctx.blob_compressor != compress::Algorithm::None;
+
+        for chunk in chunks {
+            let inner = Arc::make_mut(&mut chunk.inner);
+
+            let mut buf = vec![0u8; inner.compressed_size() as usize];
+            blob_file.seek(std::io::SeekFrom::Start(inner.compressed_offset()))?;
+            blob_file.read_exact(&mut buf)?;
+            prefetch_state.blob_writer.write_all(&buf)?;
+            let info = batch.generate_chunk_info(
+                blob_ctx.current_compressed_offset,
+                blob_ctx.current_uncompressed_offset,
+                inner.uncompressed_size(),
+                encrypted,
+            )?;
+            inner.set_blob_index(blob_info.blob_index());
+            if blob_ctx.chunk_count == u32::MAX {
+                blob_ctx.chunk_count = 0;
+            }
+            inner.set_index(blob_ctx.chunk_count);
+            blob_ctx.chunk_count += 1;
+            inner.set_compressed_offset(blob_ctx.current_compressed_offset);
+            inner.set_uncompressed_offset(blob_ctx.current_uncompressed_offset);
+            let aligned_d_size: u64 = nydus_utils::try_round_up_4k(inner.uncompressed_size())
+                .ok_or_else(|| anyhow!("invalid size"))?;
+            blob_ctx.compressed_blob_size += inner.compressed_size() as u64;
+            blob_ctx.uncompressed_blob_size += aligned_d_size;
+            blob_ctx.current_compressed_offset += inner.compressed_size() as u64;
+            blob_ctx.current_uncompressed_offset += aligned_d_size;
+            blob_ctx.add_chunk_meta_info(&inner, Some(info))?;
+            blob_ctx.blob_hash.update(&buf);
+
+            blob_info.set_meta_ci_compressed_size(
+                (blob_info.meta_ci_compressed_size() + size_of::<BlobChunkInfoV1Ondisk>() as u64)
+                    as usize,
+            );
+
+            blob_info.set_meta_ci_uncompressed_size(
+                (blob_info.meta_ci_uncompressed_size() + size_of::<BlobChunkInfoV1Ondisk>() as u64)
+                    as usize,
+            );
+        }
+
+        Ok(())
+    }
+}
+
+pub fn update_ctx_from_bootstrap(
+    ctx: &mut BuildContext,
+    config: Arc<ConfigV2>,
+    bootstrap_path: &Path,
+) -> Result<RafsSuper> {
+    let (sb, _) = RafsSuper::load_from_file(bootstrap_path, config, false)?;
+
+    ctx.blob_features = sb
+        .superblock
+        .get_blob_infos()
+        .first()
+        .ok_or_else(|| anyhow!("No blob info found in superblock"))?
+        .features();
+
+    let config = sb.meta.get_config();
+    if config.is_tarfs_mode {
+        ctx.conversion_type = ConversionType::TarToRafs;
+    }
+
+    ctx.fs_version =
+        RafsVersion::try_from(sb.meta.version).context("Failed to get RAFS version")?;
+    ctx.compressor = config.compressor;
+    Ok(sb)
+}

--- a/rafs/src/metadata/inode.rs
+++ b/rafs/src/metadata/inode.rs
@@ -17,8 +17,9 @@ use crate::metadata::direct_v6::OndiskInodeWrapper as OndiskInodeWrapperV6;
 use crate::metadata::layout::v5::{RafsV5ChunkInfo, RafsV5Inode};
 use crate::metadata::layout::v6::{RafsV6InodeCompact, RafsV6InodeExtended};
 use crate::metadata::layout::RafsXAttrs;
-use crate::metadata::{Inode, RafsVersion};
+use crate::metadata::RafsVersion;
 use crate::RafsInodeExt;
+use nydus_utils::metrics::Inode;
 
 /// An inode object wrapper for different RAFS versions.
 #[derive(Clone)]

--- a/rafs/src/metadata/layout/v6.rs
+++ b/rafs/src/metadata/layout/v6.rs
@@ -1691,7 +1691,6 @@ impl RafsV6Blob {
             );
             return false;
         }
-
         let blob_features = match BlobFeatures::try_from(self.features) {
             Ok(v) => v,
             Err(_) => return false,
@@ -1773,7 +1772,7 @@ impl RafsV6Blob {
 #[derive(Clone, Debug, Default)]
 pub struct RafsV6BlobTable {
     /// Base blob information array.
-    entries: Vec<Arc<BlobInfo>>,
+    pub entries: Vec<Arc<BlobInfo>>,
 }
 
 impl RafsV6BlobTable {

--- a/src/bin/nydus-image/deduplicate.rs
+++ b/src/bin/nydus-image/deduplicate.rs
@@ -345,7 +345,7 @@ impl Algorithm<SqliteDatabase> {
         }
         info!(
             "Chunkdict size is {}",
-            chunkdict_size as f64 / 1024 as f64 / 1024 as f64
+            chunkdict_size as f64 / 1024_f64 / 1024_f64
         );
         for chunk in all_chunks {
             if !core_image.contains(&chunk.image_reference)
@@ -790,7 +790,7 @@ impl Algorithm<SqliteDatabase> {
         }
         info!(
             "All chunk size is {}",
-            all_chunks_size as f64 / 1024 as f64 / 1024 as f64
+            all_chunks_size as f64 / 1024_f64 / 1024_f64
         );
 
         let train_percentage = 0.7;
@@ -802,7 +802,7 @@ impl Algorithm<SqliteDatabase> {
         }
         info!(
             "Train set size is {}",
-            train_set_size as f64 / 1024 as f64 / 1024 as f64
+            train_set_size as f64 / 1024_f64 / 1024_f64
         );
 
         let mut test_set_size = 0;
@@ -811,7 +811,7 @@ impl Algorithm<SqliteDatabase> {
         }
         info!(
             "Test set size is {}",
-            test_set_size as f64 / 1024 as f64 / 1024 as f64
+            test_set_size as f64 / 1024_f64 / 1024_f64
         );
 
         let mut version_datadict: HashMap<String, Vec<ChunkdictChunkInfo>> = HashMap::new();
@@ -880,7 +880,7 @@ impl Algorithm<SqliteDatabase> {
         }
         info!(
             "After deduplicating test set size is {} and deduplicating rate is {} ",
-            min_test_size as f64 / 1024 as f64 / 1024 as f64,
+            min_test_size as f64 / 1024_f64 / 1024_f64,
             1.0 - (min_test_size as f64) / (test_set_size as f64)
         );
         Ok((min_data_dict, datadict))

--- a/src/bin/nydus-image/inspect.rs
+++ b/src/bin/nydus-image/inspect.rs
@@ -392,7 +392,7 @@ RAFS Blob Size:         {rafs_size}
                 }
             }
         } else {
-            let file_path = self.rafs_meta.path_from_ino(ino as u64)?;
+            let file_path = self.rafs_meta.path_from_ino(ino)?;
             file_paths.push(file_path);
         };
         Ok(file_paths)

--- a/storage/src/device.rs
+++ b/storage/src/device.rs
@@ -229,6 +229,36 @@ impl BlobInfo {
         blob_info
     }
 
+    /// Set the chunk count
+    pub fn set_chunk_count(&mut self, count: usize) {
+        self.chunk_count = count as u32;
+    }
+
+    /// Set compressed size
+    pub fn set_compressed_size(&mut self, size: usize) {
+        self.compressed_size = size as u64;
+    }
+
+    /// Set uncompressed size
+    pub fn set_uncompressed_size(&mut self, size: usize) {
+        self.uncompressed_size = size as u64;
+    }
+
+    /// Set meta ci compressed size
+    pub fn set_meta_ci_compressed_size(&mut self, size: usize) {
+        self.meta_ci_compressed_size = size as u64;
+    }
+
+    /// Set meta ci uncompressed size
+    pub fn set_meta_ci_uncompressed_size(&mut self, size: usize) {
+        self.meta_ci_uncompressed_size = size as u64;
+    }
+
+    /// Set meta ci offset
+    pub fn set_meta_ci_offset(&mut self, size: usize) {
+        self.meta_ci_offset = size as u64;
+    }
+
     /// Set the is_chunkdict_generated flag.
     pub fn set_chunkdict_generated(&mut self, is_chunkdict_generated: bool) {
         self.is_chunkdict_generated = is_chunkdict_generated;
@@ -256,6 +286,11 @@ impl BlobInfo {
             }
         }
         self.blob_id.clone()
+    }
+
+    /// Set the blob id
+    pub fn set_blob_id(&mut self, blob_id: String) {
+        self.blob_id = blob_id
     }
 
     /// Get raw blob id, without special handling of `inlined-meta` case.

--- a/storage/src/meta/mod.rs
+++ b/storage/src/meta/mod.rs
@@ -1100,6 +1100,7 @@ impl BlobCompressionContext {
     }
 }
 
+#[derive(Clone)]
 /// A customized array to host chunk information table for a blob.
 pub enum BlobMetaChunkArray {
     /// V1 chunk compression information array.

--- a/storage/src/meta/toc.rs
+++ b/storage/src/meta/toc.rs
@@ -272,6 +272,7 @@ impl TocEntry {
     }
 }
 
+#[derive(Clone)]
 /// Container to host a group of ToC entries.
 pub struct TocEntryList {
     entries: Vec<TocEntry>,


### PR DESCRIPTION
## Relevant Issue #1589
The objective is to create an independent image layer to prioritize the fetching of necessary blobs during startup, enhancing performance.

## Details
This introduces the "optimize" subcommand, which generates a new blob containing prefetch files and creates a new RAFS format bootstrap. This ensures compatibility with the nydus-image check and optimizes the startup process.