### PR TITLE
api: support hot reload of registry authentication

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -117,9 +117,12 @@ checksum = "34ac096ce696dc2fcabef30516bb13c0a68a11d30131d3df6f04711467681b04"
 
 [[package]]
 name = "arc-swap"
-version = "1.7.1"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+checksum = "51d03449bb8ca2cc2ef70869af31463d1ae5ccc8fa3e334b307203fbf815207e"
+dependencies = [
+ "rustversion",
+]
 
 [[package]]
 name = "arrayref"
@@ -1734,6 +1737,7 @@ dependencies = [
 name = "nydus-utils"
 version = "0.5.1"
 dependencies = [
+ "arc-swap",
  "blake3",
  "crc",
  "flate2",

--- a/api/src/http.rs
+++ b/api/src/http.rs
@@ -51,6 +51,9 @@ pub struct DaemonConf {
     pub log_level: String,
 }
 
+// Set/update global configuration.
+pub type Config = std::collections::HashMap<String, String>;
+
 /// Identifier for cached blob objects.
 ///
 /// Domains are used to control the blob sharing scope. All blobs associated with the same domain
@@ -106,6 +109,10 @@ pub enum ApiRequest {
     ExportFsFilesMetrics(Option<String>, bool),
     /// Get information about filesystem inflight requests.
     ExportFsInflightMetrics,
+    /// Get global configuration.
+    GetConfig(Option<String>),
+    /// Update global configuration.
+    UpdateConfig(Option<String>, Config),
 
     // Nydus API v2
     /// Get daemon information excluding filesystem backends.
@@ -193,6 +200,8 @@ pub enum ApiResponsePayload {
     FsBackendInfo(String),
     // Filesystem Inflight Requests, v1.
     FsInflightMetrics(String),
+    // Global configuration, v1.
+    Config(Config),
 
     /// List of blob objects, v2
     BlobObjectList(String),

--- a/api/src/http_handler.rs
+++ b/api/src/http_handler.rs
@@ -24,8 +24,8 @@ use crate::http_endpoint_common::{
     SendFuseFdHandler, StartHandler, TakeoverFuseFdHandler,
 };
 use crate::http_endpoint_v1::{
-    FsBackendInfo, InfoHandler, MetricsFsAccessPatternHandler, MetricsFsFilesHandler,
-    MetricsFsGlobalHandler, MetricsFsInflightHandler, HTTP_ROOT_V1,
+    ConfigHandler, FsBackendInfo, InfoHandler, MetricsFsAccessPatternHandler,
+    MetricsFsFilesHandler, MetricsFsGlobalHandler, MetricsFsInflightHandler, HTTP_ROOT_V1,
 };
 use crate::http_endpoint_v2::{BlobObjectListHandlerV2, InfoV2Handler, HTTP_ROOT_V2};
 
@@ -158,6 +158,7 @@ lazy_static! {
         r.routes.insert(endpoint_v1!("/metrics/files"), Box::new(MetricsFsFilesHandler{}));
         r.routes.insert(endpoint_v1!("/metrics/inflight"), Box::new(MetricsFsInflightHandler{}));
         r.routes.insert(endpoint_v1!("/metrics/pattern"), Box::new(MetricsFsAccessPatternHandler{}));
+        r.routes.insert(endpoint_v1!("/config"), Box::new(ConfigHandler{}));
 
         // Nydus API, v2
         r.routes.insert(endpoint_v2!("/daemon"), Box::new(InfoV2Handler{}));

--- a/docs/nydusd.md
+++ b/docs/nydusd.md
@@ -454,3 +454,48 @@ mnt
 ├── pseudo_1
 └── pseudo_2
 ```
+
+### Hot Reload Configuration
+
+Nydusd supports hot reloading of configuration without restarting the daemon. This is useful for updating credentials or other settings at runtime.
+
+#### Update Configuration
+
+To update configuration (e.g., registry authentication):
+
+```shell
+curl --unix-socket /path/to/api.sock \
+  -X PUT "http://localhost/api/v1/config?id=/" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "registry_auth": "<base64_encoded_auth>"
+  }'
+```
+
+#### Query Current Configuration
+
+To retrieve the current configuration:
+
+```shell
+curl --unix-socket /path/to/api.sock \
+  -X GET "http://localhost/api/v1/config?id=/"
+```
+
+Example response:
+
+```json
+{
+  "registry_auth": "<base64_encoded_auth>"
+}
+```
+
+> **Note**: The `id` parameter specifies which mountpoint to configure. Use `/` for the root mountpoint or specify a sub-mountpoint path for multi-mount scenarios.
+
+#### Supported Configuration Fields
+
+The following fields can be updated via the hot reload API:
+
+| Field           | Description                                                               |
+| --------------- | ------------------------------------------------------------------------- |
+| `registry_auth` | Base64-encoded `username:password` credential for registry authentication |
+

--- a/rafs/src/metadata/mod.rs
+++ b/rafs/src/metadata/mod.rs
@@ -847,7 +847,7 @@ impl RafsSuper {
     /// The `BlobDevice` object is needed to get meta information from RAFS V6 data blobs.
     pub fn create_blob_device(&self, config: Arc<ConfigV2>) -> Result<()> {
         let blobs = self.superblock.get_blob_infos();
-        let device = BlobDevice::new(&config, &blobs)?;
+        let device = BlobDevice::new(&config, &blobs, "/")?;
         self.superblock.set_blob_device(device);
         Ok(())
     }

--- a/service/src/blob_cache.rs
+++ b/service/src/blob_cache.rs
@@ -500,7 +500,7 @@ impl DataBlob {
     pub fn new(config: &Arc<DataBlobConfig>) -> Result<Self> {
         let blob_id = config.blob_info().blob_id();
         let blob = BLOB_FACTORY
-            .new_blob_cache(config.config_v2(), &config.blob_info)
+            .new_blob_cache(config.config_v2(), &config.blob_info, "/")
             .inspect_err(|_e| {
                 warn!(
                     "blob_cache: failed to create cache object for blob {}",

--- a/service/src/fs_cache.rs
+++ b/service/src/fs_cache.rs
@@ -573,7 +573,7 @@ impl FsCacheHandler {
         let mut blob_info = config.blob_info().deref().clone();
         blob_info.set_fscache_file(Some(file));
         let blob_ref = Arc::new(blob_info);
-        BLOB_FACTORY.new_blob_cache(config.config_v2(), &blob_ref)
+        BLOB_FACTORY.new_blob_cache(config.config_v2(), &blob_ref, "/")
     }
 
     fn fill_bootstrap_cache(bootstrap: Arc<FsCacheBootstrap>) -> Result<u64> {

--- a/service/src/fs_service.rs
+++ b/service/src/fs_service.rs
@@ -146,7 +146,7 @@ pub trait FsService: Send + Sync {
         let rafs_cfg = ConfigV2::from_str(&cmd.config).map_err(RafsError::LoadConfig)?;
         let rafs_cfg = Arc::new(rafs_cfg);
 
-        rafs.update(&mut bootstrap, &rafs_cfg)
+        rafs.update(&mut bootstrap, &rafs_cfg, &cmd.mountpoint)
             .map_err(|e| match e {
                 RafsError::Unsupported => Error::Unsupported,
                 e => Error::Rafs(e),

--- a/src/bin/nydus-image/main.rs
+++ b/src/bin/nydus-image/main.rs
@@ -2041,7 +2041,7 @@ impl Command {
 
     fn get_backend(
         matches: &ArgMatches,
-        blob_id: &str,
+        id: &str,
     ) -> Result<(Arc<ConfigV2>, Arc<dyn BlobBackend + Send + Sync>)> {
         let config: Arc<ConfigV2>;
         let backend: Arc<dyn BlobBackend + Send + Sync>;
@@ -2060,12 +2060,12 @@ impl Command {
             if backend_type == "localfs" {
                 bail!("Use --blob-dir to specify localfs backend");
             } else {
-                backend = BlobFactory::new_backend_from_json(backend_type, &content, blob_id)?;
+                backend = BlobFactory::new_backend_from_json(backend_type, &content, id)?;
                 config = Arc::new(ConfigV2::default());
             }
         } else if let Some(dir) = matches.get_one::<String>("blob-dir") {
             config = Arc::new(ConfigV2::new_localfs("", dir)?);
-            backend = BlobFactory::new_backend(config.backend.as_ref().unwrap(), blob_id)?;
+            backend = BlobFactory::new_backend(config.backend.as_ref().unwrap(), id)?;
         } else {
             return Err(anyhow!("invalid backend configuration"));
         }

--- a/src/bin/nydusd/api_server_glue.rs
+++ b/src/bin/nydusd/api_server_glue.rs
@@ -19,7 +19,8 @@ use nydus::daemon::NydusDaemon;
 use nydus::{FsBackendMountCmd, FsBackendType, FsBackendUmountCmd, FsService};
 use nydus_api::{
     start_http_thread, ApiError, ApiMountCmd, ApiRequest, ApiResponse, ApiResponsePayload,
-    ApiResult, BlobCacheEntry, BlobCacheObjectId, DaemonConf, DaemonErrorKind, MetricsErrorKind,
+    ApiResult, BlobCacheEntry, BlobCacheObjectId, Config, DaemonConf, DaemonErrorKind,
+    MetricsErrorKind,
 };
 use nydus_utils::metrics;
 
@@ -58,6 +59,8 @@ impl ApiServer {
             ApiRequest::ExportFsAccessPatterns(id) => Self::export_access_patterns(id),
             ApiRequest::ExportFsBackendInfo(mountpoint) => self.backend_info(&mountpoint),
             ApiRequest::ExportFsInflightMetrics => self.export_inflight_metrics(),
+            ApiRequest::GetConfig(id) => self.get_config(id),
+            ApiRequest::UpdateConfig(id, config) => self.update_config(id, config),
 
             // Nydus API v2
             ApiRequest::GetDaemonInfoV2 => self.daemon_info(false),
@@ -323,6 +326,26 @@ impl ApiServer {
         d.trigger_start()
             .map(|_| ApiResponsePayload::Empty)
             .map_err(|e| ApiError::DaemonAbnormal(e.into()))
+    }
+
+    fn update_config(&self, id: Option<String>, config: Config) -> ApiResponse {
+        use std::convert::TryFrom;
+
+        let use_id = id.as_deref().unwrap_or("");
+        for (key_type, value) in config.iter() {
+            if let Ok(keys) = nydus_utils::config::Keys::try_from(key_type.as_str()) {
+                nydus_utils::config::set(use_id, &keys, value.clone());
+            } else {
+                return Err(ApiError::ResponsePayloadType);
+            }
+        }
+        Ok(ApiResponsePayload::Empty)
+    }
+
+    fn get_config(&self, id: Option<String>) -> ApiResponse {
+        let config_map = nydus_utils::config::get_all(id.as_deref().map(|s| s.to_string()));
+        let config: Config = config_map;
+        Ok(ApiResponsePayload::Config(config))
     }
 }
 

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -57,6 +57,7 @@ nydus-utils = { version = "0.5.1", path = "../utils", features = [
 ] }
 
 [dev-dependencies]
+http = "1.4.0"
 hyper-util = { version = "0.1.19", features = ["server"] }
 vmm-sys-util = { workspace = true }
 tar = "0.4.40"

--- a/storage/src/backend/registry.rs
+++ b/storage/src/backend/registry.rs
@@ -191,13 +191,12 @@ impl fmt::Display for Scheme {
 }
 
 struct RegistryState {
+    id: String,
     // HTTP scheme like: https, http
     scheme: Scheme,
     host: String,
     // Image repo name like: library/ubuntu
     repo: String,
-    // Base64 encoded registry auth
-    auth: Option<String>,
     // Retry limit for read operation
     retry_limit: u8,
     // Scheme specified for blob server
@@ -264,6 +263,20 @@ impl RegistryState {
         }
     }
 
+    fn get_config_auth(&self) -> String {
+        nydus_utils::config::get(&self.id, &nydus_utils::config::Keys::RegistryAuth)
+    }
+
+    fn set_config_auth(&self, auth: Option<String>) {
+        if let Some(auth) = auth {
+            nydus_utils::config::set(
+                &self.id,
+                &nydus_utils::config::Keys::RegistryAuth,
+                auth.clone(),
+            );
+        }
+    }
+
     // Request registry authentication server to get bearer token
     fn get_token(&self, auth: BearerAuth, connection: &Arc<Connection>) -> Result<TokenResponse> {
         let http_get = self
@@ -312,10 +325,11 @@ impl RegistryState {
     ) -> Result<Response> {
         let mut headers = HeaderMap::new();
 
-        if let Some(auth) = &self.auth {
+        let config_auth = self.get_config_auth();
+        if !config_auth.is_empty() {
             headers.insert(
                 HEADER_AUTHORIZATION,
-                format!("Basic {}", auth).parse().unwrap(),
+                format!("Basic {}", config_auth).parse().unwrap(),
             );
         }
 
@@ -365,11 +379,7 @@ impl RegistryState {
 
     fn get_auth_header(&self, auth: Auth, connection: &Arc<Connection>) -> Result<String> {
         match auth {
-            Auth::Basic(_) => self
-                .auth
-                .as_ref()
-                .map(|auth| format!("Basic {}", auth))
-                .ok_or_else(|| einval!("invalid auth config")),
+            Auth::Basic(_) => Ok(format!("Basic {}", self.get_config_auth())),
             Auth::Bearer(auth) => {
                 let token = self.get_token(auth, connection)?;
                 Ok(format!("Bearer {}", token.token))
@@ -839,7 +849,7 @@ pub struct Registry {
 impl Registry {
     #[allow(clippy::useless_let_if_seq)]
     pub fn new(config: &RegistryConfig, id: Option<&str>) -> Result<Registry> {
-        let id = id.ok_or_else(|| einval!("Registry backend requires blob_id"))?;
+        let id = id.ok_or_else(|| einval!("Registry backend requires id"))?;
         let con_config: ConnectionConfig = config.clone().into();
 
         let retry_limit = con_config.retry_limit;
@@ -862,10 +872,10 @@ impl Registry {
         };
 
         let state = Arc::new(RegistryState {
+            id: id.to_owned(),
             scheme,
             host: config.host.clone(),
             repo: config.repo.clone(),
-            auth,
             cached_auth,
             retry_limit,
             blob_url_scheme: config.blob_url_scheme.clone(),
@@ -875,6 +885,7 @@ impl Registry {
             token_expired_at: ArcSwapOption::new(None),
             cached_bearer_auth: ArcSwapOption::new(None),
         });
+        state.set_config_auth(auth);
 
         let registry = Registry {
             connection,
@@ -1015,8 +1026,10 @@ fn trim(value: Option<String>) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use http::response;
     use serde_json::json;
+
+    #[cfg(feature = "backend-registry")]
+    use http;
 
     #[test]
     fn test_string_cache() {
@@ -1046,10 +1059,10 @@ mod tests {
     #[test]
     fn test_state_url() {
         let state = RegistryState {
+            id: String::from("/"),
             scheme: Scheme::new(false),
             host: "alibaba-inc.com".to_string(),
             repo: "nydus".to_string(),
-            auth: None,
             retry_limit: 5,
             blob_url_scheme: "https".to_string(),
             blob_redirected_host: "oss.alibaba-inc.com".to_string(),
@@ -1185,8 +1198,8 @@ mod tests {
             "token": "test_token_value",
             "expires_in": 3600
         });
-        let response = Response::from(
-            response::Builder::new()
+        let response = reqwest::blocking::Response::from(
+            http::response::Builder::new()
                 .body(json_with_token.to_string())
                 .unwrap(),
         );
@@ -1199,8 +1212,8 @@ mod tests {
             "access_token": "test_access_token_value",
             "expires_in": 7200
         });
-        let response = Response::from(
-            response::Builder::new()
+        let response = reqwest::blocking::Response::from(
+            http::response::Builder::new()
                 .body(json_with_access_token.to_string())
                 .unwrap(),
         );
@@ -1212,8 +1225,8 @@ mod tests {
         let json_with_default_expiration = json!({
             "token": "default_expiration_token"
         });
-        let response = Response::from(
-            response::Builder::new()
+        let response = reqwest::blocking::Response::from(
+            http::response::Builder::new()
                 .body(json_with_default_expiration.to_string())
                 .unwrap(),
         );
@@ -1226,8 +1239,8 @@ mod tests {
             "token": "test_token_value",
             "access_token": "test_access_token_value",
         });
-        let response = Response::from(
-            response::Builder::new()
+        let response = reqwest::blocking::Response::from(
+            http::response::Builder::new()
                 .body(json_with_both_tokens.to_string())
                 .unwrap(),
         );
@@ -1236,8 +1249,8 @@ mod tests {
 
         // Case 5: Response contains no token
         let json_with_no_token = json!({});
-        let response = Response::from(
-            response::Builder::new()
+        let response = reqwest::blocking::Response::from(
+            http::response::Builder::new()
                 .body(json_with_no_token.to_string())
                 .unwrap(),
         );

--- a/storage/src/device.rs
+++ b/storage/src/device.rs
@@ -1174,10 +1174,14 @@ pub struct BlobDevice {
 
 impl BlobDevice {
     /// Create new blob device instance.
-    pub fn new(config: &Arc<ConfigV2>, blob_infos: &[Arc<BlobInfo>]) -> io::Result<BlobDevice> {
+    pub fn new(
+        config: &Arc<ConfigV2>,
+        blob_infos: &[Arc<BlobInfo>],
+        mountpoint: &str,
+    ) -> io::Result<BlobDevice> {
         let mut blobs = Vec::with_capacity(blob_infos.len());
         for blob_info in blob_infos.iter() {
-            let blob = BLOB_FACTORY.new_blob_cache(config, blob_info)?;
+            let blob = BLOB_FACTORY.new_blob_cache(config, blob_info, mountpoint)?;
             blobs.push(blob);
         }
 
@@ -1196,6 +1200,7 @@ impl BlobDevice {
         config: &Arc<ConfigV2>,
         blob_infos: &[Arc<BlobInfo>],
         fs_prefetch: bool,
+        mountpoint: &str,
     ) -> io::Result<()> {
         if self.blobs.load().len() != blob_infos.len() {
             return Err(einval!(
@@ -1205,7 +1210,7 @@ impl BlobDevice {
 
         let mut blobs = Vec::with_capacity(blob_infos.len());
         for blob_info in blob_infos.iter() {
-            let blob = BLOB_FACTORY.new_blob_cache(config, blob_info)?;
+            let blob = BLOB_FACTORY.new_blob_cache(config, blob_info, mountpoint)?;
             blobs.push(blob);
         }
 

--- a/storage/src/factory.rs
+++ b/storage/src/factory.rs
@@ -126,6 +126,7 @@ impl BlobFactory {
         &self,
         config: &Arc<ConfigV2>,
         blob_info: &Arc<BlobInfo>,
+        id: &str,
     ) -> IOResult<Arc<dyn BlobCache>> {
         let backend_cfg = config.get_backend_config()?;
         let cache_cfg = config.get_cache_config()?;
@@ -141,7 +142,7 @@ impl BlobFactory {
         if let Some(mgr) = guard.get(&key) {
             return mgr.get_blob_cache(blob_info);
         }
-        let backend = Self::new_backend(backend_cfg, &blob_info.blob_id())?;
+        let backend = Self::new_backend(backend_cfg, id)?;
         let mgr = match cache_cfg.cache_type.as_str() {
             "blobcache" | "filecache" => {
                 let mgr = FileCacheMgr::new(
@@ -235,38 +236,32 @@ impl BlobFactory {
     #[allow(unused_variables)]
     pub fn new_backend(
         config: &BackendConfigV2,
-        blob_id: &str,
+        id: &str,
     ) -> IOResult<Arc<dyn BlobBackend + Send + Sync>> {
         match config.backend_type.as_str() {
             #[cfg(feature = "backend-oss")]
-            "oss" => Ok(Arc::new(oss::Oss::new(
-                config.get_oss_config()?,
-                Some(blob_id),
-            )?)),
+            "oss" => Ok(Arc::new(oss::Oss::new(config.get_oss_config()?, Some(id))?)),
             #[cfg(feature = "backend-s3")]
-            "s3" => Ok(Arc::new(s3::S3::new(
-                config.get_s3_config()?,
-                Some(blob_id),
-            )?)),
+            "s3" => Ok(Arc::new(s3::S3::new(config.get_s3_config()?, Some(id))?)),
             #[cfg(feature = "backend-registry")]
             "registry" => Ok(Arc::new(registry::Registry::new(
                 config.get_registry_config()?,
-                Some(blob_id),
+                Some(id),
             )?)),
             #[cfg(feature = "backend-localfs")]
             "localfs" => Ok(Arc::new(localfs::LocalFs::new(
                 config.get_localfs_config()?,
-                Some(blob_id),
+                Some(id),
             )?)),
             #[cfg(feature = "backend-localdisk")]
             "localdisk" => Ok(Arc::new(localdisk::LocalDisk::new(
                 config.get_localdisk_config()?,
-                Some(blob_id),
+                Some(id),
             )?)),
             #[cfg(feature = "backend-http-proxy")]
             "http-proxy" => Ok(Arc::new(http_proxy::HttpProxy::new(
                 config.get_http_proxy_config()?,
-                Some(blob_id),
+                Some(id),
             )?)),
             _ => Err(einval!(format!(
                 "unsupported backend type '{}'",
@@ -277,39 +272,39 @@ impl BlobFactory {
 
     pub fn new_backend_from_json(
         backend_type: &str,
-        _content: &str,
-        _blob_id: &str,
+        content: &str,
+        id: &str,
     ) -> IOResult<Arc<dyn BlobBackend + Send + Sync>> {
         match backend_type {
             #[cfg(feature = "backend-oss")]
             "oss" => {
-                let cfg = serde_json::from_str::<OssConfig>(&_content)?;
-                Ok(Arc::new(oss::Oss::new(&cfg, Some(_blob_id))?))
+                let cfg = serde_json::from_str::<OssConfig>(&content)?;
+                Ok(Arc::new(oss::Oss::new(&cfg, Some(id))?))
             }
             #[cfg(feature = "backend-s3")]
             "s3" => {
-                let cfg = serde_json::from_str::<S3Config>(&_content)?;
-                Ok(Arc::new(s3::S3::new(&cfg, Some(_blob_id))?))
+                let cfg = serde_json::from_str::<S3Config>(&content)?;
+                Ok(Arc::new(s3::S3::new(&cfg, Some(id))?))
             }
             #[cfg(feature = "backend-registry")]
             "registry" => {
-                let cfg = serde_json::from_str::<RegistryConfig>(&_content)?;
-                Ok(Arc::new(registry::Registry::new(&cfg, Some(_blob_id))?))
+                let cfg = serde_json::from_str::<RegistryConfig>(&content)?;
+                Ok(Arc::new(registry::Registry::new(&cfg, Some(id))?))
             }
             #[cfg(feature = "backend-localfs")]
             "localfs" => {
-                let cfg = serde_json::from_str::<LocalFsConfig>(&_content)?;
-                Ok(Arc::new(localfs::LocalFs::new(&cfg, Some(_blob_id))?))
+                let cfg = serde_json::from_str::<LocalFsConfig>(&content)?;
+                Ok(Arc::new(localfs::LocalFs::new(&cfg, Some(id))?))
             }
             #[cfg(feature = "backend-localdisk")]
             "localdisk" => {
-                let cfg = serde_json::from_str::<LocalDiskConfig>(&_content)?;
-                Ok(Arc::new(localdisk::LocalDisk::new(&cfg, Some(_blob_id))?))
+                let cfg = serde_json::from_str::<LocalDiskConfig>(&content)?;
+                Ok(Arc::new(localdisk::LocalDisk::new(&cfg, Some(id))?))
             }
             #[cfg(feature = "backend-http-proxy")]
             "http-proxy" => {
-                let cfg = serde_json::from_str::<HttpProxyConfig>(&_content)?;
-                Ok(Arc::new(http_proxy::HttpProxy::new(&cfg, Some(_blob_id))?))
+                let cfg = serde_json::from_str::<HttpProxyConfig>(&content)?;
+                Ok(Arc::new(http_proxy::HttpProxy::new(&cfg, Some(id))?))
             }
             _ => Err(einval!(format!(
                 "unsupported backend type '{}'",

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/dragonflyoss/nydus"
 edition = "2021"
 
 [dependencies]
+arc-swap = "1.8.0"
 thiserror = "1.0.30"
 blake3 = "1.3"
 httpdate = "1.0"

--- a/utils/src/config.rs
+++ b/utils/src/config.rs
@@ -1,0 +1,616 @@
+// Copyright 2026 Nydus Developers. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+use arc_swap::ArcSwap;
+use std::collections::HashMap;
+use std::sync::Arc;
+
+lazy_static! {
+    static ref CONFIG_MAP: ArcSwap<HashMap<String, String>> = ArcSwap::from_pointee(HashMap::new());
+}
+
+#[cfg(test)]
+mod test_sync {
+    use std::sync::Mutex;
+    lazy_static! {
+        pub static ref TEST_LOCK: Mutex<()> = Mutex::new(());
+    }
+}
+
+/// Configuration keys for the system
+#[derive(Clone, Debug, Hash, Eq, PartialEq)]
+pub enum Keys {
+    /// Registry authentication configuration for a specific id
+    RegistryAuth,
+}
+
+impl From<&Keys> for String {
+    fn from(key: &Keys) -> Self {
+        match key {
+            Keys::RegistryAuth => "registry_auth".to_string(),
+        }
+    }
+}
+
+impl TryFrom<&str> for Keys {
+    type Error = ();
+
+    fn try_from(key: &str) -> Result<Self, Self::Error> {
+        match key {
+            "registry_auth" => Ok(Keys::RegistryAuth),
+            _ => Err(()),
+        }
+    }
+}
+
+impl TryFrom<String> for Keys {
+    type Error = ();
+
+    fn try_from(key: String) -> Result<Self, Self::Error> {
+        Keys::try_from(key.as_str())
+    }
+}
+
+/// Set the value of the key.
+///
+/// This will update the global configuration map with the given key-value pair.
+/// If the key already exists, its value will be replaced.
+///
+/// # Arguments
+///
+/// * `id` - The identifier for scoping the configuration
+/// * `key` - The configuration key
+/// * `value` - The configuration value
+///
+/// # Example
+///
+/// ```
+/// use nydus_utils::config::{self, Keys};
+///
+/// config::set("/mount", &Keys::RegistryAuth, "basic:xxx".to_string());
+/// ```
+pub fn set(id: &str, key: &Keys, value: String) {
+    let mut map = (**CONFIG_MAP.load()).clone();
+    let key_str: String = key.into();
+    map.insert(format!("{}:{}", id, key_str), value);
+    CONFIG_MAP.store(Arc::new(map));
+}
+
+/// Return the value of the key and whether it has changed compared to previous value.
+///
+/// This function checks if the current value differs from the provided previous value.
+///
+/// # Arguments
+///
+/// * `id` - The identifier for scoping the configuration
+/// * `key` - The configuration key to query
+/// * `prev` - The previous value to compare against
+///
+/// # Returns
+///
+/// A tuple containing:
+/// - The current value (or empty string if key doesn't exist)
+/// - A boolean indicating whether the value has changed
+///
+/// # Example
+///
+/// ```
+/// use nydus_utils::config::{self, Keys};
+///
+/// let (value, changed) = config::get_changed("/mount", &Keys::RegistryAuth, "basic:old");
+/// if changed {
+///     println!("Registry auth changed to: {}", value);
+/// }
+/// ```
+pub fn get_changed(id: &str, key: &Keys, prev: &str) -> (String, bool) {
+    let map = CONFIG_MAP.load();
+    let key_str: String = key.into();
+    let full_key = format!("{}:{}", id, key_str);
+    let val = map.get(&full_key).cloned().unwrap_or_default();
+    let changed = val != prev;
+    (val, changed)
+}
+
+/// Return the value of the key.
+///
+/// If the key doesn't exist, returns an empty string.
+///
+/// # Arguments
+///
+/// * `id` - The identifier
+/// * `key` - The configuration key to query
+///
+/// # Returns
+///
+/// The value associated with the key, or empty string if not found
+///
+/// # Example
+///
+/// ```
+/// use nydus_utils::config::{self, Keys};
+///
+/// let auth = config::get("/mount", &Keys::RegistryAuth);
+/// println!("Registry auth: {}", auth);
+/// ```
+pub fn get(id: &str, key: &Keys) -> String {
+    get_changed(id, key, "").0
+}
+
+/// Remove a key from the configuration map.
+///
+/// # Arguments
+///
+/// * `id` - The identifier for scoping the configuration
+/// * `key` - The configuration key to remove
+///
+/// # Returns
+///
+/// The value that was removed, or None if the key didn't exist
+///
+/// # Example
+///
+/// ```
+/// use nydus_utils::config::{self, Keys};
+///
+/// if let Some(old_value) = config::remove("/mount", &Keys::RegistryAuth) {
+///     println!("Removed registry auth: {}", old_value);
+/// }
+/// ```
+pub fn remove(id: &str, key: &Keys) -> Option<String> {
+    let mut map = (**CONFIG_MAP.load()).clone();
+    let key_str: String = key.into();
+    let full_key = format!("{}:{}", id, key_str);
+    let removed = map.remove(&full_key);
+    CONFIG_MAP.store(Arc::new(map));
+    removed
+}
+
+/// Clear all configuration entries.
+///
+/// # Example
+///
+/// ```
+/// nydus_utils::config::clear();
+/// ```
+pub fn clear() {
+    CONFIG_MAP.store(Arc::new(HashMap::new()));
+}
+
+/// Check if a key exists in the configuration.
+///
+/// # Arguments
+///
+/// * `id` - The identifier for scoping the configuration
+/// * `key` - The configuration key to check
+///
+/// # Returns
+///
+/// true if the key exists, false otherwise
+///
+/// # Example
+///
+/// ```
+/// use nydus_utils::config::{self, Keys};
+///
+/// if config::contains_key("/mount", &Keys::RegistryAuth) {
+///     println!("Registry auth is configured");
+/// }
+/// ```
+pub fn contains_key(id: &str, key: &Keys) -> bool {
+    let map = CONFIG_MAP.load();
+    let key_str: String = key.into();
+    let full_key = format!("{}:{}", id, key_str);
+    map.contains_key(&full_key)
+}
+
+/// Get all configuration key strings.
+///
+/// # Returns
+///
+/// A vector of all configuration key strings
+///
+/// # Example
+///
+/// ```
+/// let keys = nydus_utils::config::keys();
+/// for key in keys {
+///     println!("Config key: {}", key);
+/// }
+/// ```
+pub fn keys() -> Vec<String> {
+    let map = CONFIG_MAP.load();
+    map.keys().cloned().collect()
+}
+
+/// Get the number of configuration entries.
+///
+/// # Returns
+///
+/// The number of key-value pairs in the configuration
+///
+/// # Example
+///
+/// ```
+/// let count = nydus_utils::config::len();
+/// println!("Configuration has {} entries", count);
+/// ```
+pub fn len() -> usize {
+    let map = CONFIG_MAP.load();
+    map.len()
+}
+
+/// Check if the configuration is empty.
+///
+/// # Returns
+///
+/// true if there are no configuration entries, false otherwise
+///
+/// # Example
+///
+/// ```
+/// if nydus_utils::config::is_empty() {
+///     println!("No configuration set");
+/// }
+/// ```
+pub fn is_empty() -> bool {
+    len() == 0
+}
+
+/// Get all configuration entries as a HashMap.
+///
+/// # Returns
+///
+/// A HashMap containing all key-value pairs
+///
+/// # Example
+///
+/// ```
+/// let all_config = nydus_utils::config::get_all(None);
+/// for (key, value) in all_config.iter() {
+///     println!("{} = {}", key, value);
+/// }
+/// ```
+pub fn get_all(id: Option<String>) -> HashMap<String, String> {
+    let map = CONFIG_MAP.load();
+    if let Some(id_str) = id {
+        map.iter()
+            .filter_map(|(key, value)| {
+                let prefix = format!("{}:", id_str);
+                if key.starts_with(&prefix) {
+                    Some((
+                        key.strip_prefix(&prefix).unwrap().to_string(),
+                        value.clone(),
+                    ))
+                } else {
+                    None
+                }
+            })
+            .collect()
+    } else {
+        (**map).clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_set_and_get() {
+        let _guard = test_sync::TEST_LOCK.lock().unwrap();
+        clear();
+
+        let id = "test_id";
+        let key = Keys::RegistryAuth;
+        set(id, &key, "test_value".to_string());
+        let value = get(id, &key);
+        assert_eq!(value, "test_value");
+
+        clear();
+    }
+
+    #[test]
+    fn test_get_nonexistent_key() {
+        let _guard = test_sync::TEST_LOCK.lock().unwrap();
+        clear();
+
+        let id = "nonexistent";
+        let key = Keys::RegistryAuth;
+        let value = get(id, &key);
+        assert_eq!(value, "");
+
+        clear();
+    }
+
+    #[test]
+    fn test_get_changed() {
+        let _guard = test_sync::TEST_LOCK.lock().unwrap();
+        clear();
+
+        let id = "test_id";
+        let key = Keys::RegistryAuth;
+        set(id, &key, "value1".to_string());
+
+        let (value, changed) = get_changed(id, &key, "");
+        assert_eq!(value, "value1");
+        assert!(changed);
+
+        let (value, changed) = get_changed(id, &key, "value1");
+        assert_eq!(value, "value1");
+        assert!(!changed);
+
+        set(id, &key, "value2".to_string());
+        let (value, changed) = get_changed(id, &key, "value1");
+        assert_eq!(value, "value2");
+        assert!(changed);
+
+        clear();
+    }
+
+    #[test]
+    fn test_remove() {
+        let _guard = test_sync::TEST_LOCK.lock().unwrap();
+        clear();
+
+        let id = "test_id";
+        let key = Keys::RegistryAuth;
+        set(id, &key, "test_value".to_string());
+        assert_eq!(get(id, &key), "test_value");
+
+        let removed = remove(id, &key);
+        assert_eq!(removed, Some("test_value".to_string()));
+        assert_eq!(get(id, &key), "");
+
+        let removed = remove("nonexistent", &Keys::RegistryAuth);
+        assert_eq!(removed, None);
+
+        clear();
+    }
+
+    #[test]
+    fn test_clear() {
+        let _guard = test_sync::TEST_LOCK.lock().unwrap();
+        clear();
+
+        let key = Keys::RegistryAuth;
+
+        set("id1", &key, "value1".to_string());
+        set("id2", &key, "value2".to_string());
+        set("id3", &key, "value3".to_string());
+
+        assert!(contains_key("id1", &key));
+        assert!(contains_key("id2", &key));
+        assert!(contains_key("id3", &key));
+
+        clear();
+
+        assert!(!contains_key("id1", &key));
+        assert!(!contains_key("id2", &key));
+        assert!(!contains_key("id3", &key));
+    }
+
+    #[test]
+    fn test_contains_key() {
+        let _guard = test_sync::TEST_LOCK.lock().unwrap();
+        clear();
+
+        let id = "test_id";
+        let key = Keys::RegistryAuth;
+        assert!(!contains_key(id, &key));
+
+        set(id, &key, "test_value".to_string());
+        assert!(contains_key(id, &key));
+
+        remove(id, &key);
+        assert!(!contains_key(id, &key));
+
+        clear();
+    }
+
+    #[test]
+    fn test_keys() {
+        let _guard = test_sync::TEST_LOCK.lock().unwrap();
+        clear();
+
+        let key = Keys::RegistryAuth;
+        set("key1", &key, "value1".to_string());
+        set("key2", &key, "value2".to_string());
+        set("key3", &key, "value3".to_string());
+
+        let keys_list = keys();
+        assert_eq!(keys_list.len(), 3);
+        assert!(keys_list.contains(&"key1:registry_auth".to_string()));
+        assert!(keys_list.contains(&"key2:registry_auth".to_string()));
+        assert!(keys_list.contains(&"key3:registry_auth".to_string()));
+
+        clear();
+    }
+
+    #[test]
+    fn test_len_and_is_empty() {
+        let _guard = test_sync::TEST_LOCK.lock().unwrap();
+        clear();
+
+        assert_eq!(len(), 0);
+        assert!(is_empty());
+
+        let key = Keys::RegistryAuth;
+        set("key1", &key, "value1".to_string());
+        assert_eq!(len(), 1);
+        assert!(!is_empty());
+
+        set("key2", &key, "value2".to_string());
+        assert_eq!(len(), 2);
+        assert!(!is_empty());
+
+        remove("key1", &key);
+        assert_eq!(len(), 1);
+        assert!(!is_empty());
+
+        clear();
+        assert_eq!(len(), 0);
+        assert!(is_empty());
+    }
+
+    #[test]
+    fn test_update_existing_key() {
+        let _guard = test_sync::TEST_LOCK.lock().unwrap();
+        clear();
+
+        let id = "test_id";
+        let key = Keys::RegistryAuth;
+        set(id, &key, "value1".to_string());
+        assert_eq!(get(id, &key), "value1");
+
+        set(id, &key, "value2".to_string());
+        assert_eq!(get(id, &key), "value2");
+        assert_eq!(len(), 1);
+
+        clear();
+    }
+
+    #[test]
+    fn test_concurrent_access() {
+        let _guard = test_sync::TEST_LOCK.lock().unwrap();
+        clear();
+
+        // Test thread-safety by spawning threads sequentially
+        // Each thread performs atomic write-read operations
+        use std::thread;
+
+        for i in 0..10 {
+            let handle = thread::spawn(move || {
+                let id = format!("concurrent_test_{}", i);
+                let key = Keys::RegistryAuth;
+                let value = format!("value_{}", i);
+
+                // Write and immediately read - tests atomicity
+                set(&id, &key, value.clone());
+                let retrieved = get(&id, &key);
+
+                assert_eq!(
+                    retrieved, value,
+                    "Thread {} failed: expected '{}', got '{}'",
+                    i, value, retrieved
+                );
+
+                (id, key)
+            });
+
+            // Join immediately to ensure sequential execution under test lock
+            let (id, key) = handle.join().expect("Thread panicked");
+            remove(&id, &key);
+        }
+
+        clear();
+    }
+
+    #[test]
+    fn test_empty_key_and_value() {
+        let _guard = test_sync::TEST_LOCK.lock().unwrap();
+        clear();
+
+        let key = Keys::RegistryAuth;
+        set("", &key, "empty_id".to_string());
+        assert_eq!(get("", &key), "empty_id");
+
+        set("empty_value", &key, "".to_string());
+        assert_eq!(get("empty_value", &key), "");
+        assert!(contains_key("empty_value", &key));
+
+        clear();
+    }
+
+    #[test]
+    fn test_special_characters() {
+        let _guard = test_sync::TEST_LOCK.lock().unwrap();
+        clear();
+
+        let key = Keys::RegistryAuth;
+
+        set("key/with/slashes", &key, "value1".to_string());
+        assert_eq!(get("key/with/slashes", &key), "value1");
+
+        set("key.with.dots", &key, "value2".to_string());
+        assert_eq!(get("key.with.dots", &key), "value2");
+
+        set("key-with-dashes", &key, "value3".to_string());
+        assert_eq!(get("key-with-dashes", &key), "value3");
+
+        set("key_with_underscores", &key, "value4".to_string());
+        assert_eq!(get("key_with_underscores", &key), "value4");
+
+        remove("key/with/slashes", &key);
+        remove("key.with.dots", &key);
+        remove("key-with-dashes", &key);
+        remove("key_with_underscores", &key);
+    }
+
+    #[test]
+    fn test_large_values() {
+        let _guard = test_sync::TEST_LOCK.lock().unwrap();
+        clear();
+
+        let large_value = "x".repeat(10000);
+        let id = "large_key";
+        let key = Keys::RegistryAuth;
+        set(id, &key, large_value.clone());
+        assert_eq!(get(id, &key), large_value);
+
+        clear();
+    }
+
+    #[test]
+    fn test_get_all() {
+        let _guard = test_sync::TEST_LOCK.lock().unwrap();
+        clear();
+
+        let key = Keys::RegistryAuth;
+        set("key1", &key, "value1".to_string());
+        set("key2", &key, "value2".to_string());
+        set("key3", &key, "value3".to_string());
+
+        let all = get_all(None);
+        assert_eq!(all.len(), 3);
+        assert_eq!(all.get("key1:registry_auth"), Some(&"value1".to_string()));
+        assert_eq!(all.get("key2:registry_auth"), Some(&"value2".to_string()));
+        assert_eq!(all.get("key3:registry_auth"), Some(&"value3".to_string()));
+
+        clear();
+    }
+
+    #[test]
+    fn test_get_all_with_id() {
+        let _guard = test_sync::TEST_LOCK.lock().unwrap();
+        clear();
+
+        let key = Keys::RegistryAuth;
+        set("id1", &key, "value1".to_string());
+        set("id2", &key, "value2".to_string());
+        set("id3", &key, "value3".to_string());
+
+        let all = get_all(Some(String::from("id1")));
+        assert_eq!(all.len(), 1);
+        assert_eq!(all.get("registry_auth"), Some(&"value1".to_string()));
+
+        clear();
+    }
+
+    #[test]
+    fn test_key_string_conversion() {
+        let _guard = test_sync::TEST_LOCK.lock().unwrap();
+        use std::convert::TryFrom;
+
+        let key = Keys::RegistryAuth;
+        let key_str: String = (&key).into();
+        assert_eq!(key_str, "registry_auth");
+
+        let parsed = Keys::try_from(key_str.as_str());
+        assert_eq!(parsed, Ok(Keys::RegistryAuth));
+
+        // Test invalid format
+        assert_eq!(Keys::try_from("invalid_format"), Err(()));
+        assert_eq!(Keys::try_from(""), Err(()));
+    }
+}

--- a/utils/src/lib.rs
+++ b/utils/src/lib.rs
@@ -22,6 +22,7 @@ pub use self::types::*;
 pub mod async_helper;
 pub mod compact;
 pub mod compress;
+pub mod config;
 pub mod crc32;
 #[cfg(feature = "encryption")]
 pub mod crypt;


### PR DESCRIPTION
## Overview
Add HTTP API endpoints to update and query daemon configuration at
runtime without restarting nydusd. This is particularly useful for
refreshing registry credentials when tokens expire.

Key changes:
- Add GET/PUT /api/v1/config endpoints for configuration management
- Add config module in utils for centralized configuration updates
- Add smoke test cases for hot reload configuration API
- Update documentation with hot reload usage examples

## Related Issues
https://github.com/containerd/nydus-snapshotter/issues/690

## Change Details
_Please describe your changes in detail:_

## Test Results
_If you have any relevant screenshots or videos that can help illustrate your changes, please add them here._

## Change Type
_Please select the type of change your pull request relates to:_
- [ ] Bug Fix
- [x] Feature Addition
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe)

## Self-Checklist
_Before submitting a pull request, please ensure you have completed the following:_
- [ ] I have run a code style check and addressed any warnings/errors.
- [ ] I have added appropriate comments to my code (if applicable).
- [ ] I have updated the documentation (if applicable).
- [ ] I have written appropriate unit tests.