### PR TITLE
nydusify supports localfs filesystem backend

### DIFF
--- a/contrib/nydusify/cmd/nydusify.go
+++ b/contrib/nydusify/cmd/nydusify.go
@@ -79,7 +79,7 @@ func getBackendConfig(c *cli.Context, prefix string, required bool) (string, str
 		return "", "", nil
 	}
 
-	possibleBackendTypes := []string{"oss", "s3"}
+	possibleBackendTypes := []string{"oss", "s3", "localfs"}
 	if !isPossibleValue(possibleBackendTypes, backendType) {
 		return "", "", fmt.Errorf("--%sbackend-type should be one of %v", prefix, possibleBackendTypes)
 	}
@@ -89,7 +89,7 @@ func getBackendConfig(c *cli.Context, prefix string, required bool) (string, str
 	)
 	if err != nil {
 		return "", "", err
-	} else if (backendType == "oss" || backendType == "s3") && strings.TrimSpace(backendConfig) == "" {
+	} else if (backendType == "oss" || backendType == "s3" || backendType == "localfs") && strings.TrimSpace(backendConfig) == "" {
 		return "", "", errors.Errorf("backend configuration is empty, please specify option '--%sbackend-config'", prefix)
 	}
 

--- a/docs/nydusify.md
+++ b/docs/nydusify.md
@@ -78,6 +78,22 @@ nydusify convert \
   --backend-config-file /path/to/backend-config.json
 ```
 
+### localfs
+
+``` shell
+cat /path/to/backend-config.json
+{
+  "dir": "/path/to/blobs"
+}
+
+nydusify convert \
+  --source myregistry/repo:tag \
+  --target myregistry/repo:tag-nydus \
+  --backend-config-file /path/to/backend-config.json \
+```
+
+Note: Image manifest is still published to target registry (`myregistry`). Blob files are published to localfs.
+
 ## Push Nydus Image to storage backend with subcommand pack
 
 ### OSS
@@ -176,7 +192,7 @@ nydusify check \
 
 ## Mount the nydus image as a filesystem
 
-The nydusify mount command can mount a nydus image stored in the backend as a filesystem. Now  the  supported backend types include Registry (default backend), s3 and oss. 
+The nydusify mount command can mount a nydus image stored in the backend as a filesystem. Now  the  supported backend types include Registry (default backend), s3, oss, and localfs.
 
 When using Registry as the backend, you don't need to specify the `--backend-type` .
 
@@ -252,7 +268,7 @@ See `nydusify convert/check/mount --help`
 
 ## Use Nydusify as a package
 
-``` 
+```
 See `contrib/nydusify/examples/converter/main.go`
 ```
 


### PR DESCRIPTION
## Relevant Issue (if applicable)
N/A

## Details
Support `localfs` for nydusify commands. Specifically useful for `convert` for local filesystem-backed backend.  The inspiration for this change was to test running Nydus with GCSFuse backend `localfs` on GKE. This is effectively a workaround as Nydus support for GCP Artifact Registry (https://github.com/dragonflyoss/nydus/issues/1594) is still a work in progress.

## Types of changes

_What types of changes does your PullRequest introduce? Put an `x` in all the boxes that apply:_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation Update (if none of the other choices apply)

## Checklist

_Go over all the following points, and put an `x` in all the boxes that apply._

- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.