### PR TITLE
make CI runnable in forked repos

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -13,20 +13,8 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  has:
-    runs-on: ubuntu-slim
-    outputs:
-      latest-16: ${{ env.HAS_LATEST_16 }}
-    env:
-      HAS_LATEST_16: ${{ (github.repository_owner == 'dragonflyoss' || vars.HAS_LATEST_16) && '1' || '' }}
-    steps:
-      - run: |
-          true
   contrib-build:
     runs-on: ubuntu-latest-16-cores
-    needs:
-      - has
-    if: needs.has.outputs.latest-16
     steps:
     - name: Checkout
       uses: actions/checkout@v6
@@ -46,9 +34,6 @@ jobs:
 
   nydus-build:
     runs-on: ubuntu-latest-16-cores
-    needs:
-      - has
-    if: needs.has.outputs.latest-16
     steps:
     - name: Checkout
       uses: actions/checkout@v6
@@ -71,9 +56,6 @@ jobs:
 
   benchmark-description:
     runs-on: ubuntu-latest-16-cores
-    needs:
-      - has
-    if: needs.has.outputs.latest-16
     steps:
     - name: Description
       run: |
@@ -84,11 +66,7 @@ jobs:
 
   benchmark-oci:
     runs-on: ubuntu-latest-16-cores
-    if: needs.has.outputs.latest-16
-    needs:
-      - has
-      - contrib-build
-      - nydus-build
+    needs: [contrib-build, nydus-build]
     strategy:
       matrix:
         include:
@@ -135,11 +113,7 @@ jobs:
 
   benchmark-fsversion-v5:
     runs-on: ubuntu-latest-16-cores
-    needs:
-      - has
-      - contrib-build
-      - nydus-build
-    if: needs.has.outputs.latest-16
+    needs: [contrib-build, nydus-build]
     strategy:
       matrix:
         include:
@@ -185,11 +159,7 @@ jobs:
 
   benchmark-fsversion-v6:
     runs-on: ubuntu-latest-16-cores
-    needs:
-      - has
-      - contrib-build
-      - nydus-build
-    if: needs.has.outputs.latest-16
+    needs: [contrib-build, nydus-build]
     strategy:
       matrix:
         include:
@@ -235,11 +205,7 @@ jobs:
 
   benchmark-zran:
     runs-on: ubuntu-latest-16-cores
-    needs:
-      - has
-      - contrib-build
-      - nydus-build
-    if: needs.has.outputs.latest-16
+    needs: [contrib-build, nydus-build]
     strategy:
       matrix:
         include:
@@ -285,13 +251,7 @@ jobs:
 
   benchmark-result:
     runs-on: ubuntu-latest-16-cores
-    needs:
-      - has
-      - benchmark-oci
-      - benchmark-fsversion-v5
-      - benchmark-fsversion-v6
-      - benchmark-zran
-    if: needs.has.outputs.latest-16
+    needs: [benchmark-oci, benchmark-fsversion-v5, benchmark-fsversion-v6, benchmark-zran]
     strategy:
       matrix:
         include:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   contrib-build:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ${{ vars.RUNNER_OS || 'ubuntu-latest' }}
     steps:
     - name: Checkout
       uses: actions/checkout@v6
@@ -33,7 +33,7 @@ jobs:
         path: contrib/nydusify/cmd/nydusify
 
   nydus-build:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ${{ vars.RUNNER_OS || 'ubuntu-latest' }}
     steps:
     - name: Checkout
       uses: actions/checkout@v6
@@ -55,7 +55,7 @@ jobs:
           target/release/nydusd
 
   benchmark-description:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ${{ vars.RUNNER_OS || 'ubuntu-latest' }}
     steps:
     - name: Description
       run: |
@@ -65,7 +65,7 @@ jobs:
         echo "| ubuntu-22.04 | 2-core CPU (x86_64) | 7GB |" >> $GITHUB_STEP_SUMMARY
 
   benchmark-oci:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ${{ vars.RUNNER_OS || 'ubuntu-latest' }}
     needs: [contrib-build, nydus-build]
     strategy:
       matrix:
