### PR TITLE
converter: fix plain HTTP in conversion

### DIFF
--- a/contrib/nydusify/pkg/converter/converter.go
+++ b/contrib/nydusify/pkg/converter/converter.go
@@ -134,6 +134,10 @@ func Convert(ctx context.Context, opt Opt) error {
 	// Set push retry configuration
 	pvd.SetPushRetryConfig(opt.PushRetryCount, retryDelay)
 
+	if opt.WithPlainHTTP {
+		pvd.UsePlainHTTP()
+	}
+
 	cvt, err := converter.New(
 		converter.WithProvider(pvd),
 		converter.WithDriver("nydus", getConfig(opt)),


### PR DESCRIPTION
We should just use plain http when user sets the option.

Before fix:
``` bash
INFO[2025-09-01T11:28:35Z] converted image localhost:5000/busybox:latest-rafs-v5 , elapse 198.159695ms  module=converter
INFO[2025-09-01T11:28:35Z] pushing image localhost:5000/busybox:latest-rafs-v5  module=converter
WARN[2025-09-01T11:28:35Z] Operation failed, will retry                  attempt=2 error="failed to do request: Head \"https://localhost:5000/v2/busybox/blobs/sha256:60fab8113b53ba4a8d9d26e4d3fe6b2af1fe06b5c5c704c7fe1748b4531a23cb\": http: server gave HTTP response to HTTPS client" retry_delay=5s total_attempts=3
WARN[2025-09-01T11:28:40Z] Operation failed, will retry                  attempt=3 error="failed to do request: Head \"https://localhost:5000/v2/busybox/blobs/sha256:60fab8113b53ba4a8d9d26e4d3fe6b2af1fe06b5c5c704c7fe1748b4531a23cb\": http: server gave HTTP response to HTTPS client" retry_delay=5s total_attempts=3
ERRO[2025-09-01T11:28:45Z] Operation failed after all attempts           error="failed to do request: Head \"https://localhost:5000/v2/busybox/blobs/sha256:37c94177fc5ccea45c08fa808b4007c949f3086124ef448792e58e1034d25802\": http: server gave HTTP response to HTTPS client" total_attempts=3
ERRO[2025-09-01T11:28:45Z] Push failed after all attempts                error="failed to do request: Head \"https://localhost:5000/v2/busybox/blobs/sha256:37c94177fc5ccea45c08fa808b4007c949f3086124ef448792e58e1034d25802\": http: server gave HTTP response to HTTPS client"
INFO[2025-09-01T11:28:45Z] try to push with plain HTTP for localhost:5000/busybox:latest-rafs-v5  module=converter
INFO[2025-09-01T11:28:45Z] pushed image localhost:5000/busybox:latest-rafs-v5, elapse 10.041605774s  module=converter
```
After fix:
```
INFO[2025-09-01T11:29:24Z] converted image localhost:5000/busybox:latest-rafs-v5 , elapse 189.642906ms  module=converter
INFO[2025-09-01T11:29:24Z] pushing image localhost:5000/busybox:latest-rafs-v5  module=converter
INFO[2025-09-01T11:29:24Z] pushed image localhost:5000/busybox:latest-rafs-v5, elapse 6.277371ms  module=converter
```