### PR TITLE
[Fix] Add "ssl" to fallback connection error messages

### DIFF
--- a/storage/src/backend/registry.rs
+++ b/storage/src/backend/registry.rs
@@ -257,8 +257,9 @@ impl RegistryState {
                     // we are likely to encounter these types of error:
                     // https://github.com/openssl/openssl/blob/6b3d28757620e0781bb1556032bb6961ee39af63/crypto/err/openssl.txt#L1574
                     // https://github.com/containerd/nerdctl/blob/225a70bdc3b93cdb00efac7db1ceb50c098a8a16/pkg/cmd/image/push.go#LL135C66-L135C66
-                    let fallback =
-                        msg.contains("wrong version number") || msg.contains("connection refused");
+                    let fallback = msg.contains("wrong version number")
+                        || msg.contains("connection refused")
+                        || msg.to_lowercase().contains("ssl");
                     if fallback {
                         warn!("fallback to http due to tls connection error: {}", err);
                     }


### PR DESCRIPTION
## Relevant Issue (if applicable)

fix https://github.com/dragonflyoss/nydus/issues/1705

## Details

This commit addresses an issue where Nydus might fail to establish a connection due to SSL-related errors that are not currently handled by the fallback mechanism.

Previously, the fallback logic only considered "wrong version number" and "connection refused" messages . However, in certain environments, SSL failures leading to persistent connection failures without triggering the intended fallback.

This change extends the `fallback` condition to include messages containing "ssl". By doing so, Nydus will now correctly identify and handle SSL-related connection problems, improving its robustness and resilience in various network configurations.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.