### PR TITLE
fix: correct some typos about nerdctl image rm

### DIFF
--- a/docs/nydus-fscache.md
+++ b/docs/nydus-fscache.md
@@ -177,7 +177,7 @@ nerdctl pull --snapshotter=nydus docker.io/hsiangkao/ubuntu:20.04-rafs-v6
 nerdctl run --rm -t --snapshotter=nydus docker.io/hsiangkao/ubuntu:20.04-rafs-v6 ubuntu /bin/bash
 
 # remove nydus image
-nerdctl images rm docker.io/hsiangkao/ubuntu:20.04-rafs-v6
+nerdctl image rm docker.io/hsiangkao/ubuntu:20.04-rafs-v6
 ```
 
 Some RAFS v6 referenced images (in Zstd algorithms):


### PR DESCRIPTION
fix typo in nydus-fscache.md for nerdctl fault below.
Well, I just found it after last pr is merged ...

```
# nerdctl images rm docker.io/hsiangkao/ubuntu:20.04-rafs-v6
FATA[0000] accepts at most 1 arg(s), received 2         

# nerdctl image rm docker.io/hsiangkao/ubuntu:20.04-rafs-v6
Untagged: docker.io/hsiangkao/ubuntu:20.04-rafs-v6@sha256:fa8ee4f87ee9f89005a42b4327317f01ddcb1d2333dcccf886f39d1cbe31aa1f
Deleted: sha256:667a64a38375ff83228d26bc144263c3afd3ea54e071956a80e7ec127fda75aa
Deleted: sha256:7d358c723a7bf1e316d1501708cbcc62bbbac35c719b6db5d59ecbb765c8d77e
```