### PR TITLE
Only publish codecov if credentials are available and only run jobs that have available runners

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -13,8 +13,20 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  has:
+    runs-on: ubuntu-slim
+    outputs:
+      latest-16: ${{ env.HAS_LATEST_16 }}
+    env:
+      HAS_LATEST_16: ${{ (github.repository_owner == 'dragonflyoss' || vars.HAS_LATEST_16) && '1' || '' }}
+    steps:
+      - run: |
+          true
   contrib-build:
     runs-on: ubuntu-latest-16-cores
+    needs:
+      - has
+    if: needs.has.outputs.latest-16
     steps:
     - name: Checkout
       uses: actions/checkout@v6
@@ -34,6 +46,9 @@ jobs:
 
   nydus-build:
     runs-on: ubuntu-latest-16-cores
+    needs:
+      - has
+    if: needs.has.outputs.latest-16
     steps:
     - name: Checkout
       uses: actions/checkout@v6
@@ -56,6 +71,9 @@ jobs:
 
   benchmark-description:
     runs-on: ubuntu-latest-16-cores
+    needs:
+      - has
+    if: needs.has.outputs.latest-16
     steps:
     - name: Description
       run: |
@@ -66,7 +84,11 @@ jobs:
 
   benchmark-oci:
     runs-on: ubuntu-latest-16-cores
-    needs: [contrib-build, nydus-build]
+    if: needs.has.outputs.latest-16
+    needs:
+      - has
+      - contrib-build
+      - nydus-build
     strategy:
       matrix:
         include:
@@ -113,7 +135,11 @@ jobs:
 
   benchmark-fsversion-v5:
     runs-on: ubuntu-latest-16-cores
-    needs: [contrib-build, nydus-build]
+    needs:
+      - has
+      - contrib-build
+      - nydus-build
+    if: needs.has.outputs.latest-16
     strategy:
       matrix:
         include:
@@ -159,7 +185,11 @@ jobs:
 
   benchmark-fsversion-v6:
     runs-on: ubuntu-latest-16-cores
-    needs: [contrib-build, nydus-build]
+    needs:
+      - has
+      - contrib-build
+      - nydus-build
+    if: needs.has.outputs.latest-16
     strategy:
       matrix:
         include:
@@ -205,7 +235,11 @@ jobs:
 
   benchmark-zran:
     runs-on: ubuntu-latest-16-cores
-    needs: [contrib-build, nydus-build]
+    needs:
+      - has
+      - contrib-build
+      - nydus-build
+    if: needs.has.outputs.latest-16
     strategy:
       matrix:
         include:
@@ -251,7 +285,13 @@ jobs:
 
   benchmark-result:
     runs-on: ubuntu-latest-16-cores
-    needs: [benchmark-oci, benchmark-fsversion-v5, benchmark-fsversion-v6, benchmark-zran]
+    needs:
+      - has
+      - benchmark-oci
+      - benchmark-fsversion-v5
+      - benchmark-fsversion-v6
+      - benchmark-zran
+    if: needs.has.outputs.latest-16
     strategy:
       matrix:
         include:

--- a/.github/workflows/convert.yml
+++ b/.github/workflows/convert.yml
@@ -14,8 +14,20 @@ env:
   FSCK_PATCH_PATH: misc/top_images/fsck.patch
 
 jobs:
+  has:
+    runs-on: ubuntu-slim
+    outputs:
+      latest-16: ${{ env.HAS_LATEST_16 }}
+    env:
+      HAS_LATEST_16: ${{ (github.repository_owner == 'dragonflyoss' || vars.HAS_LATEST_16) && '1' || '' }}
+    steps:
+      - run: |
+          true
   nydusify-build:
     runs-on: ubuntu-latest-16-cores
+    needs:
+      - has
+    if: needs.has.outputs.latest-16
     steps:
     - name: Checkout
       uses: actions/checkout@v6
@@ -36,6 +48,9 @@ jobs:
 
   nydus-build:
     runs-on: ubuntu-latest-16-cores
+    needs:
+      - has
+    if: needs.has.outputs.latest-16
     steps:
     - name: Checkout
       uses: actions/checkout@v6
@@ -58,6 +73,9 @@ jobs:
 
   fsck-erofs-build:
     runs-on: ubuntu-latest-16-cores
+    needs:
+      - has
+    if: needs.has.outputs.latest-16
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -76,7 +94,12 @@ jobs:
 
   convert-zran:
     runs-on: ubuntu-latest-16-cores
-    needs: [nydusify-build, nydus-build, fsck-erofs-build]
+    needs:
+     - has
+     - nydusify-build
+     - nydus-build
+     - fsck-erofs-build
+    if: needs.has.outputs.latest-16
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -155,7 +178,11 @@ jobs:
 
   convert-native-v5:
     runs-on: ubuntu-latest-16-cores
-    needs: [nydusify-build, nydus-build]
+    needs:
+     - has
+     - nydusify-build
+     - nydus-build
+    if: needs.has.outputs.latest-16
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -209,7 +236,12 @@ jobs:
 
   convert-native-v6:
     runs-on: ubuntu-latest-16-cores
