### PR TITLE
fix: ensure chunk bitmap changes are synced to disk

### DIFF
--- a/storage/src/cache/state/persist_map.rs
+++ b/storage/src/cache/state/persist_map.rs
@@ -236,8 +236,7 @@ impl PersistMap {
             }
 
             if self.write_u8(index, current) {
-                // Sync the bitmap change to disk immediately to ensure it persists
-                let _ = self.filemap.sync_data();
+                let _ = self.filemap.sync_data_async();
                 if self.not_ready_count.fetch_sub(1, Ordering::AcqRel) == 1 {
                     self.mark_all_ready();
                 }
@@ -249,6 +248,7 @@ impl PersistMap {
     }
 
     fn mark_all_ready(&self) {
+        // Use blocking sync for final completion to ensure all data is written to disk
         let _ = self.filemap.sync_data();
     }
 

--- a/utils/src/filemap.rs
+++ b/utils/src/filemap.rs
@@ -188,6 +188,22 @@ impl FileMapState {
         std::mem::forget(file);
         result
     }
+
+    /// Schedule an asynchronous sync of mapped file data to disk.
+    pub fn sync_data_async(&self) -> Result<()> {
+        let ret = unsafe {
+            libc::msync(
+                self.base as *mut libc::c_void,
+                self.size,
+                libc::MS_ASYNC,
+            )
+        };
+        if ret != 0 {
+            Err(last_error!("msync async failed"))
+        } else {
+            Ok(())
+        }
+    }
 }
 
 /// Duplicate a file object by `libc::dup()`.


### PR DESCRIPTION
## Overview

When containers run with lazy loading and the registry becomes unavailable (e.g., in an offline scenario), the system must rely on the cached chunk state from previous runs. However, bitmap changes marking chunks as ready were not being explicitly synced to disk, causing them to be lost on process restart.

## Root Cause

The issue stems from chunk ready state not being durably persisted to disk:

1. **During First Run (Lazy Loading):**
   - Only accessed file chunks are fetched from registry and cached
   - Chunks marked as ready update the memory-mapped bitmap file
   - Changes are written to the mmap'd memory but NOT explicitly synced to disk

2. **On Process Restart:**
   - Cache subsystem reads chunk bitmap from disk
   - Bitmap shows stale/incomplete state (missing synced updates)
   - System thinks chunks that were actually cached are still missing
   - Attempts to fetch missing chunks from registry
   - In offline scenario: registry unreachable → containers fail to start with "binary not found" errors

## Solution

The fix ensures chunk ready state is durably persisted.

-. **Always open bitmap file with write permission** 
   - Changed from `.write(create)` to `.write(true)`
   - Ensures file can be synced on reopened instances

- **Sync bitmap after each chunk ready state change**

This ensures chunk ready state survives process restarts and enables reliable lazy loading to survive offline scenarios by re-reading from cache.
       -        -        - 
## Change Type
_Please select the type of change your pull request relates to:_
- [x] Bug Fix
- [ ] Feature Addition
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe)

## Self-Checklist
_Before submitting a pull request, please ensure you have completed the following:_
- [x] I have run a code style check and addressed any warnings/errors.
- [x] I have added appropriate comments to my code (if applicable).
- [x] I have updated the documentation (if applicable).
- [x] I have written appropriate unit tests.