### PR TITLE
fix: correct some typo in nydus-fscache.md

### DIFF
--- a/docs/nydus-fscache.md
+++ b/docs/nydus-fscache.md
@@ -171,7 +171,7 @@ For more information on how to configure containerd to use nydus snapshotter ple
 
 ``` shell
 # pull nydus image
-nerdctl images pull --snapshotter=nydus docker.io/hsiangkao/ubuntu:20.04-rafs-v6
+nerdctl pull --snapshotter=nydus docker.io/hsiangkao/ubuntu:20.04-rafs-v6
 
 # run nydus image
 nerdctl run --rm -t --snapshotter=nydus docker.io/hsiangkao/ubuntu:20.04-rafs-v6 ubuntu /bin/bash


### PR DESCRIPTION
fix typo in nydus-fscache.md for nerdctl fault below
```
# nerdctl images pull --snapshotter=nydus docker.io/hsiangkao/ubuntu:20.04-rafs-v6
FATA[0000] accepts at most 1 arg(s), received 2
```