### PR TITLE
Update fuse-backend-rs and related rust-vmm dependencies

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -61,38 +61,6 @@ jobs:
         working-directory: ${{ matrix.path }}
         args: --timeout=10m --verbose
 
-  nydus-build-debug:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v6
-    - name: Rust Cache
-      uses: Swatinem/rust-cache@v2
-      with:
-        cache-on-failure: true
-        shared-key: ${{ runner.os }}-cargo-amd64-debug
-        save-if: ${{ github.ref == 'refs/heads/master' }}
-    - uses: dsherret/rust-toolchain-file@v1
-    - name: Read Rust toolchain version
-      id: set_toolchain_version
-      run: |
-        RUST_TOOLCHAIN_VERSION=$(grep -oP '(?<=channel = ")[^"]*' rust-toolchain.toml)
-        echo "Rust toolchain version: $RUST_TOOLCHAIN_VERSION"
-        echo "rust-version=$RUST_TOOLCHAIN_VERSION" >> $GITHUB_OUTPUT
-      shell: bash
-    - name: Build Nydus Debug Version
-      run: |
-        make -e ENABLE_DEBUG=1 build
-        mv target/$RUST_TARGET/debug/nydusd .
-        mv target/$RUST_TARGET/debug/nydus-image .
-    - name: Upload Nydus Binaries
-      uses: actions/upload-artifact@v6
-      with:
-        name: nydus-artifact-debug
-        path: |
-          nydus-image
-          nydusd
-
   nydus-build:
     runs-on: ubuntu-latest
     strategy:
@@ -154,7 +122,7 @@ jobs:
       if: matrix.arch == 'amd64'
       uses: actions/upload-artifact@v6
       with:
-        name: nydus-artifact-release
+        name: nydus-artifact
         path: |
           nydus-image
           nydusd
@@ -185,7 +153,7 @@ jobs:
 
   nydus-integration-test:
     runs-on: ubuntu-latest
-    needs: [contrib-build, nydus-build-debug]
+    needs: [contrib-build, nydus-build]
     steps:
     - name: Checkout
       uses: actions/checkout@v6
@@ -195,8 +163,9 @@ jobs:
     - name: Download Nydus
       uses: actions/download-artifact@v7
       with:
-        name: nydus-artifact-debug
-        path: target/debug
+        name: nydus-artifact
+        path: |
+          target/release
     - name: Download Nydusify
       uses: actions/download-artifact@v7
       with:
@@ -241,10 +210,9 @@ jobs:
     - name: Integration Test
       run: |
         sudo mkdir -p /usr/bin/nydus-latest /home/runner/work/workdir
-        sudo chmod +x contrib/nydusify/cmd/nydusify target/debug/nydusd target/debug/nydus-image
         sudo install -D -m 755 contrib/nydusify/cmd/nydusify /usr/bin/nydus-latest
