### PR TITLE
nydus-image: modify compact interface

### DIFF
--- a/builder/src/compact.rs
+++ b/builder/src/compact.rs
@@ -48,22 +48,30 @@ pub struct Config {
     /// available value: 0-99, 0 means disable
     /// hint: it's better to disable this option when there are some shared blobs
     /// for example: build-cache
-    #[serde(default)]
-    min_used_ratio: u8,
+    pub min_used_ratio: u8,
     /// we compact blobs whose size are less than compact_blob_size
-    #[serde(default = "default_compact_blob_size")]
-    compact_blob_size: usize,
+    pub compact_blob_size: usize,
     /// size of compacted blobs should not be larger than max_compact_size
-    #[serde(default = "default_max_compact_size")]
-    max_compact_size: usize,
+    pub max_compact_size: usize,
     /// if number of blobs >= layers_to_compact, do compact
     /// 0 means always try compact
-    #[serde(default)]
-    layers_to_compact: usize,
+    pub layers_to_compact: usize,
     /// local blobs dir, may haven't upload to backend yet
     /// what's more, new blobs will output to this dir
     /// name of blob file should be equal to blob_id
-    blobs_dir: String,
+    pub blobs_dir: String,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            min_used_ratio: 0,
+            compact_blob_size: default_compact_blob_size(),
+            max_compact_size: default_max_compact_size(),
+            layers_to_compact: 0,
+            blobs_dir: String::new(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
@@ -79,7 +87,7 @@ impl ChunkKey {
         match c {
             ChunkWrapper::V5(_) => Self::Digest(*c.id()),
             ChunkWrapper::V6(_) => Self::Offset(c.blob_index(), c.compressed_offset()),
-            ChunkWrapper::Ref(_) => unimplemented!("unsupport ChunkWrapper::Ref(c)"),
+            ChunkWrapper::Ref(_) => Self::Digest(*c.id()),
         }
     }
 }
@@ -790,7 +798,6 @@ mod tests {
     }
 
     #[test]
-    #[should_panic = "not implemented: unsupport ChunkWrapper::Ref(c)"]
     fn test_chunk_key_from() {
         let cw = ChunkWrapper::new(RafsVersion::V5);
         matches!(ChunkKey::from(&cw), ChunkKey::Digest(_));

--- a/builder/src/lib.rs
+++ b/builder/src/lib.rs
@@ -27,6 +27,7 @@ pub use self::chunkdict_generator::ChunkdictBlobInfo;
 pub use self::chunkdict_generator::ChunkdictChunkInfo;
 pub use self::chunkdict_generator::Generator;
 pub use self::compact::BlobCompactor;
+pub use self::compact::Config as CompactConfig;
 pub use self::core::bootstrap::Bootstrap;
 pub use self::core::chunk_dict::{parse_chunk_dict_arg, ChunkDict, HashChunkDict};
 pub use self::core::context::{

--- a/contrib/nydusify/pkg/build/builder.go
+++ b/contrib/nydusify/pkg/build/builder.go
@@ -38,7 +38,12 @@ type CompactOption struct {
 	BackendType         string
 	BackendConfigPath   string
 	OutputJSONPath      string
-	CompactConfigPath   string
+
+	MinUsedRatio    string
+	CompactBlobSize string
+	MaxCompactSize  string
+	LayersToCompact string
+	BlobsDir        string
 }
 
 type GenerateOption struct {
@@ -82,7 +87,11 @@ func (builder *Builder) Compact(option CompactOption) error {
 	args := []string{
 		"compact",
 		"--bootstrap", option.BootstrapPath,
-		"--config", option.CompactConfigPath,
+		"--blob-dir", option.BlobsDir,
+		"--min-used-ratio", option.MinUsedRatio,
+		"--compact-blob-size", option.CompactBlobSize,
+		"--max-compact-size", option.MaxCompactSize,
+		"--layers-to-compact", option.LayersToCompact,
 		"--backend-type", option.BackendType,
 		"--backend-config-file", option.BackendConfigPath,
 		"--log-level", "info",

--- a/contrib/nydusify/pkg/compactor/compactor.go
+++ b/contrib/nydusify/pkg/compactor/compactor.go
@@ -10,18 +10,18 @@ import (
 )
 
 var defaultCompactConfig = &CompactConfig{
-	MinUsedRatio:    5,
-	CompactBlobSize: 10485760,
-	MaxCompactSize:  104857600,
-	LayersToCompact: 32,
+	MinUsedRatio:    "5",
+	CompactBlobSize: "10485760",
+	MaxCompactSize:  "104857600",
+	LayersToCompact: "32",
 }
 
 type CompactConfig struct {
-	MinUsedRatio    int    `json:"min_used_ratio"`
-	CompactBlobSize int    `json:"compact_blob_size"`
-	MaxCompactSize  int    `json:"max_compact_size"`
-	LayersToCompact int    `json:"layers_to_compact"`
-	BlobsDir        string `json:"blobs_dir,omitempty"`
+	MinUsedRatio    string
+	CompactBlobSize string
+	MaxCompactSize  string
+	LayersToCompact string
+	BlobsDir        string
 }
 
 func (cfg *CompactConfig) Dumps(filePath string) error {
@@ -81,11 +81,6 @@ func (compactor *Compactor) Compact(bootstrapPath, chunkDict, backendType, backe
 	if err := os.Remove(targetBootstrap); err != nil && !os.IsNotExist(err) {
 		return "", errors.Wrap(err, "failed to delete old bootstrap file")
 	}
-	// prepare config file
-	configFilePath := filepath.Join(compactor.workdir, "compact.json")
-	if err := compactor.cfg.Dumps(configFilePath); err != nil {
-		return "", errors.Wrap(err, "compact err")
-	}
 	outputJSONPath := filepath.Join(compactor.workdir, "compact-result.json")
 	if err := os.Remove(outputJSONPath); err != nil && !os.IsNotExist(err) {
 		return "", errors.Wrap(err, "failed to delete old output-json file")
@@ -97,7 +92,11 @@ func (compactor *Compactor) Compact(bootstrapPath, chunkDict, backendType, backe
 		BackendType:         backendType,
 		BackendConfigPath:   backendConfigFile,
 		OutputJSONPath:      outputJSONPath,
-		CompactConfigPath:   configFilePath,
+		MinUsedRatio:        compactor.cfg.MinUsedRatio,
+		CompactBlobSize:     compactor.cfg.CompactBlobSize,
+		MaxCompactSize:      compactor.cfg.MaxCompactSize,
+		LayersToCompact:     compactor.cfg.LayersToCompact,
+		BlobsDir:            compactor.cfg.BlobsDir,
 	})
 	if err != nil {
 		return "", errors.Wrap(err, "failed to run compact command")

--- a/src/bin/nydus-image/main.rs
+++ b/src/bin/nydus-image/main.rs
@@ -699,17 +699,17 @@ fn prepare_cmd_args(bti_string: &'static str) -> App {
                 .arg(
                     Arg::new("min-used-ratio")
                         .long("min-used-ratio")
-                        .help("Lower bound of used ratio for blobs to be kept")
+                        .help("Lower bound of used ratio for blobs to be kept, possible values: 0-99, 0 means disable")
                 )
                 .arg(
                     Arg::new("compact-blob-size")
                         .long("compact-blob-size")
-                        .help("Upper bound of blob size for blobs to be compacted")
+                        .help("Upper bound of blob size for blobs to be compacted, in bytes")
                 )
                 .arg(
                     Arg::new("max-compact-size")
                         .long("max-compact-size")
-                        .help("Upper bound of compacted blob size")
+                        .help("Upper bound of compacted blob size, in bytes")
                 )
                 .arg(
                     Arg::new("layers-to-compact")


### PR DESCRIPTION
This commit uses compact parameter directly  insteadof compact config file in the cli interface. It also fix a bug where chunk key for ChunkWrapper::Ref is not generated correctly.

## Types of changes

_What types of changes does your PullRequest introduce? Put an `x` in all the boxes that apply:_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)