### PR TITLE
nydusify: fix mount for standard nydus image

### DIFF
--- a/contrib/nydusify/pkg/viewer/viewer_test.go
+++ b/contrib/nydusify/pkg/viewer/viewer_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/agiledragon/gomonkey/v2"
+	"github.com/dragonflyoss/nydus/contrib/nydusify/pkg/checker/tool"
 	"github.com/dragonflyoss/nydus/contrib/nydusify/pkg/parser"
 	"github.com/dragonflyoss/nydus/contrib/nydusify/pkg/provider"
 	"github.com/dragonflyoss/nydus/contrib/nydusify/pkg/remote"
@@ -45,6 +46,9 @@ func TestPullBootstrap(t *testing.T) {
 	}
 	fsViwer := FsViewer{
 		Opt: opt,
+		NydusdConfig: tool.NydusdConfig{
+			ExternalBackendConfigPath: "/tmp/backend.json",
+		},
 	}
 	os.MkdirAll(fsViwer.WorkDir, 0755)
 	defer os.RemoveAll(fsViwer.WorkDir)


### PR DESCRIPTION
An error will throw if mount standard nydus image by nydusify mount:

[2025-08-21 12:30:46.670680 +00:00] ERROR [utils/src/error.rs:21] Error:
        "No such file or directory (os error 2)"
        at storage/src/cache/blobcache.rs:1379
        note: enable `RUST_BACKTRACE=1` env to display a backtrace

The reason is that a device.external_backend.config_path option was specified in the nydusd config, but the file does not exist.

We need to make nydusify mount compatible with both regular and model nydus images.

## Overview
_Please briefly describe the changes your pull request makes._

## Related Issues
_Please link to the relevant issue. For example: `Fix #123` or `Related #456`._

## Change Details
_Please describe your changes in detail:_

## Test Results
_If you have any relevant screenshots or videos that can help illustrate your changes, please add them here._

## Change Type
_Please select the type of change your pull request relates to:_
- [x] Bug Fix
- [ ] Feature Addition
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe)

## Self-Checklist
_Before submitting a pull request, please ensure you have completed the following:_
- [ ] I have run a code style check and addressed any warnings/errors.
- [ ] I have added appropriate comments to my code (if applicable).
- [ ] I have updated the documentation (if applicable).
- [ ] I have written appropriate unit tests.