### PR TITLE
[Feature] Support resending fuse requests when restoring nydusd.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1217,9 +1217,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776"
 
 [[package]]
 name = "libredox"

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -106,6 +106,14 @@ pub enum Error {
     // Fuse session has been shutdown.
     #[error("FUSE session has been shut down, {0}")]
     SessionShutdown(FuseTransportError),
+    #[error("FUSE device not found")]
+    FuseDeviceNotFound,
+    #[error("Fuse write error, {0}")]
+    FuseWriteError(#[source] FuseError),
+    #[error("Sysfs file open error, {0}")]
+    SysfsOpenError(#[source] io::Error),
+    #[error("Sysfs write error, {0}")]
+    SysfsWriteError(#[source] io::Error),
 
     // virtio-fs
     #[error("failed to handle event other than input event")]

--- a/service/src/upgrade.rs
+++ b/service/src/upgrade.rs
@@ -49,6 +49,8 @@ impl From<UpgradeMgrError> for Error {
 /// FUSE fail-over policies.
 #[derive(PartialEq, Eq, Debug)]
 pub enum FailoverPolicy {
+    /// Do nothing.
+    None,
     /// Flush pending requests.
     Flush,
     /// Resend pending requests.
@@ -60,6 +62,7 @@ impl TryFrom<&str> for FailoverPolicy {
 
     fn try_from(p: &str) -> std::result::Result<Self, Self::Error> {
         match p {
+            "none" => Ok(FailoverPolicy::None),
             "flush" => Ok(FailoverPolicy::Flush),
             "resend" => Ok(FailoverPolicy::Resend),
             x => Err(einval!(format!("invalid FUSE fail-over mode {}", x))),
@@ -480,13 +483,13 @@ pub mod fusedev_upgrade {
 
         // restore fuse fd
         if let Some(f) = mgr.return_file() {
-            svc.as_any()
-                .downcast_ref::<FusedevFsService>()
-                .unwrap()
-                .session
-                .lock()
-                .unwrap()
-                .set_fuse_file(f);
+            let fuse_svc = svc.as_any().downcast_ref::<FusedevFsService>().unwrap();
+            fuse_svc.session.lock().unwrap().set_fuse_file(f);
+
+            // drain fuse requests
+            if let Err(e) = fuse_svc.drain_fuse_requests() {
+                warn!("Failed to drain fuse requests: {}", e);
+            }
         }
 
         // restore vfs
@@ -523,6 +526,10 @@ mod tests {
     #[test]
     fn test_failover_policy() {
         assert_eq!(
+            FailoverPolicy::try_from("none").unwrap(),
+            FailoverPolicy::None
+        );
+        assert_eq!(
             FailoverPolicy::try_from("flush").unwrap(),
             FailoverPolicy::Flush
         );
@@ -531,11 +538,16 @@ mod tests {
             FailoverPolicy::Resend
         );
 
-        let strs = vec!["flash", "Resend"];
+        let strs = vec!["null", "flash", "Resend"];
         for s in strs.clone().into_iter() {
             assert!(FailoverPolicy::try_from(s).is_err());
         }
 
+        let str = String::from("none");
+        assert_eq!(
+            FailoverPolicy::try_from(&str).unwrap(),
+            FailoverPolicy::None
+        );
         let str = String::from("flush");
         assert_eq!(
             FailoverPolicy::try_from(&str).unwrap(),

--- a/src/bin/nydusd/main.rs
+++ b/src/bin/nydusd/main.rs
@@ -115,7 +115,7 @@ fn append_fuse_options(app: Command) -> Command {
             .long("failover-policy")
             .default_value("resend")
             .help("FUSE server failover policy")
-            .value_parser(["resend", "flush"])
+            .value_parser(["none", "resend", "flush"])
             .required(false),
     )
     .arg(


### PR DESCRIPTION
## Relevant Issue
#1697 

## Details
Support resending the fuse request when nydusd undergoes a hot upgrade or during a fault recovery process.
Requests can be resend by fuse device and sysfs.

## Types of changes

_What types of changes does your PullRequest introduce? Put an `x` in all the boxes that apply:_

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)