### PR TITLE
misc: remove centos image from image conversion CI

### DIFF
--- a/.github/workflows/convert.yml
+++ b/.github/workflows/convert.yml
@@ -139,7 +139,7 @@ jobs:
                 --source localhost:5000/$I \
                 --target localhost:5000/$I:nydus-nightly-oci-ref
 
-            sudo fsck.erofs -d1 output/nydus_bootstrap
+            sudo fsck.erofs -d1 ./output/target/nydus_bootstrap/image/image.boot
             sudo rm -rf ./output
           done
       - name: Save Nydusify Metric
@@ -256,7 +256,7 @@ jobs:
             sudo DOCKER_CONFIG=$HOME/.docker nydusify check --source $I:latest \
                 --target localhost:5000/$I:nydus-nightly-v6
 
-            sudo fsck.erofs -d1 output/nydus_bootstrap
+            sudo fsck.erofs -d1 ./output/target/nydus_bootstrap/image/image.boot
             sudo rm -rf ./output
           done
       - name: Save Nydusify Metric
@@ -321,7 +321,7 @@ jobs:
             sudo DOCKER_CONFIG=$HOME/.docker nydusify check --source $I:latest \
                 --target localhost:5000/$I:nydus-nightly-v6-batch
 
-            sudo fsck.erofs -d1 output/nydus_bootstrap
+            sudo fsck.erofs -d1 ./output/target/nydus_bootstrap/image/image.boot
             sudo rm -rf ./output
           done
       - name: Save Nydusify Metric

--- a/misc/top_images/image_list.txt
+++ b/misc/top_images/image_list.txt
@@ -15,7 +15,6 @@ mariadb
 amazoncorretto
 docker
 rabbitmq
-centos
 hello-world
 registry
 debian


### PR DESCRIPTION
The centos image has been deprecated on Docker Hub, so we can't pull it in "Convert & Check Images" CI pipeline.

See https://hub.docker.com/_/centos

The broken CI: https://github.com/dragonflyoss/nydus/actions/runs/14024645226

## Relevant Issue (if applicable)
_If there are Issues related to this PullRequest, please list it._

## Details
_Please describe the details of PullRequest._

## Types of changes

_What types of changes does your PullRequest introduce? Put an `x` in all the boxes that apply:_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Go over all the following points, and put an `x` in all the boxes that apply._

- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.