### PR TITLE
fix: builder: fix panic when a symlink overwrites a directory

### DIFF
--- a/builder/src/core/tree.rs
+++ b/builder/src/core/tree.rs
@@ -250,6 +250,9 @@ impl Tree {
             if let Some(idx) = self.get_child_idx(&u.name) {
                 u_node.overlay = Overlay::UpperModification;
                 self.children[idx].node = u.node.clone();
+                if !u_node.is_dir() {
+                    self.children[idx].children.clear();
+                }
             } else {
                 u_node.overlay = Overlay::UpperAddition;
                 self.insert_child(Tree {


### PR DESCRIPTION
When an upper-layer symlink overwrites a lower-layer directory, the directory's children were not removed from the merge tree.

The builder continued to traverse these "zombie" children. The accessing of InodeExt triggered a panic because this ref didn't be initialized by ensured_owned().

## Overview
_Please briefly describe the changes your pull request makes._

## Related Issues
_Please link to the relevant issue. For example: `Fix #123` or `Related #456`._

## Change Details
_Please describe your changes in detail:_

## Test Results
_If you have any relevant screenshots or videos that can help illustrate your changes, please add them here._

## Change Type
_Please select the type of change your pull request relates to:_
- [x] Bug Fix
- [ ] Feature Addition
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe)

## Self-Checklist
_Before submitting a pull request, please ensure you have completed the following:_
- [ ] I have run a code style check and addressed any warnings/errors.
- [ ] I have added appropriate comments to my code (if applicable).
- [ ] I have updated the documentation (if applicable).
- [ ] I have written appropriate unit tests.