@@ -112,7 +112,7 @@ jobs:
         path: smoke/${{ matrix.image }}-oci.json
 
   benchmark-fsversion-v5:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ${{ vars.RUNNER_OS || 'ubuntu-latest' }}
     needs: [contrib-build, nydus-build]
     strategy:
       matrix:
@@ -158,7 +158,7 @@ jobs:
         path: smoke/${{ matrix.image }}-fsversion-v5.json
 
   benchmark-fsversion-v6:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ${{ vars.RUNNER_OS || 'ubuntu-latest' }}
     needs: [contrib-build, nydus-build]
     strategy:
       matrix:
@@ -204,7 +204,7 @@ jobs:
         path: smoke/${{ matrix.image }}-fsversion-v6.json
 
   benchmark-zran:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ${{ vars.RUNNER_OS || 'ubuntu-latest' }}
     needs: [contrib-build, nydus-build]
     strategy:
       matrix:
@@ -250,7 +250,7 @@ jobs:
         path: smoke/${{ matrix.image }}-zran.json
 
   benchmark-result:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ${{ vars.RUNNER_OS || 'ubuntu-latest' }}
     needs: [benchmark-oci, benchmark-fsversion-v5, benchmark-fsversion-v6, benchmark-zran]
     strategy:
       matrix:

--- a/.github/workflows/convert.yml
+++ b/.github/workflows/convert.yml
@@ -14,20 +14,8 @@ env:
   FSCK_PATCH_PATH: misc/top_images/fsck.patch
 
 jobs:
-  has:
-    runs-on: ubuntu-slim
-    outputs:
-      latest-16: ${{ env.HAS_LATEST_16 }}
-    env:
-      HAS_LATEST_16: ${{ (github.repository_owner == 'dragonflyoss' || vars.HAS_LATEST_16) && '1' || '' }}
-    steps:
-      - run: |
-          true
   nydusify-build:
     runs-on: ubuntu-latest-16-cores
-    needs:
-      - has
-    if: needs.has.outputs.latest-16
     steps:
     - name: Checkout
       uses: actions/checkout@v6
@@ -48,9 +36,6 @@ jobs:
 
   nydus-build:
     runs-on: ubuntu-latest-16-cores
-    needs:
-      - has
-    if: needs.has.outputs.latest-16
     steps:
     - name: Checkout
       uses: actions/checkout@v6
@@ -73,9 +58,6 @@ jobs:
 
   fsck-erofs-build:
     runs-on: ubuntu-latest-16-cores
-    needs:
-      - has
-    if: needs.has.outputs.latest-16
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -94,12 +76,7 @@ jobs:
 
   convert-zran:
     runs-on: ubuntu-latest-16-cores
-    needs:
-     - has
-     - nydusify-build
-     - nydus-build
-     - fsck-erofs-build
-    if: needs.has.outputs.latest-16
+    needs: [nydusify-build, nydus-build, fsck-erofs-build]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -178,11 +155,7 @@ jobs:
 
   convert-native-v5:
     runs-on: ubuntu-latest-16-cores
-    needs:
-     - has
-     - nydusify-build
-     - nydus-build
-    if: needs.has.outputs.latest-16
+    needs: [nydusify-build, nydus-build]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -236,12 +209,7 @@ jobs:
 
   convert-native-v6:
     runs-on: ubuntu-latest-16-cores
-    needs:
-     - has
-     - nydusify-build
-     - nydus-build
-     - fsck-erofs-build
-    if: needs.has.outputs.latest-16
+    needs: [nydusify-build, nydus-build, fsck-erofs-build]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -304,12 +272,7 @@ jobs:
 
   convert-native-v6-batch:
     runs-on: ubuntu-latest-16-cores
