### PR TITLE
[doc] Document skip_verify controls HTTP fallback

### DIFF
--- a/api/src/config.rs
+++ b/api/src/config.rs
@@ -599,6 +599,7 @@ pub struct RegistryConfig {
     #[serde(default)]
     pub auth: Option<String>,
     /// Skip SSL certificate validation for HTTPS scheme.
+    /// When true, also allows automatic HTTPS-to-HTTP fallback on TLS errors.
     #[serde(default)]
     pub skip_verify: bool,
     /// Drop the read request once http request timeout, in seconds.

--- a/docs/containerd-env-setup.md
+++ b/docs/containerd-env-setup.md
@@ -82,7 +82,7 @@ Please refer to the nydusd [doc](./nydusd.md) to learn more options.
 
 - The `device.backend.config.scheme` is the URL scheme for the registry. Leave it empty for automatic detection, or specify `https` or `http` depending on your registry server configuration.
 - The `device.backend.config.auth` is the base64 encoded `username:password` authentication string required by nydusd to lazily pull image data from an authenticated registry. The nydus snapshotter will automatically read it from the `$HOME/.docker/config.json` configuration file, or you can also fill it with your own.
-- The `device.backend.config.skip_verify` allows you to skip the insecure https certificate checks for the registry, only set it to `true` when necessary. Note that enabling this option is a security risk for the connection to registry, so you should only use this when you are sure it is safe.
+- The `device.backend.config.skip_verify` allows you to skip the insecure https certificate checks for the registry and enables automatic HTTPS-to-HTTP fallback on TLS errors. Only set it to `true` when necessary. Note that enabling this option is a security risk for the connection to registry, so you should only use this when you are sure it is safe.
 - The `fs_prefetch.enable` option enables nydusd to prefetch image data in background, which can make container startup faster when it needs to read a large amount of image data. Set this to `false` if you don't need this functionality when it brings disk and network pressure.
 
 2. [Optional] Cleanup snapshotter environment:

--- a/docs/nydusd.md
+++ b/docs/nydusd.md
@@ -257,7 +257,8 @@ Document located at: https://github.com/adamqqqplay/nydus-localdisk/blob/master/
         "scheme": "",
         // Registry hostname with format `$host:$port`
         "host": "my-registry:5000",
-        // Skip SSL certificate validation for HTTPS scheme
+        // Skip SSL certificate validation for HTTPS scheme.
+        // When true, also allows automatic HTTPS-to-HTTP fallback on TLS errors.
         "skip_verify": false,
         // Use format `$namespace/$repo` (no image tag)
         "repo": "test/repo",

--- a/misc/configs/nydusd-blob-cache-entry-configuration-v2.toml
+++ b/misc/configs/nydusd-blob-cache-entry-configuration-v2.toml
@@ -60,6 +60,7 @@ repo = "nydus"
 # Base64_encoded(username:password), the field should be sent to registry auth server to get a bearer token.
 auth = "base64_encoded"
 # Skip SSL certificate validation for HTTPS scheme.
+# When true, also allows automatic HTTPS-to-HTTP fallback on TLS errors.
 skip_verify = true
 # Drop the read request once http request timeout, in seconds.
 timeout = 10

--- a/misc/configs/nydusd-blob-cache-entry.toml
+++ b/misc/configs/nydusd-blob-cache-entry.toml
@@ -65,6 +65,7 @@ repo = "nydus"
 # Base64_encoded(username:password), the field should be sent to registry auth server to get a bearer token.
 auth = "base64_encoded"
 # Skip SSL certificate validation for HTTPS scheme.
+# When true, also allows automatic HTTPS-to-HTTP fallback on TLS errors.
 skip_verify = true
 # Drop the read request once http request timeout, in seconds.
 timeout = 10

--- a/misc/configs/nydusd-config-v2.toml
+++ b/misc/configs/nydusd-config-v2.toml
@@ -58,6 +58,7 @@ repo = "nydus"
 # Base64_encoded(username:password), the field should be sent to registry auth server to get a bearer token.
 auth = "base64_encoded"
 # Skip SSL certificate validation for HTTPS scheme.
+# When true, also allows automatic HTTPS-to-HTTP fallback on TLS errors.
 skip_verify = true
 # Drop the read request once http request timeout, in seconds.
 timeout = 10


### PR DESCRIPTION
Update docs, config examples, and the RegistryConfig doc comment to note that skip_verify also gates HTTPS-to-HTTP fallback on TLS errors.
 
Forgot to add it in #1915 :sweat_smile: 