-    needs: [nydusify-build, nydus-build, fsck-erofs-build]
+    needs:
+     - has
+     - nydusify-build
+     - nydus-build
+     - fsck-erofs-build
+    if: needs.has.outputs.latest-16
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -272,7 +304,12 @@ jobs:
 
   convert-native-v6-batch:
     runs-on: ubuntu-latest-16-cores
-    needs: [nydusify-build, nydus-build, fsck-erofs-build]
+    needs:
+     - has
+     - nydusify-build
+     - nydus-build
+     - fsck-erofs-build
+    if: needs.has.outputs.latest-16
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -337,7 +374,13 @@ jobs:
 
   convert-metric:
     runs-on: ubuntu-latest-16-cores
-    needs: [convert-zran, convert-native-v5, convert-native-v6, convert-native-v6-batch]
+    needs:
+     - has
+     - convert-zran
+     - convert-native-v5
+     - convert-native-v6
+     - convert-native-v6-batch
+    if: needs.has.outputs.latest-16
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -16,8 +16,20 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  has:
+    runs-on: ubuntu-slim
+    outputs:
+      latest-16: ${{ env.HAS_LATEST_16 }}
+    env:
+      HAS_LATEST_16: ${{ (github.repository_owner == 'dragonflyoss' || vars.HAS_LATEST_16) && '1' || '' }}
+    steps:
+      - run: |
+          true
   nydus-unit-test-with-miri:
     runs-on: ubuntu-latest-16-cores
+    needs:
+      - has
+    if: needs.has.outputs.latest-16
     steps:
     - name: Checkout
       uses: actions/checkout@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,15 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  has:
+    runs-on: ubuntu-slim
+    outputs:
+      latest-16: ${{ env.HAS_LATEST_16 }}
+    env:
+      HAS_LATEST_16: ${{ (github.repository_owner == 'dragonflyoss' || vars.HAS_LATEST_16) && '1' || '' }}
+    steps:
+      - run: |
+          true
   nydus-linux:
     runs-on: ubuntu-latest-16-cores
     strategy:
@@ -212,7 +221,11 @@ jobs:
 
   create-release:
     runs-on: ubuntu-latest-16-cores
-    needs: [prepare-tarball-linux, prepare-tarball-darwin]
+    needs:
+     - has
+     - prepare-tarball-linux
+     - prepare-tarball-darwin
+    if: needs.has.outputs.latest-16
     steps:
     - name: download artifacts
       uses: actions/download-artifact@v7

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -16,7 +16,19 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  has:
+    runs-on: ubuntu-slim
+    outputs:
+      latest-16: ${{ env.HAS_LATEST_16 }}
+    env:
+      HAS_LATEST_16: ${{ (github.repository_owner == 'dragonflyoss' || vars.HAS_LATEST_16) && '1' || '' }}
+    steps:
+      - run: |
+          true
   contrib-build:
+    needs:
+     - has
+    if: needs.has.outputs.latest-16
     runs-on: ubuntu-latest-16-cores
     strategy:
       matrix:
@@ -40,6 +52,9 @@ jobs:
         path: contrib/nydusify/cmd
 
   contrib-lint:
+    needs:
+     - has
+    if: needs.has.outputs.latest-16
     runs-on: ubuntu-latest-16-cores
     strategy:
       matrix:
@@ -62,6 +77,9 @@ jobs:
         args: --timeout=10m --verbose
 
   nydus-build:
+    needs:
+     - has
+    if: needs.has.outputs.latest-16
     runs-on: ubuntu-latest-16-cores
     strategy:
       matrix:
@@ -152,9 +170,12 @@ jobs:
         make -e RUST_TARGET_STATIC=$RUST_TARGET -e static-release
 
   nydus-integration-test:
-    if: github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request' && needs.has.outputs.latest-16
     runs-on: ubuntu-latest-16-cores
-    needs: [contrib-build, nydus-build]
+    needs:
+     - has
+     - contrib-build
+     - nydus-build
     steps:
     - name: Checkout
       uses: actions/checkout@v6
@@ -233,6 +254,9 @@ jobs:
 
   nydus-unit-test:
     runs-on: ubuntu-latest-16-cores
+    needs:
+      - has
+    if: needs.has.outputs.latest-16
     steps:
     - name: Checkout
       uses: actions/checkout@v6
@@ -255,6 +279,9 @@ jobs:
 
   contrib-unit-test-coverage:
     runs-on: ubuntu-latest-16-cores
+    needs:
+      - has
+    if: needs.has.outputs.latest-16
     steps:
     - name: Checkout
       uses: actions/checkout@v6
@@ -274,6 +301,9 @@ jobs:
           contrib/nydusify/coverage.txt
 
   nydus-unit-test-coverage:
+    needs:
+     - has
+    if: needs.has.outputs.latest-16
     runs-on: ubuntu-latest-16-cores
     env:
       CARGO_TERM_COLOR: always
