### PR TITLE
fix: fix https://github.com/dragonflyoss/nydus/issues/1692

### DIFF
--- a/contrib/nydusify/pkg/copier/copier.go
+++ b/contrib/nydusify/pkg/copier/copier.go
@@ -471,6 +471,7 @@ func Copy(ctx context.Context, opt Opt) error {
 			return errors.Wrap(err, "read source manifest list")
 		}
 		targetIndex.Manifests = targetDescs
+		nydusifyUtils.SanitizeIndexPlatform(&targetIndex)
 
 		targetImage, err := utils.WriteJSON(ctx, pvd.ContentStore(), targetIndex, *sourceImage, target, nil)
 		if err != nil {


### PR DESCRIPTION
## Overview

fix issue https://github.com/dragonflyoss/nydus/issues/1692

## Related Issues

fix #1692

## Change Details

•  Added a utility to sanitize image indices:
•  contrib/nydusify/pkg/utils/utils.go
◦  New function SanitizeIndexPlatform(idx *ocispec.Index) that removes the feature string defined by ManifestOSFeatureNydus ("nydus.remoteimage.v1") from each manifest’s Platform.OSFeatures in the index.
•  Applied the sanitizer where manifest lists are written:
•  contrib/nydusify/pkg/copier/copier.go
◦  Just before writing the target index, call nydusifyUtils.SanitizeIndexPlatform(&targetIndex).
•  Chunkdict generator already writes individual manifests only; if you need sanitization there for a manifest list write, I can add it once we identify the exact spot (I didn’t find a manifest-list write in that file beyond what’s already using serverutils for per-manifest writes).

## Test Results
_If you have any relevant screenshots or videos that can help illustrate your changes, please add them here._

## Change Type
_Please select the type of change your pull request relates to:_
- [x] Bug Fix
- [ ] Feature Addition
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe)

## Self-Checklist
_Before submitting a pull request, please ensure you have completed the following:_
- [x] I have run a code style check and addressed any warnings/errors.
- [x] I have added appropriate comments to my code (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have written appropriate unit tests.