### PR TITLE
[registry] Disable token refresh thread when prefetch is enabled

### DIFF
--- a/storage/src/backend/registry.rs
+++ b/storage/src/backend/registry.rs
@@ -883,8 +883,12 @@ impl Registry {
             first: First::new(),
         };
 
-        registry.start_refresh_token_thread();
-        info!("Refresh token thread started.");
+        if config.disable_token_refresh {
+            info!("Refresh token thread is disabled.");
+        } else {
+            registry.start_refresh_token_thread();
+            info!("Refresh token thread started.");
+        }
 
         Ok(registry)
     }


### PR DESCRIPTION
## Overview
_Please briefly describe the changes your pull request makes._

Add a new RegistryConfig field called `enable_token_refresh` that will decide whether the registry refresh token thread is started on not. 

## Related Issues
_Please link to the relevant issue. For example: `Fix #123` or `Related #456`._

Fix #1777

## Change Details
_Please describe your changes in detail:_

The new field will be set to true by default but will be disabled when prefetch is enabled. The refresh thread is disabled in this case because it becomes useless once everything has been prefetched and it's unlikely that tokens would expire during the time it takes for the prefetch to run (as it would mean that regular image pulls  would be likely to fail as well because they download the layers in a similar time to the prefetch)

## Test Results
_If you have any relevant screenshots or videos that can help illustrate your changes, please add them here._

Running tests with this basic nydusd config:
```
{
  "device": {
    "backend": {
      "type": "registry",
      "config": {
        "timeout": 15,
        "connect_timeout": 15,
        "retry_limit": 5
      }
    },
    "cache": {
      "type": "blobcache",
      "config": {
        "work_dir": "cache"
      }
    }
  },
  "mode": "direct",
  "digest_validate": false,
  "iostats_files": false,
  "enable_xattr": true,
  "fs_prefetch": {
    "enable": true,
    "threads_count": 4
  }
}
```

The token thread isn't started:
```
INFO[2025-10-13T11:38:56.430857078+02:00] nydusd command: /containerd-local/nydusd fuse --config /containerd-local/io.containerd.snapshotter.v1.nydus/config/d3mchc1jjoq9cr38fp00/config.json --bootstrap /containerd-local/io.containerd.snapshotter.v1.nydus/snapshots/24/fs/image.boot --mountpoint /containerd-local/io.containerd.snapshotter.v1.nydus/snapshots/24/mnt --apisock /containerd-local/io.containerd.snapshotter.v1.nydus/socket/d3mchc1jjoq9cr38fp00/api.sock --log-level debug --log-rotation-size 100
[2025-10-13 11:38:56.437379 +02:00] INFO Program Version: v2.3.7-dd, Git Commit: "c100686d6b0243c451f1a261b900497f827c90aa", Build Time: "2025-10-13T09:38:39.942636660Z", Profile: "debug", Rustc Version: "rustc 1.84.0 (9fc6b4312 2025-01-07)"
[2025-10-13 11:38:56.437525 +02:00] INFO Set rlimit-nofile to 1000000, maximum 1000000
[2025-10-13 11:38:56.438354 +02:00] DEBUG [/fuse-backend-rs-0.12.1/src/api/pseudo_fs.rs:161] pseudo fs iterate "/"
[2025-10-13 11:38:56.439288 +02:00] INFO RAFS features: HASH_BLAKE3 | EXPLICIT_UID_GID | HAS_XATTR | COMPRESSION_ZSTD | INLINED_CHUNK_DIGEST | ENCRYPTION_NONE
[2025-10-13 11:38:56.439831 +02:00] INFO backend config: ConnectionConfig { proxy: ProxyConfig { url: "", ping_url: "", fallback: false, check_interval: 5, use_http: false, check_pause_elapsed: 300 }, skip_verify: false, timeout: 15, connect_timeout: 15, retry_limit: 5 }
[2025-10-13 11:38:56.454946 +02:00] INFO Refresh token thread is disabled.
```

## Change Type
_Please select the type of change your pull request relates to:_
- [x] Bug Fix
- [ ] Feature Addition
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe)

## Self-Checklist
_Before submitting a pull request, please ensure you have completed the following:_
- [ ] I have run a code style check and addressed any warnings/errors.
- [ ] I have added appropriate comments to my code (if applicable).
- [ ] I have updated the documentation (if applicable).
- [ ] I have written appropriate unit tests.