### PR TITLE
fix: save vfs_state_data before save FusedevBackendState #1788 

### DIFF
--- a/service/src/upgrade.rs
+++ b/service/src/upgrade.rs
@@ -446,12 +446,12 @@ pub mod fusedev_upgrade {
         }
 
         let mut mgr = svc.upgrade_mgr().unwrap();
+        mgr.save_vfs_stat(vfs)?;
+
         let backend_stat = FusedevBackendState::from(&mgr.fuse_deamon_stat);
 
         let state = backend_stat.save().map_err(UpgradeMgrError::Serialize)?;
         mgr.save(&state)?;
-
-        mgr.save_vfs_stat(vfs)?;
 
         Ok(())
     }


### PR DESCRIPTION
## Overview
save vfs_state_data for local UpgradeManager before using UDS to save FusedevBackendState to nydus-snapshotter.

## Related Issues
Fix #1788 

## Change Details
save vfs_state_data for local UpgradeManager before using UDS to save FusedevBackendState to nydus-snapshotter.

## Test Results
vfs_state_data will be correctly saved to nydus-snapshotter and can be properly restored during failover; the Vfs.opendir will not return error after failover.

## Change Type
_Please select the type of change your pull request relates to:_
- [x] Bug Fix
- [ ] Feature Addition
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe)