### PR TITLE
Disable HTTPS-to-HTTP fallback unless skip_verify is set

### DIFF
--- a/storage/src/backend/registry.rs
+++ b/storage/src/backend/registry.rs
@@ -205,6 +205,9 @@ struct RegistryState {
     repo: String,
     // Retry limit for read operation
     retry_limit: u8,
+    // When true, skip TLS certificate verification AND allow HTTPS-to-HTTP fallback.
+    // When false (default), TLS errors propagate as-is without falling back to HTTP.
+    skip_verify: bool,
     // Scheme specified for blob server
     blob_url_scheme: String,
     // Replace registry redirected url host with the given host
@@ -246,6 +249,9 @@ impl RegistryState {
     }
 
     fn needs_fallback_http(&self, e: &dyn Error) -> bool {
+        if !self.skip_verify {
+            return false;
+        }
         match e.source() {
             Some(err) => match err.source() {
                 Some(err) => {
@@ -950,6 +956,7 @@ impl Registry {
             cached_auth,
             cached_config_auth: Cache::new(auth.clone().unwrap_or_default()),
             retry_limit,
+            skip_verify: config.skip_verify,
             blob_url_scheme: config.blob_url_scheme.clone(),
             blob_redirected_host: config.blob_redirected_host.clone(),
             cached_auth_using_http_get: HashCache::new(),
@@ -1126,12 +1133,17 @@ mod tests {
     }
 
     fn create_state(use_https: bool) -> RegistryState {
+        create_state_with_skip_verify(use_https, false)
+    }
+
+    fn create_state_with_skip_verify(use_https: bool, skip_verify: bool) -> RegistryState {
         RegistryState {
             id: String::from("/"),
             scheme: Scheme::new(use_https),
             host: "example.com".to_string(),
             repo: "library/test".to_string(),
             retry_limit: 5,
+            skip_verify,
             blob_url_scheme: "https".to_string(),
             blob_redirected_host: "blob.example.com".to_string(),
             cached_auth_using_http_get: Default::default(),
@@ -1179,14 +1191,25 @@ mod tests {
     }
 
     #[test]
-    fn test_scheme_and_fallback_http() {
+    fn test_no_fallback_http_by_default() {
+        // With skip_verify=false (default), never fall back to http.
         let state = create_state(true);
+        assert_eq!(state.scheme.to_string(), "https");
+        assert!(!state.needs_fallback_http(&nested_error("wrong version number")));
+        assert!(!state.needs_fallback_http(&nested_error("SSL routines")));
+    }
+
+    #[test]
+    fn test_scheme_and_fallback_http() {
+        // With skip_verify=true and https, TLS errors trigger fallback.
+        let state = create_state_with_skip_verify(true, true);
         assert_eq!(state.scheme.to_string(), "https");
         assert!(state.needs_fallback_http(&nested_error("wrong version number")));
         assert!(state.needs_fallback_http(&nested_error("SSL routines")));
         assert!(!state.needs_fallback_http(&nested_error("permission denied")));
 
-        let state = create_state(false);
+        // With skip_verify=true and http, no fallback needed (already http).
+        let state = create_state_with_skip_verify(false, true);
         assert_eq!(state.scheme.to_string(), "http");
         assert!(!state.needs_fallback_http(&nested_error("wrong version number")));
     }
@@ -1217,6 +1240,7 @@ mod tests {
             host: "example.com".to_string(),
             repo: "library/test".to_string(),
             retry_limit: 5,
+            skip_verify: false,
             blob_url_scheme: "https".to_string(),
             blob_redirected_host: "blob.example.com".to_string(),
             cached_auth_using_http_get: Default::default(),
@@ -1251,6 +1275,7 @@ mod tests {
             host: "example.com".to_string(),
             repo: "library/test".to_string(),
             retry_limit: 5,
+            skip_verify: false,
             blob_url_scheme: "https".to_string(),
             blob_redirected_host: "blob.example.com".to_string(),
             cached_auth_using_http_get: Default::default(),
@@ -1296,6 +1321,7 @@ mod tests {
             host: "alibaba-inc.com".to_string(),
             repo: "nydus".to_string(),
             retry_limit: 5,
+            skip_verify: false,
             blob_url_scheme: "https".to_string(),
             blob_redirected_host: "oss.alibaba-inc.com".to_string(),
             cached_auth_using_http_get: Default::default(),


### PR DESCRIPTION
## Overview

When `skip_verify` is `false` (the default), TLS errors now propagate as-is instead of silently falling back to plaintext HTTP. The fallback is still available when `skip_verify` is `true`, aligning with nerdctl's `--insecure-registry` semantics.

## Related Issues

Fix #1910

## Change Details

- Added a `skip_verify` field to `RegistryState`, populated from `RegistryConfig.skip_verify`.
- `needs_fallback_http()` now returns `false` early when `skip_verify` is `false`, preventing any HTTPS-to-HTTP downgrade.
- When `skip_verify` is `true`, the existing fallback behavior is preserved unchanged.

## Test Results

- `test_no_fallback_http_by_default` -- verifies TLS errors are never swallowed when `skip_verify` is `false`.
- `test_scheme_and_fallback_http` -- verifies fallback still works when `skip_verify` is `true`.
- Full `nydus-storage` test suite passes.

## Change Type

- [x] Feature Addition

## Self-Checklist

- [x] I have run a code style check and addressed any warnings/errors.
- [x] I have added appropriate comments to my code (if applicable).
- [x] I have updated the documentation (if applicable).
- [x] I have written appropriate unit tests.