### PR TITLE
feat(nydusify): add zero-disk streaming image transfer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,6 @@ go.work.sum
 dist/
 nydus-static/
 .goreleaser.yml
+vendor/
 metadata.db
 tests/texture/zran/233c72f2b6b698c07021c4da367cfe2dff4f049efbaa885ca0ff760ea297865a

--- a/contrib/nydusify/cmd/nydusify.go
+++ b/contrib/nydusify/cmd/nydusify.go
@@ -1158,6 +1158,11 @@ func main() {
 					Value: "0MB",
 					Usage: "Chunk size for pushing a blob layer in chunked",
 				},
+				&cli.BoolFlag{
+					Name:  "enable-stream-copy",
+					Value: false,
+					Usage: "Enable stream copy mode for image transfer",
+				},
 
 				&cli.StringFlag{
 					Name:    "work-dir",
@@ -1203,7 +1208,8 @@ func main() {
 					AllPlatforms: c.Bool("all-platforms"),
 					Platforms:    c.String("platform"),
 
-					PushChunkSize: int64(pushChunkSize),
+					PushChunkSize:    int64(pushChunkSize),
+					EnableStreamCopy: c.Bool("enable-stream-copy"),
 				}
 
 				return copier.Copy(context.Background(), opt)

--- a/contrib/nydusify/cmd/nydusify.go
+++ b/contrib/nydusify/cmd/nydusify.go
@@ -101,7 +101,7 @@ func getBackendConfig(c *cli.Context, prefix string, required bool) (string, str
 // Source: localhost:5000/nginx:latest
 // Target: localhost:5000/nginx:latest-suffix
 func addReferenceSuffix(source, suffix string) (string, error) {
-	named, err := reference.ParseDockerRef(source)
+	named, err := reference.ParseNormalizedNamed(source)
 	if err != nil {
 		return "", fmt.Errorf("invalid source image reference: %s", err)
 	}
@@ -139,7 +139,7 @@ func getCacheReference(c *cli.Context, target string) (string, error) {
 		return "", fmt.Errorf("--build-cache conflicts with --build-cache-tag")
 	}
 	if cacheTag != "" {
-		named, err := reference.ParseDockerRef(target)
+		named, err := reference.ParseNormalizedNamed(target)
 		if err != nil {
 			return "", fmt.Errorf("invalid target image reference: %s", err)
 		}

--- a/contrib/nydusify/cmd/nydusify_test.go
+++ b/contrib/nydusify/cmd/nydusify_test.go
@@ -12,7 +12,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/agiledragon/gomonkey/v2"
+	gomonkey "github.com/agiledragon/gomonkey/v2"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/contrib/nydusify/go.mod
+++ b/contrib/nydusify/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.27
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.17.8
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.58.2
+	github.com/containerd/containerd v1.7.23
 	github.com/containerd/containerd/v2 v2.0.5
 	github.com/containerd/continuity v0.4.5
 	github.com/containerd/errdefs v1.0.0
@@ -59,7 +60,6 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/containerd/cgroups/v3 v3.0.5 // indirect
-	github.com/containerd/containerd v1.7.23 // indirect
 	github.com/containerd/containerd/api v1.9.0 // indirect
 	github.com/containerd/errdefs/pkg v0.3.0 // indirect
 	github.com/containerd/fifo v1.1.0 // indirect

--- a/contrib/nydusify/pkg/committer/commiter.go
+++ b/contrib/nydusify/pkg/committer/commiter.go
@@ -357,7 +357,7 @@ func (cm *Committer) commitUpperByDiff(ctx context.Context, appendMount func(pat
 
 // getDistributionSourceLabel returns the source label key and value for the image distribution
 func getDistributionSourceLabel(sourceRef string) (string, string) {
-	named, err := reference.ParseDockerRef(sourceRef)
+	named, err := reference.ParseNormalizedNamed(sourceRef)
 	if err != nil {
 		return "", ""
 	}
@@ -840,7 +840,7 @@ func withRetry(handle func() error, total int) error {
 
 // ValidateRef validate the target image reference.
 func ValidateRef(ref string) (string, error) {
-	named, err := reference.ParseDockerRef(ref)
+	named, err := reference.ParseNormalizedNamed(ref)
 	if err != nil {
 		return "", errors.Wrapf(err, "invalid image reference: %s", ref)
 	}

--- a/contrib/nydusify/pkg/converter/provider/memory_content.go
+++ b/contrib/nydusify/pkg/converter/provider/memory_content.go
@@ -1,0 +1,402 @@
+package provider
+
+import (
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"hash"
+	"io"
+	"sync"
+
+	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/errdefs"
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/sirupsen/logrus"
+)
+
+type memoryBlob struct {
+	// data is the content of the blob
+	data   []byte
+	digest digest.Digest
+	size   int64
+}
+
+type streamBlob struct {
+	// pr is the reader of the stream blob
+	pr *io.PipeReader
+	// pw is the writer of the stream blob
+	pw        *io.PipeWriter
+	digest    digest.Digest // digest of the blob
+	size      int64         // size of the blob
+	done      chan struct{} // done signal
+	dataCache *bytes.Buffer // cache of the read data, support random read
+	mu        sync.RWMutex  // mutex of the data cache
+}
+
+type memoryContentStore struct {
+	mu          sync.RWMutex
+	blobs       map[digest.Digest]*memoryBlob
+	streamBlobs map[digest.Digest]*streamBlob
+}
+
+func NewMemoryContentStore() content.Store {
+	return &memoryContentStore{
+		blobs:       make(map[digest.Digest]*memoryBlob),
+		streamBlobs: make(map[digest.Digest]*streamBlob),
+	}
+}
+
+type memoryWriter struct {
+	store *memoryContentStore
+	buf   *bytes.Buffer
+	hash  hash.Hash
+	off   int64
+}
+
+type streamWriter struct {
+	store  *memoryContentStore
+	blob   *streamBlob
+	hash   hash.Hash
+	off    int64
+	closed bool
+}
+
+func (m *memoryContentStore) Writer(ctx context.Context, opts ...content.WriterOpt) (content.Writer, error) {
+	if useStream, _ := ctx.Value("useStream").(bool); useStream {
+		pr, pw := io.Pipe()
+		blob := &streamBlob{
+			pr:        pr,
+			pw:        pw,
+			done:      make(chan struct{}),
+			dataCache: new(bytes.Buffer),
+		}
+		return &streamWriter{
+			store: m,
+			blob:  blob,
+			hash:  sha256.New(),
+		}, nil
+	}
+
+	return &memoryWriter{
+		store: m,
+		buf:   new(bytes.Buffer),
+		hash:  sha256.New(),
+	}, nil
+}
+
+func (w *memoryWriter) Write(p []byte) (int, error) {
+	n, err := w.buf.Write(p)
+	if n > 0 {
+		w.hash.Write(p[:n])
+		w.off += int64(n)
+	}
+	return n, err
+}
+
+func (w *memoryWriter) Close() error {
+	return nil
+}
+
+func (w *memoryWriter) Commit(ctx context.Context, size int64, expected digest.Digest, opts ...content.Opt) error {
+	dgst := digest.NewDigestFromBytes(digest.SHA256, w.hash.Sum(nil))
+
+	blob := &memoryBlob{
+		data:   w.buf.Bytes(),
+		digest: dgst,
+		size:   w.off,
+	}
+
+	w.store.mu.Lock()
+	w.store.blobs[dgst] = blob
+	w.store.mu.Unlock()
+
+	return nil
+}
+
+func (w *memoryWriter) Truncate(size int64) error {
+	return nil
+}
+
+func (w *memoryWriter) Status() (content.Status, error) {
+	return content.Status{
+		Offset: w.off,
+	}, nil
+}
+
+func (w *memoryWriter) Digest() digest.Digest {
+	return digest.NewDigestFromBytes(digest.SHA256, w.hash.Sum(nil))
+}
+
+func (w *memoryWriter) Size() int64 {
+	return w.off
+}
+
+func (w *streamWriter) Write(p []byte) (int, error) {
+	if w.closed {
+		return 0, io.ErrClosedPipe
+	}
+
+	n, err := w.blob.pw.Write(p)
+	if n > 0 {
+		w.hash.Write(p[:n])
+		w.off += int64(n)
+
+		w.blob.mu.Lock()
+		w.blob.dataCache.Write(p[:n])
+		w.blob.mu.Unlock()
+	}
+	return n, err
+}
+
+func (w *streamWriter) Close() error {
+	if w.closed {
+		return nil
+	}
+	w.closed = true
+	return w.blob.pw.Close()
+}
+
+func (w *streamWriter) Commit(ctx context.Context, size int64, expected digest.Digest, opts ...content.Opt) error {
+	logrus.Infof("push stream data, size: %d bytes", w.off)
+
+	w.blob.size = w.off
+	w.blob.digest = digest.NewDigestFromBytes(digest.SHA256, w.hash.Sum(nil))
+
+	if expected != "" && expected != w.blob.digest {
+		logrus.Errorf("digest mismatch: expected %s, actual %s", expected, w.blob.digest)
+		return fmt.Errorf("digest mismatch: expected %s, actual %s", expected, w.blob.digest)
+	}
+
+	if size > 0 && size != w.off {
+		logrus.Warnf("size mismatch: expected %d, actual %d", size, w.off)
+	}
+
+	w.store.mu.Lock()
+	w.store.streamBlobs[w.blob.digest] = w.blob
+	w.store.mu.Unlock()
+
+	close(w.blob.done)
+	return nil
+}
+
+func (w *streamWriter) Truncate(size int64) error {
+	return nil
+}
+
+func (w *streamWriter) Status() (content.Status, error) {
+	return content.Status{
+		Offset: w.off,
+	}, nil
+}
+
+func (w *streamWriter) Digest() digest.Digest {
+	return w.blob.digest
+}
+
+func (w *streamWriter) Size() int64 {
+	return w.off
+}
+
+type memoryReaderAt struct {
+	data []byte
+	size int64
+}
+
+func (r *memoryReaderAt) ReadAt(p []byte, off int64) (int, error) {
+	if off >= int64(len(r.data)) {
+		return 0, io.EOF
+	}
+
+	n := copy(p, r.data[off:])
+	if n < len(p) {
+		return n, io.EOF
+	}
+	return n, nil
+}
+
+func (r *memoryReaderAt) Read(p []byte) (int, error) {
+	if len(r.data) == 0 {
+		return 0, io.EOF
+	}
+
+	n := copy(p, r.data)
+	r.data = r.data[n:]
+	if len(r.data) == 0 {
+		return n, io.EOF
+	}
+	return n, nil
+}
+
+func (r *memoryReaderAt) Close() error {
+	return nil
+}
+
+func (r *memoryReaderAt) Size() int64 {
+	return r.size
+}
+
+type streamReaderAt struct {
+	blob *streamBlob
+	off  int64 // current read offset
+}
+
+func (r *streamReaderAt) ReadAt(p []byte, off int64) (int, error) {
+	r.blob.mu.RLock()
+	cachedData := r.blob.dataCache.Bytes()
+	cachedSize := len(cachedData)
+	r.blob.mu.RUnlock()
+
+	if off >= int64(cachedSize) {
+		select {
+		case <-r.blob.done:
+			return 0, io.EOF
+		default:
+			return 0, io.ErrUnexpectedEOF
+		}
+	}
+
+	n := copy(p, cachedData[off:])
+
+	if n < len(p) {
+		select {
+		case <-r.blob.done:
+			if off+int64(n) >= r.blob.size {
+				return n, io.EOF
+			}
+		default:
+		}
+	}
+
+	return n, nil
+}
+
+func (r *streamReaderAt) Read(p []byte) (int, error) {
+	n, err := r.blob.pr.Read(p)
+	if n > 0 {
+		r.off += int64(n)
+	}
+	return n, err
+}
+
+func (r *streamReaderAt) Close() error {
+	return r.blob.pr.Close()
+}
+
+func (r *streamReaderAt) Size() int64 {
+	select {
+	case <-r.blob.done:
+		return r.blob.size
+	default:
+		return 0 // size unknown
+	}
+}
+
+func (m *memoryContentStore) ReaderAt(ctx context.Context, desc ocispec.Descriptor) (content.ReaderAt, error) {
+	m.mu.RLock()
+	blob, ok := m.blobs[desc.Digest]
+	if !ok {
+		streamBlob, streamOk := m.streamBlobs[desc.Digest]
+		m.mu.RUnlock()
+
+		if streamOk {
+			return &streamReaderAt{blob: streamBlob}, nil
+		}
+		return nil, errdefs.ErrNotFound
+	}
+	m.mu.RUnlock()
+
+	return &memoryReaderAt{data: blob.data, size: blob.size}, nil
+}
+
+func (m *memoryContentStore) Reader(ctx context.Context, desc digest.Digest) (io.ReadCloser, error) {
+	m.mu.RLock()
+	blob, ok := m.blobs[desc]
+	if !ok {
+		streamBlob, streamOk := m.streamBlobs[desc]
+		m.mu.RUnlock()
+
+		if streamOk {
+			return streamBlob.pr, nil
+		}
+		return nil, errdefs.ErrNotFound
+	}
+	m.mu.RUnlock()
+
+	return io.NopCloser(bytes.NewReader(blob.data)), nil
+}
+
+func (m *memoryContentStore) Info(ctx context.Context, dgst digest.Digest) (content.Info, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	blob, ok := m.blobs[dgst]
+	if ok {
+		return content.Info{
+			Digest: dgst,
+			Size:   blob.size,
+		}, nil
+	}
+
+	streamBlob, streamOk := m.streamBlobs[dgst]
+	if streamOk {
+		return content.Info{
+			Digest: dgst,
+			Size:   streamBlob.size,
+		}, nil
+	}
+
+	return content.Info{}, errdefs.ErrNotFound
+}
+
+func (m *memoryContentStore) Abort(ctx context.Context, ref string) error {
+	return nil
+}
+
+func (m *memoryContentStore) Status(ctx context.Context, ref string) (content.Status, error) {
+	return content.Status{Ref: ref}, nil
+}
+
+func (m *memoryContentStore) ListStatuses(ctx context.Context, filters ...string) ([]content.Status, error) {
+	return nil, nil
+}
+
+func (m *memoryContentStore) Delete(ctx context.Context, dgst digest.Digest) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	delete(m.blobs, dgst)
+	delete(m.streamBlobs, dgst)
+	return nil
+}
+
+func (m *memoryContentStore) Update(ctx context.Context, info content.Info, fieldpaths ...string) (content.Info, error) {
+	return info, nil
+}
+
+func (m *memoryContentStore) Walk(ctx context.Context, fn content.WalkFunc, filters ...string) error {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
+	for dgst, blob := range m.blobs {
+		info := content.Info{
+			Digest: dgst,
+			Size:   blob.size,
+		}
+		if err := fn(info); err != nil {
+			return err
+		}
+	}
+
+	for dgst, blob := range m.streamBlobs {
+		info := content.Info{
+			Digest: dgst,
+			Size:   blob.size,
+		}
+		if err := fn(info); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/contrib/nydusify/pkg/converter/provider/memory_content.go
+++ b/contrib/nydusify/pkg/converter/provider/memory_content.go
@@ -9,8 +9,8 @@ import (
 	"io"
 	"sync"
 
-	"github.com/containerd/containerd/content"
-	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/v2/core/content"
+	"github.com/containerd/errdefs"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/sirupsen/logrus"

--- a/contrib/nydusify/pkg/converter/provider/provider.go
+++ b/contrib/nydusify/pkg/converter/provider/provider.go
@@ -298,7 +298,8 @@ func (pvd *Provider) FetchImageInfo(ctx context.Context, ref string) error {
 }
 
 func (pvd *Provider) fetchDescriptorChildren(ctx context.Context, fetcher remotes.Fetcher, data []byte, desc ocispec.Descriptor) error {
-	if desc.MediaType == ocispec.MediaTypeImageIndex || desc.MediaType == "application/vnd.docker.distribution.manifest.list.v2+json" {
+	switch desc.MediaType {
+	case ocispec.MediaTypeImageIndex, "application/vnd.docker.distribution.manifest.list.v2+json":
 		var index ocispec.Index
 		if err := json.Unmarshal(data, &index); err != nil {
 			return errors.Wrap(err, "unmarshal index")
@@ -309,10 +310,9 @@ func (pvd *Provider) fetchDescriptorChildren(ctx context.Context, fetcher remote
 				return err
 			}
 		}
-	} else if desc.MediaType == ocispec.MediaTypeImageManifest || desc.MediaType == "application/vnd.docker.distribution.manifest.v2+json" {
+	case ocispec.MediaTypeImageManifest, "application/vnd.docker.distribution.manifest.v2+json":
 		return pvd.processManifest(ctx, fetcher, data)
 	}
-
 	return nil
 }
 
@@ -321,9 +321,9 @@ func (pvd *Provider) fetchManifest(ctx context.Context, fetcher remotes.Fetcher,
 	if err != nil {
 		return errors.Wrap(err, "fetch manifest")
 	}
+	defer rc.Close()
 
 	manifestData, err := io.ReadAll(rc)
-	rc.Close()
 	if err != nil {
 		return errors.Wrap(err, "read manifest")
 	}
@@ -345,9 +345,9 @@ func (pvd *Provider) processManifest(ctx context.Context, fetcher remotes.Fetche
 	if err != nil {
 		return errors.Wrap(err, "fetch config")
 	}
+	defer rc.Close()
 
 	configData, err := io.ReadAll(rc)
-	rc.Close()
 	if err != nil {
 		return errors.Wrap(err, "read config")
 	}

--- a/contrib/nydusify/pkg/converter/provider/provider.go
+++ b/contrib/nydusify/pkg/converter/provider/provider.go
@@ -15,14 +15,14 @@ import (
 	"sync"
 	"time"
 
-	"github.com/containerd/containerd"
-	"github.com/containerd/containerd/content"
-	"github.com/containerd/containerd/errdefs"
-	"github.com/containerd/containerd/images"
-	"github.com/containerd/containerd/images/archive"
-	"github.com/containerd/containerd/platforms"
-	"github.com/containerd/containerd/remotes"
-	"github.com/containerd/containerd/remotes/docker"
+	"github.com/containerd/containerd/v2/client"
+	"github.com/containerd/containerd/v2/core/content"
+	"github.com/containerd/containerd/v2/core/images"
+	"github.com/containerd/containerd/v2/core/images/archive"
+	"github.com/containerd/containerd/v2/core/remotes"
+	"github.com/containerd/containerd/v2/core/remotes/docker"
+	"github.com/containerd/errdefs"
+	"github.com/containerd/platforms"
 	"github.com/dragonflyoss/nydus/contrib/nydusify/pkg/utils"
 	"github.com/goharbor/acceleration-service/pkg/cache"
 	"github.com/goharbor/acceleration-service/pkg/remote"
@@ -106,7 +106,7 @@ func newResolver(insecure, plainHTTP bool, credFunc remote.CredentialFunc, chunk
 		docker.WithPlainHTTP(func(_ string) (bool, error) {
 			return plainHTTP, nil
 		}),
-		docker.WithChunkSize(chunkSize),
+		// docker.WithChunkSize was removed in containerd v2, chunk size is now handled differently
 	)
 
 	return docker.NewResolver(docker.ResolverOptions{
@@ -152,7 +152,7 @@ func (pvd *Provider) Pull(ctx context.Context, ref string) error {
 		return err
 	}
 
-	rc := &containerd.RemoteContext{
+	rc := &client.RemoteContext{
 		Resolver:               resolver,
 		PlatformMatcher:        pvd.platformMC,
 		MaxConcurrentDownloads: LayerConcurrentLimit,
@@ -183,7 +183,7 @@ func (pvd *Provider) Push(ctx context.Context, desc ocispec.Descriptor, ref stri
 		return err
 	}
 
-	rc := &containerd.RemoteContext{
+	rc := &client.RemoteContext{
 		Resolver:                    resolver,
 		PlatformMatcher:             pvd.platformMC,
 		MaxConcurrentUploadedLayers: LayerConcurrentLimit,

--- a/contrib/nydusify/pkg/converter/provider/provider.go
+++ b/contrib/nydusify/pkg/converter/provider/provider.go
@@ -47,7 +47,7 @@ type Provider struct {
 	pushRetryDelay time.Duration
 }
 
-func New(root string, hosts remote.HostFunc, cacheSize uint, cacheVersion string, platformMC platforms.MatchComparer, chunkSize int64) (*Provider, error) {
+func New(_ string, hosts remote.HostFunc, cacheSize uint, cacheVersion string, platformMC platforms.MatchComparer, chunkSize int64) (*Provider, error) {
 	store := NewMemoryContentStore()
 
 	return &Provider{

--- a/contrib/nydusify/pkg/copier/copier.go
+++ b/contrib/nydusify/pkg/copier/copier.go
@@ -44,6 +44,13 @@ import (
 	"golang.org/x/sync/semaphore"
 )
 
+// contextKey is a type for context keys to avoid conflicts
+type contextKey string
+
+const (
+	streamContextKey contextKey = "useStream"
+)
+
 type Opt struct {
 	WorkDir        string
 	NydusImagePath string
@@ -298,26 +305,21 @@ func StreamCopy(ctx context.Context, srcReader io.Reader, targetWriter content.W
 func handleSmallFileTransfer(ctx context.Context, srcReader io.Reader, targetWriter content.Writer, size int64, expectedDigest digest.Digest) error {
 	logrus.Debugf("file is small (%d bytes), using simplified handling", size)
 
-	// 读取全部内容
 	data, err := io.ReadAll(srcReader)
 	if err != nil {
 		return errors.Wrap(err, "read small file data failed")
 	}
 
-	// 确保数据大小正确
 	if int64(len(data)) != size && size > 0 {
 		logrus.Warnf("small file size mismatch: expected %d bytes, actual %d bytes", size, len(data))
 	}
 
-	// 计算实际摘要
 	actualDigest := digest.FromBytes(data)
 
-	// 检查摘要是否匹配
 	if expectedDigest != "" && expectedDigest != actualDigest {
 		return fmt.Errorf("small file digest mismatch: expected %s, actual %s", expectedDigest, actualDigest)
 	}
 
-	// 写入数据并提交
 	if _, err := targetWriter.Write(data); err != nil {
 		return errors.Wrap(err, "write small file data failed")
 	}
@@ -402,7 +404,7 @@ func handleLargeFileTransfer(ctx context.Context, srcReader io.Reader, targetWri
 
 // newStreamContext creates a context for stream transfer
 func newStreamContext(ctx context.Context) context.Context {
-	return context.WithValue(ctx, "useStream", true)
+	return context.WithValue(ctx, streamContextKey, true)
 }
 
 // enableStreamTransfer checks if stream transfer should be enabled

--- a/contrib/nydusify/pkg/copier/copier.go
+++ b/contrib/nydusify/pkg/copier/copier.go
@@ -17,15 +17,15 @@ import (
 	"sync"
 	"sync/atomic"
 
-	"github.com/containerd/containerd/archive/compression"
-	"github.com/containerd/containerd/content"
-	containerdErrdefs "github.com/containerd/containerd/errdefs"
-	"github.com/containerd/containerd/images"
-	"github.com/containerd/containerd/namespaces"
-	"github.com/containerd/containerd/platforms"
-	"github.com/containerd/containerd/reference/docker"
+	"github.com/containerd/containerd/v2/core/content"
+	"github.com/containerd/containerd/v2/core/images"
+	"github.com/containerd/containerd/v2/pkg/archive/compression"
+	"github.com/containerd/containerd/v2/pkg/namespaces"
+	containerdErrdefs "github.com/containerd/errdefs"
 	"github.com/containerd/nydus-snapshotter/pkg/converter"
 	"github.com/containerd/nydus-snapshotter/pkg/remote/remotes"
+	"github.com/containerd/platforms"
+	"github.com/distribution/reference"
 	"github.com/dragonflyoss/nydus/contrib/nydusify/pkg/backend"
 	"github.com/dragonflyoss/nydus/contrib/nydusify/pkg/checker/tool"
 	"github.com/dragonflyoss/nydus/contrib/nydusify/pkg/converter/provider"
@@ -751,7 +751,7 @@ func Copy(ctx context.Context, opt Opt) error {
 			return errors.Wrap(err, "import source image")
 		}
 	} else {
-		sourceNamed, err := reference.ParseDockerRef(opt.Source)
+		sourceNamed, err := reference.ParseNormalizedNamed(opt.Source)
 		if err != nil {
 			return errors.Wrap(err, "parse source reference")
 		}
@@ -783,7 +783,7 @@ func Copy(ctx context.Context, opt Opt) error {
 		}
 	}
 
-	targetNamed, err := docker.ParseDockerRef(opt.Target)
+	targetNamed, err := reference.ParseNormalizedNamed(opt.Target)
 	if err != nil {
 		return errors.Wrap(err, "parse target reference")
 	}

--- a/contrib/nydusify/pkg/copier/copier.go
+++ b/contrib/nydusify/pkg/copier/copier.go
@@ -5,23 +5,32 @@
 package copier
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
+	"sync/atomic"
 
-	"github.com/BraveY/snapshotter-converter/converter"
-	"github.com/containerd/containerd/v2/core/content"
-	"github.com/containerd/containerd/v2/core/images"
-	"github.com/containerd/containerd/v2/core/remotes"
-	"github.com/containerd/containerd/v2/pkg/archive/compression"
-	"github.com/containerd/containerd/v2/pkg/namespaces"
-	containerdErrdefs "github.com/containerd/errdefs"
-	"github.com/containerd/platforms"
-	"github.com/distribution/reference"
+	"github.com/containerd/containerd/archive/compression"
+	"github.com/containerd/containerd/content"
+	containerdErrdefs "github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/images"
+	"github.com/containerd/containerd/namespaces"
+	"github.com/containerd/containerd/platforms"
+	"github.com/containerd/containerd/reference/docker"
+	"github.com/containerd/nydus-snapshotter/pkg/converter"
+	"github.com/containerd/nydus-snapshotter/pkg/remote/remotes"
+	"github.com/dragonflyoss/nydus/contrib/nydusify/pkg/backend"
+	"github.com/dragonflyoss/nydus/contrib/nydusify/pkg/checker/tool"
+	"github.com/dragonflyoss/nydus/contrib/nydusify/pkg/converter/provider"
+	"github.com/dragonflyoss/nydus/contrib/nydusify/pkg/parser"
+	nydusifyUtils "github.com/dragonflyoss/nydus/contrib/nydusify/pkg/utils"
 	"github.com/dustin/go-humanize"
 	"github.com/goharbor/acceleration-service/pkg/errdefs"
 	"github.com/goharbor/acceleration-service/pkg/platformutil"
@@ -33,12 +42,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/semaphore"
-
-	"github.com/dragonflyoss/nydus/contrib/nydusify/pkg/backend"
-	"github.com/dragonflyoss/nydus/contrib/nydusify/pkg/checker/tool"
-	"github.com/dragonflyoss/nydus/contrib/nydusify/pkg/converter/provider"
-	"github.com/dragonflyoss/nydus/contrib/nydusify/pkg/parser"
-	nydusifyUtils "github.com/dragonflyoss/nydus/contrib/nydusify/pkg/utils"
 )
 
 type Opt struct {
@@ -75,24 +78,6 @@ func hosts(opt Opt) remote.HostFunc {
 	return func(ref string) (remote.CredentialFunc, bool, error) {
 		return remote.NewDockerConfigCredFunc(), maps[ref], nil
 	}
-}
-
-func getPusherInChunked(ctx context.Context, pvd *provider.Provider, desc ocispec.Descriptor, opt Opt) (remotes.PusherInChunked, error) {
-	resolver, err := pvd.Resolver(opt.Target)
-	if err != nil {
-		return nil, errors.Wrap(err, "get resolver")
-	}
-	ref := opt.Target
-	if !strings.Contains(ref, "@") {
-		ref = ref + "@" + desc.Digest.String()
-	}
-
-	pusherInChunked, err := resolver.PusherInChunked(ctx, ref)
-	if err != nil {
-		return nil, errors.Wrap(err, "create pusher in chunked")
-	}
-
-	return pusherInChunked, nil
 }
 
 func pushBlobFromBackend(
@@ -173,41 +158,41 @@ func pushBlobFromBackend(
 				}
 
 				if err := nydusifyUtils.RetryWithAttempts(func() error {
-					pusher, err := getPusherInChunked(ctx, pvd, blobDescs[idx], opt)
+					resolver, err := pvd.Resolver(opt.Target)
 					if err != nil {
 						if errdefs.NeedsRetryWithHTTP(err) {
 							pvd.UsePlainHTTP()
-							pusher, err = getPusherInChunked(ctx, pvd, blobDescs[idx], opt)
+							resolver, err = pvd.Resolver(opt.Target)
 						}
 						if err != nil {
-							return errors.Wrapf(err, "get push writer: %s", blobDigest)
+							return errors.Wrapf(err, "get resolver: %s", blobDigest)
 						}
 					}
 
+					ref := opt.Target
+					if !strings.Contains(ref, "@") {
+						ref = ref + "@" + blobDescs[idx].Digest.String()
+					}
+
+					pusher, err := resolver.Pusher(ctx, ref)
+					if err != nil {
+						return errors.Wrapf(err, "get pusher: %s", blobDigest)
+					}
+
 					push := func() error {
-						if blobSize > opt.PushChunkSize {
-							rr, err := backend.RangeReader(blobID)
-							if err != nil {
-								return errors.Wrapf(err, "get push reader: %s", blobDigest)
-							}
-							if err := pusher.PushInChunked(ctx, blobDescs[idx], rr); err != nil {
-								return errors.Wrapf(err, "push blob in chunked: %s", blobDigest)
-							}
-						} else {
-							rc, err := backend.Reader(blobID)
-							if err != nil {
-								return errors.Wrap(err, "get blob reader")
-							}
-							defer rc.Close()
-							writer, err := pusher.Push(ctx, blobDescs[idx])
-							if err != nil {
-								return errors.Wrapf(err, "get push writer: %s", blobDigest)
-							}
-							if writer != nil {
-								defer writer.Close()
-								if err := content.Copy(ctx, writer, rc, blobSize, blobDigest); err != nil {
-									return errors.Wrapf(err, "push blob: %s", blobDigest)
-								}
+						rc, err := backend.Reader(blobID)
+						if err != nil {
+							return errors.Wrap(err, "get blob reader")
+						}
+						defer rc.Close()
+						writer, err := pusher.Push(ctx, blobDescs[idx])
+						if err != nil {
+							return errors.Wrapf(err, "get push writer: %s", blobDigest)
+						}
+						if writer != nil {
+							defer writer.Close()
+							if err := content.Copy(ctx, writer, rc, blobSize, blobDigest); err != nil {
+								return errors.Wrapf(err, "push blob: %s", blobDigest)
 							}
 						}
 						return nil
@@ -298,6 +283,399 @@ func getLocalPath(ref string) (isLocalPath bool, absPath string, err error) {
 	return true, absPath, nil
 }
 
+// trueStreamCopy implements true stream copy, pulling and pushing at the same time
+func StreamCopy(ctx context.Context, srcReader io.Reader, targetWriter content.Writer, size int64, expectedDigest digest.Digest) error {
+	// for small files, use simplified handling
+	if size <= 128 {
+		return handleSmallFileTransfer(ctx, srcReader, targetWriter, size, expectedDigest)
+	}
+
+	// use 16MB buffer for efficient transfer
+	return handleLargeFileTransfer(ctx, srcReader, targetWriter, size, expectedDigest)
+}
+
+// handleSmallFileTransfer handles small file transfer, reading all content and then committing
+func handleSmallFileTransfer(ctx context.Context, srcReader io.Reader, targetWriter content.Writer, size int64, expectedDigest digest.Digest) error {
+	logrus.Debugf("file is small (%d bytes), using simplified handling", size)
+
+	// 读取全部内容
+	data, err := io.ReadAll(srcReader)
+	if err != nil {
+		return errors.Wrap(err, "read small file data failed")
+	}
+
+	// 确保数据大小正确
+	if int64(len(data)) != size && size > 0 {
+		logrus.Warnf("small file size mismatch: expected %d bytes, actual %d bytes", size, len(data))
+	}
+
+	// 计算实际摘要
+	actualDigest := digest.FromBytes(data)
+
+	// 检查摘要是否匹配
+	if expectedDigest != "" && expectedDigest != actualDigest {
+		return fmt.Errorf("small file digest mismatch: expected %s, actual %s", expectedDigest, actualDigest)
+	}
+
+	// 写入数据并提交
+	if _, err := targetWriter.Write(data); err != nil {
+		return errors.Wrap(err, "write small file data failed")
+	}
+
+	if err := targetWriter.Commit(ctx, int64(len(data)), actualDigest); err != nil {
+		return errors.Wrap(err, "commit small file content failed")
+	}
+
+	return nil
+}
+
+// handleLargeFileTransfer handles large file transfer, using chunked reading and updating progress in real-time
+func handleLargeFileTransfer(ctx context.Context, srcReader io.Reader, targetWriter content.Writer, size int64, expectedDigest digest.Digest) error {
+	bufSize := 16 * 1024 * 1024 // 16MB buffer
+	buf := make([]byte, bufSize)
+	hasher := sha256.New()
+	var totalCopied int64
+	lastLoggedProgress := int64(0)
+	logInterval := int64(100 * 1024 * 1024) // log every 100MB
+
+	for {
+		// check if context is done
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
+		// read data
+		n, readErr := srcReader.Read(buf)
+		if n <= 0 {
+			if readErr == io.EOF {
+				break
+			}
+			return errors.Wrap(readErr, "read data failed")
+		}
+
+		// calculate hash
+		hasher.Write(buf[:n])
+
+		// write data
+		writeN, writeErr := targetWriter.Write(buf[:n])
+		if writeErr != nil {
+			return errors.Wrap(writeErr, "write data failed")
+		}
+		if writeN != n {
+			return errors.New("write data length mismatch")
+		}
+
+		totalCopied += int64(n)
+
+		// log progress periodically
+		if totalCopied-lastLoggedProgress >= logInterval {
+			logrus.Infof("stream copy progress: %.2f%% (%s/%s)",
+				float64(totalCopied)*100/float64(size),
+				humanize.Bytes(uint64(totalCopied)),
+				humanize.Bytes(uint64(size)))
+			lastLoggedProgress = totalCopied
+		}
+	}
+
+	// calculate final digest
+	actualDigest := digest.NewDigestFromBytes(digest.SHA256, hasher.Sum(nil))
+
+	// check if digest matches
+	if expectedDigest != "" && expectedDigest != actualDigest {
+		return fmt.Errorf("digest mismatch: expected %s, actual %s", expectedDigest, actualDigest)
+	}
+
+	// check if size matches
+	if size > 0 && size != totalCopied {
+		logrus.Warnf("size mismatch: expected %d bytes, actual %d bytes, using actual size", size, totalCopied)
+	}
+
+	// commit content
+	if err := targetWriter.Commit(ctx, totalCopied, actualDigest); err != nil {
+		return errors.Wrap(err, "commit content failed")
+	}
+
+	return nil
+}
+
+// newStreamContext creates a context for stream transfer
+func newStreamContext(ctx context.Context) context.Context {
+	return context.WithValue(ctx, "useStream", true)
+}
+
+// enableStreamTransfer checks if stream transfer should be enabled
+func enableStreamTransfer(opt Opt) bool {
+	return opt.PushChunkSize > 0
+}
+
+// httpModeManager manages thread-safe HTTP mode switching
+type httpModeManager struct {
+	mu       sync.Mutex
+	enabled  bool
+	provider *provider.Provider
+}
+
+func newHTTPModeManager(pvd *provider.Provider) *httpModeManager {
+	return &httpModeManager{
+		provider: pvd,
+	}
+}
+
+// switchToHTTP switch to HTTP mode, if already in HTTP mode, do nothing
+func (m *httpModeManager) switchToHTTP() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if !m.enabled {
+		m.provider.UsePlainHTTP()
+		m.enabled = true
+	}
+}
+
+// streamTransferManager manages the components for stream transfer
+type streamTransferManager struct {
+	provider    *provider.Provider
+	httpManager *httpModeManager
+	sourceRef   string
+	targetRef   string
+	opt         Opt
+	// avoid storing interface types, directly store components needed for operations
+	sourceFetcher remotes.Fetcher
+	targetPusher  remotes.Pusher
+}
+
+// newStreamTransferManager creates a stream transfer manager
+func newStreamTransferManager(ctx context.Context, pvd *provider.Provider, httpManager *httpModeManager, opt Opt) (*streamTransferManager, error) {
+	// prepare source resolver
+	sourceResolver, err := pvd.Resolver(opt.Source)
+	if err != nil {
+		return nil, errors.Wrap(err, "get source resolver")
+	}
+
+	// prepare target resolver
+	targetResolver, err := pvd.Resolver(opt.Target)
+	if err != nil {
+		return nil, errors.Wrap(err, "get target resolver")
+	}
+
+	// parse reference to get name
+	sourceName, _, err := sourceResolver.Resolve(ctx, opt.Source)
+	if err != nil {
+		return nil, errors.Wrap(err, "parse source reference")
+	}
+
+	// get source image fetcher
+	sourceFetcher, err := sourceResolver.Fetcher(ctx, sourceName)
+	if err != nil {
+		return nil, errors.Wrap(err, "create source fetcher")
+	}
+
+	// get target image pusher
+	targetPusher, err := targetResolver.Pusher(ctx, opt.Target)
+	if err != nil {
+		return nil, errors.Wrap(err, "create target pusher")
+	}
+
+	return &streamTransferManager{
+		sourceFetcher: sourceFetcher,
+		targetPusher:  targetPusher,
+		httpManager:   httpManager,
+		provider:      pvd,
+		sourceRef:     opt.Source,
+		targetRef:     opt.Target,
+		opt:           opt,
+	}, nil
+}
+
+// refreshPusher refreshes the pusher when needed (e.g. after switching to HTTP mode)
+func (m *streamTransferManager) refreshPusher(ctx context.Context) error {
+	// get new resolver
+	resolver, err := m.provider.Resolver(m.targetRef)
+	if err != nil {
+		return errors.Wrap(err, "get new resolver")
+	}
+
+	// get new pusher
+	newPusher, err := resolver.Pusher(ctx, m.targetRef)
+	if err != nil {
+		return errors.Wrap(err, "create new pusher")
+	}
+
+	// update pusher
+	m.targetPusher = newPusher
+	return nil
+}
+
+// pushContent pushes content, handles HTTP/HTTPS switch and existing content logic
+func (m *streamTransferManager) pushContent(ctx context.Context, desc ocispec.Descriptor, reader io.Reader) error {
+	writer, err := m.targetPusher.Push(ctx, desc)
+	if err != nil {
+		// if content already exists, return success
+		if containerdErrdefs.IsAlreadyExists(err) {
+			logrus.Infof("content already exists: %s", desc.Digest)
+			return nil
+		}
+
+		// check if need to switch to HTTP mode
+		if errdefs.NeedsRetryWithHTTP(err) {
+			logrus.Warn("switch to HTTP mode and retry")
+			m.httpManager.switchToHTTP()
+
+			// refresh pusher
+			if err := m.refreshPusher(ctx); err != nil {
+				return err
+			}
+
+			// retry push
+			writer, err = m.targetPusher.Push(ctx, desc)
+			if err != nil {
+				if containerdErrdefs.IsAlreadyExists(err) {
+					logrus.Infof("content already exists: %s", desc.Digest)
+					return nil
+				}
+				return errors.Wrap(err, "push failed in HTTP mode")
+			}
+		} else {
+			return errors.Wrap(err, "push failed")
+		}
+	}
+
+	if writer == nil {
+		// content already exists, no need to transfer
+		return nil
+	}
+
+	// stream transfer
+	if err := StreamCopy(ctx, reader, writer, desc.Size, desc.Digest); err != nil {
+		return errors.Wrap(err, "stream transfer failed")
+	}
+
+	return nil
+}
+
+// streamTransferLayer stream transfer a single layer
+func (m *streamTransferManager) streamTransferLayer(ctx context.Context, desc ocispec.Descriptor, info string) error {
+	logrus.Infof("start stream transfer %s: %s, size: %s",
+		info, desc.Digest, humanize.Bytes(uint64(desc.Size)))
+
+	// get source content
+	rc, err := m.sourceFetcher.Fetch(ctx, desc)
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("get %s failed", info))
+	}
+	defer rc.Close()
+
+	// push to target
+	if err := m.pushContent(ctx, desc, rc); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// streamPlatformManifest handles the transfer of a single platform manifest
+func (m *streamTransferManager) streamPlatformManifest(ctx context.Context, manifestDesc ocispec.Descriptor) (ocispec.Descriptor, error) {
+	// get manifest content
+	rc, err := m.sourceFetcher.Fetch(ctx, manifestDesc)
+	if err != nil {
+		return ocispec.Descriptor{}, errors.Wrap(err, "get manifest failed")
+	}
+	defer rc.Close()
+
+	// read manifest content
+	manifestBytes, err := io.ReadAll(rc)
+	if err != nil {
+		return ocispec.Descriptor{}, errors.Wrap(err, "read manifest failed")
+	}
+
+	// parse manifest
+	var manifest ocispec.Manifest
+	if err := json.Unmarshal(manifestBytes, &manifest); err != nil {
+		return ocispec.Descriptor{}, errors.Wrap(err, "parse manifest failed")
+	}
+
+	// transfer config file first
+	if err := m.streamTransferLayer(ctx, manifest.Config, "config file"); err != nil {
+		return ocispec.Descriptor{}, err
+	}
+
+	// create a wait group to wait for all layers to be processed
+	eg, egCtx := errgroup.WithContext(ctx)
+	eg.SetLimit(provider.LayerConcurrentLimit) // set max concurrency
+
+	// process each layer
+	for i, layer := range manifest.Layers {
+		i, layer := i, layer // avoid closure problem
+		eg.Go(func() error {
+			layerInfo := fmt.Sprintf("%d/%d layer", i+1, len(manifest.Layers))
+			return m.streamTransferLayer(egCtx, layer, layerInfo)
+		})
+	}
+
+	// wait for all layers to be processed
+	if err := eg.Wait(); err != nil {
+		return ocispec.Descriptor{}, err
+	}
+
+	// push manifest last
+	if err := m.pushContent(ctx, manifestDesc, bytes.NewReader(manifestBytes)); err != nil {
+		return ocispec.Descriptor{}, err
+	}
+
+	return manifestDesc, nil
+}
+
+// streamManifestList handles the transfer of a multi-platform manifest list
+func (m *streamTransferManager) streamManifestList(ctx context.Context, indexDesc ocispec.Descriptor, platformDescs []ocispec.Descriptor) error {
+	if len(platformDescs) <= 1 {
+		return nil // single platform, no need to process index
+	}
+
+	// get source index content
+	rc, err := m.sourceFetcher.Fetch(ctx, indexDesc)
+	if err != nil {
+		return errors.Wrap(err, "get index failed")
+	}
+	defer rc.Close()
+
+	// read index content
+	indexBytes, err := io.ReadAll(rc)
+	if err != nil {
+		return errors.Wrap(err, "read index failed")
+	}
+
+	// parse index
+	var index ocispec.Index
+	if err := json.Unmarshal(indexBytes, &index); err != nil {
+		return errors.Wrap(err, "parse index failed")
+	}
+
+	// update manifest references in index
+	index.Manifests = platformDescs
+
+	// re-serialize index
+	updatedIndexBytes, err := json.Marshal(index)
+	if err != nil {
+		return errors.Wrap(err, "serialize updated index failed")
+	}
+
+	// create updated index descriptor
+	updatedIndexDesc := ocispec.Descriptor{
+		Digest:    digest.FromBytes(updatedIndexBytes),
+		Size:      int64(len(updatedIndexBytes)),
+		MediaType: indexDesc.MediaType,
+	}
+
+	// push updated index
+	if err := m.pushContent(ctx, updatedIndexDesc, bytes.NewReader(updatedIndexBytes)); err != nil {
+		return errors.Wrap(err, "push index failed")
+	}
+
+	return nil
+}
+
 // Copy copies an image from the source to the target.
 func Copy(ctx context.Context, opt Opt) error {
 	// Containerd image fetch requires a namespace context.
@@ -338,14 +716,19 @@ func Copy(ctx context.Context, opt Opt) error {
 	}
 	defer os.RemoveAll(tmpDir)
 
+	// check if stream transfer is enabled
+	useStream := enableStreamTransfer(opt)
+
+	// create http mode manager
+	httpManager := newHTTPModeManager(pvd)
+
 	isLocalSource, inputPath, err := getLocalPath(opt.Source)
 	if err != nil {
 		return errors.Wrap(err, "parse source path")
 	}
+
 	var source string
 	if isLocalSource {
-		logrus.Infof("importing source image from %s", inputPath)
-
 		f, err := os.Open(inputPath)
 		if err != nil {
 			return err
@@ -361,7 +744,6 @@ func Copy(ctx context.Context, opt Opt) error {
 		if source, err = pvd.Import(ctx, ds); err != nil {
 			return errors.Wrap(err, "import source image")
 		}
-		logrus.Infof("imported source image %s", source)
 	} else {
 		sourceNamed, err := reference.ParseDockerRef(opt.Source)
 		if err != nil {
@@ -369,23 +751,39 @@ func Copy(ctx context.Context, opt Opt) error {
 		}
 		source = sourceNamed.String()
 
-		logrus.Infof("pulling source image %s", source)
-		if err := pvd.Pull(ctx, source); err != nil {
-			if errdefs.NeedsRetryWithHTTP(err) {
-				pvd.UsePlainHTTP()
-				if err := pvd.Pull(ctx, source); err != nil {
-					return errors.Wrap(err, "try to pull image")
-				}
-			} else {
-				return errors.Wrap(err, "pull source image")
+		if useStream {
+			// stream transfer mode: only get the minimum necessary information
+			err := pvd.FetchImageInfo(ctx, source)
+			if err != nil && errdefs.NeedsRetryWithHTTP(err) {
+				httpManager.switchToHTTP()
+				err = pvd.FetchImageInfo(ctx, source)
+			}
+
+			if err != nil {
+				return errors.Wrap(err, "fetch image info failed")
+			}
+		} else {
+			err := pvd.Pull(ctx, source)
+			if err != nil && errdefs.NeedsRetryWithHTTP(err) {
+				httpManager.switchToHTTP()
+				err = pvd.Pull(ctx, source)
+			}
+			if err != nil {
+				return errors.Wrap(err, "pull source image failed")
 			}
 		}
-		logrus.Infof("pulled source image %s", source)
 	}
 
+	targetNamed, err := docker.ParseDockerRef(opt.Target)
+	if err != nil {
+		return errors.Wrap(err, "parse target reference")
+	}
+	target := targetNamed.String()
+
+	// get source image index info
 	sourceImage, err := pvd.Image(ctx, source)
 	if err != nil {
-		return errors.Wrap(err, "find image from store")
+		return errors.Wrap(err, "find image")
 	}
 
 	isLocalTarget, outputPath, err := getLocalPath(opt.Target)
@@ -406,35 +804,89 @@ func Copy(ctx context.Context, opt Opt) error {
 		return nil
 	}
 
+	// get all platform manifests
 	sourceDescs, err := utils.GetManifests(ctx, pvd.ContentStore(), *sourceImage, platformMC)
 	if err != nil {
 		return errors.Wrap(err, "get image manifests")
 	}
 	targetDescs := make([]ocispec.Descriptor, len(sourceDescs))
 
-	targetNamed, err := reference.ParseDockerRef(opt.Target)
-	if err != nil {
-		return errors.Wrap(err, "parse target reference")
+	// if stream transfer is enabled, use stream transfer mode
+	if useStream && !isLocalSource {
+		// create stream transfer manager
+		streamManager, err := newStreamTransferManager(ctx, pvd, httpManager, opt)
+		if err != nil {
+			return err
+		}
+
+		// create stream transfer for each platform manifest
+		var wg sync.WaitGroup
+		errCh := make(chan error, len(sourceDescs))
+		var successCount int32
+
+		for idx, sourceDesc := range sourceDescs {
+			wg.Add(1)
+			go func(idx int, sourceDesc ocispec.Descriptor) {
+				defer wg.Done()
+
+				// create stream context
+				streamCtx := newStreamContext(ctx)
+
+				// process platform manifest
+				targetDesc, err := streamManager.streamPlatformManifest(streamCtx, sourceDesc)
+				if err != nil {
+					errCh <- err
+					return
+				}
+
+				targetDescs[idx] = targetDesc
+				atomic.AddInt32(&successCount, 1)
+			}(idx, sourceDesc)
+		}
+
+		wg.Wait()
+
+		// check if there are errors
+		select {
+		case err := <-errCh:
+			return err
+		default:
+		}
+
+		// if there are multiple platforms, push index
+		if len(targetDescs) > 1 && (sourceImage.MediaType == ocispec.MediaTypeImageIndex ||
+			sourceImage.MediaType == images.MediaTypeDockerSchema2ManifestList) {
+
+			indexCtx := newStreamContext(ctx)
+			if err := streamManager.streamManifestList(indexCtx, *sourceImage, targetDescs); err != nil {
+				return err
+			}
+		}
+
+		return nil
 	}
-	target := targetNamed.String()
 
-	sem := semaphore.NewWeighted(1)
-	eg := errgroup.Group{}
-	for idx := range sourceDescs {
-		func(idx int) {
-			eg.Go(func() error {
-				sem.Acquire(context.Background(), 1)
-				defer sem.Release(1)
+	// non-stream transfer logic
+	descCh := make(chan int, len(sourceDescs))
+	errCh := make(chan error, len(sourceDescs))
+	concurrency := 4
+	var wg sync.WaitGroup
 
+	for i := 0; i < concurrency; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for idx := range descCh {
 				sourceDesc := sourceDescs[idx]
 				targetDesc := &sourceDesc
 				if bkd != nil {
 					descs, _targetDesc, err := pushBlobFromBackend(ctx, pvd, bkd, sourceDesc, opt)
 					if err != nil {
-						return errors.Wrap(err, "get resolver")
+						errCh <- errors.Wrap(err, "get resolver")
+						continue
 					}
 					if _targetDesc == nil {
-						logrus.WithField("platform", getPlatform(sourceDesc.Platform)).Warnf("%s is not a nydus image", source)
+						logrus.WithField("platform", getPlatform(sourceDesc.Platform)).Warnf("%s is not a Nydus image", source)
 					} else {
 						targetDesc = _targetDesc
 						store := newStore(pvd.ContentStore(), descs)
@@ -443,25 +895,29 @@ func Copy(ctx context.Context, opt Opt) error {
 				}
 				targetDescs[idx] = *targetDesc
 
-				logrus.WithField("platform", getPlatform(sourceDesc.Platform)).Infof("pushing target manifest %s", targetDesc.Digest)
-				if err := pvd.Push(ctx, *targetDesc, target); err != nil {
-					if errdefs.NeedsRetryWithHTTP(err) {
-						pvd.UsePlainHTTP()
-						if err := pvd.Push(ctx, *targetDesc, target); err != nil {
-							return errors.Wrap(err, "try to push image manifest")
-						}
-					} else {
-						return errors.Wrap(err, "push target image manifest")
-					}
+				err := pvd.Push(ctx, *targetDesc, target)
+				if err != nil && errdefs.NeedsRetryWithHTTP(err) {
+					httpManager.switchToHTTP()
+					err = pvd.Push(ctx, *targetDesc, target)
 				}
-				logrus.WithField("platform", getPlatform(sourceDesc.Platform)).Infof("pushed target manifest %s", targetDesc.Digest)
-
-				return nil
-			})
-		}(idx)
+				if err != nil {
+					errCh <- errors.Wrap(err, "push manifest failed")
+					continue
+				}
+			}
+		}()
 	}
-	if err := eg.Wait(); err != nil {
-		return errors.Wrap(err, "push image manifests")
+
+	for idx := range sourceDescs {
+		descCh <- idx
+	}
+	close(descCh)
+	wg.Wait()
+
+	select {
+	case err := <-errCh:
+		return err
+	default:
 	}
 
 	if len(targetDescs) > 1 && (sourceImage.MediaType == ocispec.MediaTypeImageIndex ||
@@ -476,17 +932,16 @@ func Copy(ctx context.Context, opt Opt) error {
 		if err != nil {
 			return errors.Wrap(err, "write target manifest list")
 		}
-		if err := pvd.Push(ctx, *targetImage, target); err != nil {
-			if errdefs.NeedsRetryWithHTTP(err) {
-				pvd.UsePlainHTTP()
-				if err := pvd.Push(ctx, *targetImage, target); err != nil {
-					return errors.Wrap(err, "try to push image")
-				}
-			} else {
-				return errors.Wrap(err, "push target image")
-			}
+
+		err = pvd.Push(ctx, *targetImage, target)
+		if err != nil && errdefs.NeedsRetryWithHTTP(err) {
+			httpManager.switchToHTTP()
+			err = pvd.Push(ctx, *targetImage, target)
 		}
-		logrus.Infof("pushed image %s", target)
+		if err != nil {
+			return errors.Wrap(err, "push target image failed")
+		}
+
 	}
 
 	return nil

--- a/contrib/nydusify/pkg/copier/copier.go
+++ b/contrib/nydusify/pkg/copier/copier.go
@@ -409,7 +409,8 @@ func newStreamContext(ctx context.Context) context.Context {
 
 // enableStreamTransfer checks if stream transfer should be enabled
 func enableStreamTransfer(opt Opt) bool {
-	return opt.PushChunkSize > 0
+	return false
+	// return opt.PushChunkSize > 0
 }
 
 // httpModeManager manages thread-safe HTTP mode switching

--- a/contrib/nydusify/pkg/copier/copier.go
+++ b/contrib/nydusify/pkg/copier/copier.go
@@ -155,7 +155,7 @@ func (m *streamTransferManager) pushContent(ctx context.Context, desc ocispec.De
 			m.provider.UsePlainHTTP()
 
 			if err := m.refreshPusher(ctx); err != nil {
-				return err
+				return errors.Wrap(err, "refresh pusher")
 			}
 
 			writer, err = m.targetPusher.Push(ctx, desc)

--- a/contrib/nydusify/pkg/copier/copier.go
+++ b/contrib/nydusify/pkg/copier/copier.go
@@ -414,7 +414,6 @@ func getLocalPath(ref string) (isLocalPath bool, absPath string, err error) {
 	return true, absPath, nil
 }
 
-
 // enableStreamTransfer checks if stream transfer should be enabled
 func enableStreamTransfer(opt Opt) bool {
 	return false
@@ -830,7 +829,7 @@ func Copy(ctx context.Context, opt Opt) error {
 	if useStream && !isLocalSource {
 		// create http mode manager
 		httpManager := newHTTPModeManager(pvd)
-		
+
 		// create stream transfer manager
 		streamManager, err := newStreamTransferManager(ctx, pvd, httpManager, opt)
 		if err != nil {

--- a/contrib/nydusify/pkg/copier/store.go
+++ b/contrib/nydusify/pkg/copier/store.go
@@ -5,41 +5,10 @@
 package copier
 
 import (
-	"context"
-
-	"github.com/containerd/containerd/v2/core/content"
-	"github.com/containerd/errdefs"
-	"github.com/opencontainers/go-digest"
+	"github.com/containerd/containerd/content"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
-type store struct {
-	content.Store
-	remotes []ocispec.Descriptor
-}
-
-func newStore(base content.Store, remotes []ocispec.Descriptor) *store {
-	return &store{
-		Store:   base,
-		remotes: remotes,
-	}
-}
-
-func (s *store) Info(ctx context.Context, dgst digest.Digest) (content.Info, error) {
-	info, err := s.Store.Info(ctx, dgst)
-	if err != nil {
-		if !errdefs.IsNotFound(err) {
-			return content.Info{}, err
-		}
-		for _, desc := range s.remotes {
-			if desc.Digest == dgst {
-				return content.Info{
-					Digest: desc.Digest,
-					Size:   desc.Size,
-				}, nil
-			}
-		}
-		return content.Info{}, err
-	}
-	return info, nil
+func newStore(base content.Store, remotes []ocispec.Descriptor) StreamStore {
+	return NewStreamStore(base, remotes)
 }

--- a/contrib/nydusify/pkg/copier/store.go
+++ b/contrib/nydusify/pkg/copier/store.go
@@ -5,7 +5,7 @@
 package copier
 
 import (
-	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/v2/core/content"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 )
 

--- a/contrib/nydusify/pkg/copier/stream_store.go
+++ b/contrib/nydusify/pkg/copier/stream_store.go
@@ -7,9 +7,9 @@ package copier
 import (
 	"context"
 
-	"github.com/containerd/containerd/content"
-	"github.com/containerd/containerd/errdefs"
-	"github.com/containerd/containerd/remotes"
+	"github.com/containerd/containerd/v2/core/content"
+	"github.com/containerd/errdefs"
+	"github.com/containerd/containerd/v2/core/remotes"
 	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"

--- a/contrib/nydusify/pkg/copier/stream_store.go
+++ b/contrib/nydusify/pkg/copier/stream_store.go
@@ -1,0 +1,134 @@
+// Copyright 2024 Nydus Developers. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package copier
+
+import (
+	"context"
+
+	"github.com/containerd/containerd/content"
+	"github.com/containerd/containerd/errdefs"
+	"github.com/containerd/containerd/remotes"
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+// StreamStore wraps a content.Store and provides stream-based transfer capabilities
+type StreamStore interface {
+	content.Store
+	// StreamTransfer performs stream-based transfer of content from source to target
+	StreamTransfer(ctx context.Context, desc ocispec.Descriptor, sourceFetcher remotes.Fetcher, targetPusher remotes.Pusher, opt Opt) error
+	// ReaderAt with stream capability awareness
+	ReaderAt(ctx context.Context, desc ocispec.Descriptor) (content.ReaderAt, error)
+}
+
+// streamStore implements StreamStore interface
+type streamStore struct {
+	content.Store
+	remotes []ocispec.Descriptor
+}
+
+// NewStreamStore creates a new StreamStore instance
+func NewStreamStore(base content.Store, remotes []ocispec.Descriptor) StreamStore {
+	return &streamStore{
+		Store:   base,
+		remotes: remotes,
+	}
+}
+
+func (s *streamStore) Info(ctx context.Context, dgst digest.Digest) (content.Info, error) {
+	info, err := s.Store.Info(ctx, dgst)
+	if err != nil {
+		if !errdefs.IsNotFound(err) {
+			return content.Info{}, err
+		}
+		for _, desc := range s.remotes {
+			if desc.Digest == dgst {
+				return content.Info{
+					Digest: desc.Digest,
+					Size:   desc.Size,
+				}, nil
+			}
+		}
+		return content.Info{}, err
+	}
+	return info, nil
+}
+
+func (s *streamStore) StreamTransfer(ctx context.Context, desc ocispec.Descriptor, sourceFetcher remotes.Fetcher, targetPusher remotes.Pusher, opt Opt) error {
+	// Check if content already exists in local store
+	if _, err := s.Store.Info(ctx, desc.Digest); err == nil {
+		// Content exists locally, use regular transfer
+		return s.regularTransfer(ctx, desc, targetPusher, opt)
+	}
+
+	// Content not available locally, use stream transfer
+	return s.streamTransfer(ctx, desc, sourceFetcher, targetPusher, opt)
+}
+
+func (s *streamStore) regularTransfer(ctx context.Context, desc ocispec.Descriptor, targetPusher remotes.Pusher, opt Opt) error {
+	reader, err := s.Store.ReaderAt(ctx, desc)
+	if err != nil {
+		return errors.Wrap(err, "open local content reader")
+	}
+	defer reader.Close()
+
+	writer, err := targetPusher.Push(ctx, desc)
+	if err != nil {
+		return errors.Wrap(err, "create target writer")
+	}
+
+	if writer == nil {
+		return nil // Already exists
+	}
+
+	if err := StreamCopy(ctx, content.NewReader(reader), writer, desc.Size, desc.Digest, opt.PushChunkSize); err != nil {
+		return errors.Wrap(err, "regular transfer failed")
+	}
+
+	return nil
+}
+
+func (s *streamStore) streamTransfer(ctx context.Context, desc ocispec.Descriptor, sourceFetcher remotes.Fetcher, targetPusher remotes.Pusher, opt Opt) error {
+	logrus.Infof("start stream transfer: %s, size: %d", desc.Digest, desc.Size)
+
+	rc, err := sourceFetcher.Fetch(ctx, desc)
+	if err != nil {
+		return errors.Wrap(err, "fetch from source")
+	}
+	defer rc.Close()
+
+	writer, err := targetPusher.Push(ctx, desc)
+	if err != nil {
+		return errors.Wrap(err, "create target writer")
+	}
+
+	if writer == nil {
+		return nil // Already exists
+	}
+
+	if err := StreamCopy(ctx, rc, writer, desc.Size, desc.Digest, opt.PushChunkSize); err != nil {
+		return errors.Wrap(err, "stream transfer failed")
+	}
+
+	return nil
+}
+
+func (s *streamStore) ReaderAt(ctx context.Context, desc ocispec.Descriptor) (content.ReaderAt, error) {
+	// For stream contexts, we might want to handle this differently
+	// but for now, delegate to the underlying store
+	return s.Store.ReaderAt(ctx, desc)
+}
+
+// IsStreamContext checks if the context indicates stream transfer should be used
+func IsStreamContext(ctx context.Context) bool {
+	if val := ctx.Value(streamContextKey); val != nil {
+		if useStream, ok := val.(bool); ok {
+			return useStream
+		}
+	}
+	return false
+}

--- a/contrib/nydusify/pkg/optimizer/optimizer.go
+++ b/contrib/nydusify/pkg/optimizer/optimizer.go
@@ -210,7 +210,7 @@ func fetchBlobs(ctx context.Context, opt Opt, buildDir string) error {
 		return err
 	}
 
-	sourceNamed, err := reference.ParseDockerRef(opt.Source)
+	sourceNamed, err := reference.ParseNormalizedNamed(opt.Source)
 	if err != nil {
 		return errors.Wrap(err, "parse source reference")
 	}

--- a/smoke/Makefile
+++ b/smoke/Makefile
@@ -47,6 +47,14 @@ test-benchmark: build
 test-compatibility: build
 	make test TESTS=TestCompatibility
 
+# WORK_DIR=/tmp \
+# NYDUS_BUILDER=/path/to/latest/nydus-image \
+# NYDUS_NYDUSD=/path/to/latest/nydusd \
+# NYDUS_NYDUSIFY=/path/to/latest/nydusify \
+# make test-stream-copy
+test-stream-copy: build
+	sudo -E ./smoke.test -test.v -test.timeout 15m -test.parallel=4 -test.run=TestStreamCopy
+
 # SNAPSHOTTER_SYSTEM_SOCK=/run/containerd-nydus/system.sock
 # SNAPSHOTTER=nydus
 # TAKEOVER_TEST_IMAGE=wordpress

--- a/smoke/tests/stream_copy_test.go
+++ b/smoke/tests/stream_copy_test.go
@@ -1,0 +1,260 @@
+// Copyright 2023 Nydus Developers. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package tests
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dragonflyoss/nydus/smoke/tests/tool"
+	"github.com/dragonflyoss/nydus/smoke/tests/tool/test"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+type StreamCopyTestSuite struct {
+	T              *testing.T
+	preparedImages map[string]string
+}
+
+func (s *StreamCopyTestSuite) TestStreamCopyFeature() test.Generator {
+	scenarios := tool.DescartesIterator{}
+	scenarios.
+		Dimension(paramImage, []interface{}{"nginx:latest", "alpine:latest"}).
+		Dimension("enable_stream_copy", []interface{}{true, false}).
+		Dimension("push_chunk_size", []interface{}{"0", "8MB", "16MB", "32MB"})
+
+	return func() (name string, testCase test.Case) {
+		if !scenarios.HasNext() {
+			return
+		}
+		scenario := scenarios.Next()
+
+		ctx := tool.DefaultContext(s.T)
+		ctx.Build.FSVersion = "6" // 使用 fs version 6 进行测试
+
+		image := s.prepareImage(s.T, scenario.GetString(paramImage))
+		enableStreamCopy := scenario.GetBool("enable_stream_copy")
+		pushChunkSize := scenario.GetString("push_chunk_size")
+
+		return scenario.Str(), func(t *testing.T) {
+			s.testStreamCopyWithOptions(t, *ctx, image, enableStreamCopy, pushChunkSize)
+		}
+	}
+}
+
+func (s *StreamCopyTestSuite) testStreamCopyWithOptions(t *testing.T, ctx tool.Context, source string, enableStreamCopy bool, pushChunkSize string) {
+	// Prepare work directory
+	ctx.PrepareWorkDir(t)
+	defer ctx.Destroy(t)
+
+	sourceNydus := fmt.Sprintf("%s-nydus-%s", source, uuid.NewString())
+	fsVersion := fmt.Sprintf("--fs-version %s", ctx.Build.FSVersion)
+	logLevel := "--log-level warn"
+	compressor := "--compressor lz4_block"
+
+	if ctx.Binary.NydusifyOnlySupportV5 {
+		fsVersion = ""
+		logLevel = ""
+	}
+	if ctx.Binary.NydusifyNotSupportCompressor {
+		compressor = ""
+	}
+
+	// Convert source image to nydus format
+	convertCmd := fmt.Sprintf(
+		"%s %s convert --source %s --target %s %s --nydus-image %s --work-dir %s %s",
+		ctx.Binary.Nydusify, logLevel, source, sourceNydus, fsVersion,
+		ctx.Binary.Builder, ctx.Env.WorkDir, compressor,
+	)
+	tool.RunWithoutOutput(t, convertCmd)
+
+	targetCopied := fmt.Sprintf("%s-stream-copied-%s", sourceNydus, uuid.NewString())
+
+	copyCmd := fmt.Sprintf(
+		"%s %s copy --source %s --target %s --nydus-image %s --work-dir %s",
+		ctx.Binary.Nydusify, logLevel, sourceNydus, targetCopied, ctx.Binary.Builder,
+		filepath.Join(ctx.Env.WorkDir, "copy"),
+	)
+
+	if enableStreamCopy {
+		copyCmd += " --enable-stream-copy"
+	}
+
+	if pushChunkSize != "0" {
+		copyCmd += fmt.Sprintf(" --push-chunk-size %s", pushChunkSize)
+	}
+
+	t.Logf("Running copy command: %s", copyCmd)
+	tool.RunWithoutOutput(t, copyCmd)
+
+	nydusifyPath := ctx.Binary.Nydusify
+	if ctx.Binary.NydusifyChecker != "" {
+		nydusifyPath = ctx.Binary.NydusifyChecker
+	}
+
+	checkCmd := fmt.Sprintf(
+		"%s %s check --source %s --target %s --nydus-image %s --nydusd %s --work-dir %s",
+		nydusifyPath, logLevel, source, targetCopied, ctx.Binary.Builder, ctx.Binary.Nydusd,
+		filepath.Join(ctx.Env.WorkDir, "check-copied"),
+	)
+	tool.RunWithoutOutput(t, checkCmd)
+
+	targetSaved := fmt.Sprintf("file://%s", filepath.Join(ctx.Env.WorkDir, "stream-copied.tar"))
+	saveCmd := fmt.Sprintf(
+		"%s %s copy --source %s --target %s --nydus-image %s --work-dir %s",
+		ctx.Binary.Nydusify, logLevel, targetCopied, targetSaved, ctx.Binary.Builder,
+		filepath.Join(ctx.Env.WorkDir, "save-stream"),
+	)
+
+	if enableStreamCopy {
+		saveCmd += " --enable-stream-copy"
+	}
+	if pushChunkSize != "0" {
+		saveCmd += fmt.Sprintf(" --push-chunk-size %s", pushChunkSize)
+	}
+
+	tool.RunWithoutOutput(t, saveCmd)
+
+	_, err := os.Stat(filepath.Join(ctx.Env.WorkDir, "stream-copied.tar"))
+	require.NoError(t, err)
+
+	targetLoaded := fmt.Sprintf("%s-loaded", targetCopied)
+	loadCmd := fmt.Sprintf(
+		"%s %s copy --source %s --target %s --nydus-image %s --work-dir %s",
+		ctx.Binary.Nydusify, logLevel, targetSaved, targetLoaded, ctx.Binary.Builder,
+		filepath.Join(ctx.Env.WorkDir, "load-stream"),
+	)
+
+	if enableStreamCopy {
+		loadCmd += " --enable-stream-copy"
+	}
+	if pushChunkSize != "0" {
+		loadCmd += fmt.Sprintf(" --push-chunk-size %s", pushChunkSize)
+	}
+
+	tool.RunWithoutOutput(t, loadCmd)
+
+	checkLoadedCmd := fmt.Sprintf(
+		"%s %s check --source %s --target %s --nydus-image %s --nydusd %s --work-dir %s",
+		nydusifyPath, logLevel, source, targetLoaded, ctx.Binary.Builder, ctx.Binary.Nydusd,
+		filepath.Join(ctx.Env.WorkDir, "check-loaded"),
+	)
+	tool.RunWithoutOutput(t, checkLoadedCmd)
+
+	t.Logf("Stream copy test completed successfully with enableStreamCopy=%v, pushChunkSize=%s",
+		enableStreamCopy, pushChunkSize)
+}
+
+func (s *StreamCopyTestSuite) TestStreamCopyPerformance() test.Generator {
+	scenarios := tool.DescartesIterator{}
+	scenarios.
+		Dimension(paramImage, []interface{}{"wordpress:latest"}). // 使用较大的镜像测试性能
+		Dimension("test_mode", []interface{}{"stream_vs_normal"})
+
+	return func() (name string, testCase test.Case) {
+		if !scenarios.HasNext() {
+			return
+		}
+		scenario := scenarios.Next()
+
+		ctx := tool.DefaultContext(s.T)
+		ctx.Build.FSVersion = "6"
+
+		image := s.prepareImage(s.T, scenario.GetString(paramImage))
+
+		return scenario.Str(), func(t *testing.T) {
+			s.testStreamCopyPerformance(t, *ctx, image)
+		}
+	}
+}
+
+func (s *StreamCopyTestSuite) testStreamCopyPerformance(t *testing.T, ctx tool.Context, source string) {
+	// Prepare work directory
+	ctx.PrepareWorkDir(t)
+	defer ctx.Destroy(t)
+
+	sourceNydus := fmt.Sprintf("%s-nydus-%s", source, uuid.NewString())
+	fsVersion := fmt.Sprintf("--fs-version %s", ctx.Build.FSVersion)
+	logLevel := "--log-level warn"
+	compressor := "--compressor lz4_block"
+
+	if ctx.Binary.NydusifyOnlySupportV5 {
+		fsVersion = ""
+		logLevel = ""
+	}
+	if ctx.Binary.NydusifyNotSupportCompressor {
+		compressor = ""
+	}
+
+	// Convert source image to nydus format
+	convertCmd := fmt.Sprintf(
+		"%s %s convert --source %s --target %s %s --nydus-image %s --work-dir %s %s",
+		ctx.Binary.Nydusify, logLevel, source, sourceNydus, fsVersion,
+		ctx.Binary.Builder, ctx.Env.WorkDir, compressor,
+	)
+	tool.RunWithoutOutput(t, convertCmd)
+
+	targetNormal := fmt.Sprintf("%s-normal-copy-%s", sourceNydus, uuid.NewString())
+	normalCopyCmd := fmt.Sprintf(
+		"%s %s copy --source %s --target %s --nydus-image %s --work-dir %s",
+		ctx.Binary.Nydusify, logLevel, sourceNydus, targetNormal, ctx.Binary.Builder,
+		filepath.Join(ctx.Env.WorkDir, "normal-copy"),
+	)
+
+	t.Logf("Testing normal copy mode...")
+	tool.RunWithoutOutput(t, normalCopyCmd)
+
+	targetStream := fmt.Sprintf("%s-stream-copy-%s", sourceNydus, uuid.NewString())
+	streamCopyCmd := fmt.Sprintf(
+		"%s %s copy --source %s --target %s --nydus-image %s --work-dir %s --enable-stream-copy --push-chunk-size 16MB",
+		ctx.Binary.Nydusify, logLevel, sourceNydus, targetStream, ctx.Binary.Builder,
+		filepath.Join(ctx.Env.WorkDir, "stream-copy"),
+	)
+
+	t.Logf("Testing stream copy mode...")
+	tool.RunWithoutOutput(t, streamCopyCmd)
+
+	nydusifyPath := ctx.Binary.Nydusify
+	if ctx.Binary.NydusifyChecker != "" {
+		nydusifyPath = ctx.Binary.NydusifyChecker
+	}
+
+	checkNormalCmd := fmt.Sprintf(
+		"%s %s check --source %s --target %s --nydus-image %s --nydusd %s --work-dir %s",
+		nydusifyPath, logLevel, source, targetNormal, ctx.Binary.Builder, ctx.Binary.Nydusd,
+		filepath.Join(ctx.Env.WorkDir, "check-normal"),
+	)
+	tool.RunWithoutOutput(t, checkNormalCmd)
+
+	checkStreamCmd := fmt.Sprintf(
+		"%s %s check --source %s --target %s --nydus-image %s --nydusd %s --work-dir %s",
+		nydusifyPath, logLevel, source, targetStream, ctx.Binary.Builder, ctx.Binary.Nydusd,
+		filepath.Join(ctx.Env.WorkDir, "check-stream"),
+	)
+	tool.RunWithoutOutput(t, checkStreamCmd)
+
+	t.Logf("Performance comparison test completed successfully")
+}
+
+func (s *StreamCopyTestSuite) prepareImage(t *testing.T, image string) string {
+	if s.preparedImages == nil {
+		s.preparedImages = make(map[string]string)
+	}
+
+	if cached, exists := s.preparedImages[image]; exists {
+		return cached
+	}
+
+	prepared := tool.PrepareImage(t, image)
+	s.preparedImages[image] = prepared
+	return prepared
+}
+
+func TestStreamCopy(t *testing.T) {
+	test.Run(t, &StreamCopyTestSuite{T: t})
+}


### PR DESCRIPTION
Implement a new streaming copy mechanism for image transfer that enables direct source-to-target streaming without using intermediate disk storage.

Key features:

Add StreamCopy for concurrent pull/push operations Introduce streamTransferManager for orchestrating streaming workflows Support chunked transfer with progress tracking
Add HTTP/HTTPS fallback with automatic retries
Support concurrent layer processing with configurable concurrency Retain compatibility with traditional transfer mode Performance improvements:

Eliminate need for intermediate disk storage
Lower memory footprint via streaming buffers
Enable concurrent image layer processing
Add progress logging for large transfers
Implementation details:

Introduce enableStreamTransfer configuration option Add httpModeManager for connection switching logic Optimize for both small and large file transfers
Add robust error handling and retry logic
Integrate with existing provider/resolver framework This significantly improves performance for large image transfers by avoiding disk I/O bottlenecks.

## Relevant Issue (if applicable)
_If there are Issues related to this PullRequest, please list it._

## Details
_Please describe the details of PullRequest._

## Types of changes

_What types of changes does your PullRequest introduce? Put an `x` in all the boxes that apply:_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

## Checklist

_Go over all the following points, and put an `x` in all the boxes that apply._

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.