### PR TITLE
[Feature] improve VFS State Saving for Daemon Transitions

### DIFF
--- a/service/src/upgrade.rs
+++ b/service/src/upgrade.rs
@@ -437,7 +437,8 @@ pub mod fusedev_upgrade {
     /// Save state information for a FUSE daemon.
     pub fn save(daemon: &FusedevDaemon) -> Result<()> {
         let svc = daemon.get_default_fs_service().ok_or(Error::NotFound)?;
-        if !svc.get_vfs().initialized() {
+        let vfs = svc.get_vfs();
+        if !vfs.initialized() {
             return Err(Error::NotReady);
         }
 
@@ -446,6 +447,8 @@ pub mod fusedev_upgrade {
 
         let state = backend_stat.save().map_err(UpgradeMgrError::Serialize)?;
         mgr.save(&state)?;
+
+        mgr.save_vfs_stat(vfs)?;
 
         Ok(())
     }


### PR DESCRIPTION
## Relevant Issue (if applicable)
close https://github.com/dragonflyoss/nydus/issues/1715

## Details
This PR enhances the daemon's Virtual File System (VFS) state management to ensure consistency during daemon transitions like hot upgrades.

New VFS Initialization Wait Mechanism: A dedicated wait_vfs_initialized function has been added and implemented. This function ensures that save_vfs_stat operates only when the VFS is fully ready.
## Types of changes

_What types of changes does your PullRequest introduce? Put an `x` in all the boxes that apply:_

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Go over all the following points, and put an `x` in all the boxes that apply._

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.