### PR TITLE
fix(nydusd): fix parsing of failover-policy argument

### DIFF
--- a/src/bin/nydusd/main.rs
+++ b/src/bin/nydusd/main.rs
@@ -504,8 +504,8 @@ fn process_fs_service(
             .value_of("failover-policy")
             .unwrap_or(&"flush".to_string())
             .try_into()
-            .inspect(|_e| {
-                error!("Invalid failover policy");
+            .inspect_err(|e| {
+                error!("Invalid failover policy: {}", e);
             })?;
 
         // mountpoint means fuse device only


### PR DESCRIPTION
Use `inspect_err` instead of `inspect` to to correctly handle and log errors when parsing the `failover-policy` argument.

## Relevant Issue (if applicable)
_If there are Issues related to this PullRequest, please list it._
Fix the bug that nydusd reports error:`Invalid failover policy` in [CI](https://github.com/dragonflyoss/nydus/actions/runs/13449245978/job/37580814469).
```
[2025-02-21 03:17:22.252830 +00:00] ERROR [src/bin/nydusd/main.rs:508] Invalid failover policy
[2025-02-21 03:17:22.253245 +00:00] ERROR [src/bin/nydusd/main.rs:508] Invalid failover policy
[2025-02-21 03:17:22.253671 +00:00] ERROR [src/bin/nydusd/main.rs:508] Invalid failover policy
[2025-02-21 03:18:42.554628 +00:00] ERROR [src/bin/nydusd/main.rs:508] Invalid failover policy
```
## Details
_Please describe the details of PullRequest._

## Types of changes

_What types of changes does your PullRequest introduce? Put an `x` in all the boxes that apply:_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Go over all the following points, and put an `x` in all the boxes that apply._

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.