### PR TITLE
fix: dragonflyoss#1644 and #1651 resolve Algorithm to_string and FromStr inconsistency

### DIFF
--- a/utils/src/compress/mod.rs
+++ b/utils/src/compress/mod.rs
@@ -29,7 +29,13 @@ pub enum Algorithm {
 
 impl fmt::Display for Algorithm {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{:?}", self)
+        let output = match self {
+            Algorithm::None => "none",
+            Algorithm::Lz4Block => "lz4_block",
+            Algorithm::GZip => "gzip",
+            Algorithm::Zstd => "zstd",
+        };
+        write!(f, "{}", output)
     }
 }
 
@@ -250,6 +256,7 @@ mod tests {
     use std::fs::OpenOptions;
     use std::io::{Seek, SeekFrom};
     use std::path::Path;
+    use std::str::FromStr;
     use vmm_sys_util::tempfile::TempFile;
 
     #[test]
@@ -592,5 +599,47 @@ mod tests {
         assert!(!Algorithm::Lz4Block.is_none());
         assert!(!Algorithm::GZip.is_none());
         assert!(!Algorithm::Zstd.is_none());
+    }
+
+    #[test]
+    fn test_algorithm_to_string() {
+        assert_eq!(Algorithm::None.to_string(), "none");
+        assert_eq!(Algorithm::Lz4Block.to_string(), "lz4_block");
+        assert_eq!(Algorithm::GZip.to_string(), "gzip");
+        assert_eq!(Algorithm::Zstd.to_string(), "zstd");
+    }
+
+    #[test]
+    fn test_algorithm_from_str() {
+        assert_eq!(Algorithm::from_str("none").unwrap(), Algorithm::None);
+        assert_eq!(
+            Algorithm::from_str("lz4_block").unwrap(),
+            Algorithm::Lz4Block
+        );
+        assert_eq!(Algorithm::from_str("gzip").unwrap(), Algorithm::GZip);
+        assert_eq!(Algorithm::from_str("zstd").unwrap(), Algorithm::Zstd);
+    }
+
+    #[test]
+    fn test_algorithm_to_string_and_from_str_consistency() {
+        let algorithms = vec![
+            Algorithm::None,
+            Algorithm::Lz4Block,
+            Algorithm::GZip,
+            Algorithm::Zstd,
+        ];
+
+        for algo in algorithms {
+            let stringified = algo.to_string();
+            let parsed = Algorithm::from_str(&stringified).unwrap();
+            assert_eq!(algo, parsed, "Mismatch for algorithm: {:?}", algo);
+        }
+    }
+
+    #[test]
+    fn test_algorithm_from_str_invalid_input() {
+        assert!(Algorithm::from_str("invalid_algorithm").is_err());
+        assert!(Algorithm::from_str("GZIP").is_err());
+        assert!(Algorithm::from_str("LZ4_BLOCK").is_err());
     }
 }


### PR DESCRIPTION
## Relevant Issue (if applicable)
Fixes: dragonflyoss#1644  
Fixes: dragonflyoss#1651  

## Details
This Pull Request addresses the inconsistency between the `to_string` and `FromStr` implementations for the `Algorithm` enum.  
Previously:
- The `to_string` method generated PascalCase outputs (e.g., `Zstd`).
- The `FromStr` implementation expected lowercase strings (e.g., `zstd`).  
This caused parsing issues where the output of `to_string` could not be used as input for `FromStr`.

### Changes:
1. Refactored the `Display` trait for the `Algorithm` enum to ensure `to_string` produces lowercase strings matching `FromStr`.
2. Added unit tests to validate consistency and handle invalid inputs.

## Types of changes

_What types of changes does your PullRequest introduce? Put an `x` in all the boxes that apply:_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Go over all the following points, and put an `x` in all the boxes that apply._

- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
