### PR TITLE
build: fix error when running 'make contrib-build'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,7 @@ NYDUS-OVERLAYFS_PATH = contrib/nydus-overlayfs
 current_dir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 env_go_path := $(shell go env GOPATH 2> /dev/null)
 go_path := $(if $(env_go_path),$(env_go_path),"$(HOME)/go")
+go_work_version := $(shell grep '^go ' go.work | awk '{print $$2}')
 
 # Functions
 
@@ -60,7 +61,8 @@ go_path := $(if $(env_go_path),$(env_go_path),"$(HOME)/go")
 define build_golang
 	echo "Building target $@ by invoking: $(2)"
 	if [ $(DOCKER) = "true" ]; then \
-		docker run --rm -v ${go_path}:/go -v ${current_dir}:/nydus-rs --workdir /nydus-rs/$(1) golang:1.21 $(2) ;\
+		docker run --rm -v ${go_path}:/go -v ${current_dir}:/nydus-rs --workdir /nydus-rs/$(1) golang:${go_work_version} \
+			sh -c "git config --global --add safe.directory /nydus-rs && $(2)" ;\
 	else \
 		$(2) -C $(1); \
 	fi

--- a/contrib/nydus-overlayfs/go.mod
+++ b/contrib/nydus-overlayfs/go.mod
@@ -1,6 +1,6 @@
 module github.com/dragonflyoss/nydus/contrib/nydus-overlayfs
 
-go 1.21
+go 1.24.0
 
 require (
 	github.com/pkg/errors v0.9.1

--- a/contrib/nydusify/go.mod
+++ b/contrib/nydusify/go.mod
@@ -1,8 +1,8 @@
 module github.com/dragonflyoss/nydus/contrib/nydusify
 
-go 1.23.1
+go 1.24.0
 
-toolchain go1.23.6
+toolchain go1.24.0
 
 require (
 	github.com/aliyun/aliyun-oss-go-sdk v3.0.2+incompatible

--- a/smoke/go.mod
+++ b/smoke/go.mod
@@ -1,6 +1,6 @@
 module github.com/dragonflyoss/nydus/smoke
 
-go 1.23.1
+go 1.24.0
 
 require (
 	github.com/containerd/containerd v1.7.11


### PR DESCRIPTION
## Relevant Issue
#1730 

## Details
This pr update go version in `Makefile` to 1.24, and do `git config --global --add safe.directory /nydus-rs` before start building.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)