### PR TITLE
fix soundness issue of `nydus_utils::FileMapState::get_slice(_mut)`

### DIFF
--- a/utils/src/filemap.rs
+++ b/utils/src/filemap.rs
@@ -6,6 +6,7 @@ use std::fs::File;
 use std::io::Result;
 use std::mem::size_of;
 use std::os::unix::io::{AsRawFd, FromRawFd, IntoRawFd, RawFd};
+use std::ptr::NonNull;
 
 /// Struct to manage memory range mapped from file objects.
 ///
@@ -136,7 +137,12 @@ impl FileMapState {
                 self.base
             );
         }
-        Ok(unsafe { std::slice::from_raw_parts(start as *const T, count) })
+        let ptr = if size == 0 {
+            NonNull::<T>::dangling().as_ptr()
+        } else {
+            start as *const T
+        };
+        Ok(unsafe { std::slice::from_raw_parts(ptr, count) })
     }
 
     /// Get a mutable slice of 'T' at 'offset' with 'count' entries.
@@ -158,7 +164,12 @@ impl FileMapState {
                 self.base
             );
         }
-        Ok(unsafe { std::slice::from_raw_parts_mut(start as *mut T, count) })
+        let ptr = if size == 0 {
+            NonNull::<T>::dangling().as_ptr()
+        } else {
+            start as *mut T
+        };
+        Ok(unsafe { std::slice::from_raw_parts_mut(ptr, count) })
     }
 
     /// Check whether the range [offset, offset + size) is valid and return the start address.
@@ -258,11 +269,13 @@ mod tests {
         assert!(map.get_slice::<usize>(0, usize::MAX).is_err());
         assert!(map.get_slice::<usize>(usize::MAX, 1).is_err());
         assert!(map.get_slice::<usize>(4096, 4096).is_err());
+        assert!(map.get_slice::<usize>(0, 0).is_ok());
         assert!(map.get_slice::<usize>(0, 128).is_ok());
 
         assert!(map.get_slice_mut::<usize>(0, usize::MAX).is_err());
         assert!(map.get_slice_mut::<usize>(usize::MAX, 1).is_err());
         assert!(map.get_slice_mut::<usize>(4096, 4096).is_err());
+        assert!(map.get_slice_mut::<usize>(0, 0).is_ok());
         assert!(map.get_slice_mut::<usize>(0, 128).is_ok());
     }
 }


### PR DESCRIPTION
## Overview
Fix the soundness issue in nydus-utils 0.5.1 in `src/filemap.rs`:
- `FileMapState::get_slice`
- `FileMapState::get_slice_mut`

## Related Issues
Fix #1884 

## Change Details
Updated `get_slice` and `get_slice_mut` to avoid `from_raw_parts(_mut)` on a null pointer when computed byte `size == 0`.
Kept existing range validation; only pointer construction changed for zero-sized slices to use NonNull::<T>::dangling().as_ptr().

## Test Results
Tests passed and miri alarms eliminated.

## Change Type
_Please select the type of change your pull request relates to:_
- [x] Bug Fix
- [ ] Feature Addition
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe)

## Self-Checklist
_Before submitting a pull request, please ensure you have completed the following:_
- [x] I have run a code style check and addressed any warnings/errors.
- [ ] I have added appropriate comments to my code (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have written appropriate unit tests.