### PR TITLE
Fix: add recursive inode/dentry invalidation and API smoke test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -588,9 +588,9 @@ dependencies = [
 
 [[package]]
 name = "fuse-backend-rs"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f251e5fd17ca8206cad5d8863f080d11d29646b21a614dba1f1912fa6e4747"
+checksum = "5792186098090fbf991681085fbbfd0a0ea89ec05da8c049a1f117ce4ba1d23d"
 dependencies = [
  "arc-swap",
  "bitflags 1.3.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ hex = "0.4.3"
 hyper = "0.14.11"
 hyperlocal = "0.8.0"
 lazy_static = "1"
-libc = "0.2"
+libc = "0.2.175"
 log = "0.4.8"
 log-panics = { version = "2.1.0", features = ["with-backtrace"] }
 mio = { version = "0.8", features = ["os-poll", "os-ext"] }
@@ -139,4 +139,4 @@ vm-memory = "0.14.1"
 vmm-sys-util = "0.12.1"
 
 # fuse-backend-rs which depends on rust-vmm
-fuse-backend-rs = "0.12.0"
+fuse-backend-rs = "0.13.1"

--- a/rafs/src/fs.rs
+++ b/rafs/src/fs.rs
@@ -348,6 +348,11 @@ impl Rafs {
         self.sb.superblock.root_ino()
     }
 
+    pub fn get_root_inode(&self) -> Result<Arc<dyn RafsInode>> {
+        let root_ino = self.root_ino();
+        self.sb.get_inode(root_ino, self.digest_validate)
+    }
+
     fn do_prefetch(
         root_ino: u64,
         mut reader: RafsIoReader,

--- a/service/src/fusedev.rs
+++ b/service/src/fusedev.rs
@@ -5,8 +5,10 @@
 
 //! Nydus FUSE filesystem daemon.
 
+use core::option::Option::None;
+use nydus_rafs::metadata::{RafsInode, RafsInodeWalkAction};
 use std::any::Any;
-use std::ffi::{CStr, CString};
+use std::ffi::{CStr, CString, OsStr, OsString};
 use std::fs::metadata;
 use std::io::{Error, ErrorKind, Result, Write};
 use std::ops::Deref;
@@ -30,7 +32,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use fuse_backend_rs::abi::fuse_abi::{InHeader, OutHeader};
 use fuse_backend_rs::api::server::{MetricsHook, Server};
 use fuse_backend_rs::api::Vfs;
-use fuse_backend_rs::transport::{FuseChannel, FuseDevWriter, FuseSession};
+use fuse_backend_rs::transport::{FuseChannel, FuseDevWriter, FuseSession, FuseSessionExt};
 use mio::Waker;
 #[cfg(target_os = "linux")]
 use nix::sys::stat::{major, minor};
@@ -44,6 +46,8 @@ use crate::daemon::{
 use crate::fs_service::{FsBackendCollection, FsBackendMountCmd, FsService};
 use crate::upgrade::{self, FailoverPolicy, UpgradeManager};
 use crate::{Error as NydusError, FsBackendType, Result as NydusResult};
+
+const FS_IDX_SHIFT: u64 = 56;
 
 #[derive(Serialize)]
 struct FuseOp {
@@ -333,6 +337,65 @@ impl FsService for FusedevFsService {
             let resp = serde_json::to_string(&r).map_err(NydusError::Serde)?;
             Ok(Some(resp))
         }
+    }
+
+    /// Recursively walk the inode tree and send cache invalidation notifications.
+    fn walk_and_notify_invalidation(
+        &self,
+        parent_kernel_ino: u64,
+        cur_name: &str,
+        cur_inode: Arc<dyn RafsInode>,
+        fs_idx: u8,
+    ) -> NydusResult<()> {
+        let cur_kernel_ino = ((fs_idx as u64) << FS_IDX_SHIFT) | cur_inode.ino();
+
+        if cur_inode.is_dir() {
+            let mut handler =
+                |child: Option<Arc<dyn RafsInode>>, name: OsString, _ino: u64, _offset: u64| {
+                    if name != OsStr::new(".") && name != OsStr::new("..") {
+                        if let Some(child_inode) = child {
+                            let child_name = name.to_string_lossy().to_string();
+                            // Recursive call
+                            if let Err(e) = self.walk_and_notify_invalidation(
+                                cur_kernel_ino,
+                                &child_name,
+                                child_inode,
+                                fs_idx,
+                            ) {
+                                warn!("recursive walk failed for {}: {:?}", child_name, e);
+                            }
+                        }
+                    }
+                    Ok(RafsInodeWalkAction::Continue)
+                };
+
+            cur_inode.walk_children_inodes(0, &mut handler)?;
+        }
+
+        // === Post-order: invalidate cache of the current node ===
+        let cstr_name = CString::new(cur_name).map_err(|_| eother!("invalid file name"))?;
+        // Invalidate inode cache
+        self.session.lock().unwrap().with_writer(|writer| {
+            if let Err(e) = self.server.notify_inval_inode(writer, cur_kernel_ino, 0, 0) {
+                warn!("notify_inval_inode failed: {} {:?}", cur_name, e);
+            }
+        });
+
+        self.session.lock().unwrap().with_writer(|writer| {
+            if let Err(e) =
+                self.server
+                    .notify_inval_entry(writer, parent_kernel_ino, cstr_name.as_c_str())
+            {
+                warn!("notify_inval_entry failed: {} {:?}", cur_name, e);
+            }
+        });
+
+        Ok(())
+    }
+
+    /// Check whether the filesystem service is a FUSE service.
+    fn is_fuse(&self) -> bool {
+        true
     }
 
     fn as_any(&self) -> &dyn Any {

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -114,6 +114,8 @@ pub enum Error {
     SysfsOpenError(#[source] io::Error),
     #[error("Sysfs write error, {0}")]
     SysfsWriteError(#[source] io::Error),
+    #[error("failed to walk and notify invalidation: {0}")]
+    WalkNotifyInvalidation(#[from] std::io::Error),
 
     // virtio-fs
     #[error("failed to handle event other than input event")]


### PR DESCRIPTION
## Overview
Performing more than 255 sub-mount operations on nydusd can lead to file system corruption, even if each mount is properly unmounted. The corruption occurs because fuse-backend-rs uses a u8 type for pseudo inode indexing, and after unmounting, it does not invalidate the FUSE dentry or inode caches. As a result, kernel caches may retain stale pseudo inodes. Once the 255 pseudo inode limit is exceeded, new mount points can reuse old pseudo inodes, causing users to access files or content from previous mounts, leading to inconsistencies.
## Related Issues
Fix #1694 

## Change Details
- Before unmounting a RAFS filesystem, recursively invalidate all inodes and dentries to prevent stale kernel caches when using shared mounts.
- Added a new smoke test `TestSubMountCache` to mount/unmount sub-mounts multiple times (300 iterations) and verify file, directory, symlink.



## Test Results

In the smoke test, the first mount uses a “thin” filesystem containing fewer files, while the next 255 mounts use a full filesystem with more files.

Before this patch, on the 256th mount, accessing files that exist in the full filesystem but not in the thin filesystem could fail:
```
[2025-08-28 13:39:12.597203 +08:00] INFO RAFS filesystem imported
[2025-08-28 13:39:12.597339 +08:00] INFO Rafs filesystem mounted at /mount-255
[2025-08-28 13:39:12.597602 +08:00] ERROR fuse: reply error header OutHeader { len: 16, error: -5, unique: 72202 }, error Custom { kind: NotADirectory, error: "Not a directory (os error 20)" }
api_test.go:263: 
        Error Trace:    /root/nydus/smoke/tests/api_test.go:263
        Error:          Received unexpected error:
                        stat /tmp/nydus-smoke-1919054383/mnt/mount-255/dir-1/file-1: input/output error
        Test:           TestAPI/TestSubMountCache
        Messages:       stat file-1 failed


```
This happens because the pseudo inode cache from the first mount (thin filesystem) is reused in the 256th mount, and the kernel cache has not been invalidated. As a result, the kernel sees stale pseudo inodes, causing read errors when accessing files that exist in the full filesystem but not in the thin one.

After applying this patch, the test passes completely, as recursive inode/dentry invalidation ensures that kernel caches are cleared and pseudo inode reuse no longer causes inconsistencies.
```
[2025-08-28 13:59:08.047650 +08:00] INFO State machine(pid=1116461): from Running to Ready, input [Stop], output [Some(TerminateService)]
[2025-08-28 13:59:08.047787 +08:00] INFO State machine(pid=1116461): from Ready to Die, input [Stop], output [Some(Umount)]
[2025-08-28 13:59:08.047835 +08:00] INFO state_machine thread exits
--- PASS: TestAPI (0.00s)
    --- PASS: TestAPI/TestSubMountCache (9.30s)
PASS
```

## Change Type
_Please select the type of change your pull request relates to:_
- [x] Bug Fix
- [ ] Feature Addition
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe)

## Self-Checklist
_Before submitting a pull request, please ensure you have completed the following:_
- [ ] I have run a code style check and addressed any warnings/errors.
- [ ] I have added appropriate comments to my code (if applicable).
- [ ] I have updated the documentation (if applicable).
- [ ] I have written appropriate unit tests.