### PR TITLE
builder: remove redundant blobs for merge subcommand

### DIFF
--- a/builder/src/core/context.rs
+++ b/builder/src/core/context.rs
@@ -819,7 +819,7 @@ impl BlobContext {
     }
 
     /// Get blob id if the blob has some chunks.
-    pub fn blob_id(&mut self) -> Option<String> {
+    pub fn blob_id(&self) -> Option<String> {
         if self.uncompressed_blob_size > 0 {
             Some(self.blob_id.to_string())
         } else {

--- a/smoke/tests/texture/layer.go
+++ b/smoke/tests/texture/layer.go
@@ -111,6 +111,19 @@ func MakeLowerLayer(t *testing.T, workDir string, makers ...LayerMaker) *tool.La
 	return layer
 }
 
+func MakeThinLowerLayer(t *testing.T, workDir string) *tool.Layer {
+	layer := tool.NewLayer(t, workDir)
+
+	layer.CreateDir(t, "dir-1")
+	layer.CreateFile(t, "dir-1/file-2", []byte("dir-1/file-2"))
+
+	layer.CreateDir(t, "dir-2")
+	layer.CreateFile(t, "dir-2/file-1", []byte("dir-2/file-1"))
+	layer.CreateFile(t, "dir-2/file-2", []byte("dir-2/file-2"))
+
+	return layer
+}
+
 func MakeUpperLayer(t *testing.T, workDir string) *tool.Layer {
 	layer := tool.NewLayer(t, workDir)
 


### PR DESCRIPTION
After merging all trees, we need to re-calculate the blob index of referenced blobs, as the upper tree might have deleted some files or directories by opaques, and some blobs are dereferenced.

## Relevant Issue (if applicable)
_If there are Issues related to this PullRequest, please list it._

## Details
_Please describe the details of PullRequest._

## Types of changes

_What types of changes does your PullRequest introduce? Put an `x` in all the boxes that apply:_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Go over all the following points, and put an `x` in all the boxes that apply._

- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.