### PR TITLE
fix: correct some bugs and add feature of backend config for optimize subcommand

### DIFF
--- a/builder/src/lib.rs
+++ b/builder/src/lib.rs
@@ -41,6 +41,7 @@ pub use self::core::prefetch::{Prefetch, PrefetchPolicy};
 pub use self::core::tree::{MetadataTreeBuilder, Tree, TreeNode};
 pub use self::directory::DirectoryBuilder;
 pub use self::merge::Merger;
+pub use self::optimize_prefetch::generate_prefetch_file_info;
 pub use self::optimize_prefetch::update_ctx_from_bootstrap;
 pub use self::optimize_prefetch::OptimizePrefetch;
 pub use self::stargz::StargzBuilder;

--- a/builder/src/optimize_prefetch.rs
+++ b/builder/src/optimize_prefetch.rs
@@ -20,6 +20,7 @@ use nydus_api::ConfigV2;
 use nydus_rafs::metadata::layout::RafsBlobTable;
 use nydus_rafs::metadata::RafsSuper;
 use nydus_rafs::metadata::RafsVersion;
+use nydus_storage::backend::BlobBackend;
 use nydus_storage::device::BlobInfo;
 use nydus_storage::meta::BatchContextGenerator;
 use nydus_storage::meta::BlobChunkInfoV2Ondisk;
@@ -27,8 +28,6 @@ use nydus_utils::compress;
 use serde::Deserialize;
 use sha2::Digest;
 use std::cmp::{max, min};
-use std::fs::File;
-use std::io::{Read, Seek, Write};
 use std::mem::size_of;
 use std::sync::Arc;
 pub struct OptimizePrefetch {}
