### PR TITLE
Update fuse-backend-rs version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -588,9 +588,9 @@ dependencies = [
 
 [[package]]
 name = "fuse-backend-rs"
-version = "0.12.1"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f251e5fd17ca8206cad5d8863f080d11d29646b21a614dba1f1912fa6e4747"
+checksum = "5792186098090fbf991681085fbbfd0a0ea89ec05da8c049a1f117ce4ba1d23d"
 dependencies = [
  "arc-swap",
  "bitflags 1.3.2",
@@ -1217,9 +1217,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
 name = "libredox"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,12 +35,12 @@ path = "src/lib.rs"
 anyhow = "1"
 clap = { version = "4.0.18", features = ["derive", "cargo"] }
 flexi_logger = { version = "0.25", features = ["compress"] }
-fuse-backend-rs = "^0.12.0"
+fuse-backend-rs = { version = "^0.13.0" }
 hex = "0.4.3"
 hyper = "0.14.11"
 hyperlocal = "0.8.0"
 lazy_static = "1"
-libc = "0.2"
+libc = "0.2.175"
 log = "0.4.8"
 log-panics = { version = "2.1.0", features = ["with-backtrace"] }
 mio = { version = "0.8", features = ["os-poll", "os-ext"] }

--- a/clib/Cargo.toml
+++ b/clib/Cargo.toml
@@ -15,7 +15,7 @@ crate-type = ["cdylib", "staticlib"]
 [dependencies]
 libc = "0.2.137"
 log = "0.4.17"
-fuse-backend-rs = "^0.12.0"
+fuse-backend-rs = "^0.13.0"
 nydus-api = { version = "0.4.0", path = "../api" }
 nydus-rafs = { version = "0.4.0", path = "../rafs" }
 nydus-storage = { version = "0.7.0", path = "../storage" }

--- a/rafs/Cargo.toml
+++ b/rafs/Cargo.toml
@@ -19,7 +19,7 @@ nix = "0.24"
 serde = { version = "1.0.110", features = ["serde_derive", "rc"] }
 serde_json = "1.0.53"
 vm-memory = "0.14.1"
-fuse-backend-rs = "^0.12.0"
+fuse-backend-rs = "^0.13.0"
 thiserror = "1"
 
 nydus-api = { version = "0.4.0", path = "../api" }

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 [dependencies]
 bytes = { version = "1", optional = true }
 dbs-allocator = { version = "0.1.1", optional = true }
-fuse-backend-rs = { version = "^0.12.0", features = ["persist"] }
+fuse-backend-rs = { version = "^0.13.0", features = ["persist"] }
 libc = "0.2"
 log = "0.4.8"
 mio = { version = "0.8", features = ["os-poll", "os-ext"] }

--- a/service/src/fs_service.rs
+++ b/service/src/fs_service.rs
@@ -100,7 +100,10 @@ pub trait FsService: Send + Sync {
     /// Get the [BackFileSystem](https://docs.rs/fuse-backend-rs/latest/fuse_backend_rs/api/vfs/type.BackFileSystem.html)
     /// object associated with a mount point.
     fn backend_from_mountpoint(&self, mp: &str) -> Result<Option<Arc<BackFileSystem>>> {
-        self.get_vfs().get_rootfs(mp).map_err(|e| e.into())
+        self.get_vfs()
+            .get_rootfs(mp)
+            .map(|opt| opt.map(|(fs, _)| fs))
+            .map_err(|e| e.into())
     }
 
     /// Get handle to the optional upgrade manager.

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -42,7 +42,7 @@ tokio = { version = "1.19.0", features = [
 ] }
 url = { version = "2.1.1", optional = true }
 vm-memory = "0.14.1"
-fuse-backend-rs = "^0.12.0"
+fuse-backend-rs = "^0.13.0"
 gpt = { version = "3.1.0", optional = true }
 
 nydus-api = { version = "0.4.0", path = "../api" }


### PR DESCRIPTION
## Overview
Update fuse-backend-rs version to 0.13.0 and update libc version to 0.2.175.