### PR TITLE
action: fix up macos release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,7 +82,7 @@ jobs:
           configs
 
   nydus-macos:
-    runs-on: macos-13
+    runs-on: macos-15
     strategy:
       matrix:
         arch: [amd64, arm64]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,7 +104,8 @@ jobs:
         cargo install --version 0.2.5 cross
         rustup target add ${RUST_TARGET}
         make -e RUST_TARGET_STATIC=$RUST_TARGET -e CARGO=cross static-release
-        sudo mv target/$RUST_TARGET/release/nydusd nydusd
+        sudo mv target/$RUST_TARGET/release/nydusd .
+        sudo mv target/$RUST_TARGET/release/nydusctl .
         sudo cp -r misc/configs .
         sudo chown -R $(id -un):$(id -gn) . ~/.cargo/
     - name: store-artifacts
@@ -114,7 +115,6 @@ jobs:
         path: |
           nydusctl
           nydusd
-          nydus-image
           configs
 
   contrib-linux:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,9 +101,8 @@ jobs:
         else
           RUST_TARGET="aarch64-apple-darwin"
         fi
-        cargo install --version 0.2.5 cross
         rustup target add ${RUST_TARGET}
-        make -e RUST_TARGET_STATIC=$RUST_TARGET -e CARGO=cross static-release
+        make -e RUST_TARGET_STATIC=$RUST_TARGET static-release
         sudo mv target/$RUST_TARGET/release/nydusd .
         sudo mv target/$RUST_TARGET/release/nydusctl .
         sudo cp -r misc/configs .

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -148,9 +148,8 @@ jobs:
         else
           RUST_TARGET="aarch64-apple-darwin"
         fi
-        cargo install --version 0.2.5 cross
         rustup target add ${RUST_TARGET}
-        make -e RUST_TARGET_STATIC=$RUST_TARGET -e CARGO=cross static-release
+        make -e RUST_TARGET_STATIC=$RUST_TARGET -e static-release
 
   nydus-integration-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -128,7 +128,7 @@ jobs:
           nydusd
 
   nydusd-build-macos:
-    runs-on: macos-13
+    runs-on: macos-15
     strategy:
       matrix:
         arch: [amd64, arm64]


### PR DESCRIPTION
* macos-13 has been deprecated in github action
* cross does not really work on macos
* add missing nydusctl binary
