### PR TITLE
fix: correct some bugs and add feature of backend config for optimize subcommand

### DIFF
--- a/builder/src/lib.rs
+++ b/builder/src/lib.rs
@@ -41,6 +41,7 @@ pub use self::core::prefetch::{Prefetch, PrefetchPolicy};
 pub use self::core::tree::{MetadataTreeBuilder, Tree, TreeNode};
 pub use self::directory::DirectoryBuilder;
 pub use self::merge::Merger;
+pub use self::optimize_prefetch::generate_prefetch_file_info;
 pub use self::optimize_prefetch::update_ctx_from_bootstrap;
 pub use self::optimize_prefetch::OptimizePrefetch;
 pub use self::stargz::StargzBuilder;

--- a/builder/src/optimize_prefetch.rs
+++ b/builder/src/optimize_prefetch.rs
@@ -148,11 +148,11 @@ impl OptimizePrefetch {
             )?;
         }
 
-        let blob_mgr = Self::dump_blob(ctx, blob_table, &mut blob_state)?;
+        Self::dump_blob(ctx, blob_table, &mut blob_state)?;
 
         debug!("prefetch blob id: {}", ctx.blob_id);
 
-        Self::build_dump_bootstrap(tree, ctx, bootstrap_mgr, blob_table)?;
+        let blob_mgr = Self::build_dump_bootstrap(tree, ctx, bootstrap_mgr, blob_table)?;
         BuildOutput::new(&blob_mgr, &bootstrap_mgr.bootstrap_storage)
     }
 
