### PR TITLE
[nydusify] Convert nydus images to/from local archives

### DIFF
--- a/contrib/nydusify/pkg/converter/converter.go
+++ b/contrib/nydusify/pkg/converter/converter.go
@@ -42,9 +42,11 @@ type Opt struct {
 	ContainerdAddress string
 	NydusImagePath    string
 
-	Source       string
-	Target       string
-	ChunkDictRef string
+	Source        string
+	SourceArchive string
+	Target        string
+	TargetArchive string
+	ChunkDictRef  string
 
 	SourceBackendType   string
 	SourceBackendConfig string
@@ -133,6 +135,9 @@ func Convert(ctx context.Context, opt Opt) error {
 
 	// Set push retry configuration
 	pvd.SetPushRetryConfig(opt.PushRetryCount, retryDelay)
+	// Set potential local source/target archives
+	pvd.WithLocalSource(opt.SourceArchive)
+	pvd.WithLocalTarget(opt.TargetArchive)
 
 	if opt.WithPlainHTTP {
 		pvd.UsePlainHTTP()

--- a/contrib/nydusify/pkg/copier/copier.go
+++ b/contrib/nydusify/pkg/copier/copier.go
@@ -367,9 +367,11 @@ func Copy(ctx context.Context, opt Opt) error {
 		}
 		defer ds.Close()
 
-		if source, err = pvd.Import(ctx, ds); err != nil {
+		var sourceImage images.Image
+		if sourceImage, err = pvd.Import(ctx, ds); err != nil {
 			return errors.Wrap(err, "import source image")
 		}
+		source = sourceImage.Name
 		logrus.Infof("imported source image %s", source)
 	} else {
 		sourceNamed, err := reference.ParseDockerRef(opt.Source)


### PR DESCRIPTION
This adds the ability to convert nydus images to and from local archive files using nydusify convert.
The main benefits are that images conversions can now be run in environments without access to a container registry (or internet for that matter), while still being able to use nydusify capabilities to build images with merge platforms or OCI referrer.
The feature is used with the flags --source-archive and --target-archive to specify the input and output archive files respectively. It's not necessary to specify both.
The --source and --target/--target-suffix flags remain necessary as they are needed to identify the images imported/exported in the archives.
The reason why we had to add new flags instead of using the existing --source and --target ones with a prepended `file://` like `nydusify copy` is doing is explained [here](https://github.com/dragonflyoss/nydus/issues/1787#issuecomment-3421854764).

Fixes #1787 

## Test 

I exported a busybox archive with `docker pull busybox && docker save busybox > busybox.tar`

Example running the following command without internet access:

```
./cmd/nydusify convert --source localhost:5000/busybox --source-archive ~/busybox.tar --target localhost:5000/busybox:local-nydus --target-archive ~/busybox-nydus.tar --merge-platform --platform "linux/amd64,linux/arm64"
INFO[2025-10-17T16:08:59+02:00] pulling image localhost:5000/busybox:latest   module=converter
INFO[2025-10-17T16:08:59+02:00] importing source image from /home/baptiste.girardcarrabin/busybox.tar
INFO[2025-10-17T16:08:59+02:00] pulled image localhost:5000/busybox:latest , elapse 379.38326ms  module=converter
INFO[2025-10-17T16:08:59+02:00] converting image localhost:5000/busybox:latest  module=converter
INFO[2025-10-17T16:09:00+02:00] converted image localhost:5000/busybox:local-nydus , elapse 742.086177ms  module=converter
INFO[2025-10-17T16:09:00+02:00] pushing image localhost:5000/busybox:local-nydus  module=converter
INFO[2025-10-17T16:09:00+02:00] exporting target image to /home/baptiste.girardcarrabin/busybox-nydus.tar
INFO[2025-10-17T16:09:00+02:00] pushed image localhost:5000/busybox:local-nydus, elapse 47.466626ms  module=converter
```

and then running a copy to a regisrty:
```
nydusify copy --source file://$HOME/busybox-nydus.tar --target localhost:5000/busybox:local-nydus-copy-merged --platform "linux/amd64,linux/arm64"
```

did output a merged manifest like expected: 
```
crane manifest localhost:5000/busybox:local-nydus-copy-merged | jq
{
  "schemaVersion": 2,
  "manifests": [
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "digest": "sha256:57da378a280dc1c91101c11600db0d1ac74268aac5a2097c426cf8b10579b401",
      "size": 1197,
      "annotations": {
        "com.docker.official-images.bashbrew.arch": "amd64",
        "containerd.io/snapshot/nydus-source-digest": "sha256:182014572d8981d8323fe9944876f63b39694e16ce08ae6296e97686c52b150c",
        "org.opencontainers.image.base.name": "scratch",
        "org.opencontainers.image.created": "2025-08-12T17:10:01Z",
        "org.opencontainers.image.revision": "3fe52725c149a6966493eefe94d32a2704b6b7bf",
        "org.opencontainers.image.source": "https://github.com/docker-library/busybox.git",
        "org.opencontainers.image.url": "https://hub.docker.com/_/busybox",
        "org.opencontainers.image.version": "1.37.0-glibc"
      },
      "platform": {
        "architecture": "amd64",
        "os": "linux"
      }
    },
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "digest": "sha256:4b057b92407cba1eed319d3f208f6e31421fb31584e7fe69b0223b816a2e40e6",
      "size": 1197,
      "annotations": {
        "com.docker.official-images.bashbrew.arch": "arm64v8",
        "containerd.io/snapshot/nydus-source-digest": "sha256:cddc8af5547af9de5e6fb66b36d66ef7418561204e1255ae528d0b2c919d09a3",
        "org.opencontainers.image.base.name": "scratch",
        "org.opencontainers.image.created": "2025-08-12T17:10:01Z",
        "org.opencontainers.image.revision": "ab49e875ac9a27b182e49d70672530d6ec71d5d7",
        "org.opencontainers.image.source": "https://github.com/docker-library/busybox.git",
        "org.opencontainers.image.url": "https://hub.docker.com/_/busybox",
        "org.opencontainers.image.version": "1.37.0-glibc"
      },
      "platform": {
        "architecture": "arm64",
        "os": "linux",
        "variant": "v8"
      }
    },
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "digest": "sha256:2f471a23c8dd0bc477e277e14d1ceca0139d85804f9de942e50d14d9fe9d408d",
      "size": 1387,
      "annotations": {
        "com.docker.official-images.bashbrew.arch": "amd64",
        "org.opencontainers.image.base.name": "scratch",
        "org.opencontainers.image.created": "2025-08-12T17:10:01Z",
        "org.opencontainers.image.revision": "3fe52725c149a6966493eefe94d32a2704b6b7bf",
        "org.opencontainers.image.source": "https://github.com/docker-library/busybox.git",
        "org.opencontainers.image.url": "https://hub.docker.com/_/busybox",
        "org.opencontainers.image.version": "1.37.0-glibc"
      },
      "platform": {
        "architecture": "amd64",
        "os": "linux"
      },
      "artifactType": "application/vnd.nydus.image.manifest.v1+json"
    },
    {
      "mediaType": "application/vnd.oci.image.manifest.v1+json",
      "digest": "sha256:83feb1f8fb6efe6e00be076744a87af3f9754aeb7dd01c6981608da8260d4959",
      "size": 1387,
      "annotations": {
        "com.docker.official-images.bashbrew.arch": "arm64v8",
        "org.opencontainers.image.base.name": "scratch",
        "org.opencontainers.image.created": "2025-08-12T17:10:01Z",
        "org.opencontainers.image.revision": "ab49e875ac9a27b182e49d70672530d6ec71d5d7",
        "org.opencontainers.image.source": "https://github.com/docker-library/busybox.git",
        "org.opencontainers.image.url": "https://hub.docker.com/_/busybox",
        "org.opencontainers.image.version": "1.37.0-glibc"
      },
      "platform": {
        "architecture": "arm64",
        "os": "linux",
        "variant": "v8"
      },
      "artifactType": "application/vnd.nydus.image.manifest.v1+json"
    }
  ]
}
```