### PR TITLE
security: add ignore rule for RUSTSEC-2025-0141

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -42,6 +42,7 @@ yanked = "warn"
 # output a note when they are encountered.
 ignore = [
     { id = "RUSTSEC-2024-0436", reason = "No safe upgrade is available!" },
+    { id = "RUSTSEC-2025-0141", reason = "No safe upgrade is available! The team considers version 1.3.3 a complete version of bincode that is not in need of any updates" },
 ]
 # Threshold for security vulnerabilities, any vulnerability with a CVSS score
 # lower than the range specified will be ignored. Note that ignored advisories


### PR DESCRIPTION
│ bincode 1.3.3 registry+https://github.com/rust-lang/crates.io-index │ ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ unmaintained advisory detected │
├ ID: RUSTSEC-2025-0141
├ Advisory: https://rustsec.org/advisories/RUSTSEC-2025-0141 ├ Due to a doxxing and harassment incident, the bincode team has taken the decision to cease development permanently.

  The team considers version 1.3.3 a complete version of bincode that is not in need of any updates.

Add a new ignore entry for the security advisory RUSTSEC-2025-0141 in deny.toml. This advisory is ignored because no safe upgrade is available, and the team considers version 1.3.3 of bincode stable and not requiring updates.
