### PR TITLE
rafs: fix bug in InodeWrapper::is_sock()

### DIFF
--- a/rafs/src/metadata/inode.rs
+++ b/rafs/src/metadata/inode.rs
@@ -183,7 +183,7 @@ impl InodeWrapper {
         match self {
             InodeWrapper::V5(i) => i.is_sock(),
             InodeWrapper::V6(i) => i.is_sock(),
-            InodeWrapper::Ref(i) => i.as_inode().is_dir(),
+            InodeWrapper::Ref(i) => i.as_inode().is_sock(),
         }
     }
 


### PR DESCRIPTION
We incorrectly use is_dir() to check if a file is a socket. This patch fixes it.

## Types of changes

_What types of changes does your PullRequest introduce? Put an `x` in all the boxes that apply:_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)