@@ -64,7 +63,7 @@ struct PrefetchFileJson {
 }
 
 impl PrefetchBlobState {
-    fn new(ctx: &BuildContext, blob_layer_num: u32, blobs_dir_path: &Path) -> Result<Self> {
+    fn new(ctx: &BuildContext, blob_layer_num: u32, output_blob_dir_path: &Path) -> Result<Self> {
         let mut blob_info = BlobInfo::new(
             blob_layer_num,
             String::from("prefetch-blob"),
@@ -79,7 +78,7 @@ impl PrefetchBlobState {
         let mut blob_ctx = BlobContext::from(ctx, &blob_info, ChunkSource::Build)?;
         blob_ctx.blob_meta_info_enabled = true;
         let blob_writer = ArtifactWriter::new(crate::ArtifactStorage::FileDir((
-            blobs_dir_path.to_path_buf(),
+            output_blob_dir_path.to_path_buf(),
             String::new(),
         )))
         .map(|writer| Box::new(writer) as Box<dyn Artifact>)?;
@@ -98,8 +97,9 @@ impl OptimizePrefetch {
         ctx: &mut BuildContext,
         bootstrap_mgr: &mut BootstrapManager,
         blob_table: &mut RafsBlobTable,
-        blobs_dir_path: PathBuf,
+        output_blob_dir_path: PathBuf,
         prefetch_files: Vec<PrefetchFileInfo>,
+        backend: Arc<dyn BlobBackend + Send + Sync>,
     ) -> Result<BuildOutput> {
         // create a new blob for prefetch layer
 
@@ -107,7 +107,8 @@ impl OptimizePrefetch {
             RafsBlobTable::V5(table) => table.get_all().len(),
             RafsBlobTable::V6(table) => table.get_all().len(),
         };
-        let mut blob_state = PrefetchBlobState::new(&ctx, blob_layer_num as u32, &blobs_dir_path)?;
+        let mut blob_state =
+            PrefetchBlobState::new(&ctx, blob_layer_num as u32, &output_blob_dir_path)?;
         let mut batch = BatchContextGenerator::new(0)?;
         for node in prefetch_files.clone() {
             Self::process_prefetch_node(
@@ -116,7 +117,7 @@ impl OptimizePrefetch {
                 &mut blob_state,
                 &mut batch,
                 blob_table,
-                &blobs_dir_path,
+                backend.clone(),
             )?;
         }
 
@@ -257,7 +258,7 @@ impl OptimizePrefetch {
         prefetch_state: &mut PrefetchBlobState,
         batch: &mut BatchContextGenerator,
         blob_table: &RafsBlobTable,
-        blobs_dir_path: &Path,
+        backend: Arc<dyn BlobBackend + Send + Sync>,
     ) -> Result<()> {
         let file = prefetch_file_info.file.clone();
         if tree.get_node_mut(&file).is_none() {
@@ -300,13 +301,17 @@ impl OptimizePrefetch {
                 .get(chunk.inner.blob_index() as usize)
                 .map(|entry| entry.blob_id())
                 .ok_or(anyhow!("failed to get blob id"))?;
-            let mut blob_file = Arc::new(File::open(blobs_dir_path.join(blob_id))?);
 
             let inner = Arc::make_mut(&mut chunk.inner);
 
+            let reader = backend
+                .clone()
+                .get_reader(&blob_id.clone())
+                .expect("get blob err");
             let mut buf = vec![0u8; inner.compressed_size() as usize];
-            blob_file.seek(std::io::SeekFrom::Start(inner.compressed_offset()))?;
-            blob_file.read_exact(&mut buf)?;
+            reader
+                .read(&mut buf, inner.compressed_offset())
+                .expect("read blob err");
             prefetch_state.blob_writer.write_all(&buf)?;
             inner.set_blob_index(blob_info.blob_index());
             if blob_ctx.chunk_count == u32::MAX {

--- a/builder/src/optimize_prefetch.rs
+++ b/builder/src/optimize_prefetch.rs
@@ -45,6 +45,7 @@ struct PrefetchFileRange {
     size: usize,
 }
 
+#[derive(Clone)]
 pub struct PrefetchFileInfo {
     file: PathBuf,
     ranges: Option<Vec<PrefetchFileRange>>,
@@ -108,7 +109,7 @@ impl OptimizePrefetch {
         };
         let mut blob_state = PrefetchBlobState::new(&ctx, blob_layer_num as u32, &blobs_dir_path)?;
         let mut batch = BatchContextGenerator::new(0)?;
-        for node in prefetch_files {
+        for node in prefetch_files.clone() {
             Self::process_prefetch_node(
                 tree,
                 node,
@@ -123,7 +124,8 @@ impl OptimizePrefetch {
 
         debug!("prefetch blob id: {}", ctx.blob_id);
 
-        let blob_mgr = Self::build_dump_bootstrap(tree, ctx, bootstrap_mgr, blob_table)?;
+        let blob_mgr =
+            Self::build_dump_bootstrap(tree, ctx, bootstrap_mgr, blob_table, prefetch_files)?;
         BuildOutput::new(&blob_mgr, None, &bootstrap_mgr.bootstrap_storage, &None)
     }
 
@@ -132,6 +134,7 @@ impl OptimizePrefetch {
         ctx: &mut BuildContext,
         bootstrap_mgr: &mut BootstrapManager,
         blob_table: &mut RafsBlobTable,
+        prefetch_files: Vec<PrefetchFileInfo>,
     ) -> Result<BlobManager> {
         let mut bootstrap_ctx = bootstrap_mgr.create_ctx()?;
         let mut bootstrap = Bootstrap::new(tree.clone())?;
@@ -139,6 +142,38 @@ impl OptimizePrefetch {
         // Build bootstrap
         bootstrap.build(ctx, &mut bootstrap_ctx)?;
 
+        // Fix hardlink
+        for node in prefetch_files.clone() {
+            let file = &node.file;
+            if tree.get_node(&file).is_none() {
+                warn!(
+                    "prefetch file {} is skipped, no need to fixing hardlink",
+                    file.display()
+                );
+                continue;
+            }
+
+            let tree_node = tree
+                .get_node(&file)
+                .ok_or(anyhow!("failed to get node"))?
+                .node
+                .as_ref();
+            let child_node = tree_node.borrow();
+            let key = (
+                child_node.layer_idx,
+                child_node.info.src_ino,
+                child_node.info.src_dev,
+            );
+            let chunks = child_node.chunks.clone();
+            drop(child_node);
+
+            if let Some(indexes) = bootstrap_ctx.inode_map.get_mut(&key) {
+                for n in indexes.iter() {
+                    // Rewrite blob chunks to the prefetch blob's chunks
+                    n.borrow_mut().chunks = chunks.clone();
+                }
+            }
+        }
         // generate blob table with extended table
         let mut blob_mgr = BlobManager::new(ctx.digester, false);
         let blob_info = match blob_table {
@@ -222,7 +257,7 @@ impl OptimizePrefetch {
         blob_table: &RafsBlobTable,
         blobs_dir_path: &Path,
     ) -> Result<()> {
-        let file = prefetch_file_info.file;
+        let file = prefetch_file_info.file.clone();
         if tree.get_node_mut(&file).is_none() {
             warn!("prefetch file {} is bad, skip it", file.display());
             return Ok(());
@@ -238,7 +273,6 @@ impl OptimizePrefetch {
             RafsBlobTable::V6(table) => table.get_all(),
         };
 
-        tree_node.borrow_mut().layer_idx = prefetch_state.blob_info.blob_index() as u16;
         let mut child = tree_node.borrow_mut();
         let chunks: &mut Vec<NodeChunk> = child.chunks.as_mut();
         let blob_ctx = &mut prefetch_state.blob_ctx;

--- a/builder/src/optimize_prefetch.rs
+++ b/builder/src/optimize_prefetch.rs
@@ -329,6 +329,9 @@ impl OptimizePrefetch {
             blob_ctx.add_chunk_meta_info(&inner, Some(info))?;
             blob_ctx.blob_hash.update(&buf);
 
+            blob_info.set_compressed_size(blob_ctx.compressed_blob_size as usize);
+            blob_info.set_uncompressed_size(blob_ctx.uncompressed_blob_size as usize);
+            blob_info.set_chunk_count(blob_ctx.chunk_count as usize);
             blob_info.set_meta_ci_compressed_size(
                 (blob_info.meta_ci_compressed_size() + size_of::<BlobChunkInfoV1Ondisk>() as u64)
                     as usize,

--- a/builder/src/optimize_prefetch.rs
+++ b/builder/src/optimize_prefetch.rs
@@ -22,7 +22,7 @@ use nydus_rafs::metadata::RafsSuper;
 use nydus_rafs::metadata::RafsVersion;
 use nydus_storage::device::BlobInfo;
 use nydus_storage::meta::BatchContextGenerator;
-use nydus_storage::meta::BlobChunkInfoV1Ondisk;
+use nydus_storage::meta::BlobChunkInfoV2Ondisk;
 use nydus_utils::compress;
 use serde::Deserialize;
 use sha2::Digest;
@@ -210,9 +210,11 @@ impl OptimizePrefetch {
         blob_mgr.add_blob(blob_state.blob_ctx.clone());
         blob_mgr.set_current_blob_index(0);
         Blob::finalize_blob_data(&ctx, &mut blob_mgr, blob_state.blob_writer.as_mut())?;
-        if let Some((_, blob_ctx)) = blob_mgr.get_current_blob() {
-            Blob::dump_meta_data(&ctx, blob_ctx, blob_state.blob_writer.as_mut()).unwrap();
-        };
+        if let RafsBlobTable::V6(_) = blob_table {
+            if let Some((_, blob_ctx)) = blob_mgr.get_current_blob() {
+                Blob::dump_meta_data(&ctx, blob_ctx, blob_state.blob_writer.as_mut()).unwrap();
+            };
+        }
         ctx.blob_id = String::from("");
         blob_mgr.get_current_blob().unwrap().1.blob_id = String::from("");
         finalize_blob(ctx, &mut blob_mgr, blob_state.blob_writer.as_mut())?;
@@ -306,12 +308,6 @@ impl OptimizePrefetch {
             blob_file.seek(std::io::SeekFrom::Start(inner.compressed_offset()))?;
             blob_file.read_exact(&mut buf)?;
             prefetch_state.blob_writer.write_all(&buf)?;
-            let info = batch.generate_chunk_info(
-                blob_ctx.current_compressed_offset,
-                blob_ctx.current_uncompressed_offset,
-                inner.uncompressed_size(),
-                encrypted,
-            )?;
             inner.set_blob_index(blob_info.blob_index());
             if blob_ctx.chunk_count == u32::MAX {
                 blob_ctx.chunk_count = 0;
@@ -320,27 +316,36 @@ impl OptimizePrefetch {
             blob_ctx.chunk_count += 1;
             inner.set_compressed_offset(blob_ctx.current_compressed_offset);
             inner.set_uncompressed_offset(blob_ctx.current_uncompressed_offset);
-            let aligned_d_size: u64 = nydus_utils::try_round_up_4k(inner.uncompressed_size())
-                .ok_or_else(|| anyhow!("invalid size"))?;
+            let mut aligned_d_size: u64 = inner.uncompressed_size() as u64;
+            if let RafsBlobTable::V6(_) = blob_table {
+                aligned_d_size = nydus_utils::try_round_up_4k(inner.uncompressed_size())
+                    .ok_or_else(|| anyhow!("invalid size"))?;
+                let info = batch.generate_chunk_info(
+                    blob_ctx.current_compressed_offset,
+                    blob_ctx.current_uncompressed_offset,
+                    inner.uncompressed_size(),
+                    encrypted,
+                )?;
+                blob_info.set_meta_ci_compressed_size(
+                    (blob_info.meta_ci_compressed_size()
+                        + size_of::<BlobChunkInfoV2Ondisk>() as u64) as usize,
+                );
+
+                blob_info.set_meta_ci_uncompressed_size(
+                    (blob_info.meta_ci_uncompressed_size()
+                        + size_of::<BlobChunkInfoV2Ondisk>() as u64) as usize,
+                );
+                blob_ctx.add_chunk_meta_info(&inner, Some(info))?;
+            }
             blob_ctx.compressed_blob_size += inner.compressed_size() as u64;
             blob_ctx.uncompressed_blob_size += aligned_d_size;
             blob_ctx.current_compressed_offset += inner.compressed_size() as u64;
             blob_ctx.current_uncompressed_offset += aligned_d_size;
-            blob_ctx.add_chunk_meta_info(&inner, Some(info))?;
             blob_ctx.blob_hash.update(&buf);
 
             blob_info.set_compressed_size(blob_ctx.compressed_blob_size as usize);
             blob_info.set_uncompressed_size(blob_ctx.uncompressed_blob_size as usize);
             blob_info.set_chunk_count(blob_ctx.chunk_count as usize);
-            blob_info.set_meta_ci_compressed_size(
-                (blob_info.meta_ci_compressed_size() + size_of::<BlobChunkInfoV1Ondisk>() as u64)
-                    as usize,
-            );
-
-            blob_info.set_meta_ci_uncompressed_size(
-                (blob_info.meta_ci_uncompressed_size() + size_of::<BlobChunkInfoV1Ondisk>() as u64)
-                    as usize,
-            );
         }
 
         Ok(())

--- a/builder/src/optimize_prefetch.rs
+++ b/builder/src/optimize_prefetch.rs
@@ -222,8 +222,14 @@ impl OptimizePrefetch {
         blob_table: &RafsBlobTable,
         blobs_dir_path: &Path,
     ) -> Result<()> {
+        let file = prefetch_file_info.file;
+        if tree.get_node_mut(&file).is_none() {
+            warn!("prefetch file {} is bad, skip it", file.display());
+            return Ok(());
+        }
+
         let tree_node = tree
-            .get_node_mut(&prefetch_file_info.file)
+            .get_node_mut(&file)
             .ok_or(anyhow!("failed to get node"))?
             .node
             .as_ref();

--- a/contrib/nydusify/pkg/optimizer/builder.go
+++ b/contrib/nydusify/pkg/optimizer/builder.go
@@ -19,9 +19,13 @@ func isSignalKilled(err error) bool {
 }
 
 type BuildOption struct {
-	BuilderPath         string
-	PrefetchFilesPath   string
-	BootstrapPath       string
+	BuilderPath       string
+	PrefetchFilesPath string
+	BootstrapPath     string
+	BackendType       string
+	BackendConfig     string
+	// `BlobDir` is used to store optimized blob,
+	// Beside, `BlobDir` is also used to store the original blobs when backend is localfs
 	BlobDir             string
 	OutputBootstrapPath string
 	OutputJSONPath      string
@@ -42,12 +46,19 @@ func Build(option BuildOption) (string, error) {
 		option.PrefetchFilesPath,
 		"--bootstrap",
 		option.BootstrapPath,
-		"--blob-dir",
+		"--output-blob-dir",
 		option.BlobDir,
 		"--output-bootstrap",
 		option.OutputBootstrapPath,
 		"--output-json",
 		outputJSONPath,
+	}
+
+	if option.BackendType == "localfs" {
+		args = append(args, "--blob-dir", option.BlobDir)
+	} else {
+		args = append(args, "--backend-type", option.BackendType)
+		args = append(args, "--backend-config", option.BackendConfig)
 	}
 
 	ctx := context.Background()

--- a/contrib/nydusify/pkg/optimizer/optimizer.go
+++ b/contrib/nydusify/pkg/optimizer/optimizer.go
@@ -59,6 +59,9 @@ type Opt struct {
 	Platforms    string
 
 	PushChunkSize int64
+
+	BackendType   string
+	BackendConfig string
 }
 
 // the information generated during building
@@ -267,8 +270,10 @@ func Optimize(ctx context.Context, opt Opt) error {
 	}
 	defer os.RemoveAll(buildDir)
 
-	if err := fetchBlobs(ctx, opt, buildDir); err != nil {
-		return errors.Wrap(err, "prepare nydus blobs")
+	if opt.BackendType == "localfs" {
+		if err := fetchBlobs(ctx, opt, buildDir); err != nil {
+			return errors.Wrap(err, "prepare nydus blobs")
+		}
 	}
 
 	originalBootstrap := filepath.Join(buildDir, "nydus_bootstrap")
@@ -287,12 +292,17 @@ func Optimize(ctx context.Context, opt Opt) error {
 
 	compressAlgo := bootstrapDesc.Digest.Algorithm().String()
 	blobDir := filepath.Join(buildDir + "/content/blobs/" + compressAlgo)
+	if err := os.MkdirAll(blobDir, 0755); err != nil {
+		return errors.Wrap(err, "create blob directory")
+	}
 	outPutJSONPath := filepath.Join(buildDir, "output.json")
 	newBootstrapPath := filepath.Join(buildDir, "optimized_bootstrap")
 	builderOpt := BuildOption{
 		BuilderPath:         opt.NydusImagePath,
 		PrefetchFilesPath:   opt.PrefetchFilesPath,
 		BootstrapPath:       originalBootstrap,
+		BackendType:         opt.BackendType,
+		BackendConfig:       opt.BackendConfig,
 		BlobDir:             blobDir,
 		OutputBootstrapPath: newBootstrapPath,
 		OutputJSONPath:      outPutJSONPath,

--- a/docs/nydusify.md
+++ b/docs/nydusify.md
@@ -262,6 +262,36 @@ nerdctl --snapshotter nydus run \
 
 The original container ID need to be a full container ID rather than an abbreviation.
 
+## Optimize nydus image from prefetch files
+
+The nydusify optimize command can optimize a nydus image from prefetch files, prefetch files are file access patterns during container startup. This will generate a new bootstrap and a new blob wich contains all data indicated by prefetch files.
+
+The content of prefetch files likes this:
+```json
+{
+  "version": "v1",
+  "files": [
+    {
+      "path": "/path/to/file1",
+      "ranges": [[100, 20], [140, 50]] // [[offset, size]]
+    },
+    {
+      "path": "/path/to/file2",
+      "ranges": [[200, 30], [250, 40]]
+    },
+    ...
+  ]
+}
+```
+
+``` shell
+nydusify optimize \
+  --nydus-image  /path/to/nydus-image \
+  --source myregistry/repo:tag-nydus \
+  --target myregistry/repo:tag-nydus-optimized \
+  --prefetch-files /path/to/prefetch-files \
+```
+
 ## More Nydusify Options
 
 See `nydusify convert/check/mount --help`

--- a/src/bin/nydus-image/main.rs
+++ b/src/bin/nydus-image/main.rs
@@ -577,6 +577,32 @@ fn prepare_cmd_args(bti_string: &'static str) -> App {
             )
             .arg(arg_config.clone())
             .arg(
+                Arg::new("backend-type")
+                    .long("backend-type")
+                    .help(format!(
+                        "Type of backend [possible values: {}]",
+                        BlobFactory::supported_backends()
+                            .into_iter()
+                            .filter(|x| x != "localfs")
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    ))
+                    .required(false)
+            )
+            .arg(
+                Arg::new("backend-config")
+                    .long("backend-config")
+                    .help("Config string of backend")
+                    .required(false),
+            )
+            .arg(
+                Arg::new("backend-config-file")
+                    .long("backend-config-file")
+                    .help("Config file of backend")
+                    .conflicts_with("backend-config")
+                    .required(false),
+            )
+            .arg(
                 Arg::new("blob-dir")
                     .long("blob-dir")
                     .short('D')
@@ -586,10 +612,21 @@ fn prepare_cmd_args(bti_string: &'static str) -> App {
                     ),
             )
             .arg(
+                Arg::new("blob")
+                    .long("blob")
+                    .short('b')
+                    .help("Path to RAFS data blob file")
+            )
+            .arg(
                 Arg::new("output-bootstrap")
                     .long("output-bootstrap")
                     .short('O')
                     .help("Output path of optimized bootstrap"),
+            )
+            .arg(
+                Arg::new("output-blob-dir")
+                    .long("output-blob-dir")
+                    .help("Directroy path for storing optimized blob"),
             )
             .arg(
                 arg_output_json.clone(),
@@ -1714,7 +1751,7 @@ impl Command {
     }
 
     fn optimize(matches: &ArgMatches, build_info: &BuildTimeInfo) -> Result<()> {
-        let blobs_dir_path = Self::get_blobs_dir(matches)?;
+        let output_blob_dir_path = Self::get_output_blob_dir(matches)?;
         let prefetch_file = Self::get_prefetch_files(matches)?;
         let bootstrap_path = Self::get_bootstrap(matches)?;
         let dst_bootstrap = match matches.get_one::<String>("output-bootstrap") {
@@ -1728,6 +1765,13 @@ impl Command {
             blob_id: String::from("prefetch-blob"),
             blob_inline_meta: true,
             ..Default::default()
+        };
+
+        let (_c, backend) = match Self::get_backend(matches, "optimizer") {
+            Ok((c, b)) => (c, b),
+            Err(e) => {
+                bail!("{}, --blob-dir or --backend-type must be specified", e);
+            }
         };
 
         let sb = update_ctx_from_bootstrap(&mut build_ctx, config, bootstrap_path)?;
@@ -1749,8 +1793,9 @@ impl Command {
             &mut build_ctx,
             &mut bootstrap_mgr,
             &mut blob_table,
-            blobs_dir_path.to_path_buf(),
+            output_blob_dir_path.to_path_buf(),
             prefetch_nodes,
+            backend,
         )
         .with_context(|| "Failed to generate prefetch bootstrap")?;
 
@@ -1863,10 +1908,10 @@ impl Command {
         }
     }
 
-    fn get_blobs_dir(matches: &ArgMatches) -> Result<&Path> {
-        match matches.get_one::<String>("blob-dir") {
+    fn get_output_blob_dir(matches: &ArgMatches) -> Result<&Path> {
+        match matches.get_one::<String>("output-blob-dir") {
             Some(s) => Ok(Path::new(s)),
-            None => bail!("missing parameter `blob-dir`"),
+            None => bail!("missing parameter `output-blob-dir`"),
         }
     }
 

--- a/src/bin/nydus-image/main.rs
+++ b/src/bin/nydus-image/main.rs
@@ -31,11 +31,11 @@ use nix::unistd::{getegid, geteuid};
 use nydus::{get_build_time_info, setup_logging};
 use nydus_api::{BuildTimeInfo, ConfigV2, LocalFsConfig};
 use nydus_builder::{
-    attributes::Attributes, parse_chunk_dict_arg, update_ctx_from_bootstrap, ArtifactStorage,
-    BlobCacheGenerator, BlobCompactor, BlobManager, BootstrapManager, BuildContext, BuildOutput,
-    Builder, ChunkdictBlobInfo, ChunkdictChunkInfo, ConversionType, DirectoryBuilder, Feature,
-    Features, Generator, HashChunkDict, Merger, OptimizePrefetch, Prefetch, PrefetchPolicy,
-    StargzBuilder, TarballBuilder, Tree, TreeNode, WhiteoutSpec,
+    attributes::Attributes, generate_prefetch_file_info, parse_chunk_dict_arg,
+    update_ctx_from_bootstrap, ArtifactStorage, BlobCacheGenerator, BlobCompactor, BlobManager,
+    BootstrapManager, BuildContext, BuildOutput, Builder, ChunkdictBlobInfo, ChunkdictChunkInfo,
+    ConversionType, DirectoryBuilder, Feature, Features, Generator, HashChunkDict, Merger,
+    OptimizePrefetch, Prefetch, PrefetchPolicy, StargzBuilder, TarballBuilder, Tree, WhiteoutSpec,
 };
 
 use nydus_rafs::metadata::{MergeError, RafsSuper, RafsSuperConfig, RafsVersion};
@@ -1715,8 +1715,7 @@ impl Command {
 
     fn optimize(matches: &ArgMatches, build_info: &BuildTimeInfo) -> Result<()> {
         let blobs_dir_path = Self::get_blobs_dir(matches)?;
-        let prefetch_files = Self::get_prefetch_files(matches)?;
-        prefetch_files.iter().for_each(|f| println!("{}", f));
+        let prefetch_file = Self::get_prefetch_files(matches)?;
         let bootstrap_path = Self::get_bootstrap(matches)?;
         let dst_bootstrap = match matches.get_one::<String>("output-bootstrap") {
             None => ArtifactStorage::SingleFile(PathBuf::from("optimized_bootstrap")),
@@ -1733,17 +1732,8 @@ impl Command {
 
         let sb = update_ctx_from_bootstrap(&mut build_ctx, config, bootstrap_path)?;
         let mut tree = Tree::from_bootstrap(&sb, &mut ())?;
-
-        let mut prefetch_nodes: Vec<TreeNode> = Vec::new();
-        // Init prefetch nodes
-        for f in prefetch_files.iter() {
-            let path = PathBuf::from(f);
-            if let Some(tree) = tree.get_node(&path) {
-                prefetch_nodes.push(tree.node.clone());
-            }
-        }
-
         let mut bootstrap_mgr = BootstrapManager::new(Some(dst_bootstrap), None);
+        let prefetch_nodes = generate_prefetch_file_info(prefetch_file)?;
         let blobs = sb.superblock.get_blob_infos();
 
         let mut blob_table = match build_ctx.fs_version {
@@ -1880,21 +1870,9 @@ impl Command {
         }
     }
 
-    fn get_prefetch_files(matches: &ArgMatches) -> Result<Vec<String>> {
+    fn get_prefetch_files(matches: &ArgMatches) -> Result<&Path> {
         match matches.get_one::<String>("prefetch-files") {
-            Some(v) => {
-                let content = std::fs::read_to_string(v)
-                    .map_err(|e| anyhow!("failed to read prefetch files from {}: {}", v, e))?;
-
-                let mut prefetch_files: Vec<String> = Vec::new();
-                for line in content.lines() {
-                    if line.is_empty() || line.trim().is_empty() {
-                        continue;
-                    }
-                    prefetch_files.push(line.trim().to_string());
-                }
-                Ok(prefetch_files)
-            }
+            Some(s) => Ok(Path::new(s)),
             None => bail!("missing parameter `prefetch-files`"),
         }
     }


### PR DESCRIPTION
## Details

There are some bugs in optimize subcommand, following bugs are fixed in this patchset:
- read chunk from wrong blob
- missing extended table in new bootstrap
- hardlink is broken in new image
- missing blobinfo updates
- wrong chunk align for fs-version 5

By the way, implement the backend config support for optimize subcommand, thus we can read chunk on-demand during build process. 



## Types of changes

_What types of changes does your PullRequest introduce? Put an `x` in all the boxes that apply:_

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation Update (if none of the other choices apply)

