### PR TITLE
fix(blobfs): Update fs ops for `fuse_backend_rs` 0.12.0

### DIFF
--- a/rafs/Cargo.toml
+++ b/rafs/Cargo.toml
@@ -25,6 +25,7 @@ thiserror = "1"
 nydus-api = { version = "0.3", path = "../api" }
 nydus-storage = { version = "0.6", path = "../storage", features = [
     "backend-localfs",
+    "dedup",
 ] }
 nydus-utils = { version = "0.4", path = "../utils" }
 

--- a/rafs/src/blobfs/sync_io.rs
+++ b/rafs/src/blobfs/sync_io.rs
@@ -178,7 +178,7 @@ impl FileSystem for BlobFs {
         inode: Inode,
         flags: u32,
         _fuse_flags: u32,
-    ) -> io::Result<(Option<Handle>, OpenOptions)> {
+    ) -> io::Result<(Option<Handle>, OpenOptions, Option<u32>)> {
         self.pfs.open(_ctx, inode, flags, _fuse_flags)
     }
 
@@ -188,7 +188,7 @@ impl FileSystem for BlobFs {
         _parent: Inode,
         _name: &CStr,
         _args: CreateIn,
-    ) -> io::Result<(Entry, Option<Handle>, OpenOptions)> {
+    ) -> io::Result<(Entry, Option<Handle>, OpenOptions, Option<u32>)> {
         Err(eacces!("Create request is not allowed in blobfs"))
     }
 


### PR DESCRIPTION
## Relevant Issue (if applicable)
_If there are Issues related to this PullRequest, please list it._

## Details

1. Use the correct result types in `blobfs` for `open` and `create` with `fuse_backend_rs` 0.12.0
2. Add missing `dedup` feature for `storage` crate dependency of `rafs`

## Types of changes

_What types of changes does your PullRequest introduce? Put an `x` in all the boxes that apply:_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Go over all the following points, and put an `x` in all the boxes that apply._

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.