-        sudo install -D -m 755 target/debug/nydusd target/debug/nydus-image /usr/bin/nydus-latest
-        sudo INSTALL_TARGET_TYPE=debug bash misc/prepare.sh
+        sudo install -D -m 755 target/release/nydusd target/release/nydus-image /usr/bin/nydus-latest
+        sudo bash misc/prepare.sh
 
         export NYDUS_STABLE_VERSION=$(curl https://api.github.com/repos/Dragonflyoss/nydus/releases/latest | jq -r '.tag_name')
         export NYDUS_STABLE_VERSION_EXPORT="${NYDUS_STABLE_VERSION//./_}"
@@ -260,16 +228,7 @@ jobs:
         done
 
         curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sudo sh -s -- -b /usr/bin v2.1.6
-        sudo -E ENABLE_DEBUG=1 make smoke-only
-        sudo -E "PATH=$PATH" make generate-codecov-markdown
-        grep Total coverage/coverage.md
-        sudo -E "PATH=$PATH" make generate-codecov
-        sudo cp coverage/coverage.info smoke-coverage.info
-    - name: Upload Nydus Smoke Coverage
-      uses: actions/upload-artifact@v6
-      with:
-        name: nydus-coverage-smoke
-        path: smoke-coverage.info
+        sudo -E make smoke-only
 
   nydus-unit-test:
     runs-on: ubuntu-latest
@@ -288,18 +247,12 @@ jobs:
       run: sudo bash misc/fscache/setup.sh
     - name: Unit Test
       run: |
-        sudo -E ENABLE_DEBUG=1 "PATH=$PATH" make ut-nextest
-        sudo -E "PATH=$PATH" make generate-codecov-markdown
-        grep Total coverage/coverage.md
-        sudo -E "PATH=$PATH" make generate-codecov
-        sudo cp coverage/coverage.info ut-coverage.info
-    - name: Upload Nydus UT Coverage
-      uses: actions/upload-artifact@v6
-      with:
-        name: nydus-coverage-ut
-        path: ut-coverage.info
+        CARGO_HOME=${HOME}/.cargo
+        CARGO_BIN=$(which cargo)
+        RUSTUP_BIN=$(which rustup)
+        sudo -E RUSTUP=${RUSTUP_BIN} make ut-nextest
 
-  contrib-unit-test:
+  contrib-unit-test-coverage:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
@@ -318,6 +271,57 @@ jobs:
         name: contrib-test-coverage-artifact
         path: |
           contrib/nydusify/coverage.txt
+
+  nydus-unit-test-coverage:
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_COLOR: always
+    steps:
+      - uses: actions/checkout@v6
+      - name: Rust Cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          cache-on-failure: true
+          shared-key: Linux-cargo-amd64
+          save-if: ${{ github.ref == 'refs/heads/master' }}
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Fscache Setup
+        run: sudo bash misc/fscache/setup.sh
+      - name: Generate code coverage
+        run: |
+          CARGO_HOME=${HOME}/.cargo
+          CARGO_BIN=$(which cargo)
+          RUSTUP_BIN=$(which rustup)
+          sudo -E RUSTUP=${RUSTUP_BIN} make coverage-codecov
+      - name: Upload nydus coverage file
+        uses: actions/upload-artifact@v6
+        with:
+          name: nydus-test-coverage-artifact
+          path: |
+            codecov.json
+
+  upload-coverage-to-codecov:
+    runs-on: ubuntu-latest
+    needs: [contrib-unit-test-coverage, nydus-unit-test-coverage]
+    steps:
+    - uses: actions/checkout@v6
+    - name: Download nydus coverage file
+      uses: actions/download-artifact@v7
+      with:
+        name: nydus-test-coverage-artifact
+    - name: Download contrib coverage file
+      uses: actions/download-artifact@v7
+      with:
+        name: contrib-test-coverage-artifact
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v5
+      env:
+        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      with:
+        files: ./codecov.json,./coverage.txt
+        verbose: true
+        fail_ci_if_error: true
 
   nydus-cargo-deny:
     name: cargo-deny
@@ -342,7 +346,7 @@ jobs:
     - name: Download Nydus
       uses: actions/download-artifact@v7
       with:
-        name: nydus-artifact-release
+        name: nydus-artifact
         path: target/release
     - name: Download Nydusify
       uses: actions/download-artifact@v7
@@ -359,15 +363,15 @@ jobs:
 
   takeover-test:
     runs-on: ubuntu-latest
-    needs: [contrib-build, nydus-build-debug]
+    needs: [contrib-build, nydus-build]
     steps:
     - name: Checkout
       uses: actions/checkout@v6
     - name: Download Nydus
       uses: actions/download-artifact@v7
       with:
-        name: nydus-artifact-debug
-        path: target/debug
+        name: nydus-artifact
+        path: target/release
     - name: Download Nydusify
       uses: actions/download-artifact@v7
       with:
@@ -375,49 +379,8 @@ jobs:
         path: contrib/nydusify/cmd
     - name: Prepare Nydus Container Environment
       run: |
-        sudo INSTALL_TARGET_TYPE=debug bash misc/prepare.sh takeover_test
+        sudo bash misc/prepare.sh takeover_test
     - name: Takeover Test
       run: |
-        export NEW_NYDUSD_BINARY_PATH=target/debug/nydusd
-        sudo chmod +x target/debug/nydus-image
-        sudo -E ENABLE_DEBUG=1 make smoke-takeover
-        sudo -E "PATH=$PATH" make generate-codecov-markdown
-        grep Total coverage/coverage.md
-        sudo -E "PATH=$PATH" make generate-codecov
-        sudo cp coverage/coverage.info takeover-coverage.info
-    - name: Upload Nydus Takeover
-      uses: actions/upload-artifact@v6
-      with:
-        name: nydus-coverage-takeover
-        path: takeover-coverage.info
-
-  nydus-coverage:
-    runs-on: ubuntu-latest
-    needs: [takeover-test,nydus-integration-test,nydus-unit-test]
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v6
-    - name: Download Nydus Smoke Coverage
-      uses: actions/download-artifact@v7
-      with:
-        name: nydus-coverage-smoke
-    - name: Download Nydus UT Coverage
-      uses: actions/download-artifact@v7
-      with:
-        name: nydus-coverage-ut
-    - name: Download Nydus Takeover Coverage
-      uses: actions/download-artifact@v7
-      with:
-        name: nydus-coverage-takeover
-    - name: Download contrib coverage file
-      uses: actions/download-artifact@v7
-      with:
-        name: contrib-test-coverage-artifact
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v5
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-      with:
-        files: smoke-coverage.info,ut-coverage.info,takeover-coverage.info,coverage.txt
-        verbose: true
-        fail_ci_if_error: true
+        export NEW_NYDUSD_BINARY_PATH=target/release/nydusd
+        sudo -E make smoke-takeover

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -607,9 +607,9 @@ dependencies = [
 
 [[package]]
 name = "fuse-backend-rs"
-version = "0.13.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39179fe2c126f4695984992b6ce08b3b90994b1b1b581c3c58ca29585a56ca81"
+checksum = "13d8148185e731fa601a078e4ae8c742bf4b69e86e19136848780deaef08fd7d"
 dependencies = [
  "arc-swap",
  "bitflags 1.3.2",
@@ -627,7 +627,7 @@ dependencies = [
  "vhost",
  "virtio-queue",
  "vm-memory",
- "vmm-sys-util",
+ "vmm-sys-util 0.15.0",
 ]
 
 [[package]]
@@ -732,7 +732,7 @@ dependencies = [
  "gix-trace",
  "kstring",
  "smallvec",
- "thiserror 2.0.11",
+ "thiserror 2.0.18",
  "unicode-bom",
 ]
 
@@ -768,7 +768,7 @@ dependencies = [
  "gix-trace",
  "home",
  "once_cell",
- "thiserror 2.0.11",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -779,7 +779,7 @@ checksum = "1b005c550bf84de3b24aa5e540a23e6146a1c01c7d30470e35d75a12f827f969"
 dependencies = [
  "bstr",
  "gix-utils",
- "thiserror 2.0.11",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1538,7 +1538,7 @@ dependencies = [
  "thiserror 1.0.69",
  "toml",
  "url",
- "vmm-sys-util",
+ "vmm-sys-util 0.15.0",
 ]
 
 [[package]]
@@ -1562,7 +1562,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tar",
- "vmm-sys-util",
+ "vmm-sys-util 0.15.0",
  "xattr",
 ]
 
@@ -1598,7 +1598,7 @@ dependencies = [
  "serde_json",
  "thiserror 1.0.69",
  "vm-memory",
- "vmm-sys-util",
+ "vmm-sys-util 0.15.0",
 ]
 
 [[package]]
@@ -1636,10 +1636,10 @@ dependencies = [
  "tokio",
  "vhost",
  "vhost-user-backend",
- "virtio-bindings 0.1.0",
+ "virtio-bindings",
  "virtio-queue",
  "vm-memory",
- "vmm-sys-util",
+ "vmm-sys-util 0.15.0",
  "xattr",
 ]
 
@@ -1671,10 +1671,10 @@ dependencies = [
  "versionize_derive",
  "vhost",
  "vhost-user-backend",
- "virtio-bindings 0.1.0",
+ "virtio-bindings",
  "virtio-queue",
  "vm-memory",
- "vmm-sys-util",
+ "vmm-sys-util 0.15.0",
 ]
 
 [[package]]
@@ -1716,7 +1716,7 @@ dependencies = [
  "toml",
  "url",
  "vm-memory",
- "vmm-sys-util",
+ "vmm-sys-util 0.15.0",
 ]
 
 [[package]]
@@ -1753,7 +1753,7 @@ dependencies = [
  "tar",
  "thiserror 1.0.69",
  "tokio",
- "vmm-sys-util",
+ "vmm-sys-util 0.15.0",
  "zstd",
 ]
 
@@ -2518,11 +2518,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.11"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.11",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -2538,9 +2538,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.11"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2866,7 +2866,7 @@ dependencies = [
  "serde_derive",
  "syn 1.0.109",
  "versionize_derive",
- "vmm-sys-util",
+ "vmm-sys-util 0.12.1",
 ]
 
 [[package]]
@@ -2882,64 +2882,60 @@ dependencies = [
 
 [[package]]
 name = "vhost"
-version = "0.11.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6be08d1166d41a78861ad50212ab3f9eca0729c349ac3a7a8f557c62406b87cc"
+checksum = "c76d90ce3c6b37d610a5304c9a445cfff580cf8b4b9fd02fb256aaf68552c28a"
 dependencies = [
  "bitflags 2.8.0",
  "libc",
+ "uuid",
  "vm-memory",
- "vmm-sys-util",
+ "vmm-sys-util 0.15.0",
 ]
 
 [[package]]
 name = "vhost-user-backend"
-version = "0.15.0"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f0ffb1dd8e00a708a0e2c32d5efec5812953819888591fff9ff68236b8a5096"
+checksum = "783587813a59c42c36519a6e12bb31eb2d7fa517377428252ba4cc2312584243"
 dependencies = [
  "libc",
  "log",
  "vhost",
- "virtio-bindings 0.2.4",
+ "virtio-bindings",
  "virtio-queue",
  "vm-memory",
- "vmm-sys-util",
+ "vmm-sys-util 0.15.0",
 ]
 
 [[package]]
 name = "virtio-bindings"
-version = "0.1.0"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff512178285488516ed85f15b5d0113a7cdb89e9e8a760b269ae4f02b84bd6b"
-
-[[package]]
-name = "virtio-bindings"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1711e61c00f8cb450bd15368152a1e37a12ef195008ddc7d0f4812f9e2b30a68"
+checksum = "091f1f09cfbf2a78563b562e7a949465cce1aef63b6065645188d995162f8868"
 
 [[package]]
 name = "virtio-queue"
-version = "0.12.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07d8406e7250c934462de585d8f2d2781c31819bca1fbb7c5e964ca6bbaabfe8"
+checksum = "e358084f32ed165fddb41d98ff1b7ff3c08b9611d8d6114a1b422e2e85688baf"
 dependencies = [
+ "libc",
  "log",
- "virtio-bindings 0.2.4",
+ "virtio-bindings",
  "vm-memory",
- "vmm-sys-util",
+ "vmm-sys-util 0.15.0",
 ]
 
 [[package]]
 name = "vm-memory"
-version = "0.14.1"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3aba5064cc5f6f7740cddc8dae34d2d9a311cac69b60d942af7f3ab8fc49f4"
+checksum = "f39348a049689cabd3377cdd9182bf526ec76a6f823b79903896452e9d7a7380"
 dependencies = [
  "arc-swap",
  "libc",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "winapi",
 ]
 
@@ -2948,6 +2944,16 @@ name = "vmm-sys-util"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d1435039746e20da4f8d507a72ee1b916f7b4b05af7a91c093d2c6561934ede"
+dependencies = [
+ "bitflags 1.3.2",
+ "libc",
+]
+
+[[package]]
+name = "vmm-sys-util"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "506c62fdf617a5176827c2f9afbcf1be155b03a9b4bf9617a60dbc07e3a1642f"
 dependencies = [
  "bitflags 1.3.2",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,9 +77,7 @@ nydus-utils = { version = "0.5.0", path = "utils" }
 
 vhost = { workspace = true, features = ["vhost-user"], optional = true }
 vhost-user-backend = { workspace = true, optional = true }
-virtio-bindings = { workspace = true, features = [
-    "virtio-v5_0_0",
-], optional = true }
+virtio-bindings = { workspace = true, optional = true }
 virtio-queue = { workspace = true, optional = true }
 vm-memory = { workspace = true, features = [
     "backend-mmap",
@@ -140,12 +138,12 @@ members = [
 
 [workspace.dependencies]
 # rust-vmm crates
-vhost = "0.11.0"
-vhost-user-backend = "0.15.0"
-virtio-bindings = "0.1"
-virtio-queue = "0.12.0"
-vm-memory = "0.14.1"
-vmm-sys-util = "0.12.1"
+vhost = "0.15.0"
+virtio-bindings = "0.2.7"
+virtio-queue = "0.17.0"
+vm-memory = "=0.17.1"
+vmm-sys-util = "0.15.0"
+vhost-user-backend = "0.21.0"
 
 # fuse-backend-rs which depends on rust-vmm
-fuse-backend-rs = "0.13.1"
+fuse-backend-rs = "0.14.0"

--- a/Makefile
+++ b/Makefile
@@ -156,6 +156,10 @@ generate-codecov-markdown: prepare-codecov
 generate-codecov: prepare-codecov
 	grcov $(dir ${LLVM_PROFILE_FILE})/*.profraw -t lcov $(GRCOV_ARGS) --output-path coverage/coverage.info
 
+# write unit teset coverage to codecov.json, used for Github CI
+coverage-codecov:
+	TEST_WORKDIR_PREFIX=$(TEST_WORKDIR_PREFIX) ${RUSTUP} run stable cargo llvm-cov --codecov --output-path codecov.json --workspace $(EXCLUDE_PACKAGES) $(CARGO_COMMON) $(CARGO_BUILD_FLAGS) -- --skip integration --nocapture --test-threads=8
+
 
 contrib-build: nydusify nydus-overlayfs
 

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -34,9 +34,7 @@ nydus-utils = { version = "0.5.0", path = "../utils" }
 
 vhost = { workspace = true, features = ["vhost-user"], optional = true }
 vhost-user-backend = { workspace = true, optional = true }
-virtio-bindings = { workspace = true, features = [
-    "virtio-v5_0_0",
-], optional = true }
+virtio-bindings = { workspace = true, optional = true }
 virtio-queue = { workspace = true, optional = true }
 vm-memory = { workspace = true, features = ["backend-mmap"], optional = true }
 

--- a/src/bin/nydusd/virtiofs.rs
+++ b/src/bin/nydusd/virtiofs.rs
@@ -25,7 +25,7 @@ use virtio_queue::QueueOwnedT;
 use vm_memory::mmap::NewBitmap;
 use vm_memory::{GuestAddressSpace, GuestMemoryAtomic, GuestMemoryLoadGuard, GuestMemoryMmap};
 use vmm_sys_util::epoll::EventSet;
-use vmm_sys_util::eventfd::EventFd;
+use vmm_sys_util::event::{EventConsumer, EventNotifier};
 
 use nydus::daemon::{
     DaemonState, DaemonStateMachineContext, DaemonStateMachineInput, DaemonStateMachineSubscriber,
@@ -50,7 +50,7 @@ type VhostUserBackendResult<T> = std::io::Result<T>;
 
 struct VhostUserFsBackend {
     event_idx: bool,
-    kill_evt: EventFd,
+    kill_evt: (EventConsumer, EventNotifier),
     mem: Option<GuestMemoryAtomic<GuestMemoryMmap>>,
     server: Arc<Server<Arc<Vfs>>>,
     // handle request from slave to master
@@ -89,9 +89,7 @@ impl VhostUserFsBackend {
                 .handle_message(
                     reader,
                     writer,
-                    self.vu_req
-                        .as_mut()
-                        .map(|x| x as &mut dyn FsCacheReqHandler),
+                    None as Option<&mut dyn FsCacheReqHandler>,
                     None,
                 )
                 .map_err(Error::ProcessQueue)?;
@@ -132,7 +130,10 @@ impl VhostUserFsBackendHandler {
     fn new(vfs: Arc<Vfs>) -> std::io::Result<Self> {
         let backend = VhostUserFsBackend {
             event_idx: false,
-            kill_evt: EventFd::new(libc::EFD_NONBLOCK).map_err(Error::Epoll)?,
+            kill_evt: vmm_sys_util::event::new_event_consumer_and_notifier(
+                vmm_sys_util::event::EventFlag::NONBLOCK,
+            )
+            .map_err(Error::Epoll)?,
             mem: None,
             server: Arc::new(Server::new(vfs)),
             vu_req: None,
@@ -183,10 +184,13 @@ impl VhostUserBackendMut for VhostUserFsBackendHandler {
         self.backend.lock().unwrap().vu_req = Some(vu_req);
     }
 
-    fn exit_event(&self, _thread_index: usize) -> Option<EventFd> {
+    fn exit_event(&self, _thread_index: usize) -> Option<(EventConsumer, EventNotifier)> {
         // FIXME: need to patch vhost-user-backend to return KILL_EVENT
         // so that daemon stop event gets popped up.
-        Some(self.backend.lock().unwrap().kill_evt.try_clone().unwrap())
+        let backend = self.backend.lock().unwrap();
+        let consumer = backend.kill_evt.0.try_clone().unwrap();
+        let notifier = backend.kill_evt.1.try_clone().unwrap();
+        Some((consumer, notifier))
     }
 
     fn handle_event(
@@ -316,7 +320,7 @@ where
     }
 
     fn start(&self) -> Result<()> {
-        let listener =
+        let mut listener =
             Listener::new(&self.sock, true).map_err(|e| Error::StartService(format!("{}", e)))?;
         let vu_daemon = self.daemon.clone();
         let _ = thread::Builder::new()
@@ -325,7 +329,7 @@ where
                 vu_daemon
                     .lock()
                     .unwrap()
-                    .start(listener)
+                    .start(&mut listener)
                     .unwrap_or_else(|e| error!("{:?}", e));
             })
             .map_err(Error::ThreadSpawn)?;


### PR DESCRIPTION
1. Update fuse-backend-rs and related rust-vmm dependencies
2. One key change is that virtiofs DAX is removed.
3. Revert the profraw approach as it constantly causes ENOSPC error on github action