-    needs:
-     - has
-     - nydusify-build
-     - nydus-build
-     - fsck-erofs-build
-    if: needs.has.outputs.latest-16
+    needs: [nydusify-build, nydus-build, fsck-erofs-build]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -374,13 +337,7 @@ jobs:
 
   convert-metric:
     runs-on: ubuntu-latest-16-cores
-    needs:
-     - has
-     - convert-zran
-     - convert-native-v5
-     - convert-native-v6
-     - convert-native-v6-batch
-    if: needs.has.outputs.latest-16
+    needs: [convert-zran, convert-native-v5, convert-native-v6, convert-native-v6-batch]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/convert.yml
+++ b/.github/workflows/convert.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   nydusify-build:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ${{ vars.RUNNER_OS || 'ubuntu-latest' }}
     steps:
     - name: Checkout
       uses: actions/checkout@v6
@@ -35,7 +35,7 @@ jobs:
         path: contrib/nydusify/cmd/nydusify
 
   nydus-build:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ${{ vars.RUNNER_OS || 'ubuntu-latest' }}
     steps:
     - name: Checkout
       uses: actions/checkout@v6
@@ -57,7 +57,7 @@ jobs:
           target/release/nydusd
 
   fsck-erofs-build:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ${{ vars.RUNNER_OS || 'ubuntu-latest' }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -75,7 +75,7 @@ jobs:
             /usr/local/bin/fsck.erofs
 
   convert-zran:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ${{ vars.RUNNER_OS || 'ubuntu-latest' }}
     needs: [nydusify-build, nydus-build, fsck-erofs-build]
     steps:
       - name: Checkout repository
@@ -154,7 +154,7 @@ jobs:
           path: convert-zran
 
   convert-native-v5:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ${{ vars.RUNNER_OS || 'ubuntu-latest' }}
     needs: [nydusify-build, nydus-build]
     steps:
       - name: Checkout repository
@@ -208,7 +208,7 @@ jobs:
           path: convert-native-v5
 
   convert-native-v6:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ${{ vars.RUNNER_OS || 'ubuntu-latest' }}
     needs: [nydusify-build, nydus-build, fsck-erofs-build]
     steps:
       - name: Checkout repository
@@ -271,7 +271,7 @@ jobs:
           path: convert-native-v6
 
   convert-native-v6-batch:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ${{ vars.RUNNER_OS || 'ubuntu-latest' }}
     needs: [nydusify-build, nydus-build, fsck-erofs-build]
     steps:
       - name: Checkout repository
@@ -336,7 +336,7 @@ jobs:
           path: convert-native-v6-batch
 
   convert-metric:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ${{ vars.RUNNER_OS || 'ubuntu-latest' }}
     needs: [convert-zran, convert-native-v5, convert-native-v6, convert-native-v6-batch]
     steps:
       - name: Checkout repository

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -16,20 +16,8 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  has:
-    runs-on: ubuntu-slim
-    outputs:
-      latest-16: ${{ env.HAS_LATEST_16 }}
-    env:
-      HAS_LATEST_16: ${{ (github.repository_owner == 'dragonflyoss' || vars.HAS_LATEST_16) && '1' || '' }}
-    steps:
-      - run: |
-          true
   nydus-unit-test-with-miri:
     runs-on: ubuntu-latest-16-cores
-    needs:
-      - has
-    if: needs.has.outputs.latest-16
     steps:
     - name: Checkout
       uses: actions/checkout@v6

--- a/.github/workflows/miri.yml
+++ b/.github/workflows/miri.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   nydus-unit-test-with-miri:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ${{ vars.RUNNER_OS || 'ubuntu-latest' }}
     steps:
     - name: Checkout
       uses: actions/checkout@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ env:
 
 jobs:
   nydus-linux:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ${{ vars.RUNNER_OS || 'ubuntu-latest' }}
     strategy:
       matrix:
         arch: [amd64, arm64, ppc64le, riscv64]
@@ -117,7 +117,7 @@ jobs:
           configs
 
   contrib-linux:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ${{ vars.RUNNER_OS || 'ubuntu-latest' }}
     strategy:
       matrix:
         arch: [amd64, arm64, ppc64le, riscv64]
@@ -145,7 +145,7 @@ jobs:
           containerd-nydus-grpc
 
   prepare-tarball-linux:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ${{ vars.RUNNER_OS || 'ubuntu-latest' }}
     strategy:
       matrix:
         arch: [amd64, arm64, ppc64le, riscv64]
@@ -179,7 +179,7 @@ jobs:
 
   # use a seperate job for darwin because github action if: condition cannot handle && properly.
   prepare-tarball-darwin:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ${{ vars.RUNNER_OS || 'ubuntu-latest' }}
     strategy:
       matrix:
         arch: [amd64, arm64]
@@ -211,7 +211,7 @@ jobs:
           ${{ env.tarball_shasum }}
 
   create-release:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ${{ vars.RUNNER_OS || 'ubuntu-latest' }}
     needs: [prepare-tarball-linux, prepare-tarball-darwin]
     steps:
     - name: download artifacts
@@ -249,7 +249,7 @@ jobs:
     needs: [nydus-linux, contrib-linux]
     permissions:
       contents: write
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ${{ vars.RUNNER_OS || 'ubuntu-latest' }}
     timeout-minutes: 60
     outputs:
       hashes: ${{ steps.hash.outputs.hashes }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,15 +13,6 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  has:
-    runs-on: ubuntu-slim
-    outputs:
-      latest-16: ${{ env.HAS_LATEST_16 }}
-    env:
-      HAS_LATEST_16: ${{ (github.repository_owner == 'dragonflyoss' || vars.HAS_LATEST_16) && '1' || '' }}
-    steps:
-      - run: |
-          true
   nydus-linux:
     runs-on: ubuntu-latest-16-cores
     strategy:
@@ -221,11 +212,7 @@ jobs:
 
   create-release:
     runs-on: ubuntu-latest-16-cores
-    needs:
-     - has
-     - prepare-tarball-linux
-     - prepare-tarball-darwin
-    if: needs.has.outputs.latest-16
+    needs: [prepare-tarball-linux, prepare-tarball-darwin]
     steps:
     - name: download artifacts
       uses: actions/download-artifact@v7

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -17,7 +17,7 @@ env:
 
 jobs:
   contrib-build:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ${{ vars.RUNNER_OS || 'ubuntu-latest' }}
     strategy:
       matrix:
         arch: [amd64, arm64, ppc64le, riscv64]
@@ -40,7 +40,7 @@ jobs:
         path: contrib/nydusify/cmd
 
   contrib-lint:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ${{ vars.RUNNER_OS || 'ubuntu-latest' }}
     strategy:
       matrix:
         include:
@@ -62,7 +62,7 @@ jobs:
         args: --timeout=10m --verbose
 
   nydus-build:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ${{ vars.RUNNER_OS || 'ubuntu-latest' }}
     strategy:
       matrix:
         arch: [amd64, arm64, ppc64le, riscv64]
@@ -153,7 +153,7 @@ jobs:
 
   nydus-integration-test:
     if: github.event_name != 'pull_request'
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ${{ vars.RUNNER_OS || 'ubuntu-latest' }}
     needs: [contrib-build, nydus-build]
     steps:
     - name: Checkout
@@ -232,7 +232,7 @@ jobs:
         sudo -E make smoke-only
 
   nydus-unit-test:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ${{ vars.RUNNER_OS || 'ubuntu-latest' }}
     steps:
     - name: Checkout
       uses: actions/checkout@v6
@@ -254,7 +254,7 @@ jobs:
         sudo -E RUSTUP=${RUSTUP_BIN} make ut-nextest
 
   contrib-unit-test-coverage:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ${{ vars.RUNNER_OS || 'ubuntu-latest' }}
     steps:
     - name: Checkout
       uses: actions/checkout@v6
@@ -274,7 +274,7 @@ jobs:
           contrib/nydusify/coverage.txt
 
   nydus-unit-test-coverage:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ${{ vars.RUNNER_OS || 'ubuntu-latest' }}
     env:
       CARGO_TERM_COLOR: always
       HAS_CODECOV_CREDENTIALS: ${{ secrets.CODECOV_TOKEN != '' && '1' || '' }}
@@ -308,7 +308,7 @@ jobs:
   nydus-integration-test-coverage:
     if: github.event_name == 'pull_request'
     needs: [contrib-build]
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ${{ vars.RUNNER_OS || 'ubuntu-latest' }}
     env:
       CARGO_TERM_COLOR: always
     steps:
@@ -523,7 +523,7 @@ jobs:
 
   upload-coverage-to-codecov:
     if: github.event_name != 'pull_request' && needs.nydus-unit-test-coverage.outputs.has-codecov-credentials
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ${{ vars.RUNNER_OS || 'ubuntu-latest' }}
     needs: [contrib-unit-test-coverage, nydus-unit-test-coverage]
     env:
       COVERAGE_FILES: ./codecov.json ./coverage.txt
@@ -620,7 +620,7 @@ jobs:
 
   upload-pr-coverage-to-codecov:
     if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ${{ vars.RUNNER_OS || 'ubuntu-latest' }}
     needs: [contrib-unit-test-coverage, nydus-unit-test-coverage, nydus-integration-test-coverage]
     env:
       COVERAGE_FILES: ./codecov.json ./coverage.txt ./smoke-codecov.json ./smoke-go-coverage.txt
@@ -721,7 +721,7 @@ jobs:
 
   nydus-cargo-deny:
     name: cargo-deny
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ${{ vars.RUNNER_OS || 'ubuntu-latest' }}
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
@@ -737,7 +737,7 @@ jobs:
           rust-version: ${{ steps.set_toolchain_version.outputs.rust-version }}
 
   performance-test:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ${{ vars.RUNNER_OS || 'ubuntu-latest' }}
     needs: [contrib-build, nydus-build]
     strategy:
       matrix:
@@ -767,7 +767,7 @@ jobs:
         sudo -E make smoke-performance
 
   takeover-test:
-    runs-on: ubuntu-latest-16-cores
+    runs-on: ${{ vars.RUNNER_OS || 'ubuntu-latest' }}
     needs: [contrib-build, nydus-build]
     steps:
     - name: Checkout

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -16,19 +16,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  has:
-    runs-on: ubuntu-slim
-    outputs:
-      latest-16: ${{ env.HAS_LATEST_16 }}
-    env:
-      HAS_LATEST_16: ${{ (github.repository_owner == 'dragonflyoss' || vars.HAS_LATEST_16) && '1' || '' }}
-    steps:
-      - run: |
-          true
   contrib-build:
-    needs:
-     - has
-    if: needs.has.outputs.latest-16
     runs-on: ubuntu-latest-16-cores
     strategy:
       matrix:
@@ -52,9 +40,6 @@ jobs:
         path: contrib/nydusify/cmd
 
   contrib-lint:
-    needs:
-     - has
-    if: needs.has.outputs.latest-16
     runs-on: ubuntu-latest-16-cores
     strategy:
       matrix:
@@ -77,9 +62,6 @@ jobs:
         args: --timeout=10m --verbose
 
   nydus-build:
-    needs:
-     - has
-    if: needs.has.outputs.latest-16
     runs-on: ubuntu-latest-16-cores
     strategy:
       matrix:
@@ -170,12 +152,9 @@ jobs:
         make -e RUST_TARGET_STATIC=$RUST_TARGET -e static-release
 
   nydus-integration-test:
-    if: github.event_name != 'pull_request' && needs.has.outputs.latest-16
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest-16-cores
-    needs:
-     - has
-     - contrib-build
-     - nydus-build
+    needs: [contrib-build, nydus-build]
     steps:
     - name: Checkout
       uses: actions/checkout@v6
@@ -254,9 +233,6 @@ jobs:
 
   nydus-unit-test:
     runs-on: ubuntu-latest-16-cores
-    needs:
-      - has
-    if: needs.has.outputs.latest-16
     steps:
     - name: Checkout
       uses: actions/checkout@v6
@@ -279,9 +255,6 @@ jobs:
 
   contrib-unit-test-coverage:
     runs-on: ubuntu-latest-16-cores
-    needs:
-      - has
-    if: needs.has.outputs.latest-16
     steps:
     - name: Checkout
       uses: actions/checkout@v6
@@ -301,9 +274,6 @@ jobs:
           contrib/nydusify/coverage.txt
 
   nydus-unit-test-coverage:
-    needs:
-     - has
-    if: needs.has.outputs.latest-16
     runs-on: ubuntu-latest-16-cores
     env:
       CARGO_TERM_COLOR: always
@@ -552,12 +522,9 @@ jobs:
           smoke-missing-lines.txt
 
   upload-coverage-to-codecov:
-    if: github.event_name != 'pull_request' && needs.has.outputs.latest-16 && needs.nydus-unit-test-coverage.outputs.has-codecov-credentials
+    if: github.event_name != 'pull_request' && needs.nydus-unit-test-coverage.outputs.has-codecov-credentials
     runs-on: ubuntu-latest-16-cores
-    needs:
-     - has
-     - contrib-unit-test-coverage
-     - nydus-unit-test-coverage
+    needs: [contrib-unit-test-coverage, nydus-unit-test-coverage]
     env:
       COVERAGE_FILES: ./codecov.json ./coverage.txt
     steps:
@@ -652,13 +619,9 @@ jobs:
         fail_ci_if_error: true
 
   upload-pr-coverage-to-codecov:
-    if: github.event_name == 'pull_request' && needs.has.outputs.latest-16
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest-16-cores
-    needs:
-     - has
-     - contrib-unit-test-coverage
-     - nydus-unit-test-coverage
-     - nydus-integration-test-coverage
+    needs: [contrib-unit-test-coverage, nydus-unit-test-coverage, nydus-integration-test-coverage]
     env:
       COVERAGE_FILES: ./codecov.json ./coverage.txt ./smoke-codecov.json ./smoke-go-coverage.txt
     steps:
@@ -758,9 +721,6 @@ jobs:
 
   nydus-cargo-deny:
     name: cargo-deny
-    needs:
-     - has
-    if: needs.has.outputs.latest-16
     runs-on: ubuntu-latest-16-cores
     timeout-minutes: 10
     steps:
@@ -778,11 +738,7 @@ jobs:
 
   performance-test:
     runs-on: ubuntu-latest-16-cores
-    needs:
-     - has
-     - contrib-build
-     - nydus-build
-    if: needs.has.outputs.latest-16
+    needs: [contrib-build, nydus-build]
     strategy:
       matrix:
         include:
@@ -812,11 +768,7 @@ jobs:
 
   takeover-test:
     runs-on: ubuntu-latest-16-cores
-    needs:
-     - has
-     - contrib-build
-     - nydus-build
-    if: needs.has.outputs.latest-16
+    needs: [contrib-build, nydus-build]
     steps:
     - name: Checkout
       uses: actions/checkout@v6

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -95,8 +95,8 @@ jobs:
         push: false
         load: true
         tags: rust-cross-compile-riscv64:latest
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
+        cache-from: type=gha,scope=buildx-riscv64
+        cache-to: type=gha,mode=max,scope=buildx-riscv64
         build-args: |
           RUST_VERSION=${{ steps.set_toolchain_version.outputs.rust-version }}
     - name: Build Nydus Non-RISC-V


### PR DESCRIPTION
Use `vars.RUNNER_OS` to define runner OS so that the master repo can still use `ubuntu-latest-16-cores` via predefined env.