### PR TITLE
feat(nydusify): After converting the image, if the push operation fails, increase the number of retries.

### DIFF
--- a/contrib/nydusify/cmd/nydusify.go
+++ b/contrib/nydusify/cmd/nydusify.go
@@ -432,6 +432,18 @@ func main() {
 					Usage:   "Enable plain http for Nydus image push",
 					EnvVars: []string{"PLAIN_HTTP"},
 				},
+				&cli.IntFlag{
+					Name:    "push-retry-count",
+					Value:   3,
+					Usage:   "Number of retries when pushing to registry fails",
+					EnvVars: []string{"PUSH_RETRY_COUNT"},
+				},
+				&cli.StringFlag{
+					Name:    "push-retry-delay",
+					Value:   "5s",
+					Usage:   "Delay between push retries (e.g. 5s, 1m, 1h)",
+					EnvVars: []string{"PUSH_RETRY_DELAY"},
+				},
 			},
 			Action: func(c *cli.Context) error {
 				setupLogLevel(c)
@@ -530,8 +542,10 @@ func main() {
 					AllPlatforms: c.Bool("all-platforms"),
 					Platforms:    c.String("platform"),
 
-					OutputJSON:    c.String("output-json"),
-					WithPlainHTTP: c.Bool("plain-http"),
+					OutputJSON:     c.String("output-json"),
+					WithPlainHTTP:  c.Bool("plain-http"),
+					PushRetryCount: c.Int("push-retry-count"),
+					PushRetryDelay: c.String("push-retry-delay"),
 				}
 
 				return converter.Convert(context.Background(), opt)
@@ -1443,7 +1457,8 @@ func getGlobalFlags() []cli.Flag {
 			Required: false,
 			Value:    false,
 			Usage:    "Enable debug log level, overwrites the 'log-level' option",
-			EnvVars:  []string{"DEBUG_LOG_LEVEL"}},
+			EnvVars:  []string{"DEBUG_LOG_LEVEL"},
+		},
 		&cli.StringFlag{
 			Name:    "log-level",
 			Aliases: []string{"l"},

--- a/contrib/nydusify/pkg/converter/converter.go
+++ b/contrib/nydusify/pkg/converter/converter.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	modelspec "github.com/CloudNativeAI/model-spec/specs-go/v1"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -81,6 +82,9 @@ type Opt struct {
 	Platforms    string
 
 	OutputJSON string
+
+	PushRetryCount int
+	PushRetryDelay string
 }
 
 type SourceBackendConfig struct {
@@ -124,6 +128,15 @@ func Convert(ctx context.Context, opt Opt) error {
 		return err
 	}
 	defer os.RemoveAll(tmpDir)
+
+	// Parse retry delay
+	retryDelay, err := time.ParseDuration(opt.PushRetryDelay)
+	if err != nil {
+		return errors.Wrap(err, "parse push retry delay")
+	}
+
+	// Set push retry configuration
+	pvd.SetPushRetryConfig(opt.PushRetryCount, retryDelay)
 
 	cvt, err := converter.New(
 		converter.WithProvider(pvd),

--- a/contrib/nydusify/pkg/provider/source.go
+++ b/contrib/nydusify/pkg/provider/source.go
@@ -18,6 +18,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/containerd/containerd/mount"
 	"github.com/opencontainers/go-digest"
@@ -113,7 +114,7 @@ func (sl *defaultSourceLayer) Mount(ctx context.Context) ([]mount.Mount, func() 
 		}
 
 		return nil
-	}); err != nil {
+	}, 3, 5*time.Second); err != nil {
 		return nil, nil, err
 	}
 

--- a/contrib/nydusify/pkg/utils/utils_test.go
+++ b/contrib/nydusify/pkg/utils/utils_test.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"syscall"
 	"testing"
+	"time"
 
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
@@ -243,7 +244,7 @@ func TestWithRetry(t *testing.T) {
 	err := WithRetry(func() error {
 		_, err := http.Get("http://localhost:5000")
 		return err
-	})
+	}, 3, 5*time.Second)
 	require.ErrorIs(t, err, syscall.ECONNREFUSED)
 }
 


### PR DESCRIPTION
## Details
When the image is too large, during the push process, there might be some issues in the middle, causing a significant amount of time to be spent on conversion each time.  To address this problem, a retry mechanism was added during the push process.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Go over all the following points, and put an `x` in all the boxes that apply._

- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.