@@ -519,9 +549,12 @@ jobs:
           smoke-missing-lines.txt
 
   upload-coverage-to-codecov:
-    if: github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request' && needs.has.outputs.latest-16
     runs-on: ubuntu-latest-16-cores
-    needs: [contrib-unit-test-coverage, nydus-unit-test-coverage]
+    needs:
+     - has
+     - contrib-unit-test-coverage
+     - nydus-unit-test-coverage
     env:
       COVERAGE_FILES: ./codecov.json ./coverage.txt
     steps:
@@ -616,9 +649,13 @@ jobs:
         fail_ci_if_error: true
 
   upload-pr-coverage-to-codecov:
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && needs.has.outputs.latest-16
     runs-on: ubuntu-latest-16-cores
-    needs: [contrib-unit-test-coverage, nydus-unit-test-coverage, nydus-integration-test-coverage]
+    needs:
+     - has
+     - contrib-unit-test-coverage
+     - nydus-unit-test-coverage
+     - nydus-integration-test-coverage
     env:
       COVERAGE_FILES: ./codecov.json ./coverage.txt ./smoke-codecov.json ./smoke-go-coverage.txt
     steps:
@@ -718,6 +755,9 @@ jobs:
 
   nydus-cargo-deny:
     name: cargo-deny
+    needs:
+     - has
+    if: needs.has.outputs.latest-16
     runs-on: ubuntu-latest-16-cores
     timeout-minutes: 10
     steps:
@@ -726,7 +766,11 @@ jobs:
 
   performance-test:
     runs-on: ubuntu-latest-16-cores
-    needs: [contrib-build, nydus-build]
+    needs:
+     - has
+     - contrib-build
+     - nydus-build
+    if: needs.has.outputs.latest-16
     strategy:
       matrix:
         include:
@@ -756,7 +800,11 @@ jobs:
 
   takeover-test:
     runs-on: ubuntu-latest-16-cores
-    needs: [contrib-build, nydus-build]
+    needs:
+     - has
+     - contrib-build
+     - nydus-build
+    if: needs.has.outputs.latest-16
     steps:
     - name: Checkout
       uses: actions/checkout@v6

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -307,6 +307,9 @@ jobs:
     runs-on: ubuntu-latest-16-cores
     env:
       CARGO_TERM_COLOR: always
+      HAS_CODECOV_CREDENTIALS: ${{ secrets.CODECOV_TOKEN != '' && '1' || '' }}
+    outputs:
+      has-codecov-credentials: ${{ env.HAS_CODECOV_CREDENTIALS }}
     steps:
       - uses: actions/checkout@v6
       - name: Rust Cache
@@ -549,7 +552,7 @@ jobs:
           smoke-missing-lines.txt
 
   upload-coverage-to-codecov:
-    if: github.event_name != 'pull_request' && needs.has.outputs.latest-16
+    if: github.event_name != 'pull_request' && needs.has.outputs.latest-16 && needs.nydus-unit-test-coverage.outputs.has-codecov-credentials
     runs-on: ubuntu-latest-16-cores
     needs:
      - has


### PR DESCRIPTION
## Overview
Ensure that forks can at least get ✅.

Note that it is possible to specify a fallback runner instead of unconditionally using the `ubuntu-latest-16-cores` runner, but I'm not sure if the 16 core runner was chosen for speed or because memory/disk requirements. This change is the closest to the current behavior minus the ❌. I can provide code to allow `runs-on:` to take a fallback path (it's pretty simple).

## Related Issues
- Fixes #1891 

## Change Details
1. Introduce a cheap job that reports whether the repository is owned by dragonflyoss or has a variable `HAS_LATEST_16` defined (so others could set up runners and the variable) and make all jobs with `runs-on: ubuntu-latest-16-cores` need that job and check the output.
2. Expose an output in `nydus-unit-test-coverage` to report the presence of the CODECOV secret and make upload-coverage-to-codecov check that output.

## Test Results
https://github.com/jsoref/nydus/commit/a4b7b5b809ef16c0955ef69e69d0cfbecdd1a83f
https://github.com/jsoref/nydus/actions/runs/23554703768 has 3/3 ✅ 
https://github.com/jsoref/nydus/actions/runs/23554703757/job/68578130351 has 1/1 ✅ 

For comparison:
https://github.com/jsoref/nydus/actions/runs/23550907854 will take 1 day to ❌ while GitHub waits to see if my account will connect a runner pool for `ubuntu-latest-16-cores`.

## Change Type
_Please select the type of change your pull request relates to:_
- [x] Bug Fix
- [ ] Feature Addition
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe)

## Self-Checklist
_Before submitting a pull request, please ensure you have completed the following:_
- [ ] I have run a code style check and addressed any warnings/errors.
- [ ] I have added appropriate comments to my code (if applicable).
- [ ] I have updated the documentation (if applicable).
- [ ] I have written appropriate unit tests.