### PR TITLE
registry: move config auth refresh to background thread

### DIFF
--- a/api/src/config.rs
+++ b/api/src/config.rs
@@ -623,9 +623,6 @@ pub struct RegistryConfig {
     /// Enable HTTP proxy for the read request.
     #[serde(default)]
     pub proxy: ProxyConfig,
-    /// Disable background token refresh thread. Defaults to false.
-    #[serde(skip_deserializing)]
-    pub disable_token_refresh: bool,
 }
 
 /// Configuration information for blob cache manager.
@@ -1364,7 +1361,7 @@ impl TryFrom<RafsConfig> for ConfigV2 {
     type Error = std::io::Error;
 
     fn try_from(v: RafsConfig) -> std::result::Result<Self, Self::Error> {
-        let mut backend: BackendConfigV2 = (&v.device.backend).try_into()?;
+        let backend: BackendConfigV2 = (&v.device.backend).try_into()?;
         let mut cache: CacheConfigV2 = (&v.device.cache).try_into()?;
         let rafs = RafsConfigV2 {
             mode: v.mode,
@@ -1378,13 +1375,6 @@ impl TryFrom<RafsConfig> for ConfigV2 {
         };
         if !cache.prefetch.enable && rafs.prefetch.enable {
             cache.prefetch = rafs.prefetch.clone();
-        }
-
-        // If prefetch is enabled, disable token refresh by default
-        if cache.prefetch.enable {
-            if let Some(registry) = backend.registry.as_mut() {
-                registry.disable_token_refresh = true;
-            }
         }
 
         Ok(ConfigV2 {
@@ -1516,19 +1506,11 @@ impl TryFrom<&BlobCacheEntryConfig> for BlobCacheEntryConfigV2 {
             cache_validate: false,
             prefetch_config: v.prefetch_config.clone(),
         };
-        let mut backend: BackendConfigV2 = (&backend_config).try_into()?;
-
-        // If prefetch is enabled, disable token refresh by default
-        if cache_config.prefetch_config.enable {
-            if let Some(registry) = backend.registry.as_mut() {
-                registry.disable_token_refresh = true;
-            }
-        }
 
         Ok(BlobCacheEntryConfigV2 {
             version: 2,
             id: v.id.clone(),
-            backend,
+            backend: (&backend_config).try_into()?,
             external_backends: v.external_backends.clone(),
             cache: (&cache_config).try_into()?,
             metadata_path: v.metadata_path.clone(),
@@ -2115,15 +2097,6 @@ mod tests {
         "#;
         let config = ConfigV2::from_str(content).unwrap();
         assert_eq!(&config.id, "");
-        // token refresh should be disabled when prefetch is enabled
-        assert!(
-            config
-                .get_backend_config()
-                .unwrap()
-                .get_registry_config()
-                .unwrap()
-                .disable_token_refresh
-        );
     }
 
     #[test]

--- a/storage/src/backend/registry.rs
+++ b/storage/src/backend/registry.rs
@@ -966,12 +966,8 @@ impl Registry {
             first: First::new(),
         };
 
-        if config.disable_token_refresh {
-            info!("Refresh token thread is disabled.");
-        } else {
-            registry.start_refresh_token_thread();
-            info!("Refresh token thread started.");
-        }
+        registry.start_refresh_token_thread();
+        info!("Refresh token thread started.");
 
         Ok(registry)
     }

--- a/storage/src/backend/registry.rs
+++ b/storage/src/backend/registry.rs
@@ -32,6 +32,7 @@ const HEADER_AUTHORIZATION: &str = "Authorization";
 const HEADER_WWW_AUTHENTICATE: &str = "www-authenticate";
 
 const REGISTRY_DEFAULT_TOKEN_EXPIRATION: u64 = 10 * 60; // in seconds
+const REGISTRY_CONFIG_POLL_INTERVAL: u64 = 5; // in seconds
 
 /// Error codes related to registry storage backend operations.
 #[derive(Debug)]
@@ -327,13 +328,14 @@ impl RegistryState {
                 self.cached_auth
                     .set(&last_cached_auth, format!("Basic {}", config_auth));
                 self.token_expired_at.store(None);
+                debug!("refreshed basic registry auth after registry_auth config update");
             }
             Some(ConfigAuthUpdate::RefreshBearer(auth)) => match self.get_token(auth, connection) {
                 Ok(token) => {
                     let last_cached_auth = self.cached_auth.get();
                     self.cached_auth
                         .set(&last_cached_auth, format!("Bearer {}", token.token));
-                    debug!("refreshed registry token after registry_auth config update");
+                    debug!("refreshed bearer registry token after registry_auth config update");
                 }
                 Err(err) => {
                     warn!(
@@ -619,8 +621,6 @@ impl RegistryReader {
         mut headers: HeaderMap,
         catch_status: bool,
     ) -> RegistryResult<Response> {
-        self.state.refresh_cached_auth_from_config(&self.connection);
-
         // Try get authorization header from cache for this request
         let mut last_cached_auth = String::new();
         let cached_auth = self.state.cached_auth.get();
@@ -1007,6 +1007,9 @@ impl Registry {
         let mut refresh_interval = REGISTRY_DEFAULT_TOKEN_EXPIRATION;
         thread::spawn(move || {
             loop {
+                // Check for config auth changes every tick.
+                state.refresh_cached_auth_from_config(&conn);
+
                 if let Ok(now_timestamp) = SystemTime::now().duration_since(UNIX_EPOCH) {
                     if let Some(token_expired_at) = state.token_expired_at.load().as_deref() {
                         // If the token will expire within the next refresh interval,
@@ -1045,7 +1048,7 @@ impl Registry {
                 if conn.shutdown.load(Ordering::Acquire) {
                     break;
                 }
-                thread::sleep(Duration::from_secs(refresh_interval));
+                thread::sleep(Duration::from_secs(REGISTRY_CONFIG_POLL_INTERVAL));
                 if conn.shutdown.load(Ordering::Acquire) {
                     break;
                 }


### PR DESCRIPTION
## Overview

Move `refresh_cached_auth_from_config` from the hot request path to the background refresh token thread, and remove the `disable_token_refresh` workaround that was disabling the thread when prefetch was enabled.

## Related Issues

Fixes #1893

## Change Details

**Move config auth refresh to background thread:** `refresh_cached_auth_from_config` was called at the top of every `request()`. When multiple concurrent requests detect a config change simultaneously, each one independently calls `get_token()`, potentially causing a thundering herd on the auth server. Additionally, performing the refresh in the request path adds latency to the first request after a config update.

The refresh is now performed in the existing background thread, polling every 5 seconds for update in the config.

**Remove `disable_token_refresh`:** This was introduced in #1784 to silence noisy 401/403 errors from the refresh thread when using expired tokens with prefetch enabled. With config auth changes now handled properly by the thread, the workaround is no longer needed. Always starting the thread ensures config auth updates via the API are picked up promptly regardless of prefetch configuration.

## Test Results

Existing unit tests pass. 

Tested manually using an AWS private ECR:
```
DEBU[2026-04-03T17:17:25.689707264+02:00] Trying to get credentials from kubelet        ref="111111111111.dkr.ecr.us-east-1.amazonaws.com/datadog-agent:7.75.0-rc.7-jmx-zstd-nydus"
INFO[2026-04-03T17:17:30.773328562+02:00] Got credentials from provider kubelet         ref="111111111111.dkr.ecr.us-east-1.amazonaws.com/datadog-agent:7.75.0-rc.7-jmx-zstd-nydus"
DEBU[2026-04-03T17:17:30.773347970+02:00] adding credential entry to store              ref="111111111111.dkr.ecr.us-east-1.amazonaws.com/datadog-agent:7.75.0-rc.7-jmx-zstd-nydus"
[2026-04-03 17:17:30.773598 +02:00] DEBUG [/src/http_handler.rs:186] <--- Put Uri { string: "/api/v1/config?id=%2F" }
[2026-04-03 17:17:30.773682 +02:00] DEBUG [/src/http_handler.rs:191] ---> Put Status Code: NoContent, Elapse: Ok(88.86µs), Body Size: 0
[2026-04-03 17:17:33.628709 +02:00] DEBUG [/src/backend/registry.rs:331] refreshed basic registry auth after registry_auth config update
```

## Change Type

- [x] Bug Fix
- [ ] Feature Addition
- [ ] Documentation Update
- [x] Code Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe)

## Self-Checklist

- [x] I have run a code style check and addressed any warnings/errors.
- [x] I have added appropriate comments to my code (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have written appropriate unit tests.