### PR TITLE
tests: replace fmt.Println with log for better logging

### DIFF
--- a/smoke/proxy/main.go
+++ b/smoke/proxy/main.go
@@ -35,7 +35,7 @@ func main() {
 func httpsProxy(w http.ResponseWriter, r *http.Request) {
 	destAddr := r.URL.Host
 
-	fmt.Println("Tunneling established", destAddr)
+	log.Println("Tunneling established", destAddr)
 
 	destConn, err := net.DialTimeout("tcp", destAddr, 10*time.Second)
 	if err != nil {

--- a/smoke/tests/image_test.go
+++ b/smoke/tests/image_test.go
@@ -6,6 +6,7 @@ package tests
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -217,7 +218,7 @@ func (i *ImageTestSuite) TestChundict(t *testing.T, ctx tool.Context, images []s
 		target := fmt.Sprintf("%s-nydus-%s", image, uuid.NewString())
 		targets = append(targets, target)
 
-		fmt.Println("target:", target)
+		log.Println("target:", target)
 		convertCmd := fmt.Sprintf(
 			"%s %s convert --source %s --target %s %s %s %s %s --nydus-image %s --work-dir %s %s",
 			ctx.Binary.Nydusify, logLevel, image, target, fsVersion, enableOCIRef, "", enableEncrypt, ctx.Binary.Builder, ctx.Env.WorkDir, compressor,
@@ -228,13 +229,13 @@ func (i *ImageTestSuite) TestChundict(t *testing.T, ctx tool.Context, images []s
 
 	// Generate chunkdict.
 	chunkdict := fmt.Sprintf("%s/redis:nydus-chunkdict-%s", strings.SplitN(testImage, "/", 2)[0], uuid.NewString())
-	fmt.Println("chunkdict:", chunkdict)
+	log.Println("chunkdict:", chunkdict)
 	generateCmd := fmt.Sprintf(
 		"%s %s chunkdict generate --sources %s --target %s --source-insecure --target-insecure --nydus-image %s --work-dir %s",
 		ctx.Binary.Nydusify, logLevel, targetsStr, chunkdict, ctx.Binary.Builder, filepath.Join(ctx.Env.WorkDir, "generate"),
 	)
 	tool.RunWithoutOutput(t, generateCmd)
-	fmt.Println("generateCmd:", generateCmd)
+	log.Println("generateCmd:", generateCmd)
 
 	// Covert test image by chunkdict.
 	target := fmt.Sprintf("%s-nydus-%s", testImage, uuid.NewString())
@@ -250,7 +251,6 @@ func (i *ImageTestSuite) TestChundict(t *testing.T, ctx tool.Context, images []s
 		ctx.Binary.Nydusify, logLevel, target, ctx.Binary.Builder, ctx.Binary.Nydusd, filepath.Join(ctx.Env.WorkDir, "check"),
 	)
 	tool.RunWithoutOutput(t, checkCmd)
-	fmt.Println("checkCmd:", checkCmd)
 	ctx.Destroy(t)
 }
 

--- a/smoke/tests/main_test.go
+++ b/smoke/tests/main_test.go
@@ -5,6 +5,7 @@
 package tests
 
 import (
+	"log"
 	"os"
 	"testing"
 
@@ -27,6 +28,9 @@ func TestMain(m *testing.M) {
 	if os.Getenv("DISABLE_REGISTRY") == "" {
 		reg = tool.NewRegistry()
 	}
+
+	log.SetFlags(log.Lshortfile | log.LstdFlags)
+	log.SetOutput(os.Stderr)
 
 	code := m.Run()
 

--- a/smoke/tests/texture/golang/main.go
+++ b/smoke/tests/texture/golang/main.go
@@ -1,7 +1,7 @@
 package main
 
-import "fmt"
+import "log"
 
 func main() {
-	fmt.Println("hello")
+	log.Println("hello")
 }

--- a/smoke/tests/tool/iterator.go
+++ b/smoke/tests/tool/iterator.go
@@ -106,7 +106,7 @@ func (d *DescartesItem) Str() string {
 //	   //       age: 30, name: imoer
 //	   for products.HasNext(){
 //	       item := products.Next()
-//	       fmt.Println(item.Str())
+//	       log.Println(item.Str())
 //	   }
 type DescartesIterator struct {
 	cursors   []int

--- a/smoke/tests/tool/util.go
+++ b/smoke/tests/tool/util.go
@@ -7,6 +7,7 @@ package tool
 import (
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"os/exec"
 	"regexp"
@@ -23,6 +24,7 @@ var defaultBinary = map[string]string{
 }
 
 func RunWithCombinedOutput(cmd string) (string, error) {
+	log.Println("RunWithCombinedOutput:", cmd)
 	_cmd := exec.Command("sh", "-c", cmd)
 	output, err := _cmd.CombinedOutput()
 
@@ -30,6 +32,7 @@ func RunWithCombinedOutput(cmd string) (string, error) {
 }
 
 func Run(t *testing.T, cmd string) {
+	log.Println("Run:", cmd)
 	_cmd := exec.Command("sh", "-c", cmd)
 	_cmd.Stdout = os.Stdout
 	_cmd.Stderr = os.Stderr
@@ -38,6 +41,7 @@ func Run(t *testing.T, cmd string) {
 }
 
 func RunWithoutOutput(t *testing.T, cmd string) {
+	log.Println("RunWithoutOutput:", cmd)
 	_cmd := exec.Command("sh", "-c", cmd)
 	_cmd.Stdout = io.Discard
 	_cmd.Stderr = os.Stderr
@@ -46,6 +50,7 @@ func RunWithoutOutput(t *testing.T, cmd string) {
 }
 
 func RunWithOutput(cmd string) string {
+	log.Println("RunWithOutput:", cmd)
 	_cmd := exec.Command("sh", "-c", cmd)
 	_cmd.Stderr = os.Stderr
 


### PR DESCRIPTION
Replace all occurrences of fmt.Println with log.Println across multiple test files and the proxy main.go to standardize logging output and improve log formatting.

Add log output for command execution functions in tool/util.go to enhance debugging and traceability during test runs.

Configure log flags and output in tests/main_test.go to include timestamps and file info in logs.