@@ -161,31 +161,36 @@ impl OptimizePrefetch {
         ctx: &mut BuildContext,
         bootstrap_mgr: &mut BootstrapManager,
         blob_table: &mut RafsBlobTable,
-    ) -> Result<()> {
+    ) -> Result<BlobManager> {
         let mut bootstrap_ctx = bootstrap_mgr.create_ctx()?;
         let mut bootstrap = Bootstrap::new(tree.clone())?;
 
         // Build bootstrap
         bootstrap.build(ctx, &mut bootstrap_ctx)?;
 
-        let blob_table_withprefetch = match blob_table {
-            RafsBlobTable::V5(table) => RafsBlobTable::V5(table.clone()),
-            RafsBlobTable::V6(table) => RafsBlobTable::V6(table.clone()),
+        // generate blob table with extended table
+        let mut blob_mgr = BlobManager::new(ctx.digester);
+        let blob_info = match blob_table {
+            RafsBlobTable::V5(table) => table.get_all(),
+            RafsBlobTable::V6(table) => table.get_all(),
         };
+        blob_mgr.extend_from_blob_table(ctx, blob_info)?;
+        let blob_table_withprefetch = blob_mgr.to_blob_table(&ctx)?;
+
         bootstrap.dump(
             ctx,
             &mut bootstrap_mgr.bootstrap_storage,
             &mut bootstrap_ctx,
             &blob_table_withprefetch,
         )?;
-        Ok(())
+        Ok(blob_mgr)
     }
 
     fn dump_blob(
         ctx: &mut BuildContext,
         blob_table: &mut RafsBlobTable,
         blob_state: &mut PrefetchBlobState,
-    ) -> Result<BlobManager> {
+    ) -> Result<()> {
         match blob_table {
             RafsBlobTable::V5(table) => {
                 table.entries.push(blob_state.blob_info.clone().into());
@@ -235,7 +240,7 @@ impl OptimizePrefetch {
                 rewrite_blob_id(&mut table.entries, "prefetch-blob", ctx.blob_id.clone())
             }
         }
-        Ok(blob_mgr)
+        Ok(())
     }
 
     fn process_prefetch_node(

--- a/builder/src/optimize_prefetch.rs
+++ b/builder/src/optimize_prefetch.rs
@@ -251,8 +251,14 @@ impl OptimizePrefetch {
         blob_table: &RafsBlobTable,
         blobs_dir_path: &Path,
     ) -> Result<()> {
+        let file = prefetch_file_info.file;
+        if tree.get_node_mut(&file).is_none() {
+            warn!("prefetch file {} is bad, skip it", file.display());
+            return Ok(());
+        }
+
         let tree_node = tree
-            .get_node_mut(&prefetch_file_info.file)
+            .get_node_mut(&file)
             .ok_or(anyhow!("failed to get node"))?
             .node
             .as_ref();

--- a/builder/src/optimize_prefetch.rs
+++ b/builder/src/optimize_prefetch.rs
@@ -358,6 +358,9 @@ impl OptimizePrefetch {
             blob_ctx.add_chunk_meta_info(&inner, Some(info))?;
             blob_ctx.blob_hash.update(&buf);
 
+            blob_info.set_compressed_size(blob_ctx.compressed_blob_size as usize);
+            blob_info.set_uncompressed_size(blob_ctx.uncompressed_blob_size as usize);
+            blob_info.set_chunk_count(blob_ctx.chunk_count as usize);
             blob_info.set_meta_ci_compressed_size(
                 (blob_info.meta_ci_compressed_size() + size_of::<BlobChunkInfoV1Ondisk>() as u64)
                     as usize,

--- a/builder/src/optimize_prefetch.rs
+++ b/builder/src/optimize_prefetch.rs
@@ -202,14 +202,6 @@ impl OptimizePrefetch {
             RafsBlobTable::V5(table) => table.get_all(),
             RafsBlobTable::V6(table) => table.get_all(),
         };
-        let blob_id = tree_node
-            .borrow()
-            .chunks
-            .first()
-            .and_then(|chunk| entries.get(chunk.inner.blob_index() as usize).cloned())
-            .map(|entry| entry.blob_id())
-            .ok_or(anyhow!("failed to get blob id"))?;
-        let mut blob_file = Arc::new(File::open(blobs_dir_path.join(blob_id))?);
 
         tree_node.borrow_mut().layer_idx = prefetch_state.blob_info.blob_index() as u16;
 
@@ -220,6 +212,12 @@ impl OptimizePrefetch {
         let encrypted = blob_ctx.blob_compressor != compress::Algorithm::None;
 
         for chunk in chunks {
+            let blob_id = entries
+                .get(chunk.inner.blob_index() as usize)
+                .map(|entry| entry.blob_id())
+                .ok_or(anyhow!("failed to get blob id"))?;
+            let mut blob_file = Arc::new(File::open(blobs_dir_path.join(blob_id))?);
+
             let inner = Arc::make_mut(&mut chunk.inner);
 
             let mut buf = vec![0u8; inner.compressed_size() as usize];

--- a/contrib/nydusify/cmd/nydusify.go
+++ b/contrib/nydusify/cmd/nydusify.go
@@ -200,7 +200,8 @@ func main() {
 			Required: false,
 			Value:    false,
 			Usage:    "Enable debug log level, overwrites the 'log-level' option",
-			EnvVars:  []string{"DEBUG_LOG_LEVEL"}},
+			EnvVars:  []string{"DEBUG_LOG_LEVEL"},
+		},
 		&cli.StringFlag{
 			Name:    "log-level",
 			Aliases: []string{"l"},
@@ -1223,9 +1224,51 @@ func main() {
 					Value: "0MB",
 					Usage: "Chunk size for pushing a blob layer in chunked",
 				},
+
+				&cli.StringFlag{
+					Name:    "source-backend-type",
+					Value:   "",
+					Usage:   "Type of storage backend, enable verification of file data in Nydus image if specified, possible values: 'oss', 's3', 'localfs'",
+					EnvVars: []string{"BACKEND_TYPE"},
+				},
+				&cli.StringFlag{
+					Name:    "source-backend-config",
+					Value:   "",
+					Usage:   "Json string for storage backend configuration",
+					EnvVars: []string{"BACKEND_CONFIG"},
+				},
+				&cli.PathFlag{
+					Name:      "source-backend-config-file",
+					Value:     "",
+					TakesFile: true,
+					Usage:     "Json configuration file for storage backend",
+					EnvVars:   []string{"BACKEND_CONFIG_FILE"},
+				},
 			},
 			Action: func(c *cli.Context) error {
 				setupLogLevel(c)
+
+				backendType, backendConfig, err := getBackendConfig(c, "source-", false)
+				if err != nil {
+					return err
+				} else if backendConfig == "" {
+					backendType = "registry"
+					parsed, err := reference.ParseNormalizedNamed(c.String("target"))
+					if err != nil {
+						return err
+					}
+
+					backendConfigStruct, err := utils.NewRegistryBackendConfig(parsed, c.Bool("target-insecure"))
+					if err != nil {
+						return errors.Wrap(err, "parse registry backend configuration")
+					}
+
+					bytes, err := json.Marshal(backendConfigStruct)
+					if err != nil {
+						return errors.Wrap(err, "marshal registry backend configuration")
+					}
+					backendConfig = string(bytes)
+				}
 
 				pushChunkSize, err := humanize.ParseBytes(c.String("push-chunk-size"))
 				if err != nil {
@@ -1248,6 +1291,9 @@ func main() {
 
 					PushChunkSize:     int64(pushChunkSize),
 					PrefetchFilesPath: c.String("prefetch-files"),
+
+					BackendType:   backendType,
+					BackendConfig: backendConfig,
 				}
 
 				return optimizer.Optimize(context.Background(), opt)

--- a/contrib/nydusify/pkg/optimizer/builder.go
+++ b/contrib/nydusify/pkg/optimizer/builder.go
@@ -19,9 +19,13 @@ func isSignalKilled(err error) bool {
 }
 
 type BuildOption struct {
-	BuilderPath         string
-	PrefetchFilesPath   string
-	BootstrapPath       string
+	BuilderPath       string
+	PrefetchFilesPath string
+	BootstrapPath     string
+	BackendType       string
+	BackendConfig     string
+	// `BlobDir` is used to store optimized blob,
+	// Beside, `BlobDir` is also used to store the original blobs when backend is localfs
 	BlobDir             string
 	OutputBootstrapPath string
 	OutputJSONPath      string
@@ -42,12 +46,19 @@ func Build(option BuildOption) (string, error) {
 		option.PrefetchFilesPath,
 		"--bootstrap",
 		option.BootstrapPath,
-		"--blob-dir",
+		"--output-blob-dir",
 		option.BlobDir,
 		"--output-bootstrap",
 		option.OutputBootstrapPath,
 		"--output-json",
 		outputJSONPath,
+	}
+
+	if option.BackendType == "localfs" {
+		args = append(args, "--blob-dir", option.BlobDir)
+	} else {
+		args = append(args, "--backend-type", option.BackendType)
+		args = append(args, "--backend-config", option.BackendConfig)
 	}
 
 	ctx := context.Background()

--- a/docs/nydusify.md
+++ b/docs/nydusify.md
@@ -262,6 +262,24 @@ nerdctl --snapshotter nydus run \
 
 The original container ID need to be a full container ID rather than an abbreviation.
 
+## Optimize nydus image from prefetch files
+
+The nydusify optimize command can optimize a nydus image from prefetch files, prefetch files are file access patterns during container startup. This will generate a new bootstrap and a new blob wich contains all data indicated by prefetch files.
+
+The content of prefetch files likes this:
+```
+/path/to/file1 start_offset1-end_offset1, start_offset2-end_offset2, ...
+/path/to/file2 start_offset1-end_offset1, start_offset2-end_offset2, ...
+```
+
+``` shell
+nydusify optimize \
+  --nydus-image  /path/to/nydus-image \
+  --source myregistry/repo:tag-nydus \
+  --target myregistry/repo:tag-nydus-optimized \
+  --prefetch-files /path/to/prefetch-files \
+```
+
 ## More Nydusify Options
 
 See `nydusify convert/check/mount --help`


### PR DESCRIPTION

## Details

There are some bugs in optimize subcommand, following bugs are fixed in this patchset:
- read chunk from wrong blob
- missing extended table in new bootstrap
- hardlink is broken in new image
- missing blobinfo updates
- wrong chunk align for fs-version 5

By the way, implement the backend config support for optimize subcommand, thus we can read chunk on-demand during build process. 



## Types of changes

_What types of changes does your PullRequest introduce? Put an `x` in all the boxes that apply:_

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

