### PR TITLE
rafs: cleanup errors

### DIFF
--- a/api/src/config.rs
+++ b/api/src/config.rs
@@ -124,7 +124,7 @@ impl ConfigV2 {
     pub fn get_backend_config(&self) -> Result<&BackendConfigV2> {
         self.backend.as_ref().ok_or_else(|| {
             Error::new(
-                ErrorKind::InvalidInput,
+                ErrorKind::InvalidData,
                 "no configuration information for backend",
             )
         })
@@ -163,7 +163,7 @@ impl ConfigV2 {
     pub fn get_rafs_config(&self) -> Result<&RafsConfigV2> {
         self.rafs.as_ref().ok_or_else(|| {
             Error::new(
-                ErrorKind::InvalidInput,
+                ErrorKind::InvalidData,
                 "no configuration information for rafs",
             )
         })

--- a/api/src/error.rs
+++ b/api/src/error.rs
@@ -63,6 +63,8 @@ define_libc_error_macro!(ealready, EALREADY);
 define_libc_error_macro!(enosys, ENOSYS);
 define_libc_error_macro!(epipe, EPIPE);
 define_libc_error_macro!(eio, EIO);
+define_libc_error_macro!(erange, ERANGE);
+define_libc_error_macro!(enodata, ENODATA);
 
 /// Return EINVAL error with formatted error message.
 #[macro_export]

--- a/rafs/src/fs.rs
+++ b/rafs/src/fs.rs
@@ -735,7 +735,7 @@ impl FileSystem for Rafs {
         let mut recorder = FopRecorder::settle(Getxattr, inode, &self.ios);
 
         if !self.xattr_supported() {
-            return Err(std::io::Error::from_raw_os_error(libc::ENOSYS));
+            return Err(enosys!());
         }
 
         let name = OsStr::from_bytes(name.to_bytes());
@@ -744,7 +744,7 @@ impl FileSystem for Rafs {
         let r = match value {
             Some(value) => match size {
                 0 => Ok(GetxattrReply::Count((value.len() + 1) as u32)),
-                x if x < value.len() as u32 => Err(std::io::Error::from_raw_os_error(libc::ERANGE)),
+                x if x < value.len() as u32 => Err(erange!()),
                 _ => Ok(GetxattrReply::Value(value)),
             },
             None => {
@@ -752,7 +752,7 @@ impl FileSystem for Rafs {
                 // the future to wrap this method thus to handle different reasonable
                 // errors in a clean way.
                 recorder.mark_success(0);
-                Err(std::io::Error::from_raw_os_error(libc::ENODATA))
+                Err(enodata!())
             }
         };
 
@@ -765,7 +765,7 @@ impl FileSystem for Rafs {
     fn listxattr(&self, _ctx: &Context, inode: u64, size: u32) -> Result<ListxattrReply> {
         let mut rec = FopRecorder::settle(Listxattr, inode, &self.ios);
         if !self.xattr_supported() {
-            return Err(std::io::Error::from_raw_os_error(libc::ENOSYS));
+            return Err(enosys!());
         }
 
         let inode = self.sb.get_inode(inode, false)?;
@@ -783,7 +783,7 @@ impl FileSystem for Rafs {
 
         match size {
             0 => Ok(ListxattrReply::Count(count as u32)),
-            x if x < count as u32 => Err(std::io::Error::from_raw_os_error(libc::ERANGE)),
+            x if x < count as u32 => Err(erange!()),
             _ => Ok(ListxattrReply::Names(buf)),
         }
     }

--- a/rafs/src/metadata/direct_v6.rs
+++ b/rafs/src/metadata/direct_v6.rs
@@ -237,7 +237,7 @@ impl DirectSuperBlockV6 {
         let block_size = state.block_size();
         let unit_size = size_of::<RafsV5ChunkInfo>();
         if size % unit_size != 0 {
-            return Err(std::io::Error::from_raw_os_error(libc::EINVAL));
+            return Err(einval!());
         }
 
         for idx in 0..(size / unit_size) {


### PR DESCRIPTION
Based on the error definition, InvalidData is preferable than InvalidInput.

Data not valid for the operation were encountered. Unlike [InvalidInput], this typically means that the operation parameters were valid, however the error was caused by malformed input data. For example, a function that reads a file into a string will error with InvalidData if the file's contents are not valid UTF-8.

## Relevant Issue (if applicable)
_If there are Issues related to this PullRequest, please list it._

## Details
_Please describe the details of PullRequest._

## Types of changes

_What types of changes does your PullRequest introduce? Put an `x` in all the boxes that apply:_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Go over all the following points, and put an `x` in all the boxes that apply._

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.