### PR TITLE
feat: Introduce a uffd-based block device service for virtio-pmem DAX backend

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -393,7 +393,7 @@ jobs:
         echo "  GO_BINARY_COVERDIR=${GO_BINARY_COVERDIR}"
         echo "  GO_TEST_BUILD_FLAGS=${GO_TEST_BUILD_FLAGS}"
         cargo llvm-cov clean --workspace
-        cargo build --release --features=virtiofs --bins
+        cargo build --release --features=virtiofs,block-uffd --bins
         echo "Built instrumented binaries:"
         ls -l target/release/nydusd target/release/nydus-image contrib/nydusify/cmd/nydusify
         target/release/nydusd --version || true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1258,6 +1258,9 @@ name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+dependencies = [
+ "getrandom 0.2.15",
+]
 
 [[package]]
 name = "filetime"
@@ -1309,6 +1312,18 @@ dependencies = [
  "nu-ansi-term",
  "regex",
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "flume"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-sink",
+ "spin 0.9.8",
 ]
 
 [[package]]
@@ -3012,6 +3027,7 @@ version = "0.4.0"
 dependencies = [
  "bytes",
  "dbs-allocator",
+ "flume",
  "fuse-backend-rs",
  "libc",
  "log",
@@ -3024,8 +3040,10 @@ dependencies = [
  "nydus-utils",
  "procfs",
  "rust-fsm",
+ "sendfd",
  "serde",
  "serde_json",
+ "serde_repr",
  "thiserror 1.0.69",
  "time",
  "tokio",
@@ -4727,6 +4745,9 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
 
 [[package]]
 name = "spki"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,6 +115,7 @@ virtiofs = [
     "vmm-sys-util",
 ]
 block-nbd = ["nydus-service/block-nbd"]
+block-uffd = ["nydus-service/block-uffd"]
 
 backend-http-proxy = [
     "nydus-storage/backend-http-proxy",

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ UNAME_M := $(shell uname -m)
 UNAME_S := $(shell uname -s)
 STATIC_TARGET = $(UNAME_M)-unknown-linux-musl
 ifeq ($(UNAME_S),Linux)
-	CARGO_COMMON += --features=virtiofs
+	CARGO_COMMON += --features=virtiofs,block-uffd
 ifeq ($(UNAME_M),ppc64le)
 	STATIC_TARGET = powerpc64le-unknown-linux-gnu
 endif

--- a/docs/nydus-uffd.md
+++ b/docs/nydus-uffd.md
@@ -1,0 +1,427 @@
+# Nydus UFFD Block Device
+
+Export a RAFS v6 image as a block device through [userfaultfd](https://www.kernel.org/doc/html/latest/admin-guide/mm/userfaultfd.html), enabling on-demand paging via `mmap`.
+
+## Overview
+
+The UFFD block device service (`nydusd uffd`) provides an `mmap`-based access mode for RAFS images, designed for clients that map the image as a contiguous virtual address space and handle page faults on demand.
+
+When a client accesses an unmapped page, the kernel delivers a page fault via userfaultfd to `nydusd`, which resolves it through one of two modes:
+
+- **Zerocopy mode**: Returns a blob file descriptor; the client `mmap`s it directly to the faulting address (zero-copy).
+- **Copy mode**: Writes data to the faulting address via `UFFDIO_COPY`.
+
+**Benefits**:
+- In VM scenarios, zerocopy mode combined with guest-side DAX avoids memory duplication, reducing host memory pressure.
+- The UFFD protocol is stateless; clients can reconnect after a server restart without losing state.
+
+```
+Client                          nydusd (UFFD service)            RAFS Image
+--------                        ---------------------            ----------
+page fault → userfaultfd ──→ resolve fault
+                                  │
+                                  ├─ Zerocopy: mmap blob fd ──→ read blob
+                                  │              ← send fd
+                                  │
+                                  └─ Copy: UFFDIO_COPY ──→ read blob
+                                            ← write data
+```
+
+## Requirements
+
+- Linux kernel with `CONFIG_USERFAULTFD=y` (5.10+ recommended)
+- RAFS v6 filesystem image (built with `nydus-image create --fs-version 6`)
+- `nydusd` compiled with `--features block-uffd`
+
+## Quick Start
+
+```bash
+# Build nydusd with UFFD support
+cargo build --bin nydusd --features block-uffd
+
+# Start UFFD service (localfs backend)
+nydusd uffd \
+  --sock /tmp/uffd.sock \
+  --bootstrap /path/to/image.boot \
+  --localfs-dir /path/to/blobs \
+  --threads 4
+
+# Start UFFD service (config file backend)
+nydusd uffd \
+  --sock /tmp/uffd.sock \
+  --bootstrap /path/to/image.boot \
+  --config /path/to/config.json
+```
+
+## Command Line Options
+
+| Option | Short | Required | Description |
+|--------|-------|----------|-------------|
+| `--sock` | `-S` | Yes | Path to the UFFD service Unix socket |
+| `--bootstrap` | `-B` | Yes | Path to the RAFS v6 bootstrap file |
+| `--config` | `-C` | No | Path to ConfigV2 JSON file (mutually exclusive with `--localfs-dir`) |
+| `--localfs-dir` | `-D` | No | Path to localfs working directory (mutually exclusive with `--config`) |
+| `--threads` | | No | Number of worker threads (default: 4) |
+
+## Protocol
+
+The UFFD service communicates with clients over a Unix domain socket using JSON messages, with file descriptors passed via `SCM_RIGHTS`. The protocol is compatible with [Firecracker's UFFD handler](https://github.com/firecracker-microvm/firecracker/blob/main/docs/snapshotting/handling-page-faults-on-snapshot-resume.md).
+
+### Message Types
+
+| Message | Direction | Description |
+|---------|-----------|-------------|
+| `HandshakeRequest` + uffd fd | Client → Server | Register VMA regions, set fault policy |
+| `StatRequest` | Client → Server | Query device size and block size |
+| `StatResponse` | Server → Client | Returns size, block_size, version |
+| `PageFaultResponse` + fd(s) | Server → Client | Provide data for faulting pages |
+
+### Handshake
+
+The client connects to the Unix socket and sends a `HandshakeRequest` JSON message along with the userfaultfd file descriptor via `SCM_RIGHTS`:
+
+```json
+{
+  "type": 0,
+  "regions": [
+    {
+      "base_host_virt_addr": 140737488351232,
+      "size": 8589934592,
+      "offset": 0,
+      "page_size": 2097152,
+      "page_size_kib": 2048,
+      "prot": 1,
+      "flags": 34
+    }
+  ],
+  "policy": 0,
+  "enable_prefault": false
+}
+```
+
+**Field Descriptions**:
+- `type`: Message type, 0 = Handshake
+- `regions`: Array of VMA regions, each describing a contiguous virtual address range
+- `policy`: Fault handling policy, 0 = Zerocopy, 1 = Copy
+- `enable_prefault`: If true, the server asynchronously sends blob fds for locally cached block ranges immediately after handshake, bypassing the page fault round-trip for those ranges. This reduces UFFD overhead for data already present in the cache (default: false).
+- `page_size`: UFFD fault resolution granularity in bytes — the size of each chunk that the server fetches and maps per fault. Typically 2MB (2097152) for huge-page-aligned block devices. The mmap region should be aligned to this value.
+- `prot`, `flags`: Protection and flags for `mmap`. These fields are reserved for future kernel support of cross-process `mmap`, allowing the server to perform the mapping directly on behalf of the client.
+
+**Firecracker Compatibility**: The server also accepts a bare JSON array (without the wrapper object), which is the format Firecracker uses:
+
+```json
+[
+  {
+    "base_host_virt_addr": 140737488351232,
+    "size": 8589934592,
+    "offset": 0,
+    "page_size": 2097152,
+    "page_size_kib": 2048
+  }
+]
+```
+
+### Fault Policies
+
+| Policy | Value | Description |
+|--------|-------|-------------|
+| `Zerocopy` | 0 | Server sends blob file descriptors; client maps them directly to the faulting address via `mmap(MAP_FIXED)` |
+| `Copy` | 1 | Server writes data directly to client memory via `UFFDIO_COPY` or `UFFDIO_ZEROPAGE` |
+
+**Note on Zerocopy Mode**: The current Linux kernel does not support mapping files from another process directly. Therefore, zerocopy mode requires client cooperation: the server sends blob fds via `SCM_RIGHTS`, and the client performs the `mmap` call. If future kernels add cross-process `mmap` support, the client implementation can be further simplified.
+
+### Page Fault Response
+
+When a page fault occurs, the server responds with a `PageFaultResponse` containing one or more blob ranges with associated file descriptors:
+
+```json
+{
+  "type": 1,
+  "ranges": [
+    { "len": 2097152, "blob_offset": 4096, "block_offset": 0 }
+  ]
+}
+```
+
+In zerocopy mode, the client `mmap`s each range using the returned file descriptor. In copy mode, the server calls `UFFDIO_COPY` or `UFFDIO_ZEROPAGE` directly.
+
+### Stat Request
+
+The client can query device information at any time:
+
+```json
+{ "type": 2 }
+```
+
+Response:
+
+```json
+{
+  "type": 3,
+  "size": 8589934592,
+  "block_size": 4096,
+  "flags": 0,
+  "version": 1
+}
+```
+
+## Configuration
+
+### Localfs Backend
+
+The simplest configuration uses `--bootstrap` with `--localfs-dir`:
+
+```bash
+nydusd uffd \
+  --sock /tmp/uffd.sock \
+  --bootstrap /path/to/image.boot \
+  --localfs-dir /path/to/blobs
+```
+
+### Config File Backend
+
+For more complex backends (registry, OSS, etc.), use a ConfigV2 JSON file:
+
+```bash
+nydusd uffd \
+  --sock /tmp/uffd.sock \
+  --bootstrap /path/to/image.boot \
+  --config /path/to/config.json
+```
+
+The config file format is the same as the [FUSE mode configuration](nydusd.md), with `backend` and `cache` sections.
+
+## Architecture
+
+```
+┌────────────────────────────────────────────────────┐
+│                 nydusd uffd service                │
+│                                                    │
+│ ┌───────────────────────────────────────────────┐  │
+│ │             Unix Socket Listener              │  │
+│ └─────────────────────┬─────────────────────────┘  │
+│                       │                            │
+│        ┌──────────────┬──────────────┐             │
+│        │              │              │             │
+│  ┌─────▼─────┐  ┌─────▼─────┐  ┌─────▼─────┐       │
+│  │ Worker 0  │  │ Worker 1  │  │ Worker N  │       │
+│  │  (tokio)  │  │  (tokio)  │  │  (tokio)  │       │
+│  └─────┬─────┘  └─────┬─────┘  └─────┬─────┘       │
+│        │              │              │             │
+│        └──────────────┼──────────────┘             │
+│                       │                            │
+│        ┌──────────────▼───────────────────┐        │
+│        │           BlockDevice            │        │
+│        │ ┌──────────┐    ┌──────────┐     │        │
+│        │ │ MetaBlob │    │ DataBlob │ ... │        │
+│        │ └──────────┘    └──────────┘     │        │
+│        └──────────────────────────────────┘        │
+└────────────────────────────────────────────────────┘
+```
+
+- **Unix Socket Listener**: Accepts client connections and dispatches to workers
+- **Workers**: Each worker handles multiple client connections, asynchronously reading uffd events and resolving page faults
+- **BlockDevice**: Reads blob data from the RAFS v6 image, mapping block ranges to blob files
+
+## Integration with Hypervisors
+
+### Firecracker (Protocol Compatible)
+
+Firecracker's UFFD handler uses a bare JSON array format to send VMA region information, which the nydusd UFFD service accepts natively. A pull request is being prepared to add UFFD block device support to Firecracker.
+
+### Cloud Hypervisor (Planned Support)
+
+Support for Cloud Hypervisor via `--pmem` with UFFD backend is planned for future development. The expected usage pattern is:
+
+```bash
+cloud-hypervisor \
+  --pmem file=/tmp/uffd.sock,size=8G,backend_type=uffd \
+  --kernel /path/to/vmlinux \
+  ...
+```
+
+## Example Client
+
+The following is a minimal Rust client pseudocode demonstrating how to connect to the UFFD service:
+
+```rust
+use std::os::unix::net::UnixStream;
+use sendfd::{RecvWithFd, SendWithFd};
+
+// 1. Create userfaultfd
+let uffd_fd = unsafe { libc::userfaultfd(libc::O_CLOEXEC | libc::O_NONBLOCK) };
+
+// 2. UFFD_API handshake (ioctl UFFDIO_API)
+// ... set up api struct and call ioctl ...
+
+// 3. mmap a contiguous region for the block device (anonymous, no backing file)
+let block_base = unsafe {
+    libc::mmap(
+        std::ptr::null_mut(),  // Let kernel choose address
+        block_size,
+        libc::PROT_READ | libc::PROT_WRITE,
+        libc::MAP_PRIVATE | libc::MAP_ANONYMOUS,
+        -1,
+        0,
+    )
+};
+
+// 4. Register the region with userfaultfd (UFFDIO_REGISTER)
+// ... set up uffdio_register struct and call ioctl ...
+
+// 5. Connect to UFFD service
+let mut stream = UnixStream::connect("/tmp/uffd.sock")?;
+
+// 6. Send handshake request (with uffd fd)
+let handshake = serde_json::json!({
+    "type": 0,
+    "regions": [{
+        "base_host_virt_addr": block_base as u64,
+        "size": block_size,
+        "offset": 0,
+        "page_size": 2097152,  // 2MB
+    }],
+    "policy": 0,  // Zerocopy
+    "enable_prefault": false,
+});
+let mut buf = serde_json::to_vec(&handshake)?;
+stream.send_with_fd(&mut buf, &[uffd_fd])?;
+
+// 7. Listen for and handle page fault events
+loop {
+    let mut msg_buf = [0u8; 4096];
+    let mut fds = [0i32; 16];
+    let (bytes_read, fd_count) = stream.recv_with_fd(&mut msg_buf, &mut fds)?;
+
+    let response: PageFaultResponse = serde_json::from_slice(&msg_buf[..bytes_read])?;
+
+    // Zerocopy mode: mmap blob fd to faulting address
+    let received_fds = &fds[..fd_count];
+    for (range, &blob_fd) in response.ranges.iter().zip(received_fds.iter()) {
+        // Calculate the faulting address:
+        // fault_addr = block_base + (block_offset - client_region_offset)
+        // where client_region_offset is typically 0 if the region was registered with offset=0
+        let fault_offset = range.block_offset - client_region_offset;
+        let fault_addr = (block_base as u64).wrapping_add(fault_offset);
+
+        unsafe {
+            libc::mmap(
+                fault_addr as *mut _,
+                range.len,
+                libc::PROT_READ,
+                libc::MAP_FIXED | libc::MAP_SHARED,
+                blob_fd,
+                range.blob_offset as _,
+            );
+        }
+    }
+}
+```
+
+**Note**: The `block_offset` in the response represents the absolute position within the block device. To calculate the target address for `mmap`:
+1. Compute the relative offset: `fault_offset = block_offset - client_region_offset`
+2. Add to the client's base address: `fault_addr = block_base + fault_offset`
+
+For clients that register their region with `offset=0` (the common case), `fault_offset` equals `block_offset` directly.
+
+## Builtin Mode
+
+In addition to the daemon mode (Unix socket server), `UffdCore` can be embedded directly into your application. This bypasses the socket protocol entirely — your code creates the userfaultfd, maps the region, and calls `UffdCore::handle_page_fault` in-process. No separate daemon, no socket protocol overhead.
+
+The following is a minimal Rust example demonstrating builtin mode with zerocopy:
+
+```rust
+use std::sync::Arc;
+use nydus_service::block_device::BlockDevice;
+use nydus_service::block_uffd::{
+    read_uffd_msg, uffdio_wake, PageFaultResult, UffdCore, UFFD_EVENT_PAGEFAULT,
+};
+use nydus_service::uffd_proto::{FaultPolicy, VmaRegion};
+
+// 1. Create BlockDevice from a RAFS v6 bootstrap
+let device = Arc::new(BlockDevice::new(entry)?);
+let device_size = device.blocks_to_size(device.blocks());
+let page_size: u64 = 2 * 1024 * 1024; // 2MB: UFFD fault resolution granularity
+
+// 2. After creating userfaultfd and mmap'ing an anonymous region at base_addr,
+//    register the VMA with the block device layout:
+let vma_regions = vec![VmaRegion::new(
+    base_addr as u64,       // start of the mmap region
+    device_size as usize,   // size in bytes
+    0,                      // offset within block device
+    page_size as usize,     // UFFD fault resolution granularity (chunk size per fault)
+)];
+
+// 3. Run the page fault event loop inside tokio_uring
+tokio_uring::start(async move {
+    let core = UffdCore::new(device);
+    loop {
+        let msg = match read_uffd_msg(uffd_fd) {
+            Ok(Some(m)) => m,
+            Ok(None) => continue,   // no event (EAGAIN)
+            Err(e) => break,
+        };
+        if msg.event != UFFD_EVENT_PAGEFAULT { continue; }
+
+        let result = core
+            .handle_page_fault(&msg, &vma_regions, FaultPolicy::Zerocopy, uffd_fd)
+            .await?;
+
+        match result {
+            PageFaultResult::Zerocopy(zr) => {
+                for (blob_fd, blob_offset, len, block_offset) in &zr.ranges {
+                    let target_addr = base_addr as u64 + block_offset - vma_regions[0].offset;
+                    // Map the blob directly at the faulting address
+                    unsafe {
+                        libc::mmap(
+                            target_addr as *mut _, *len, libc::PROT_READ,
+                            libc::MAP_SHARED | libc::MAP_FIXED, *blob_fd, *blob_offset as i64,
+                        );
+                    }
+                    // Wake the faulting thread
+                    uffdio_wake(uffd_fd, target_addr, *len as u64).await?;
+                }
+            }
+            PageFaultResult::Copy | PageFaultResult::Noop => {}
+        }
+    }
+});
+```
+
+**`FaultPolicy`** determines how page faults are resolved:
+
+| Policy | Behavior |
+|--------|----------|
+| `FaultPolicy::Zerocopy` | Returns blob fd + offset; the caller `mmap`s the blob directly and calls `uffdio_wake` |
+| `FaultPolicy::Copy` | Writes data into the faulting address via `UFFDIO_COPY`/`UFFDIO_ZEROPAGE`; no further action needed |
+
+**`PageFaultResult`** variants:
+
+| Variant | Description |
+|---------|-------------|
+| `Zerocopy` | `ranges: Vec<(RawFd, u64, usize, u64)>` — each tuple is `(blob_fd, blob_offset, len, block_offset)` |
+| `Copy` | Data already written by `UFFDIO_COPY` |
+| `Noop` | Address falls in a gap (hole); already zero-filled |
+
+## Build
+
+```bash
+# Build with UFFD support
+cargo build --release --bin nydusd --features block-uffd
+
+# Build with both virtiofs and UFFD support
+cargo build --release --bin nydusd --features virtiofs,block-uffd
+```
+
+## Testing
+
+### Smoke Tests
+
+```bash
+cd smoke && go test -v -run TestUffd ./tests/
+```
+
+## See Also
+
+- [nydusd](nydusd.md) — FUSE and virtiofs daemon modes
+- [nydus-image](nydus-image.md) — Building RAFS images

--- a/service/Cargo.toml
+++ b/service/Cargo.toml
@@ -12,14 +12,17 @@ resolver = "2"
 [dependencies]
 bytes = { version = "1", optional = true }
 dbs-allocator = { version = "0.1.1", optional = true }
+flume = "0.12"
 fuse-backend-rs = { workspace = true, features = ["persist"] }
 libc = "0.2"
 log = "0.4.8"
 mio = { version = "0.8", features = ["os-poll", "os-ext"] }
 nix = "0.24.0"
 rust-fsm = "0.6.0"
+sendfd = "0.4"
 serde = { version = "1.0.110", features = ["serde_derive", "rc"] }
 serde_json = "1.0.51"
+serde_repr = "0.1"
 thiserror = "1.0"
 time = { version = "0.3.14", features = ["serde-human-readable"] }
 tokio = { version = "1.24", features = ["macros"] }
@@ -60,5 +63,6 @@ virtiofs = [
 
 block-device = ["dbs-allocator", "tokio/fs"]
 block-nbd = ["block-device", "bytes"]
+block-uffd = ["block-device"]
 
 coco = ["fuse-backend-rs/fusedev", "nydus-storage/backend-registry"]

--- a/service/src/blob_cache.rs
+++ b/service/src/blob_cache.rs
@@ -486,12 +486,17 @@ impl MetaBlob {
     pub async fn async_read<T: IoBufMut>(&self, pos: u64, buf: T) -> (Result<usize>, T) {
         self.file.read_at(buf, pos).await
     }
+
+    pub fn file(&self) -> &File {
+        &self.file
+    }
 }
 
 /// Structure representing a cached data blob.
 pub struct DataBlob {
     blob_id: String,
     blob: Arc<dyn BlobCache>,
+    blob_info: Arc<BlobInfo>,
     file: File,
 }
 
@@ -499,6 +504,7 @@ impl DataBlob {
     /// Create a new instance of [DataBlob].
     pub fn new(config: &Arc<DataBlobConfig>) -> Result<Self> {
         let blob_id = config.blob_info().blob_id();
+        let blob_info = config.blob_info().clone();
         let blob = BLOB_FACTORY
             .new_blob_cache(config.config_v2(), &config.blob_info, "/")
             .inspect_err(|_e| {
@@ -516,6 +522,7 @@ impl DataBlob {
                 Ok(DataBlob {
                     blob_id,
                     blob,
+                    blob_info,
                     file,
                 })
             }
@@ -526,31 +533,48 @@ impl DataBlob {
         }
     }
 
-    /// Read data from the cached data blob in asynchronous mode.
-    pub async fn async_read<T: IoBufMut>(&self, pos: u64, buf: T) -> (Result<usize>, T) {
-        let len = buf.bytes_total() as u64;
+    /// Ensure a range of data is available in the local cache, downloading if necessary.
+    pub async fn async_fetch(&self, pos: u64, len: usize) -> Result<()> {
+        if len == 0 {
+            return Ok(());
+        }
+
         let blob = self.blob.clone();
         let blob_id = self.blob_id.clone();
 
         // Blocking thread pool is needed because reqwest::blocking may be called
-        match tokio::task::spawn_blocking(move || -> Result<()> {
+        tokio::task::spawn_blocking(move || -> Result<()> {
             let obj = blob.get_blob_object().ok_or_else(|| {
                 eio!(format!(
                     "blob_cache: failed to get BlobObject for blob {}",
                     blob_id
                 ))
             })?;
-            if len > 0 {
-                obj.fetch_range_uncompressed(pos, len)?;
-            }
-            Ok(())
+            obj.fetch_range_uncompressed(pos, len as u64)
         })
         .await
-        {
-            Ok(Ok(())) => self.file.read_at(buf, pos).await,
-            Ok(Err(e)) => (Err(e), buf),
-            Err(e) => (Err(eother!(format!("spawn_blocking join error: {e}"))), buf),
+        .map_err(|e| eother!(format!("spawn_blocking join error: {e}")))?
+    }
+
+    /// Read data from the cached data blob in asynchronous mode.
+    pub async fn async_read<T: IoBufMut>(&self, pos: u64, buf: T) -> (Result<usize>, T) {
+        let len = buf.bytes_total();
+        match self.async_fetch(pos, len).await {
+            Ok(()) => self.file.read_at(buf, pos).await,
+            Err(e) => (Err(e), buf),
         }
+    }
+
+    pub fn file(&self) -> &File {
+        &self.file
+    }
+
+    pub fn blob(&self) -> &Arc<dyn BlobCache> {
+        &self.blob
+    }
+
+    pub fn blob_info(&self) -> &Arc<BlobInfo> {
+        &self.blob_info
     }
 }
 
@@ -891,6 +915,121 @@ mod tests {
             assert_eq!(buf[1027], 0xe0);
             let (res, _buf) = meta_blob.async_read(0x6000, buf).await;
             assert_eq!(res.unwrap(), 0);
+        });
+    }
+
+    #[test]
+    fn test_meta_blob_file() {
+        use std::os::fd::AsRawFd;
+
+        let root_dir = &std::env::var("CARGO_MANIFEST_DIR").expect("$CARGO_MANIFEST_DIR");
+        let mut source_path = PathBuf::from(root_dir);
+        source_path.push("../tests/texture/bootstrap/rafs-v6-2.2.boot");
+
+        tokio_uring::start(async move {
+            let meta_blob = MetaBlob::new(&source_path).unwrap();
+            let file = meta_blob.file();
+            assert!(file.as_raw_fd() >= 0);
+        });
+    }
+
+    /// Helper to create a DataBlob from the test fixture bootstrap.
+    /// Returns (DataBlob, TempDir) — TempDir must be kept alive.
+    fn create_data_blob() -> (DataBlob, TempDir) {
+        use std::os::fd::AsRawFd;
+
+        let tmp_dir = TempDir::new().unwrap();
+        let root_dir = &std::env::var("CARGO_MANIFEST_DIR").expect("$CARGO_MANIFEST_DIR");
+
+        // Copy blob file to tmpdir
+        let mut blob_src = PathBuf::from(root_dir);
+        blob_src.push("../tests/texture/blobs/be7d77eeb719f70884758d1aa800ed0fb09d701aaec469964e9d54325f0d5fef");
+        let mut blob_dst = tmp_dir.as_path().to_path_buf();
+        blob_dst.push("be7d77eeb719f70884758d1aa800ed0fb09d701aaec469964e9d54325f0d5fef");
+        std::fs::copy(&blob_src, &blob_dst).unwrap();
+
+        let mut boot_path = PathBuf::from(root_dir);
+        boot_path.push("../tests/texture/bootstrap/rafs-v6-2.2.boot");
+
+        let config = r#"
+        {
+            "type": "bootstrap",
+            "id": "rafs-v6",
+            "domain_id": "domain-test",
+            "config_v2": {
+                "version": 2,
+                "id": "factory1",
+                "backend": {
+                    "type": "localfs",
+                    "localfs": { "dir": "/tmp/nydus" }
+                },
+                "cache": {
+                    "type": "filecache",
+                    "filecache": { "work_dir": "/tmp/nydus" }
+                },
+                "metadata_path": "BOOT_PATH"
+            }
+        }"#;
+        let content = config
+            .replace("/tmp/nydus", tmp_dir.as_path().to_str().unwrap())
+            .replace("BOOT_PATH", &boot_path.display().to_string());
+        let mut entry: BlobCacheEntry = serde_json::from_str(&content).unwrap();
+        assert!(entry.prepare_configuration_info());
+
+        let mgr = BlobCacheMgr::new();
+        mgr.add_blob_entry(&entry).unwrap();
+
+        let blob_key = generate_blob_key(
+            "domain-test",
+            "be7d77eeb719f70884758d1aa800ed0fb09d701aaec469964e9d54325f0d5fef",
+        );
+        let blob_config = mgr.get_config(&blob_key).unwrap();
+        let data_blob_config = match blob_config {
+            BlobConfig::DataBlob(c) => c,
+            _ => panic!("expected DataBlob config"),
+        };
+
+        let data_blob = DataBlob::new(&data_blob_config).unwrap();
+        assert!(data_blob.file().as_raw_fd() >= 0);
+        (data_blob, tmp_dir)
+    }
+
+    #[test]
+    fn test_data_blob_getters() {
+        use std::os::fd::AsRawFd;
+
+        let (data_blob, _tmp_dir) = create_data_blob();
+
+        assert!(data_blob.file().as_raw_fd() >= 0);
+        assert!(!data_blob.blob_info().blob_id().is_empty());
+        // blob() returns the BlobCache reference
+        let _ = data_blob.blob();
+    }
+
+    #[test]
+    fn test_data_blob_async_fetch_zero_len() {
+        let (data_blob, _tmp_dir) = create_data_blob();
+        tokio_uring::start(async move {
+            // len=0 should short-circuit with Ok(())
+            let res = data_blob.async_fetch(0, 0).await;
+            assert!(res.is_ok());
+        });
+    }
+
+    #[test]
+    fn test_data_blob_async_fetch_and_read() {
+        let (data_blob, _tmp_dir) = create_data_blob();
+        tokio_uring::start(async move {
+            // Normal fetch
+            let res = data_blob.async_fetch(0, 4096).await;
+            assert!(res.is_ok());
+
+            // Read after fetch
+            let buf = vec![0u8; 4096];
+            let (res, buf) = data_blob.async_read(0, buf).await;
+            assert_eq!(res.unwrap(), 4096);
+            // Verify we got actual data (not all zeros)
+            assert!(buf.iter().any(|&b| b != 0));
         });
     }
 }

--- a/service/src/blob_cache.rs
+++ b/service/src/blob_cache.rs
@@ -528,18 +528,28 @@ impl DataBlob {
 
     /// Read data from the cached data blob in asynchronous mode.
     pub async fn async_read<T: IoBufMut>(&self, pos: u64, buf: T) -> (Result<usize>, T) {
-        match self.blob.get_blob_object() {
-            Some(obj) => match obj.fetch_range_uncompressed(pos, buf.bytes_total() as u64) {
-                Ok(_) => self.file.read_at(buf, pos).await,
-                Err(e) => (Err(e), buf),
-            },
-            None => (
-                Err(eio!(format!(
+        let len = buf.bytes_total() as u64;
+        let blob = self.blob.clone();
+        let blob_id = self.blob_id.clone();
+
+        // Blocking thread pool is needed because reqwest::blocking may be called
+        match tokio::task::spawn_blocking(move || -> Result<()> {
+            let obj = blob.get_blob_object().ok_or_else(|| {
+                eio!(format!(
                     "blob_cache: failed to get BlobObject for blob {}",
-                    self.blob_id
-                ))),
-                buf,
-            ),
+                    blob_id
+                ))
+            })?;
+            if len > 0 {
+                obj.fetch_range_uncompressed(pos, len)?;
+            }
+            Ok(())
+        })
+        .await
+        {
+            Ok(Ok(())) => self.file.read_at(buf, pos).await,
+            Ok(Err(e)) => (Err(e), buf),
+            Err(e) => (Err(eother!(format!("spawn_blocking join error: {e}"))), buf),
         }
     }
 }

--- a/service/src/block_device.rs
+++ b/service/src/block_device.rs
@@ -14,6 +14,7 @@
 use std::cmp::{max, min};
 use std::fs::OpenOptions;
 use std::io::Result;
+use std::os::fd::{AsRawFd, RawFd};
 use std::path::PathBuf;
 use std::rc::Rc;
 use std::sync::{Arc, Mutex};
@@ -297,6 +298,140 @@ impl BlockDevice {
         }
 
         (Ok(total_size), buf)
+    }
+
+    /// Fetch block ranges (fd, offset, len, block_offset) for direct mmap access.
+    ///
+    /// Holes are always skipped (no data to return).
+    /// When `probe_only` is true, only ready chunks are returned.
+    pub async fn fetch_ranges(
+        &self,
+        mut start: u32,
+        mut blocks: u32,
+        probe_only: bool,
+    ) -> Result<Vec<(RawFd, u64, usize, u64)>> {
+        if start.checked_add(blocks).is_none() {
+            return Err(einval!(
+                "block_device: invalid parameters to fetch_ranges()"
+            ));
+        }
+
+        let mut ranges = Vec::new();
+        while blocks > 0 {
+            let (range, node) = match self.ranges.get_superset(&Range::new_point(start)) {
+                Some(v) => v,
+                None => {
+                    return Err(eio!(format!(
+                        "block_device: can not locate block 0x{:x} for meta blob {}",
+                        start, self.blob_id
+                    )));
+                }
+            };
+
+            if let NodeState::Valued(r) = node {
+                let count = min(range.max as u32 - start + 1, blocks);
+
+                match r {
+                    BlockRange::Hole => {
+                        // Skip holes - no data to return
+                    }
+                    BlockRange::MetaBlob(m) => {
+                        // Meta blob doesn't have chunk map, treat as fully ready
+                        let offset = self.blocks_to_size(start - range.min as u32);
+                        let sz = self.blocks_to_size(count) as usize;
+                        let block_offset = self.blocks_to_size(range.min as u32) + offset;
+                        ranges.push((m.file().as_raw_fd(), offset, sz, block_offset));
+                    }
+                    BlockRange::DataBlob(b) => {
+                        if probe_only {
+                            let data_ranges =
+                                self.probe_blob_ranges(b, start - range.min as u32, count)?;
+                            let fd = b.file().as_raw_fd();
+                            let base_offset = self.blocks_to_size(range.min as u32);
+                            for (blob_offset, blob_len) in data_ranges {
+                                ranges.push((fd, blob_offset, blob_len, base_offset + blob_offset));
+                            }
+                        } else {
+                            let offset = self.blocks_to_size(start - range.min as u32);
+                            let sz = self.blocks_to_size(count) as usize;
+                            b.async_fetch(offset, sz).await?;
+                            let block_offset = self.blocks_to_size(range.min as u32) + offset;
+                            ranges.push((b.file().as_raw_fd(), offset, sz, block_offset));
+                        }
+                    }
+                }
+
+                start += count;
+                blocks -= count;
+            } else {
+                return Err(eio!(format!(
+                    "block_device: block range 0x{:x}/0x{:x} of meta blob {} is unhandled",
+                    start, blocks, self.blob_id,
+                )));
+            }
+        }
+
+        Ok(ranges)
+    }
+
+    /// Probe ready ranges in a data blob.
+    fn probe_blob_ranges(
+        &self,
+        blob: &DataBlob,
+        start_block: u32,
+        num_blocks: u32,
+    ) -> Result<Vec<(u64, usize)>> {
+        let blob_info = blob.blob_info();
+        let chunk_size = blob_info.chunk_size() as u64;
+        let blob_size = blob_info.uncompressed_size();
+        let chunk_count = blob_info.chunk_count() as u64;
+
+        if chunk_size == 0 || chunk_count == 0 {
+            return Ok(Vec::new());
+        }
+
+        let byte_start = self.blocks_to_size(start_block);
+        let byte_end = self.blocks_to_size(start_block + num_blocks).min(blob_size);
+        let start_chunk = (byte_start / chunk_size) as u32;
+        let end_chunk = (byte_end.div_ceil(chunk_size)).min(chunk_count) as u32;
+
+        let blob_cache = blob.blob();
+        let chunk_map = blob_cache.get_chunk_map();
+
+        let mut ranges = Vec::new();
+        let mut range_start: Option<u32> = None;
+
+        for chunk_idx in start_chunk..end_chunk {
+            let is_ready = blob_cache
+                .get_chunk_info(chunk_idx)
+                .map(|c| chunk_map.is_ready(c.as_ref()).unwrap_or(false))
+                .unwrap_or(false);
+
+            match (range_start, is_ready) {
+                (Some(start), false) => {
+                    let blob_offset = start as u64 * chunk_size;
+                    let blob_len =
+                        ((chunk_idx as u64 * chunk_size).min(blob_size) - blob_offset) as usize;
+                    if blob_len > 0 {
+                        ranges.push((blob_offset, blob_len));
+                    }
+                    range_start = None;
+                }
+                (None, true) => range_start = Some(chunk_idx),
+                _ => {}
+            }
+        }
+
+        // Handle the last range
+        if let Some(start) = range_start {
+            let blob_offset = start as u64 * chunk_size;
+            let blob_len = ((end_chunk as u64 * chunk_size).min(blob_size) - blob_offset) as usize;
+            if blob_len > 0 {
+                ranges.push((blob_offset, blob_len));
+            }
+        }
+
+        Ok(ranges)
     }
 
     /// Export a RAFS filesystem as a raw block disk image.
@@ -671,6 +806,18 @@ mod tests {
         device
     }
 
+    /// Like `create_block_device` but also returns TempDir to keep blob files alive
+    /// during async operations (async_fetch accesses cache files by path).
+    fn create_block_device_with_tmpdir() -> (BlockDevice, TempDir) {
+        let tmp_dir = TempDir::new().unwrap();
+        let entry = create_bootstrap_entry(&tmp_dir);
+
+        let device = BlockDevice::new(entry).unwrap();
+        assert_eq!(device.blocks(), 0x209);
+
+        (device, tmp_dir)
+    }
+
     #[test]
     fn test_block_size() {
         let mut device = create_block_device();
@@ -759,5 +906,221 @@ mod tests {
     fn test_export() {
         assert!(test_export_arg_thread(1).is_ok());
         assert!(test_export_arg_thread(2).is_ok());
+    }
+
+    #[test]
+    fn test_fetch_ranges_invalid() {
+        let device = create_block_device();
+        tokio_uring::start(async move {
+            // Overflow check
+            let res = device.fetch_ranges(u32::MAX, u32::MAX, false).await;
+            assert!(res.is_err());
+        });
+    }
+
+    #[test]
+    fn test_fetch_ranges_out_of_range() {
+        let device = create_block_device();
+        tokio_uring::start(async move {
+            // Past device end
+            let res = device.fetch_ranges(0x20A, 1, false).await;
+            assert!(res.is_err());
+        });
+    }
+
+    #[test]
+    fn test_fetch_ranges_meta_blob() {
+        let device = create_block_device();
+        tokio_uring::start(async move {
+            // Block 0 is MetaBlob
+            let ranges = device.fetch_ranges(0, 1, false).await.unwrap();
+            assert!(!ranges.is_empty());
+            let (fd, _offset, sz, _block_offset) = &ranges[0];
+            assert!(*fd >= 0);
+            assert_eq!(*sz, 4096);
+
+            // Multiple MetaBlob blocks
+            let ranges = device.fetch_ranges(0, 5, false).await.unwrap();
+            assert!(!ranges.is_empty());
+            let (fd, _offset, sz, _block_offset) = &ranges[0];
+            assert!(*fd >= 0);
+            assert_eq!(*sz, 5 * 4096);
+        });
+    }
+
+    #[test]
+    fn test_fetch_ranges_meta_blob_probe() {
+        let device = create_block_device();
+        tokio_uring::start(async move {
+            // probe_only on MetaBlob should still return ranges (MetaBlob is always ready)
+            let ranges = device.fetch_ranges(0, 1, true).await.unwrap();
+            assert!(!ranges.is_empty());
+            let (fd, _offset, sz, _block_offset) = &ranges[0];
+            assert!(*fd >= 0);
+            assert_eq!(*sz, 4096);
+        });
+    }
+
+    #[test]
+    fn test_fetch_ranges_data_blob() {
+        let (device, _tmp_dir) = create_block_device_with_tmpdir();
+        tokio_uring::start(async move {
+            // Block 0x200 is DataBlob
+            let ranges = device.fetch_ranges(0x200, 2, false).await.unwrap();
+            assert!(!ranges.is_empty());
+            let (fd, _offset, sz, _block_offset) = &ranges[0];
+            assert!(*fd >= 0);
+            assert_eq!(*sz, 2 * 4096);
+        });
+    }
+
+    #[test]
+    fn test_fetch_ranges_data_blob_probe() {
+        let (device, _tmp_dir) = create_block_device_with_tmpdir();
+        tokio_uring::start(async move {
+            // probe_only on DataBlob exercises probe_blob_ranges
+            let ranges = device.fetch_ranges(0x200, 2, true).await.unwrap();
+            // May or may not have ready ranges depending on cache state,
+            // but should not error
+            for (fd, _offset, sz, _block_offset) in &ranges {
+                assert!(*fd >= 0);
+                assert!(*sz > 0);
+            }
+        });
+    }
+
+    #[test]
+    fn test_fetch_ranges_mixed() {
+        let (device, _tmp_dir) = create_block_device_with_tmpdir();
+        tokio_uring::start(async move {
+            // Span across MetaBlob + Hole: blocks 0-5+
+            // MetaBlob is blocks 0-4, after that is Hole until DataBlob
+            let ranges = device.fetch_ranges(0, 6, false).await.unwrap();
+            // Should have at least MetaBlob range; Hole is skipped
+            assert!(!ranges.is_empty());
+        });
+    }
+
+    #[test]
+    fn test_fetch_ranges_hole() {
+        let device = create_block_device();
+        tokio_uring::start(async move {
+            // Block 5 is in the hole region between MetaBlob and DataBlob
+            let ranges = device.fetch_ranges(5, 1, false).await.unwrap();
+            // Holes produce no ranges
+            assert!(ranges.is_empty());
+        });
+    }
+
+    #[test]
+    fn test_fetch_ranges_zero_blocks() {
+        let device = create_block_device();
+        tokio_uring::start(async move {
+            let ranges = device.fetch_ranges(0, 0, false).await.unwrap();
+            assert!(ranges.is_empty());
+        });
+    }
+
+    #[test]
+    fn test_fetch_ranges_meta_blob_offsets() {
+        let device = create_block_device();
+        tokio_uring::start(async move {
+            // Fetch blocks 2..5 from MetaBlob (blocks 0-4)
+            let ranges = device.fetch_ranges(2, 3, false).await.unwrap();
+            assert_eq!(ranges.len(), 1);
+            let (fd, offset, sz, block_offset) = &ranges[0];
+            assert!(*fd >= 0);
+            assert_eq!(*offset, 2 * 4096);
+            assert_eq!(*sz, 3 * 4096);
+            assert_eq!(*block_offset, 2 * 4096);
+        });
+    }
+
+    #[test]
+    fn test_fetch_ranges_data_blob_offsets() {
+        let (device, _tmp_dir) = create_block_device_with_tmpdir();
+        tokio_uring::start(async move {
+            // Block 0x200 is the start of DataBlob region
+            let ranges = device.fetch_ranges(0x200, 1, false).await.unwrap();
+            assert_eq!(ranges.len(), 1);
+            let (_fd, offset, sz, block_offset) = &ranges[0];
+            assert_eq!(*sz, 4096);
+            assert_eq!(*block_offset, 0x200u64 * 4096);
+            // offset is relative to the DataBlob range start
+            assert_eq!(*offset, 0);
+        });
+    }
+
+    #[test]
+    fn test_fetch_ranges_probe_after_fetch() {
+        let (device, _tmp_dir) = create_block_device_with_tmpdir();
+        tokio_uring::start(async move {
+            // First fetch to populate cache (makes chunks ready)
+            let ranges = device.fetch_ranges(0x200, 2, false).await.unwrap();
+            assert!(!ranges.is_empty());
+
+            // Now probe — chunks should be ready, exercising:
+            // - (None, true) branch in probe_blob_ranges
+            // - last-range closing logic
+            let probe_ranges = device.fetch_ranges(0x200, 2, true).await.unwrap();
+            assert!(!probe_ranges.is_empty());
+            for (fd, _offset, sz, _block_offset) in &probe_ranges {
+                assert!(*fd >= 0);
+                assert!(*sz > 0);
+            }
+        });
+    }
+
+    #[test]
+    fn test_fetch_ranges_probe_cold() {
+        let (device, _tmp_dir) = create_block_device_with_tmpdir();
+        tokio_uring::start(async move {
+            // Probe without prior fetch — no chunks ready
+            let ranges = device.fetch_ranges(0x200, 2, true).await.unwrap();
+            // Empty or partial depending on cache state
+            // This exercises the (None, false) -> _ => {} branch
+            let _ = ranges;
+        });
+    }
+
+    #[test]
+    fn test_fetch_ranges_probe_mixed_ready() {
+        let (device, _tmp_dir) = create_block_device_with_tmpdir();
+        tokio_uring::start(async move {
+            // Fetch only 1 block to make some chunks ready
+            let _ = device.fetch_ranges(0x200, 1, false).await.unwrap();
+
+            // Probe 2 blocks — first block's chunks ready, second not yet
+            // Exercises (Some(start), false) transition in probe_blob_ranges
+            let ranges = device.fetch_ranges(0x200, 2, true).await.unwrap();
+            // Should have at least the ready range
+            for (fd, _offset, sz, _block_offset) in &ranges {
+                assert!(*fd >= 0);
+                assert!(*sz > 0);
+            }
+        });
+    }
+
+    #[test]
+    fn test_async_read_zero_buf() {
+        let (device, _tmp_dir) = create_block_device_with_tmpdir();
+        tokio_uring::start(async move {
+            // Zero-length read triggers async_fetch(pos, 0) short-circuit
+            let buf = vec![0u8; 0];
+            let (res, _buf) = device.async_read(0x200, 0, buf).await;
+            assert_eq!(res.unwrap(), 0);
+        });
+    }
+
+    #[test]
+    fn test_async_read_data_blob() {
+        let (device, _tmp_dir) = create_block_device_with_tmpdir();
+        tokio_uring::start(async move {
+            // Read from DataBlob — exercises async_fetch normal path
+            // and async_read Ok branch in blob_cache.rs
+            let buf = vec![0u8; 4096];
+            let (res, _buf) = device.async_read(0x200, 1, buf).await;
+            assert_eq!(res.unwrap(), 4096);
+        });
     }
 }

--- a/service/src/block_uffd.rs
+++ b/service/src/block_uffd.rs
@@ -1,0 +1,2571 @@
+// Copyright (C) 2026 Ant Group. All rights reserved.
+//
+// SPDX-License-Identifier: (Apache-2.0)
+
+//! Export a RAFSv6 image as a block device through userfaultfd (uffd) protocol.
+//!
+//! The UffdService provides a way to handle page faults for a RAFSv6 image via
+//! userfaultfd. Clients connect to the unix socket and send:
+//! - uffd file descriptor (via SCM_RIGHTS)
+//! - VMA (Virtual Memory Area) information about the memory region to monitor
+//!
+//! When a page fault occurs, the service responds with blob fds and range metadata
+//! (len, blob_offset, block_offset) so the client can mmap the data directly (zero-copy).
+//!
+//! This module provides two integration modes:
+//!
+//! **Daemon mode** (`UffdService` / `UffdDaemon`): A standalone Unix-domain-socket
+//! server. Clients connect, send a uffd fd + VMA regions via SCM_RIGHTS, and the
+//! server resolves page faults asynchronously over the socket.
+//!
+//! **Builtin mode** (`UffdCore`): An embeddable library. The consumer creates the
+//! userfaultfd, mmaps the region, and calls `UffdCore::handle_page_fault` directly
+//! in-process — no socket, no protocol overhead.
+//!
+//! Protocol (JSON + fd format, Firecracker compatible):
+//! - [Handshake] JSON HandshakeRequest + SCM_RIGHTS (uffd fds)
+//! - [Page Fault Response] JSON PageFaultResponse + SCM_RIGHTS (blob fds)
+//! - [Stat Request] JSON StatRequest
+//! - [Stat Response] JSON StatResponse
+
+use std::any::Any;
+use std::io::{Error, Result};
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
+use std::os::unix::net::UnixListener;
+use std::os::unix::net::UnixStream as StdUnixStream;
+use std::sync::atomic::{AtomicBool, AtomicI32, Ordering};
+use std::sync::{Arc, Mutex};
+use std::thread::JoinHandle;
+
+use flume;
+use mio::Waker;
+use nydus_api::{BlobCacheEntry, BuildTimeInfo};
+use nydus_storage::utils::alloc_buf;
+use sendfd::{RecvWithFd, SendWithFd};
+use tokio::io::unix::AsyncFd;
+use tokio::sync::broadcast::Sender;
+use tokio::task::spawn_blocking;
+
+use crate::blob_cache::{generate_blob_key, BlobCacheMgr};
+use crate::block_device::BlockDevice;
+use crate::daemon::{
+    DaemonState, DaemonStateMachineContext, DaemonStateMachineInput, DaemonStateMachineSubscriber,
+    NydusDaemon,
+};
+use crate::{Error as NydusError, Result as NydusResult};
+
+use super::uffd_proto::*;
+
+// ---------------------------------------------------------------------------
+// UFFD kernel ABI constants
+// ---------------------------------------------------------------------------
+
+/// UFFD event type for page fault (from linux/userfaultfd.h).
+pub const UFFD_EVENT_PAGEFAULT: u8 = 0x12;
+
+/// Maximum number of ranges (and fds) per message.
+const MAX_RANGES_PER_MSG: usize = 16;
+
+/// Maximum receive buffer size for socket messages.
+const RECV_BUF_SIZE: usize = 4096;
+
+// UFFDIO ioctl definitions (from linux/userfaultfd.h).
+pub(crate) const UFFDIO_COPY: libc::Ioctl = 0xc028aa03u32 as libc::Ioctl;
+pub(crate) const UFFDIO_ZEROPAGE: libc::Ioctl = 0xc020aa04u32 as libc::Ioctl;
+#[allow(dead_code)]
+pub(crate) const UFFDIO_WAKE: libc::Ioctl = 0x8010aa02u32 as libc::Ioctl;
+
+// ---------------------------------------------------------------------------
+// Kernel ABI structs
+// ---------------------------------------------------------------------------
+
+/// Kernel uffd_msg struct layout (from linux/userfaultfd.h).
+#[repr(C)]
+pub struct UffdMsg {
+    pub event: u8,
+    _reserved1: [u8; 3],
+    _reserved2: u32,
+    /// Union field for UFFD_EVENT_PAGEFAULT
+    pub pagefault: UffdPagefault,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub struct UffdPagefault {
+    pub flags: u64,
+    pub address: u64,
+    pub feat: u64,
+}
+
+#[repr(C)]
+pub(crate) struct UffdioCopy {
+    dst: u64,
+    src: u64,
+    len: u64,
+    mode: u64,
+    copy: i64,
+}
+
+#[repr(C)]
+pub(crate) struct UffdioZeropage {
+    range_start: u64,
+    range_len: u64,
+    mode: u64,
+    zeropage: i64,
+}
+
+// ---------------------------------------------------------------------------
+// Result types
+// ---------------------------------------------------------------------------
+
+/// Result of resolving a zerocopy page fault.
+/// Data ranges must be delivered by the caller (socket for daemon, mmap for builtin).
+/// Holes have already been zeroed via UFFDIO_ZEROPAGE.
+#[derive(Debug)]
+pub struct ZerocopyResult {
+    /// (blob_fd, blob_offset, len, block_offset)
+    pub ranges: Vec<(RawFd, u64, usize, u64)>,
+}
+
+/// Result of handling a single uffd page fault event.
+#[derive(Debug)]
+pub enum PageFaultResult {
+    /// Zerocopy: data ranges need delivery by the caller.
+    Zerocopy(ZerocopyResult),
+    /// Copy: UFFDIO_COPY already performed.
+    Copy,
+    /// Not a page-fault event, or address not in any VMA region.
+    Noop,
+}
+
+// ---------------------------------------------------------------------------
+// Low-level UFFDIO functions
+// ---------------------------------------------------------------------------
+
+/// Read a `uffd_msg` from a non-blocking uffd fd.
+/// Returns `Ok(None)` if no event is available (WouldBlock).
+/// Returns `Ok(Some(msg))` on successful read.
+pub fn read_uffd_msg(uffd_fd: RawFd) -> Result<Option<UffdMsg>> {
+    let mut msg = std::mem::MaybeUninit::<UffdMsg>::uninit();
+    let n = unsafe {
+        libc::read(
+            uffd_fd,
+            msg.as_mut_ptr() as *mut libc::c_void,
+            std::mem::size_of::<UffdMsg>(),
+        )
+    };
+
+    if n < 0 {
+        let err = std::io::Error::last_os_error();
+        if err.kind() == std::io::ErrorKind::WouldBlock {
+            return Ok(None);
+        }
+        return Err(eother!(format!("uffd read failed: {}", err)));
+    }
+    if (n as usize) < std::mem::size_of::<UffdMsg>() {
+        return Err(eother!(format!("uffd short read: {n} bytes")));
+    }
+
+    Ok(Some(unsafe { msg.assume_init() }))
+}
+
+/// Perform UFFDIO_ZEROPAGE ioctl asynchronously.
+pub async fn uffdio_zeropage(uffd_fd: RawFd, start_addr: u64, len: u64) -> Result<()> {
+    spawn_blocking(move || {
+        let mut ioctl_arg = UffdioZeropage {
+            range_start: start_addr,
+            range_len: len,
+            mode: 0,
+            zeropage: 0,
+        };
+        let ret = unsafe { libc::ioctl(uffd_fd, UFFDIO_ZEROPAGE, &mut ioctl_arg) };
+        if ret < 0 {
+            let err = std::io::Error::last_os_error();
+            if err.raw_os_error() == Some(libc::EEXIST) {
+                return Ok(());
+            }
+            return Err(eother!(format!("UFFDIO_ZEROPAGE failed: {}", err)));
+        }
+        Ok(())
+    })
+    .await
+    .map_err(|e| eother!(format!("join error: {e}")))?
+}
+
+/// Perform UFFDIO_COPY ioctl asynchronously.
+/// `buf` holds the source data; ownership is transferred to ensure the buffer
+/// lives until the ioctl completes inside `spawn_blocking`.
+pub async fn uffdio_copy(uffd_fd: RawFd, dst: u64, buf: Vec<u8>, len: u64) -> Result<()> {
+    spawn_blocking(move || {
+        let src = buf.as_ptr() as u64;
+        let mut ioctl_arg = UffdioCopy {
+            dst,
+            src,
+            len,
+            mode: 0,
+            copy: 0,
+        };
+        let ret = unsafe { libc::ioctl(uffd_fd, UFFDIO_COPY, &mut ioctl_arg) };
+        if ret < 0 {
+            return Err(eother!(format!(
+                "UFFDIO_COPY failed: {}",
+                std::io::Error::last_os_error()
+            )));
+        }
+        Ok(())
+    })
+    .await
+    .map_err(|e| eother!(format!("join error: {e}")))?
+}
+
+/// Perform UFFDIO_WAKE ioctl asynchronously.
+#[allow(dead_code)]
+pub async fn uffdio_wake(uffd_fd: RawFd, start_addr: u64, len: u64) -> Result<()> {
+    spawn_blocking(move || {
+        #[repr(C)]
+        struct UffdioRange {
+            start: u64,
+            len: u64,
+        }
+        let mut range = UffdioRange {
+            start: start_addr,
+            len,
+        };
+        let ret = unsafe { libc::ioctl(uffd_fd, UFFDIO_WAKE, &mut range) };
+        if ret < 0 {
+            let err = std::io::Error::last_os_error();
+            if err.raw_os_error() == Some(libc::EEXIST) {
+                return Ok(());
+            }
+            return Err(eother!(format!("UFFDIO_WAKE failed: {}", err)));
+        }
+        Ok(())
+    })
+    .await
+    .map_err(|e| eother!(format!("join error: {e}")))?
+}
+
+// ---------------------------------------------------------------------------
+// UffdCore — page fault resolution engine
+// ---------------------------------------------------------------------------
+
+/// Core UFFD page fault resolution engine.
+///
+/// Holds a `BlockDevice` reference and provides methods to resolve page faults.
+/// Must be used within a tokio_uring runtime (BlockDevice is !Send).
+pub struct UffdCore {
+    device: Arc<BlockDevice>,
+    device_size: u64,
+    block_size: u64,
+}
+
+impl UffdCore {
+    pub fn new(device: Arc<BlockDevice>) -> Self {
+        let device_size = device.blocks_to_size(device.blocks());
+        let block_size = device.block_size();
+        UffdCore {
+            device,
+            device_size,
+            block_size,
+        }
+    }
+
+    /// Access the underlying BlockDevice.
+    pub fn device(&self) -> &Arc<BlockDevice> {
+        &self.device
+    }
+
+    /// Handle a single uffd page fault event.
+    ///
+    /// - Copy policy: performs UFFDIO_COPY directly.
+    /// - Zerocopy policy: zeroes holes via UFFDIO_ZEROPAGE, returns data ranges
+    ///   for the caller to deliver.
+    /// - Beyond-device regions: zeroed via UFFDIO_ZEROPAGE.
+    pub async fn handle_page_fault(
+        &self,
+        msg: &UffdMsg,
+        vma_regions: &[VmaRegion],
+        policy: FaultPolicy,
+        uffd_fd: RawFd,
+    ) -> Result<PageFaultResult> {
+        if msg.event != UFFD_EVENT_PAGEFAULT {
+            warn!("uffd_core: unexpected uffd event: {}", msg.event);
+            return Ok(PageFaultResult::Noop);
+        }
+
+        let fault_addr = msg.pagefault.address;
+        debug!(
+            "uffd_core: page fault at 0x{:x}, policy {:?}",
+            fault_addr, policy
+        );
+
+        let vma_region = match vma_regions.iter().find(|v| {
+            fault_addr >= v.base_host_virt_addr
+                && fault_addr < v.base_host_virt_addr + v.size as u64
+        }) {
+            Some(v) => v,
+            None => {
+                warn!("uffd_core: fault addr 0x{:x} not in any VMA", fault_addr);
+                return Ok(PageFaultResult::Noop);
+            }
+        };
+
+        let fetch_size = vma_region.page_size as u64;
+        let fault_block_offset = vma_region.offset + (fault_addr - vma_region.base_host_virt_addr);
+        let region_offset_end = vma_region.offset + vma_region.size as u64;
+        let aligned_start = (fault_block_offset / fetch_size) * fetch_size;
+        let fetch_start = std::cmp::max(aligned_start, vma_region.offset);
+        let fetch_end = std::cmp::min(fetch_start + fetch_size, region_offset_end);
+
+        // Handle range beyond device bounds with UFFDIO_ZEROPAGE.
+        if fetch_end > self.device_size {
+            let zero_start = std::cmp::max(fetch_start, self.device_size);
+            let zero_len = fetch_end - zero_start;
+            let zero_addr = vma_region.base_host_virt_addr + (zero_start - vma_region.offset);
+            uffdio_zeropage(uffd_fd, zero_addr, zero_len).await?;
+        }
+
+        match policy {
+            FaultPolicy::Zerocopy => {
+                let mut all_ranges: Vec<(RawFd, u64, usize, u64)> = Vec::new();
+
+                if fetch_start < self.device_size {
+                    let data_end = std::cmp::min(fetch_end, self.device_size);
+                    let data_len = data_end - fetch_start;
+                    let result = self
+                        .resolve_zerocopy_ranges(fetch_start, data_len, vma_region, uffd_fd)
+                        .await?;
+                    all_ranges.extend(result.ranges);
+                }
+
+                Ok(PageFaultResult::Zerocopy(ZerocopyResult {
+                    ranges: all_ranges,
+                }))
+            }
+            FaultPolicy::Copy => {
+                if fetch_start < self.device_size {
+                    let data_end = std::cmp::min(fetch_end, self.device_size);
+                    let data_len = data_end - fetch_start;
+                    let data_addr =
+                        vma_region.base_host_virt_addr + (fetch_start - vma_region.offset);
+                    self.resolve_copy(fetch_start, data_len, data_addr, uffd_fd)
+                        .await?;
+                }
+
+                Ok(PageFaultResult::Copy)
+            }
+        }
+    }
+
+    /// Resolve zerocopy ranges for a sub-range within device bounds.
+    pub async fn resolve_zerocopy_ranges(
+        &self,
+        block_offset: u64,
+        len: u64,
+        vma_region: &VmaRegion,
+        uffd_fd: RawFd,
+    ) -> Result<ZerocopyResult> {
+        let start_block = (block_offset / self.block_size) as u32;
+        let num_blocks = len.div_ceil(self.block_size) as u32;
+        let ranges = self
+            .device
+            .fetch_ranges(start_block, num_blocks, false)
+            .await?;
+
+        if ranges.is_empty() {
+            let target_addr = vma_region.base_host_virt_addr + (block_offset - vma_region.offset);
+            uffdio_zeropage(uffd_fd, target_addr, len).await?;
+            return Ok(ZerocopyResult { ranges: Vec::new() });
+        }
+
+        let mut current_offset = block_offset;
+        let end_offset = block_offset + len;
+        let mut data_ranges: Vec<(RawFd, u64, usize, u64)> = Vec::new();
+
+        for (blob_fd, blob_offset, blob_len, range_offset) in ranges {
+            if range_offset > current_offset {
+                let hole_len = range_offset - current_offset;
+                let target_addr =
+                    vma_region.base_host_virt_addr + (current_offset - vma_region.offset);
+                uffdio_zeropage(uffd_fd, target_addr, hole_len).await?;
+            }
+
+            if blob_len > 0 && range_offset < end_offset {
+                let actual_len =
+                    std::cmp::min(range_offset + blob_len as u64, end_offset) - range_offset;
+                data_ranges.push((blob_fd, blob_offset, actual_len as usize, range_offset));
+                current_offset = range_offset + actual_len;
+            }
+        }
+
+        if current_offset < end_offset {
+            let hole_len = end_offset - current_offset;
+            let target_addr = vma_region.base_host_virt_addr + (current_offset - vma_region.offset);
+            uffdio_zeropage(uffd_fd, target_addr, hole_len).await?;
+        }
+
+        Ok(ZerocopyResult {
+            ranges: data_ranges,
+        })
+    }
+
+    /// Resolve a range using copy mode: async_read + UFFDIO_COPY.
+    pub async fn resolve_copy(
+        &self,
+        block_offset: u64,
+        len: u64,
+        target_addr: u64,
+        uffd_fd: RawFd,
+    ) -> Result<()> {
+        let start_block = (block_offset / self.block_size) as u32;
+        let num_blocks = len.div_ceil(self.block_size) as u32;
+
+        let read_len = num_blocks as usize * self.block_size as usize;
+        let buf = alloc_buf(read_len);
+        let (res, buf) = self.device.async_read(start_block, num_blocks, buf).await;
+        let bytes_read = res.map_err(|e| eother!(format!("async_read failed: {}", e)))?;
+        if bytes_read != read_len {
+            return Err(eother!(format!(
+                "read {} bytes, expected {}",
+                bytes_read, read_len
+            )));
+        }
+
+        uffdio_copy(uffd_fd, target_addr, buf, len).await
+    }
+
+    /// Probe already-cached ranges for prefaulting (probe_only=true).
+    pub async fn prefault_ranges(
+        &self,
+        vma_regions: &[VmaRegion],
+    ) -> Result<Vec<(RawFd, u64, usize, u64)>> {
+        let mut all_ranges: Vec<(RawFd, u64, usize, u64)> = Vec::new();
+
+        for vma_region in vma_regions.iter() {
+            let region_start = vma_region.offset;
+            let region_end = vma_region.offset + vma_region.size as u64;
+            if region_start >= self.device_size {
+                continue;
+            }
+
+            let effective_end = std::cmp::min(region_end, self.device_size);
+            let start_block = (region_start / self.block_size) as u32;
+            let num_blocks = (effective_end - region_start).div_ceil(self.block_size) as u32;
+
+            let ranges = match self
+                .device
+                .fetch_ranges(start_block, num_blocks, true)
+                .await
+            {
+                Ok(r) => r,
+                Err(e) => {
+                    warn!("uffd_core: pre-fault fetch_ranges failed: {}", e);
+                    continue;
+                }
+            };
+
+            for (blob_fd, blob_offset, blob_len, block_offset) in ranges {
+                if blob_len == 0 {
+                    continue;
+                }
+                all_ranges.push((blob_fd, blob_offset, blob_len, block_offset));
+            }
+        }
+
+        Ok(all_ranges)
+    }
+}
+
+/// Connection state after handshake.
+struct ConnState {
+    vma_regions: Vec<VmaRegion>,
+    policy: FaultPolicy,
+    uffd_async: AsyncFd<OwnedFd>,
+}
+
+/// A worker to handle uffd connections in asynchronous mode.
+struct UffdWorker {
+    active: Arc<AtomicBool>,
+    active_conns: Arc<Mutex<Vec<RawFd>>>,
+    blob_id: String,
+    cache_mgr: Arc<BlobCacheMgr>,
+    conn_receiver: flume::Receiver<StdUnixStream>,
+    sender: Arc<Sender<u32>>,
+    name: String,
+}
+
+// BlockDevice uses tokio-uring (single-threaded) and is not Send+Sync,
+// but Arc is needed for sharing across async tasks within the same thread.
+#[allow(clippy::arc_with_non_send_sync)]
+impl UffdWorker {
+    async fn run(self) {
+        info!("block_uffd: worker {} start", self.name);
+
+        let device =
+            match BlockDevice::new_with_cache_manager(self.blob_id.clone(), self.cache_mgr.clone())
+            {
+                Ok(v) => Arc::new(v),
+                Err(e) => {
+                    error!(
+                        "block_uffd: worker {} failed to create block device: {}",
+                        self.name, e
+                    );
+                    return;
+                }
+            };
+
+        let mut receiver = self.sender.subscribe();
+        loop {
+            if !self.active.load(Ordering::Acquire) {
+                break;
+            }
+            tokio::select! {
+                Ok(stream) = self.conn_receiver.recv_async() => {
+                    stream.set_nonblocking(true).expect("failed to set nonblocking");
+                    let active = self.active.clone();
+                    let active_conns = self.active_conns.clone();
+                    let device = device.clone();
+                    let sender = self.sender.clone();
+                    tokio_uring::spawn(async move {
+                        if let Err(e) = Self::handle_conn(active, active_conns, device, stream, sender).await {
+                            warn!("block_uffd: connection handler exited with error: {e}");
+                        }
+                    });
+                }
+                _ = receiver.recv() => break,
+            }
+        }
+
+        info!("block_uffd: worker {} exit!", self.name);
+    }
+
+    /// Run the event loop to handle uffd requests in asynchronous mode.
+    async fn handle_conn(
+        active: Arc<AtomicBool>,
+        active_conns: Arc<Mutex<Vec<RawFd>>>,
+        device: Arc<BlockDevice>,
+        stream: StdUnixStream,
+        sender: Arc<Sender<u32>>,
+    ) -> Result<()> {
+        let fd = stream.as_raw_fd();
+        info!("block_uffd: conn {} start!", fd);
+
+        // Register fd so stop() can shutdown this socket.
+        active_conns.lock().unwrap().push(fd);
+
+        let sock_async = AsyncFd::new(stream)
+            .map_err(|e| eother!(format!("Failed to create AsyncFd for sock: {}", e)))?;
+
+        let mut receiver = sender.subscribe();
+        let device_size = device.blocks_to_size(device.blocks());
+        let block_size = device.block_size();
+        let core = UffdCore::new(device);
+        let mut conn_state: Option<ConnState> = None;
+        while active.load(Ordering::Acquire) {
+            tokio::select! {
+                res = sock_async.readable() => {
+                    let mut guard = res.map_err(|e| eother!(format!("sock readable: {e}")))?;
+                    let msg = Self::try_recv_from_sock(guard.get_inner());
+                    guard.clear_ready();
+                    match msg {
+                        Ok(None) => continue,
+                        Err(e) => {
+                            warn!("block_uffd: sock recv error: {e}");
+                            break;
+                        }
+                        Ok(Some((json_val, fds, msg_type))) => {
+                            Self::dispatch_message(
+                                msg_type, json_val, &fds,
+                                &sock_async, &core, &mut conn_state,
+                                device_size, block_size,
+                            ).await?;
+                        }
+                    }
+                }
+
+                res = async {
+                    if let Some(ref state) = conn_state {
+                        state.uffd_async.readable().await
+                    } else {
+                        std::future::pending().await
+                    }
+                } => {
+                    let mut guard = res.map_err(|e| eother!(format!("uffd readable: {e}")))?;
+                    let state = conn_state.as_ref().unwrap();
+                    if let Err(e) = Self::handle_uffd_event(state, &core, &sock_async).await {
+                        warn!("block_uffd: failed to handle page fault: {e}");
+                    }
+                    guard.clear_ready();
+                }
+
+                _ = receiver.recv() => {
+                    info!("block_uffd: conn receive exit signal");
+                    break;
+                }
+            }
+        }
+
+        // Unregister fd.
+        active_conns.lock().unwrap().retain(|&f| f != fd);
+        info!("block_uffd: conn {} exit!", fd);
+
+        Ok(())
+    }
+
+    /// Dispatch a received message by type.
+    #[allow(clippy::too_many_arguments)]
+    async fn dispatch_message(
+        msg_type: MessageType,
+        json_val: serde_json::Value,
+        fds: &[RawFd],
+        sock_async: &AsyncFd<StdUnixStream>,
+        core: &UffdCore,
+        conn_state: &mut Option<ConnState>,
+        device_size: u64,
+        block_size: u64,
+    ) -> Result<()> {
+        match msg_type {
+            MessageType::Handshake => {
+                if conn_state.is_some() {
+                    warn!("block_uffd: received handshake but already handshaked");
+                    return Ok(());
+                }
+                *conn_state = Some(Self::handle_handshake(json_val, fds, sock_async, core)?);
+            }
+            MessageType::Stat => {
+                Self::handle_stat_request(sock_async, device_size, block_size).await?;
+            }
+            other => {
+                warn!("block_uffd: unexpected message type: {other:?}");
+            }
+        }
+        Ok(())
+    }
+
+    /// Handle handshake request from client. Returns ConnState on success.
+    /// Also accepts Firecracker-compatible bare array of regions.
+    fn handle_handshake(
+        json_val: serde_json::Value,
+        fds: &[RawFd],
+        sock_async: &AsyncFd<StdUnixStream>,
+        core: &UffdCore,
+    ) -> Result<ConnState> {
+        let request: HandshakeRequest = if json_val.is_array() {
+            // Firecracker-compatible: bare array of regions, all defaults
+            let regions: Vec<VmaRegion> = serde_json::from_value(json_val)
+                .map_err(|e| eother!(format!("Invalid region array: {}", e)))?;
+            HandshakeRequest {
+                r#type: MessageType::Handshake,
+                regions,
+                policy: FaultPolicy::default(),
+                enable_prefault: false,
+            }
+        } else {
+            serde_json::from_value(json_val)
+                .map_err(|e| eother!(format!("Invalid HandshakeRequest: {}", e)))?
+        };
+
+        info!(
+            "block_uffd: handshake successful, {} regions, {} uffd fds, policy {:?}, enable_prefault={}",
+            request.regions.len(), fds.len(), request.policy, request.enable_prefault
+        );
+
+        let fd = fds
+            .first()
+            .copied()
+            .ok_or_else(|| eother!("No uffd fd received during handshake"))?;
+
+        // Close extra fds beyond the first one
+        for &extra_fd in &fds[1..] {
+            unsafe { libc::close(extra_fd) };
+        }
+
+        // Set uffd fd to non-blocking mode
+        let flags = unsafe { libc::fcntl(fd, libc::F_GETFL, 0) };
+        if flags < 0 {
+            unsafe { libc::close(fd) };
+            return Err(std::io::Error::last_os_error());
+        }
+        if unsafe { libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) } < 0 {
+            let err = std::io::Error::last_os_error();
+            unsafe { libc::close(fd) };
+            return Err(err);
+        }
+
+        let owned_fd = unsafe { OwnedFd::from_raw_fd(fd) };
+        let uffd_async = AsyncFd::new(owned_fd)
+            .map_err(|e| eother!(format!("Failed to create AsyncFd for uffd: {}", e)))?;
+        let state = ConnState {
+            vma_regions: request.regions.clone(),
+            policy: request.policy,
+            uffd_async,
+        };
+
+        // Spawn pre-fault task if enabled and policy is zerocopy
+        if request.enable_prefault && request.policy == FaultPolicy::Zerocopy {
+            let stream_prefault = sock_async
+                .get_ref()
+                .try_clone()
+                .map_err(|e| eother!(format!("Failed to clone stream for prefault: {}", e)))?;
+            stream_prefault
+                .set_nonblocking(true)
+                .expect("failed to set nonblocking");
+
+            let device_prefault = core.device().clone();
+            let regions_prefault = request.regions;
+            tokio_uring::spawn(async move {
+                if let Err(e) =
+                    Self::do_prefault(device_prefault, stream_prefault, regions_prefault).await
+                {
+                    warn!("block_uffd: pre-fault task error: {}", e);
+                }
+            });
+        }
+
+        Ok(state)
+    }
+
+    /// Handle stat request from client.
+    async fn handle_stat_request(
+        sock_async: &AsyncFd<StdUnixStream>,
+        device_size: u64,
+        block_size: u64,
+    ) -> Result<()> {
+        let response = StatResponse::new(device_size, block_size as u32, 0, UFFD_PROTOCOL_VERSION);
+        let json_data = serde_json::to_vec(&response)
+            .map_err(|e| eother!(format!("Failed to serialize StatResponse: {}", e)))?;
+        Self::async_send_with_fd(sock_async, &json_data, &[]).await
+    }
+
+    /// Handle uffd page fault event.
+    async fn handle_uffd_event(
+        state: &ConnState,
+        core: &UffdCore,
+        sock_async: &AsyncFd<StdUnixStream>,
+    ) -> Result<()> {
+        let uffd_fd = state.uffd_async.get_ref().as_raw_fd();
+        let msg = match read_uffd_msg(uffd_fd)? {
+            Some(m) => m,
+            None => return Ok(()),
+        };
+
+        let result = core
+            .handle_page_fault(&msg, &state.vma_regions, state.policy, uffd_fd)
+            .await?;
+
+        match result {
+            PageFaultResult::Zerocopy(zr) => {
+                for chunk in zr.ranges.chunks(MAX_RANGES_PER_MSG) {
+                    Self::send_batch_response(sock_async, chunk).await?;
+                }
+            }
+            PageFaultResult::Copy | PageFaultResult::Noop => {}
+        }
+
+        Ok(())
+    }
+
+    fn close_fds(fds: &[i32]) {
+        for &fd in fds {
+            unsafe {
+                libc::close(fd);
+            }
+        }
+    }
+
+    /// Try to receive a message from sock (non-blocking).
+    /// Returns parsed JSON Value, received fds, and inferred message type.
+    fn try_recv_from_sock(
+        sock: &StdUnixStream,
+    ) -> Result<Option<(serde_json::Value, Vec<RawFd>, MessageType)>> {
+        let mut data_buf = [0u8; RECV_BUF_SIZE];
+        let mut fds = [0i32; MAX_RANGES_PER_MSG];
+        match sock.recv_with_fd(&mut data_buf, &mut fds) {
+            Ok((bytes_read, fd_count)) => {
+                if bytes_read == 0 {
+                    return Err(std::io::Error::new(
+                        std::io::ErrorKind::UnexpectedEof,
+                        "client disconnected",
+                    ));
+                }
+
+                let received_fds = &fds[..fd_count];
+                let json_str = match std::str::from_utf8(&data_buf[..bytes_read]) {
+                    Ok(s) => s,
+                    Err(e) => {
+                        Self::close_fds(received_fds);
+                        return Err(eother!(format!("Invalid UTF-8: {}", e)));
+                    }
+                };
+                let json_val: serde_json::Value = match serde_json::from_str(json_str) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        Self::close_fds(received_fds);
+                        return Err(eother!(format!("Invalid JSON: {}", e)));
+                    }
+                };
+                let msg_type = json_val
+                    .get("type")
+                    .and_then(|v| v.as_u64())
+                    .and_then(|v| serde_json::from_value(serde_json::Value::Number(v.into())).ok())
+                    .unwrap_or(MessageType::Handshake);
+                let fd_vec = received_fds.to_vec();
+                Ok(Some((json_val, fd_vec, msg_type)))
+            }
+            Err(e) => {
+                if e.kind() == std::io::ErrorKind::WouldBlock {
+                    return Ok(None);
+                }
+                Err(eother!(format!("recv_with_fd failed: {}", e)))
+            }
+        }
+    }
+
+    /// Send data with fd asynchronously using tokio's try_io pattern.
+    /// This avoids spawn_blocking by using the async socket's readiness notification.
+    async fn async_send_with_fd(
+        sock: &AsyncFd<StdUnixStream>,
+        data: &[u8],
+        fds: &[RawFd],
+    ) -> Result<()> {
+        loop {
+            match sock.get_ref().send_with_fd(data, fds) {
+                Ok(_) => return Ok(()),
+                Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                    // Wait for socket to become writable
+                    let mut guard = sock
+                        .writable()
+                        .await
+                        .map_err(|e| eother!(format!("socket writable failed: {}", e)))?;
+                    guard.clear_ready();
+                }
+                Err(e) => return Err(eother!(format!("send_with_fd failed: {}", e))),
+            }
+        }
+    }
+
+    /// Send a batch of page fault responses with blob fds to client. Zerocopy only
+    async fn send_batch_response(
+        stream: &AsyncFd<StdUnixStream>,
+        batch: &[(RawFd, u64, usize, u64)],
+    ) -> Result<()> {
+        let response = PageFaultResponse {
+            r#type: MessageType::PageFault,
+            ranges: batch
+                .iter()
+                .map(|(_, blob_offset, len, block_offset)| BlobRange {
+                    len: *len,
+                    blob_offset: *blob_offset,
+                    block_offset: *block_offset,
+                })
+                .collect(),
+        };
+        let json_data = serde_json::to_vec(&response)
+            .map_err(|e| eother!(format!("Failed to serialize PageFaultResponse: {}", e)))?;
+
+        let fds: Vec<RawFd> = batch.iter().map(|(fd, _, _, _)| *fd).collect();
+        Self::async_send_with_fd(stream, &json_data, &fds).await
+    }
+
+    /// Pre-fault: probe ready ranges and send them to client proactively.
+    async fn do_prefault(
+        device: Arc<BlockDevice>,
+        stream: StdUnixStream,
+        vma_regions: Vec<VmaRegion>,
+    ) -> Result<()> {
+        let stream = AsyncFd::new(stream)
+            .map_err(|e| eother!(format!("Failed to create AsyncFd for pre-fault: {}", e)))?;
+        let core = UffdCore::new(device);
+        let ranges = core.prefault_ranges(&vma_regions).await?;
+        for chunk in ranges.chunks(MAX_RANGES_PER_MSG) {
+            Self::send_batch_response(&stream, chunk).await?;
+        }
+        Ok(())
+    }
+}
+
+/// Uffd server to expose RAFSv6 images as block devices via userfaultfd.
+pub struct UffdService {
+    active: Arc<AtomicBool>,
+    blob_id: String,
+    cache_mgr: Arc<BlobCacheMgr>,
+    uds_path: String,
+    sender: Arc<Sender<u32>>,
+    active_conns: Arc<Mutex<Vec<RawFd>>>,
+    worker_senders: Mutex<Vec<flume::Sender<StdUnixStream>>>,
+    worker_threads: Mutex<Vec<JoinHandle<Result<()>>>>,
+}
+
+impl UffdService {
+    /// Create a new instance of [UffdService] to expose a RAFSv6 image as a block device.
+    ///
+    /// It accepts unix sockets from `uds_path` and receives uffd fd and VMA info
+    /// from clients to monitor for page faults.
+    pub fn new(device: Arc<BlockDevice>, uds_path: String) -> Result<Self> {
+        let (sender, _receiver) = tokio::sync::broadcast::channel(4);
+
+        Ok(UffdService {
+            active: Arc::new(AtomicBool::new(true)),
+            blob_id: device.meta_blob_id().to_string(),
+            cache_mgr: device.cache_mgr().clone(),
+            uds_path,
+            sender: Arc::new(sender),
+            active_conns: Arc::new(Mutex::new(Vec::new())),
+            worker_threads: Mutex::new(Vec::new()),
+            worker_senders: Mutex::new(Vec::new()),
+        })
+    }
+
+    /// Create a [UffdWorker] to run the event loop to handle uffd connections.
+    pub fn create_worker(&self, waker: Arc<Waker>) -> Result<()> {
+        let (tx, rx) = flume::unbounded::<StdUnixStream>();
+        let worker_index = self.worker_threads.lock().unwrap().len();
+        let name = format!("block_uffd_worker_{}", worker_index);
+        let worker = UffdWorker {
+            active: self.active.clone(),
+            active_conns: self.active_conns.clone(),
+            blob_id: self.blob_id.clone(),
+            cache_mgr: self.cache_mgr.clone(),
+            conn_receiver: rx,
+            sender: self.sender.clone(),
+            name: name.clone(),
+        };
+
+        let thread: std::thread::JoinHandle<Result<()>> = std::thread::Builder::new()
+            .name(name)
+            .spawn(move || {
+                tokio_uring::start(async move {
+                    worker.run().await;
+                    // Notify the daemon controller that one working thread has exited.
+                    if let Err(err) = waker.wake() {
+                        error!("block: fail to exit daemon, error: {:?}", err);
+                    }
+                });
+                Ok(())
+            })
+            .map_err(crate::Error::ThreadSpawn)?;
+        self.worker_senders.lock().unwrap().push(tx);
+        self.worker_threads.lock().unwrap().push(thread);
+
+        Ok(())
+    }
+
+    /// Run the event loop to handle incoming uffd connection requests.
+    pub fn run(&self) -> Result<()> {
+        info!("block_uffd: service start!");
+
+        let _ = std::fs::remove_file(&self.uds_path);
+        let listener = UnixListener::bind(&self.uds_path)?;
+        listener.set_nonblocking(true)?;
+
+        let mut curr_worker = 0;
+        let worker_num = self.worker_threads.lock().unwrap().len();
+        while self.active.load(Ordering::Acquire) {
+            match listener.accept() {
+                Ok((stream, _addr)) => {
+                    if !self.active.load(Ordering::Acquire) {
+                        info!("block_uffd: shutting down, drop the accepted stream");
+                        break;
+                    }
+
+                    let senders = self.worker_senders.lock().unwrap();
+                    let _ = senders[curr_worker].send(stream);
+                    curr_worker = (curr_worker + 1) % worker_num;
+                }
+                Err(e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                    std::thread::sleep(std::time::Duration::from_millis(50));
+                    continue;
+                }
+                Err(e) => {
+                    warn!("block_uffd: accept error: {e}");
+                }
+            }
+        }
+
+        self.active.store(false, Ordering::Release);
+        let _ = self.sender.send(1);
+        loop {
+            let handle = self.worker_threads.lock().unwrap().pop();
+            if let Some(handle) = handle {
+                handle
+                    .join()
+                    .map_err(|e| {
+                        let e = *e
+                            .downcast::<Error>()
+                            .unwrap_or_else(|e| Box::new(eother!(e)));
+                        crate::Error::WaitDaemon(e)
+                    })?
+                    .map_err(crate::Error::WaitDaemon)?;
+            } else {
+                // No more handles to wait
+                break;
+            }
+        }
+
+        info!("block_uffd: service exit!");
+
+        Ok(())
+    }
+
+    /// Deactivate the uffd session, send exit notification to workers,
+    /// shutdown all active client sockets, and send dummy connect to
+    /// wake up the accept loop.
+    pub fn stop(&self) {
+        self.active.store(false, Ordering::Release);
+        let _ = self.sender.send(0);
+        // Shutdown all active client sockets so handle_conn tasks exit.
+        let conns = self.active_conns.lock().unwrap();
+        for &fd in conns.iter() {
+            unsafe {
+                libc::shutdown(fd, libc::SHUT_RDWR);
+            }
+        }
+        drop(conns);
+        // wake up blocking accept()
+        let _ = std::os::unix::net::UnixStream::connect(&self.uds_path);
+    }
+
+    pub fn get_blob_cache_mgr(&self) -> Option<Arc<BlobCacheMgr>> {
+        Some(self.cache_mgr.clone())
+    }
+
+    pub fn save(&self) -> crate::Result<()> {
+        info!("block_uffd: stateless, no need to save");
+        Ok(())
+    }
+
+    pub fn restore(&self) -> crate::Result<()> {
+        info!("block_uffd: stateless, no need to restore");
+        Ok(())
+    }
+}
+
+/// A [NydusDaemon] implementation to expose RAFS v6 images as block devices through uffd.
+pub struct UffdDaemon {
+    service: Arc<UffdService>,
+
+    bti: BuildTimeInfo,
+    id: Option<String>,
+    supervisor: Option<String>,
+
+    nr_threads: u32,
+    service_threads: Mutex<Vec<JoinHandle<Result<()>>>>,
+    request_sender: Arc<Mutex<std::sync::mpsc::Sender<DaemonStateMachineInput>>>,
+    result_receiver: Mutex<std::sync::mpsc::Receiver<NydusResult<()>>>,
+    state: AtomicI32,
+    state_machine_thread: Mutex<Option<JoinHandle<Result<()>>>>,
+    waker: Arc<Waker>,
+}
+
+impl UffdDaemon {
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        service: Arc<UffdService>,
+        threads: u32,
+        trigger: std::sync::mpsc::Sender<DaemonStateMachineInput>,
+        receiver: std::sync::mpsc::Receiver<NydusResult<()>>,
+        waker: Arc<Waker>,
+        bti: BuildTimeInfo,
+        id: Option<String>,
+        supervisor: Option<String>,
+    ) -> Result<Self> {
+        Ok(UffdDaemon {
+            service,
+
+            bti,
+            id,
+            supervisor,
+
+            nr_threads: threads,
+            service_threads: Mutex::new(Vec::new()),
+            state: AtomicI32::new(DaemonState::INIT as i32),
+            request_sender: Arc::new(Mutex::new(trigger)),
+            result_receiver: Mutex::new(receiver),
+            state_machine_thread: Mutex::new(None),
+            waker,
+        })
+    }
+}
+
+impl DaemonStateMachineSubscriber for UffdDaemon {
+    fn on_event(&self, event: DaemonStateMachineInput) -> NydusResult<()> {
+        self.request_sender
+            .lock()
+            .expect("uffd: failed to lock request sender!")
+            .send(event)
+            .map_err(NydusError::ChannelSend)?;
+
+        self.result_receiver
+            .lock()
+            .expect("uffd: failed to lock result receiver!")
+            .recv()
+            .map_err(NydusError::ChannelReceive)?
+    }
+}
+
+impl NydusDaemon for UffdDaemon {
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn id(&self) -> Option<String> {
+        self.id.clone()
+    }
+
+    fn version(&self) -> BuildTimeInfo {
+        self.bti.clone()
+    }
+
+    fn get_state(&self) -> DaemonState {
+        self.state.load(Ordering::Relaxed).into()
+    }
+
+    fn set_state(&self, state: DaemonState) {
+        self.state.store(state as i32, Ordering::Relaxed);
+    }
+
+    fn start(&self) -> NydusResult<()> {
+        info!("start uffd service with {} worker threads", self.nr_threads);
+        for _ in 0..self.nr_threads {
+            self.service.create_worker(self.waker.clone())?;
+        }
+
+        let service = self.service.clone();
+        let waker = self.waker.clone();
+        let thread = std::thread::spawn(move || {
+            if let Err(e) = service.run() {
+                error!("uffd: failed to run uffd control loop, {}", e);
+            }
+            // Notify the daemon controller that server thread has exited.
+            if let Err(err) = waker.wake() {
+                error!("uffd: fail to exit daemon, error: {:?}", err);
+            }
+            Ok(())
+        });
+        self.service_threads.lock().unwrap().push(thread);
+
+        Ok(())
+    }
+
+    fn umount(&self) -> NydusResult<()> {
+        Ok(())
+    }
+
+    fn stop(&self) {
+        self.service.stop();
+    }
+
+    fn wait(&self) -> NydusResult<()> {
+        self.wait_state_machine()?;
+        self.wait_service()
+    }
+
+    fn wait_service(&self) -> NydusResult<()> {
+        loop {
+            let handle = self.service_threads.lock().unwrap().pop();
+            if let Some(handle) = handle {
+                handle
+                    .join()
+                    .map_err(|e| {
+                        let e = *e
+                            .downcast::<Error>()
+                            .unwrap_or_else(|e| Box::new(eother!(e)));
+                        NydusError::WaitDaemon(e)
+                    })?
+                    .map_err(NydusError::WaitDaemon)?;
+            } else {
+                // No more handles to wait
+                break;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn wait_state_machine(&self) -> NydusResult<()> {
+        let mut guard = self.state_machine_thread.lock().unwrap();
+        if let Some(handler) = guard.take() {
+            let result = handler.join().map_err(|e| {
+                let e = *e
+                    .downcast::<Error>()
+                    .unwrap_or_else(|e| Box::new(eother!(e)));
+                NydusError::WaitDaemon(e)
+            })?;
+            result.map_err(NydusError::WaitDaemon)
+        } else {
+            Ok(())
+        }
+    }
+
+    fn supervisor(&self) -> Option<String> {
+        self.supervisor.clone()
+    }
+
+    fn save(&self) -> NydusResult<()> {
+        self.service.save()
+    }
+
+    fn restore(&self) -> NydusResult<()> {
+        self.service.restore()
+    }
+
+    fn get_blob_cache_mgr(&self) -> Option<Arc<BlobCacheMgr>> {
+        self.service.get_blob_cache_mgr()
+    }
+}
+
+/// Create and start a [UffdDaemon] instance to expose a RAFS v6 image as a block device through uffd.
+#[allow(clippy::too_many_arguments, clippy::arc_with_non_send_sync)]
+pub fn create_uffd_daemon(
+    sock: String,
+    threads: u32,
+    blob_entry: BlobCacheEntry,
+    bti: BuildTimeInfo,
+    id: Option<String>,
+    supervisor: Option<String>,
+    waker: Arc<Waker>,
+) -> Result<Arc<dyn NydusDaemon>> {
+    let blob_id = generate_blob_key(&blob_entry.domain_id, &blob_entry.blob_id);
+    let cache_mgr = Arc::new(BlobCacheMgr::new());
+    cache_mgr.add_blob_entry(&blob_entry)?;
+    let block_device = BlockDevice::new_with_cache_manager(blob_id.clone(), cache_mgr.clone())?;
+    let service = Arc::new(UffdService::new(Arc::new(block_device), sock)?);
+
+    let (trigger, events_rx) = std::sync::mpsc::channel::<DaemonStateMachineInput>();
+    let (result_sender, result_receiver) = std::sync::mpsc::channel::<NydusResult<()>>();
+    let daemon = UffdDaemon::new(
+        service,
+        threads,
+        trigger,
+        result_receiver,
+        waker,
+        bti,
+        id,
+        supervisor,
+    )?;
+    let daemon = Arc::new(daemon);
+    let machine = DaemonStateMachineContext::new(daemon.clone(), events_rx, result_sender);
+    let machine_thread = machine.kick_state_machine()?;
+    *daemon.state_machine_thread.lock().unwrap() = Some(machine_thread);
+    daemon
+        .on_event(DaemonStateMachineInput::Mount)
+        .map_err(|e| eother!(e))?;
+    daemon
+        .on_event(DaemonStateMachineInput::Start)
+        .map_err(|e| eother!(e))?;
+
+    Ok(daemon)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::blob_cache::{generate_blob_key, BlobCacheMgr};
+    use nydus_api::BlobCacheEntry;
+    use std::io::Read;
+    use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+    use std::path::PathBuf;
+    use std::time::Duration;
+    use vmm_sys_util::tempdir::TempDir;
+
+    // ---- UFFD test helpers ----
+
+    fn setup_uffd_region(size: usize) -> Result<(i32, u64, usize)> {
+        let uffd_fd = create_userfaultfd_for_test()?;
+        let align = 2 * 1024 * 1024; // 2MB
+        let mmap_size = size.div_ceil(align) * align;
+        let addr = unsafe {
+            libc::mmap(
+                std::ptr::null_mut(),
+                mmap_size,
+                libc::PROT_READ | libc::PROT_WRITE,
+                libc::MAP_PRIVATE | libc::MAP_ANONYMOUS,
+                -1,
+                0,
+            )
+        };
+        if addr == libc::MAP_FAILED {
+            unsafe { libc::close(uffd_fd) };
+            return Err(std::io::Error::last_os_error());
+        }
+        if let Err(e) = uffd_register_for_test(uffd_fd, addr as u64, mmap_size as u64) {
+            unsafe {
+                libc::munmap(addr, mmap_size);
+                libc::close(uffd_fd);
+            }
+            return Err(e);
+        }
+        Ok((uffd_fd, addr as u64, mmap_size))
+    }
+
+    fn cleanup_uffd_region(uffd_fd: i32, addr: u64, size: usize) {
+        unsafe {
+            libc::munmap(addr as *mut _, size);
+            libc::close(uffd_fd);
+        }
+    }
+
+    fn create_userfaultfd_for_test() -> Result<i32> {
+        let fd = unsafe { libc::syscall(libc::SYS_userfaultfd, libc::O_CLOEXEC | libc::O_NONBLOCK) }
+            as i32;
+        if fd < 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        #[repr(C)]
+        struct UffdioApi {
+            api: u64,
+            features: u64,
+            ioctls: u64,
+        }
+        let mut api = UffdioApi {
+            api: 0xaa,
+            features: 0,
+            ioctls: 0,
+        };
+        const UFFDIO_API_IOCTL: libc::Ioctl = 0xc018aa3fu32 as libc::Ioctl;
+        let ret = unsafe { libc::ioctl(fd, UFFDIO_API_IOCTL, &mut api) };
+        if ret < 0 {
+            unsafe { libc::close(fd) };
+            return Err(std::io::Error::last_os_error());
+        }
+        Ok(fd)
+    }
+
+    fn uffd_register_for_test(fd: i32, addr: u64, len: u64) -> Result<()> {
+        #[repr(C)]
+        struct UffdioRegister {
+            range_start: u64,
+            range_len: u64,
+            mode: u64,
+            ioctls: u64,
+        }
+        const UFFDIO_REGISTER_IOCTL: libc::Ioctl = 0xc020aa00u32 as libc::Ioctl;
+        const UFFDIO_REGISTER_MODE_MISSING: u64 = 1;
+        let mut reg = UffdioRegister {
+            range_start: addr,
+            range_len: len,
+            mode: UFFDIO_REGISTER_MODE_MISSING,
+            ioctls: 0,
+        };
+        let ret = unsafe { libc::ioctl(fd, UFFDIO_REGISTER_IOCTL, &mut reg) };
+        if ret < 0 {
+            return Err(std::io::Error::last_os_error());
+        }
+        Ok(())
+    }
+
+    #[allow(clippy::arc_with_non_send_sync)]
+    fn create_block_device(tmpdir: PathBuf) -> Result<Arc<BlockDevice>> {
+        let root_dir = &std::env::var("CARGO_MANIFEST_DIR").expect("$CARGO_MANIFEST_DIR");
+        let mut source_path = PathBuf::from(root_dir);
+        source_path.push("../tests/texture/blobs/be7d77eeb719f70884758d1aa800ed0fb09d701aaec469964e9d54325f0d5fef");
+        let mut dest_path = tmpdir.clone();
+        dest_path.push("be7d77eeb719f70884758d1aa800ed0fb09d701aaec469964e9d54325f0d5fef");
+        std::fs::copy(&source_path, &dest_path).unwrap();
+
+        let mut source_path = PathBuf::from(root_dir);
+        source_path.push("../tests/texture/bootstrap/rafs-v6-2.2.boot");
+        let config = r#"
+        {
+            "type": "bootstrap",
+            "id": "rafs-v6",
+            "domain_id": "domain2",
+            "config_v2": {
+                "version": 2,
+                "id": "factory1",
+                "backend": {
+                    "type": "localfs",
+                    "localfs": {
+                        "dir": "/tmp/nydus"
+                    }
+                },
+                "cache": {
+                    "type": "filecache",
+                    "filecache": {
+                        "work_dir": "/tmp/nydus"
+                    }
+                },
+                "metadata_path": "RAFS_V6"
+            }
+          }"#;
+        let content = config
+            .replace("/tmp/nydus", tmpdir.as_path().to_str().unwrap())
+            .replace("RAFS_V6", &source_path.display().to_string());
+        let mut entry: BlobCacheEntry = serde_json::from_str(&content).unwrap();
+        assert!(entry.prepare_configuration_info());
+
+        let mgr = BlobCacheMgr::new();
+        mgr.add_blob_entry(&entry).unwrap();
+        let blob_id = generate_blob_key(&entry.domain_id, &entry.blob_id);
+        assert!(mgr.get_config(&blob_id).is_some());
+
+        // Check existence of data blob referenced by the bootstrap.
+        let key = generate_blob_key(
+            &entry.domain_id,
+            "be7d77eeb719f70884758d1aa800ed0fb09d701aaec469964e9d54325f0d5fef",
+        );
+        assert!(mgr.get_config(&key).is_some());
+
+        let mgr = Arc::new(mgr);
+        let device = BlockDevice::new_with_cache_manager(blob_id.clone(), mgr).unwrap();
+
+        Ok(Arc::new(device))
+    }
+
+    #[test]
+    fn test_uffd_daemon_lifecycle() {
+        let tmpdir = TempDir::new().unwrap();
+        let device = create_block_device(tmpdir.as_path().to_path_buf()).unwrap();
+        let sock_path = format!("{}/test_daemon.sock", tmpdir.as_path().display());
+        let service = Arc::new(UffdService::new(device, sock_path.clone()).unwrap());
+
+        let (trigger, events_rx) = std::sync::mpsc::channel::<DaemonStateMachineInput>();
+        let (result_sender, result_receiver) = std::sync::mpsc::channel::<NydusResult<()>>();
+        let poll = mio::Poll::new().unwrap();
+        let waker = Arc::new(Waker::new(poll.registry(), mio::Token(0)).unwrap());
+
+        let daemon = UffdDaemon::new(
+            service,
+            2,
+            trigger,
+            result_receiver,
+            waker,
+            BuildTimeInfo {
+                package_ver: String::new(),
+                git_commit: String::new(),
+                build_time: String::new(),
+                profile: String::new(),
+                rustc: String::new(),
+            },
+            None,
+            None,
+        )
+        .unwrap();
+        let daemon = Arc::new(daemon);
+
+        // Start state machine thread
+        let machine = DaemonStateMachineContext::new(daemon.clone(), events_rx, result_sender);
+        let machine_thread = machine.kick_state_machine().unwrap();
+        *daemon.state_machine_thread.lock().unwrap() = Some(machine_thread);
+
+        // Drive through Mount -> Start
+        // Wait for state machine thread to be ready
+        for _ in 0..100 {
+            if daemon.get_state() != DaemonState::INIT {
+                break;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(5));
+        }
+        daemon.on_event(DaemonStateMachineInput::Mount).unwrap();
+        daemon.on_event(DaemonStateMachineInput::Start).unwrap();
+        assert_eq!(daemon.get_state(), DaemonState::RUNNING);
+
+        // Verify interface methods
+        assert!(daemon.id().is_none());
+        assert!(daemon.supervisor().is_none());
+        assert!(daemon.save().is_ok());
+        assert!(daemon.restore().is_ok());
+        assert!(daemon.get_blob_cache_mgr().is_some());
+
+        // Graceful shutdown
+        daemon.on_event(DaemonStateMachineInput::Stop).unwrap();
+        assert_eq!(daemon.get_state(), DaemonState::READY);
+        daemon.on_event(DaemonStateMachineInput::Stop).unwrap();
+        assert_eq!(daemon.get_state(), DaemonState::STOPPED);
+
+        // Also test create_uffd_daemon convenience function
+        let tmpdir2 = TempDir::new().unwrap();
+        let entry = create_test_blob_entry(tmpdir2.as_path().to_path_buf());
+        let sock_path2 = format!("{}/test_daemon2.sock", tmpdir2.as_path().display());
+        let poll2 = mio::Poll::new().unwrap();
+        let waker2 = Arc::new(Waker::new(poll2.registry(), mio::Token(0)).unwrap());
+
+        let daemon2 = create_uffd_daemon(
+            sock_path2,
+            1,
+            entry,
+            BuildTimeInfo {
+                package_ver: "test".to_string(),
+                git_commit: "test".to_string(),
+                build_time: "test".to_string(),
+                profile: "test".to_string(),
+                rustc: "test".to_string(),
+            },
+            None,
+            None,
+            waker2,
+        )
+        .expect("create_uffd_daemon failed");
+        assert_eq!(daemon2.get_state(), DaemonState::RUNNING);
+
+        let _ = daemon2.on_event(DaemonStateMachineInput::Stop);
+    }
+
+    // --- UffdService basic tests ---
+
+    #[test]
+    fn test_uffd_service_stop_flag() {
+        let tmpdir = TempDir::new().unwrap();
+        let device = create_block_device(tmpdir.as_path().to_path_buf()).unwrap();
+        let sock_path = format!("{}/test.sock", tmpdir.as_path().display());
+        let service = UffdService::new(device, sock_path).unwrap();
+
+        assert!(service.active.load(Ordering::Acquire));
+        service.stop();
+        assert!(!service.active.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn test_uffd_service_save_restore() {
+        let tmpdir = TempDir::new().unwrap();
+        let device = create_block_device(tmpdir.as_path().to_path_buf()).unwrap();
+        let sock_path = format!("{}/test.sock", tmpdir.as_path().display());
+        let service = UffdService::new(device, sock_path).unwrap();
+
+        // save and restore are no-ops for stateless service
+        assert!(service.save().is_ok());
+        assert!(service.restore().is_ok());
+    }
+
+    #[test]
+    fn test_uffd_service_get_blob_cache_mgr() {
+        let tmpdir = TempDir::new().unwrap();
+        let device = create_block_device(tmpdir.as_path().to_path_buf()).unwrap();
+        let sock_path = format!("{}/test.sock", tmpdir.as_path().display());
+        let service = UffdService::new(device, sock_path).unwrap();
+
+        assert!(service.get_blob_cache_mgr().is_some());
+    }
+
+    // --- close_fds test ---
+
+    #[test]
+    fn test_close_fds_empty() {
+        // Closing an empty list should not panic
+        UffdWorker::close_fds(&[]);
+    }
+
+    #[test]
+    fn test_close_fds_invalid_fd() {
+        // Closing invalid fds should not panic (close returns EBADF but we ignore it)
+        UffdWorker::close_fds(&[-1, -2]);
+    }
+
+    // --- try_recv_from_sock tests ---
+
+    #[test]
+    fn test_try_recv_from_sock_eof() {
+        // Create a pair of unix stream sockets, close the sender side
+        let (sock1, sock2) = std::os::unix::net::UnixStream::pair().unwrap();
+        drop(sock2); // close the peer
+
+        let result = UffdWorker::try_recv_from_sock(&sock1);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert_eq!(err.kind(), std::io::ErrorKind::UnexpectedEof);
+    }
+
+    #[test]
+    fn test_try_recv_from_sock_would_block() {
+        // Create a pair and set non-blocking, read without writing -> WouldBlock -> Ok(None)
+        let (sock1, _sock2) = std::os::unix::net::UnixStream::pair().unwrap();
+        sock1.set_nonblocking(true).unwrap();
+
+        let result = UffdWorker::try_recv_from_sock(&sock1);
+        assert!(result.is_ok());
+        assert!(result.unwrap().is_none());
+    }
+
+    #[test]
+    fn test_try_recv_from_sock_valid_handshake() {
+        let (sock1, sock2) = std::os::unix::net::UnixStream::pair().unwrap();
+
+        let request = HandshakeRequest {
+            r#type: MessageType::Handshake,
+            regions: vec![VmaRegion::new(0x1000, 0x2000, 0, 2 * 1024 * 1024)],
+            policy: FaultPolicy::Zerocopy,
+            enable_prefault: false,
+        };
+        let json_data = serde_json::to_vec(&request).unwrap();
+        sock2.send_with_fd(&json_data, &[]).unwrap();
+
+        let result = UffdWorker::try_recv_from_sock(&sock1);
+        assert!(result.is_ok());
+        let (json_val, fds, msg_type) = result.unwrap().unwrap();
+        assert_eq!(msg_type, MessageType::Handshake);
+        assert!(fds.is_empty());
+        assert!(json_val.is_object());
+        assert!(json_val.get("regions").unwrap().is_array());
+    }
+
+    #[test]
+    fn test_try_recv_from_sock_stat_request() {
+        let (sock1, sock2) = std::os::unix::net::UnixStream::pair().unwrap();
+
+        let request = StatRequest::new();
+        let json_data = serde_json::to_vec(&request).unwrap();
+        sock2.send_with_fd(&json_data, &[]).unwrap();
+
+        let result = UffdWorker::try_recv_from_sock(&sock1);
+        assert!(result.is_ok());
+        let (_, _, msg_type) = result.unwrap().unwrap();
+        assert_eq!(msg_type, MessageType::Stat);
+    }
+
+    #[test]
+    fn test_try_recv_from_sock_invalid_utf8() {
+        let (sock1, sock2) = std::os::unix::net::UnixStream::pair().unwrap();
+
+        // Send invalid UTF-8 bytes
+        let invalid_data: &[u8] = &[0xff, 0xfe, 0xfd];
+        sock2.send_with_fd(invalid_data, &[]).unwrap();
+
+        let result = UffdWorker::try_recv_from_sock(&sock1);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_try_recv_from_sock_invalid_json() {
+        let (sock1, sock2) = std::os::unix::net::UnixStream::pair().unwrap();
+
+        // Send valid UTF-8 but invalid JSON
+        let bad_json = b"not valid json {{{";
+        sock2.send_with_fd(bad_json, &[]).unwrap();
+
+        let result = UffdWorker::try_recv_from_sock(&sock1);
+        assert!(result.is_err());
+    }
+
+    // --- handle_handshake Firecracker compatibility test ---
+
+    #[test]
+    fn test_handle_handshake_firecracker_format() {
+        let (sock1, sock2) = std::os::unix::net::UnixStream::pair().unwrap();
+
+        // Send Firecracker-compatible bare array format
+        let regions = vec![VmaRegion::new(0x1000, 0x2000, 0, 2 * 1024 * 1024)];
+        let json_data = serde_json::to_vec(&regions).unwrap();
+        sock2.send_with_fd(&json_data, &[]).unwrap();
+        drop(sock2);
+
+        // Read back and parse as HandshakeRequest
+        let mut data_buf = [0u8; RECV_BUF_SIZE];
+        let mut fds = [0i32; MAX_RANGES_PER_MSG];
+        let (bytes_read, fd_count) = sock1.recv_with_fd(&mut data_buf, &mut fds).unwrap();
+        assert!(bytes_read > 0);
+        assert_eq!(fd_count, 0);
+
+        let json_str = std::str::from_utf8(&data_buf[..bytes_read]).unwrap();
+        let json_val: serde_json::Value = serde_json::from_str(json_str).unwrap();
+        assert!(json_val.is_array());
+
+        // Parse as HandshakeRequest (should accept bare array)
+        let request: HandshakeRequest = if json_val.is_array() {
+            let regions: Vec<VmaRegion> = serde_json::from_value(json_val).unwrap();
+            HandshakeRequest {
+                r#type: MessageType::Handshake,
+                regions,
+                policy: FaultPolicy::default(),
+                enable_prefault: false,
+            }
+        } else {
+            serde_json::from_value(json_val).unwrap()
+        };
+
+        assert_eq!(request.regions.len(), 1);
+        assert_eq!(request.policy, FaultPolicy::Zerocopy);
+        assert!(!request.enable_prefault);
+    }
+
+    // --- do_prefault test ---
+
+    #[test]
+    fn test_do_prefault() {
+        tokio_uring::start(async {
+            let tmpdir = TempDir::new().unwrap();
+            let device = create_block_device(tmpdir.as_path().to_path_buf()).unwrap();
+            let (sock1, sock2) = std::os::unix::net::UnixStream::pair().unwrap();
+            sock2.set_nonblocking(true).unwrap();
+
+            let vma_regions = vec![VmaRegion::new(
+                0,
+                device.blocks_to_size(device.blocks()) as usize,
+                0,
+                device.block_size() as usize,
+            )];
+
+            // Run do_prefault in background
+            let prefault_task = tokio_uring::spawn(async move {
+                UffdWorker::do_prefault(device, sock2, vma_regions).await
+            });
+
+            // Read messages from sock1
+            sock1
+                .set_read_timeout(Some(std::time::Duration::from_millis(500)))
+                .unwrap();
+            let mut total_messages = 0;
+            loop {
+                let mut buf = [0u8; 4096];
+                let mut fds = Vec::new();
+                match sock1.recv_with_fd(&mut buf, &mut fds) {
+                    Ok((bytes_read, _fd_count)) => {
+                        if bytes_read == 0 {
+                            break;
+                        }
+                        total_messages += 1;
+                    }
+                    Err(_) => break,
+                }
+            }
+
+            let res = prefault_task.await.unwrap();
+            assert!(res.is_ok());
+            let _ = total_messages;
+        });
+    }
+
+    // --- send_batch_response test ---
+
+    #[test]
+    fn test_send_batch_response() {
+        tokio_uring::start(async {
+            let (sock1, sock2) = std::os::unix::net::UnixStream::pair().unwrap();
+            let sock_async = AsyncFd::new(sock1).unwrap();
+
+            // Create a mock batch response
+            let batch = vec![
+                (sock2.as_raw_fd(), 0u64, 4096usize, 0u64),
+                (sock2.as_raw_fd(), 4096u64, 4096usize, 4096u64),
+            ];
+
+            let res = UffdWorker::send_batch_response(&sock_async, &batch).await;
+            assert!(res.is_ok());
+
+            // Read back and verify via sock2
+            sock2
+                .set_read_timeout(Some(std::time::Duration::from_millis(100)))
+                .unwrap();
+            let mut buf = [0u8; 4096];
+            let mut fds = [0i32; MAX_RANGES_PER_MSG];
+            let (bytes_read, fd_count) = sock2.recv_with_fd(&mut buf, &mut fds).unwrap();
+            assert!(bytes_read > 0);
+            assert_eq!(fd_count, 2); // 2 fds in batch
+
+            let response: PageFaultResponse = serde_json::from_slice(&buf[..bytes_read]).unwrap();
+            assert_eq!(response.ranges.len(), 2);
+            assert_eq!(response.ranges[0].len, 4096);
+            assert_eq!(response.ranges[1].blob_offset, 4096);
+        });
+    }
+
+    // --- dispatch_message tests ---
+
+    #[test]
+    fn test_dispatch_message_stat() {
+        tokio_uring::start(async {
+            let (sock1, sock2) = std::os::unix::net::UnixStream::pair().unwrap();
+            sock2.set_nonblocking(true).unwrap();
+            let sock_async = AsyncFd::new(sock1).unwrap();
+
+            let tmpdir = TempDir::new().unwrap();
+            let device = create_block_device(tmpdir.as_path().to_path_buf()).unwrap();
+            let core = UffdCore::new(device);
+            let mut conn_state: Option<ConnState> = None;
+
+            let json_val = serde_json::to_value(StatRequest::new()).unwrap();
+            let res = UffdWorker::dispatch_message(
+                MessageType::Stat,
+                json_val,
+                &[],
+                &sock_async,
+                &core,
+                &mut conn_state,
+                1024 * 1024,
+                4096,
+            )
+            .await;
+            assert!(res.is_ok());
+            assert!(conn_state.is_none()); // stat doesn't change conn_state
+        });
+    }
+
+    #[test]
+    fn test_dispatch_message_unexpected_type() {
+        tokio_uring::start(async {
+            let (sock1, _sock2) = std::os::unix::net::UnixStream::pair().unwrap();
+            sock1.set_nonblocking(true).unwrap();
+            let sock_async = AsyncFd::new(sock1).unwrap();
+
+            let tmpdir = TempDir::new().unwrap();
+            let device = create_block_device(tmpdir.as_path().to_path_buf()).unwrap();
+            let core = UffdCore::new(device);
+            let mut conn_state: Option<ConnState> = None;
+
+            let json_val = serde_json::json!({"type": 99});
+            let res = UffdWorker::dispatch_message(
+                MessageType::PageFault,
+                json_val,
+                &[],
+                &sock_async,
+                &core,
+                &mut conn_state,
+                1024 * 1024,
+                4096,
+            )
+            .await;
+            assert!(res.is_ok()); // unexpected type is logged but not an error
+        });
+    }
+
+    #[test]
+    fn test_dispatch_message_handshake_already_handshaked() {
+        tokio_uring::start(async {
+            let (sock1, _sock2) = std::os::unix::net::UnixStream::pair().unwrap();
+            sock1.set_nonblocking(true).unwrap();
+            let sock_async = AsyncFd::new(sock1).unwrap();
+
+            let tmpdir = TempDir::new().unwrap();
+            let device = create_block_device(tmpdir.as_path().to_path_buf()).unwrap();
+            let core = UffdCore::new(device);
+
+            // Pre-set conn_state to simulate already handshaked
+            let (uffd_sock, _) = std::os::unix::net::UnixStream::pair().unwrap();
+            uffd_sock.set_nonblocking(true).unwrap();
+            let uffd_fd = unsafe { OwnedFd::from_raw_fd(uffd_sock.as_raw_fd()) };
+            let uffd_async = AsyncFd::new(uffd_fd).unwrap();
+            let mut conn_state: Option<ConnState> = Some(ConnState {
+                vma_regions: vec![VmaRegion::new(0x1000, 0x2000, 0, 4096)],
+                policy: FaultPolicy::Zerocopy,
+                uffd_async,
+            });
+
+            let json_val = serde_json::to_value(HandshakeRequest {
+                r#type: MessageType::Handshake,
+                regions: vec![VmaRegion::new(0x1000, 0x2000, 0, 4096)],
+                policy: FaultPolicy::Zerocopy,
+                enable_prefault: false,
+            })
+            .unwrap();
+
+            let res = UffdWorker::dispatch_message(
+                MessageType::Handshake,
+                json_val,
+                &[],
+                &sock_async,
+                &core,
+                &mut conn_state,
+                1024 * 1024,
+                4096,
+            )
+            .await;
+            assert!(res.is_ok()); // double handshake is logged but not an error
+                                  // conn_state should remain unchanged
+            assert!(conn_state.is_some());
+            std::mem::forget(uffd_sock); // prevent double-close
+        });
+    }
+
+    // --- handle_stat_request test ---
+
+    #[test]
+    fn test_handle_stat_request() {
+        tokio_uring::start(async {
+            let (sock1, sock2) = std::os::unix::net::UnixStream::pair().unwrap();
+            sock1.set_nonblocking(true).unwrap();
+            let sock_async = AsyncFd::new(sock1).unwrap();
+
+            let res = UffdWorker::handle_stat_request(&sock_async, 1024 * 1024, 4096).await;
+            assert!(res.is_ok());
+
+            // Read back the stat response from sock2
+            sock2
+                .set_read_timeout(Some(std::time::Duration::from_millis(500)))
+                .unwrap();
+            let mut buf = [0u8; 4096];
+            let mut fds = [0i32; MAX_RANGES_PER_MSG];
+            let (bytes_read, fd_count) = sock2.recv_with_fd(&mut buf, &mut fds).unwrap();
+            assert!(bytes_read > 0);
+            assert_eq!(fd_count, 0);
+
+            let response: StatResponse = serde_json::from_slice(&buf[..bytes_read]).unwrap();
+            assert_eq!(response.r#type, MessageType::StatResp);
+            assert_eq!(response.size, 1024 * 1024);
+            assert_eq!(response.block_size, 4096);
+        });
+    }
+
+    // --- handle_handshake with real uffd fd ---
+
+    #[test]
+    fn test_handle_handshake_with_uffd_fd() {
+        tokio_uring::start(async {
+            let tmpdir = TempDir::new().unwrap();
+            let device = create_block_device(tmpdir.as_path().to_path_buf()).unwrap();
+            let core = UffdCore::new(device);
+
+            let (sock1, _sock2) = std::os::unix::net::UnixStream::pair().unwrap();
+            sock1.set_nonblocking(true).unwrap();
+            let sock_async = AsyncFd::new(sock1).unwrap();
+
+            let uffd_fd = create_userfaultfd_for_test().unwrap();
+
+            let json_val = serde_json::to_value(HandshakeRequest {
+                r#type: MessageType::Handshake,
+                regions: vec![VmaRegion::new(0x1000, 0x2000, 0, 2 * 1024 * 1024)],
+                policy: FaultPolicy::Zerocopy,
+                enable_prefault: false,
+            })
+            .unwrap();
+
+            let result = UffdWorker::handle_handshake(json_val, &[uffd_fd], &sock_async, &core);
+            assert!(result.is_ok());
+            let state = result.unwrap();
+            assert_eq!(state.vma_regions.len(), 1);
+            assert_eq!(state.policy, FaultPolicy::Zerocopy);
+        });
+    }
+
+    #[test]
+    fn test_handle_handshake_no_uffd_fd() {
+        tokio_uring::start(async {
+            let tmpdir = TempDir::new().unwrap();
+            let device = create_block_device(tmpdir.as_path().to_path_buf()).unwrap();
+            let core = UffdCore::new(device);
+
+            let (sock1, _sock2) = std::os::unix::net::UnixStream::pair().unwrap();
+            sock1.set_nonblocking(true).unwrap();
+            let sock_async = AsyncFd::new(sock1).unwrap();
+
+            let json_val = serde_json::to_value(HandshakeRequest {
+                r#type: MessageType::Handshake,
+                regions: vec![VmaRegion::new(0x1000, 0x2000, 0, 4096)],
+                policy: FaultPolicy::Copy,
+                enable_prefault: false,
+            })
+            .unwrap();
+
+            // No uffd fd provided — should fail
+            let result = UffdWorker::handle_handshake(json_val, &[], &sock_async, &core);
+            assert!(result.is_err());
+        });
+    }
+
+    #[test]
+    fn test_handle_handshake_copy_policy() {
+        tokio_uring::start(async {
+            let tmpdir = TempDir::new().unwrap();
+            let device = create_block_device(tmpdir.as_path().to_path_buf()).unwrap();
+            let core = UffdCore::new(device);
+
+            let (sock1, _sock2) = std::os::unix::net::UnixStream::pair().unwrap();
+            sock1.set_nonblocking(true).unwrap();
+            let sock_async = AsyncFd::new(sock1).unwrap();
+
+            let uffd_fd = create_userfaultfd_for_test().unwrap();
+
+            let json_val = serde_json::to_value(HandshakeRequest {
+                r#type: MessageType::Handshake,
+                regions: vec![VmaRegion::new(0x1000, 0x2000, 0, 4096)],
+                policy: FaultPolicy::Copy,
+                enable_prefault: false,
+            })
+            .unwrap();
+
+            let result = UffdWorker::handle_handshake(json_val, &[uffd_fd], &sock_async, &core);
+            assert!(result.is_ok());
+            let state = result.unwrap();
+            assert_eq!(state.policy, FaultPolicy::Copy);
+        });
+    }
+
+    // --- UffdService create_worker test ---
+
+    #[test]
+    fn test_uffd_service_create_worker() {
+        let tmpdir = TempDir::new().unwrap();
+        let device = create_block_device(tmpdir.as_path().to_path_buf()).unwrap();
+        let sock_path = format!("{}/test_worker.sock", tmpdir.as_path().display());
+        let service = UffdService::new(device, sock_path).unwrap();
+        let service = Arc::new(service);
+
+        // Create a waker for the worker
+        let poll = mio::Poll::new().unwrap();
+        let waker = Arc::new(Waker::new(poll.registry(), mio::Token(0)).unwrap());
+
+        assert!(service.create_worker(waker).is_ok());
+        assert_eq!(service.worker_threads.lock().unwrap().len(), 1);
+        assert_eq!(service.worker_senders.lock().unwrap().len(), 1);
+
+        service.stop();
+    }
+
+    // --- async_send_with_fd test ---
+
+    #[test]
+    fn test_async_send_with_fd() {
+        tokio_uring::start(async {
+            let (sock1, sock2) = std::os::unix::net::UnixStream::pair().unwrap();
+            sock1.set_nonblocking(true).unwrap();
+            let sock_async = AsyncFd::new(sock1).unwrap();
+
+            let data = b"hello world";
+            let res = UffdWorker::async_send_with_fd(&sock_async, data, &[]).await;
+            assert!(res.is_ok());
+
+            // Read back
+            sock2
+                .set_read_timeout(Some(std::time::Duration::from_millis(100)))
+                .unwrap();
+            let mut buf = [0u8; 64];
+            let mut fds = [0i32; 4];
+            let (n, fd_count) = sock2.recv_with_fd(&mut buf, &mut fds).unwrap();
+            assert_eq!(&buf[..n], b"hello world");
+            assert_eq!(fd_count, 0);
+        });
+    }
+
+    // --- stop() shutdown socket test ---
+
+    #[test]
+    fn test_service_stop_shutdown_sockets() {
+        let tmpdir = TempDir::new().unwrap();
+        let device = create_block_device(tmpdir.as_path().to_path_buf()).unwrap();
+        let sock_path = format!("{}/test_stop.sock", tmpdir.as_path().display());
+
+        let service = Arc::new(UffdService::new(device, sock_path.clone()).unwrap());
+
+        // Create a worker
+        let poll = mio::Poll::new().unwrap();
+        let waker = Arc::new(Waker::new(poll.registry(), mio::Token(0)).unwrap());
+        service.create_worker(waker).unwrap();
+
+        // Start service in background thread
+        let service_clone = service.clone();
+        let handle = std::thread::spawn(move || {
+            service_clone.run().unwrap();
+        });
+
+        // Wait for service to start listening by retrying connect
+        let mut client = None;
+        for _ in 0..50 {
+            match std::os::unix::net::UnixStream::connect(&sock_path) {
+                Ok(c) => {
+                    client = Some(c);
+                    break;
+                }
+                Err(_) => std::thread::sleep(std::time::Duration::from_millis(10)),
+            }
+        }
+        let mut client = client.expect("service did not start listening");
+
+        let client_fd = client.as_raw_fd();
+
+        // Register the fd in active_conns (simulating what handle_conn does)
+        service.active_conns.lock().unwrap().push(client_fd);
+
+        // Call stop - this should shutdown the client socket
+        service.stop();
+
+        // Wait for service thread to exit
+        let _ = handle.join();
+
+        // Verify client socket was shutdown (reading should return EOF/error)
+        let mut buf = [0u8; 1];
+        let result = client.read(&mut buf);
+        // After shutdown, read should return Ok(0) (EOF) or error
+        assert!(result.is_err() || result.unwrap() == 0);
+
+        drop(client);
+    }
+
+    // --- handle_conn graceful shutdown test ---
+
+    #[test]
+    fn test_handle_conn_graceful_shutdown() {
+        tokio_uring::start(async {
+            let tmpdir = TempDir::new().unwrap();
+            let device = create_block_device(tmpdir.as_path().to_path_buf()).unwrap();
+
+            let (client_sock, server_sock) = std::os::unix::net::UnixStream::pair().unwrap();
+            client_sock.set_nonblocking(true).unwrap();
+            server_sock.set_nonblocking(true).unwrap();
+
+            let client_async = AsyncFd::new(client_sock).unwrap();
+
+            let (uffd_fd, addr, mmap_size) = setup_uffd_region(4096).unwrap();
+
+            // Send handshake with uffd fd via SCM_RIGHTS.
+            // After send_with_fd, the fd ownership transfers to the receiver,
+            // so we must NOT close it via cleanup_uffd_region afterward.
+            let handshake = HandshakeRequest {
+                r#type: MessageType::Handshake,
+                regions: vec![VmaRegion::new(addr as u64, 4096, 0, 4096)],
+                policy: FaultPolicy::Zerocopy,
+                enable_prefault: false,
+            };
+            let json = serde_json::to_vec(&handshake).unwrap();
+            client_async
+                .get_ref()
+                .send_with_fd(&json, &[uffd_fd])
+                .unwrap();
+
+            // Spawn handle_conn with broadcast sender for graceful shutdown
+            let active = Arc::new(AtomicBool::new(true));
+            let (sender, _receiver) = tokio::sync::broadcast::channel(4);
+            let sender = Arc::new(sender);
+            let sender_clone = sender.clone();
+            let handle = tokio_uring::spawn(async move {
+                UffdWorker::handle_conn(
+                    active,
+                    Arc::new(Mutex::new(Vec::new())),
+                    device,
+                    server_sock,
+                    sender_clone,
+                )
+                .await
+            });
+
+            // Yield to let the runtime process the handshake
+            for _ in 0..10 {
+                tokio::task::yield_now().await;
+            }
+
+            // Graceful shutdown via broadcast signal
+            let _ = sender.send(0);
+
+            // Only unmap the memory region; do NOT close uffd_fd since
+            // ownership was transferred to handle_conn via SCM_RIGHTS.
+            unsafe {
+                libc::munmap(addr as *mut _, mmap_size);
+            }
+
+            let result = tokio::time::timeout(Duration::from_secs(2), handle).await;
+            assert!(result.is_ok(), "handle_conn did not exit within timeout");
+        });
+    }
+
+    // --- handle_uffd_event test ---
+
+    #[test]
+    fn test_handle_uffd_event_no_event() {
+        tokio_uring::start(async {
+            let tmpdir = TempDir::new().unwrap();
+            let device = create_block_device(tmpdir.as_path().to_path_buf()).unwrap();
+            let core = UffdCore::new(device);
+
+            // Create sockets for communication
+            let (sock1, _sock2) = std::os::unix::net::UnixStream::pair().unwrap();
+            sock1.set_nonblocking(true).unwrap();
+            let sock_async = AsyncFd::new(sock1).unwrap();
+
+            // Setup uffd region - OwnedFd takes ownership of uffd_fd
+            let (uffd_fd, addr, mmap_size) = setup_uffd_region(4096).unwrap();
+            let vma_regions = vec![VmaRegion::new(addr as u64, 4096, 0, 4096)];
+            let state = ConnState {
+                vma_regions,
+                policy: FaultPolicy::Zerocopy,
+                uffd_async: AsyncFd::new(unsafe { OwnedFd::from_raw_fd(uffd_fd) }).unwrap(),
+            };
+
+            // Call handle_uffd_event without triggering a page fault.
+            // Since no fault occurred, read_uffd_msg returns WouldBlock -> Ok(None)
+            // and handle_uffd_event should return Ok(()).
+            let result = UffdWorker::handle_uffd_event(&state, &core, &sock_async).await;
+            assert!(result.is_ok());
+
+            // Only unmap; OwnedFd owns uffd_fd and will close it on drop.
+            unsafe {
+                libc::munmap(addr as *mut _, mmap_size);
+            }
+        });
+    }
+
+    // Helper function to create test blob entry
+    fn create_test_blob_entry(tmpdir: PathBuf) -> BlobCacheEntry {
+        let root_dir = std::env::var("CARGO_MANIFEST_DIR").expect("$CARGO_MANIFEST_DIR");
+        let mut source_path = PathBuf::from(&root_dir);
+        source_path.push("../tests/texture/blobs/be7d77eeb719f70884758d1aa800ed0fb09d701aaec469964e9d54325f0d5fef");
+        let mut dest_path = tmpdir.clone();
+        dest_path.push("be7d77eeb719f70884758d1aa800ed0fb09d701aaec469964e9d54325f0d5fef");
+        std::fs::copy(&source_path, &dest_path).unwrap();
+
+        let mut boot_source = PathBuf::from(&root_dir);
+        boot_source.push("../tests/texture/bootstrap/rafs-v6-2.2.boot");
+        let mut boot_dest = tmpdir.clone();
+        boot_dest.push("image.boot");
+        std::fs::copy(&boot_source, &boot_dest).unwrap();
+
+        let config = format!(
+            r#"{{
+                "type": "bootstrap",
+                "id": "test-daemon",
+                "domain_id": "test-domain",
+                "config_v2": {{
+                    "version": 2,
+                    "id": "test-factory",
+                    "backend": {{
+                        "type": "localfs",
+                        "localfs": {{ "dir": "{}" }}
+                    }},
+                    "cache": {{
+                        "type": "filecache",
+                        "filecache": {{ "work_dir": "{}" }}
+                    }},
+                    "metadata_path": "{}/image.boot"
+                }}
+            }}"#,
+            tmpdir.display(),
+            tmpdir.display(),
+            tmpdir.display()
+        );
+        let mut entry: BlobCacheEntry = serde_json::from_str(&config).unwrap();
+        assert!(
+            entry.prepare_configuration_info(),
+            "prepare_configuration_info failed"
+        );
+        entry
+    }
+
+    // ---- UffdCore tests (from merged uffd_core module) ----
+
+    #[test]
+    fn test_read_uffd_msg_would_block() {
+        let (read_fd, write_fd) = unsafe {
+            let mut fds: [libc::c_int; 2] = [-1, -1];
+            let ret = libc::pipe(fds.as_mut_ptr());
+            assert_eq!(ret, 0);
+            (fds[0], fds[1])
+        };
+        let flags = unsafe { libc::fcntl(read_fd, libc::F_GETFL, 0) };
+        assert!(flags >= 0);
+        unsafe { libc::fcntl(read_fd, libc::F_SETFL, flags | libc::O_NONBLOCK) };
+
+        let result = read_uffd_msg(read_fd);
+        assert!(result.unwrap().is_none());
+
+        unsafe {
+            libc::close(read_fd);
+            libc::close(write_fd);
+        }
+    }
+
+    #[test]
+    fn test_uffd_core_new_and_device() {
+        let tmpdir = TempDir::new().unwrap();
+        let device = create_block_device(tmpdir.as_path().to_path_buf()).unwrap();
+        let device_size = device.blocks_to_size(device.blocks());
+        let block_size = device.block_size();
+
+        let core = UffdCore::new(device.clone());
+        assert_eq!(core.device_size, device_size);
+        assert_eq!(core.block_size, block_size);
+        assert!(Arc::ptr_eq(core.device(), &device));
+    }
+
+    #[test]
+    fn test_handle_page_fault_not_pagefault_event() {
+        let tmpdir = TempDir::new().unwrap();
+        let device = create_block_device(tmpdir.as_path().to_path_buf()).unwrap();
+        let core = UffdCore::new(device);
+        let vma_regions = vec![VmaRegion::new(0x1000, 0x2000, 0, 4096)];
+
+        let msg = UffdMsg {
+            event: 0x01,
+            _reserved1: [0; 3],
+            _reserved2: 0,
+            pagefault: UffdPagefault {
+                flags: 0,
+                address: 0x1000,
+                feat: 0,
+            },
+        };
+
+        tokio_uring::start(async {
+            let result = core
+                .handle_page_fault(&msg, &vma_regions, FaultPolicy::Copy, -1)
+                .await
+                .unwrap();
+            assert!(matches!(result, PageFaultResult::Noop));
+        });
+    }
+
+    #[test]
+    fn test_handle_page_fault_addr_not_in_vma() {
+        let tmpdir = TempDir::new().unwrap();
+        let device = create_block_device(tmpdir.as_path().to_path_buf()).unwrap();
+        let core = UffdCore::new(device);
+        let vma_regions = vec![VmaRegion::new(0x1000, 0x2000, 0, 4096)];
+
+        let msg = UffdMsg {
+            event: UFFD_EVENT_PAGEFAULT,
+            _reserved1: [0; 3],
+            _reserved2: 0,
+            pagefault: UffdPagefault {
+                flags: 0,
+                address: 0x5000,
+                feat: 0,
+            },
+        };
+
+        tokio_uring::start(async {
+            let result = core
+                .handle_page_fault(&msg, &vma_regions, FaultPolicy::Copy, -1)
+                .await
+                .unwrap();
+            assert!(matches!(result, PageFaultResult::Noop));
+        });
+    }
+
+    #[test]
+    fn test_handle_page_fault_copy_mode() {
+        let tmpdir = TempDir::new().unwrap();
+        let device = create_block_device(tmpdir.as_path().to_path_buf()).unwrap();
+        let device_size = device.blocks_to_size(device.blocks()) as usize;
+        let core = UffdCore::new(device);
+
+        let (uffd_fd, addr, mmap_size) = setup_uffd_region(device_size).unwrap();
+        let vma_regions = vec![VmaRegion::new(addr, device_size, 0, 4096)];
+
+        let msg = UffdMsg {
+            event: UFFD_EVENT_PAGEFAULT,
+            _reserved1: [0; 3],
+            _reserved2: 0,
+            pagefault: UffdPagefault {
+                flags: 0,
+                address: addr,
+                feat: 0,
+            },
+        };
+
+        tokio_uring::start(async {
+            let result = core
+                .handle_page_fault(&msg, &vma_regions, FaultPolicy::Copy, uffd_fd)
+                .await
+                .unwrap();
+            assert!(matches!(result, PageFaultResult::Copy));
+
+            let magic_ptr = (addr + 1024) as *const u8;
+            let magic = unsafe {
+                (*magic_ptr) as u32
+                    | (*magic_ptr.add(1) as u32) << 8
+                    | (*magic_ptr.add(2) as u32) << 16
+                    | (*magic_ptr.add(3) as u32) << 24
+            };
+            assert_eq!(magic, 0xE0F5E1E2, "EROFS magic mismatch in copy mode");
+        });
+
+        cleanup_uffd_region(uffd_fd, addr, mmap_size);
+    }
+
+    #[test]
+    fn test_handle_page_fault_zerocopy_mode() {
+        let tmpdir = TempDir::new().unwrap();
+        let device = create_block_device(tmpdir.as_path().to_path_buf()).unwrap();
+        let device_size = device.blocks_to_size(device.blocks()) as usize;
+        let core = UffdCore::new(device);
+
+        let (uffd_fd, addr, mmap_size) = setup_uffd_region(device_size).unwrap();
+        let vma_regions = vec![VmaRegion::new(addr, device_size, 0, 4096)];
+
+        let msg = UffdMsg {
+            event: UFFD_EVENT_PAGEFAULT,
+            _reserved1: [0; 3],
+            _reserved2: 0,
+            pagefault: UffdPagefault {
+                flags: 0,
+                address: addr,
+                feat: 0,
+            },
+        };
+
+        tokio_uring::start(async {
+            let result = core
+                .handle_page_fault(&msg, &vma_regions, FaultPolicy::Zerocopy, uffd_fd)
+                .await
+                .unwrap();
+            match result {
+                PageFaultResult::Zerocopy(zr) => {
+                    assert!(!zr.ranges.is_empty(), "zerocopy should return data ranges");
+                }
+                other => panic!("expected Zerocopy result, got {:?}", other),
+            }
+        });
+
+        cleanup_uffd_region(uffd_fd, addr, mmap_size);
+    }
+
+    #[test]
+    fn test_resolve_copy() {
+        let tmpdir = TempDir::new().unwrap();
+        let device = create_block_device(tmpdir.as_path().to_path_buf()).unwrap();
+        let device_size = device.blocks_to_size(device.blocks()) as usize;
+        let core = UffdCore::new(device);
+
+        let (uffd_fd, addr, mmap_size) = setup_uffd_region(device_size).unwrap();
+
+        tokio_uring::start(async {
+            core.resolve_copy(0, 4096, addr, uffd_fd).await.unwrap();
+            let magic_ptr = (addr + 1024) as *const u8;
+            let magic = unsafe {
+                (*magic_ptr) as u32
+                    | (*magic_ptr.add(1) as u32) << 8
+                    | (*magic_ptr.add(2) as u32) << 16
+                    | (*magic_ptr.add(3) as u32) << 24
+            };
+            assert_eq!(magic, 0xE0F5E1E2);
+        });
+
+        cleanup_uffd_region(uffd_fd, addr, mmap_size);
+    }
+
+    #[test]
+    fn test_resolve_zerocopy_ranges() {
+        let tmpdir = TempDir::new().unwrap();
+        let device = create_block_device(tmpdir.as_path().to_path_buf()).unwrap();
+        let device_size = device.blocks_to_size(device.blocks()) as usize;
+        let core = UffdCore::new(device);
+
+        let (uffd_fd, addr, mmap_size) = setup_uffd_region(device_size).unwrap();
+        let vma_region = VmaRegion::new(addr, device_size, 0, 4096);
+
+        tokio_uring::start(async {
+            let result = core
+                .resolve_zerocopy_ranges(0, 4096, &vma_region, uffd_fd)
+                .await
+                .unwrap();
+            assert!(!result.ranges.is_empty());
+        });
+
+        cleanup_uffd_region(uffd_fd, addr, mmap_size);
+    }
+
+    #[test]
+    fn test_prefault_ranges() {
+        let tmpdir = TempDir::new().unwrap();
+        let device = create_block_device(tmpdir.as_path().to_path_buf()).unwrap();
+        let device_size = device.blocks_to_size(device.blocks()) as usize;
+        let core = UffdCore::new(device);
+
+        let vma_regions = vec![VmaRegion::new(0, device_size, 0, 4096)];
+
+        tokio_uring::start(async {
+            let _ranges = core.prefault_ranges(&vma_regions).await.unwrap();
+        });
+    }
+
+    #[test]
+    fn test_handle_page_fault_beyond_device_zerocopy() {
+        let tmpdir = TempDir::new().unwrap();
+        let device = create_block_device(tmpdir.as_path().to_path_buf()).unwrap();
+        let device_size = device.blocks_to_size(device.blocks());
+
+        let vma_size = device_size as usize + 0x200000;
+        let core = UffdCore::new(device);
+
+        let (uffd_fd, addr, mmap_size) = setup_uffd_region(vma_size).unwrap();
+        let vma_regions = vec![VmaRegion::new(addr, vma_size, 0, 4096)];
+
+        let fault_addr = addr + device_size + 4096;
+        let msg = UffdMsg {
+            event: UFFD_EVENT_PAGEFAULT,
+            _reserved1: [0; 3],
+            _reserved2: 0,
+            pagefault: UffdPagefault {
+                flags: 0,
+                address: fault_addr,
+                feat: 0,
+            },
+        };
+
+        tokio_uring::start(async {
+            let result = core
+                .handle_page_fault(&msg, &vma_regions, FaultPolicy::Zerocopy, uffd_fd)
+                .await
+                .unwrap();
+            match result {
+                PageFaultResult::Zerocopy(zr) => {
+                    assert!(
+                        zr.ranges.is_empty(),
+                        "beyond-device should have no data ranges"
+                    );
+                }
+                other => panic!("expected Zerocopy, got {:?}", other),
+            }
+        });
+
+        cleanup_uffd_region(uffd_fd, addr, mmap_size);
+    }
+
+    #[test]
+    fn test_handle_page_fault_beyond_device_copy() {
+        let tmpdir = TempDir::new().unwrap();
+        let device = create_block_device(tmpdir.as_path().to_path_buf()).unwrap();
+        let device_size = device.blocks_to_size(device.blocks());
+
+        let vma_size = device_size as usize + 0x200000;
+        let core = UffdCore::new(device);
+
+        let (uffd_fd, addr, mmap_size) = setup_uffd_region(vma_size).unwrap();
+        let vma_regions = vec![VmaRegion::new(addr, vma_size, 0, 4096)];
+
+        let fault_addr = addr + device_size + 4096;
+        let msg = UffdMsg {
+            event: UFFD_EVENT_PAGEFAULT,
+            _reserved1: [0; 3],
+            _reserved2: 0,
+            pagefault: UffdPagefault {
+                flags: 0,
+                address: fault_addr,
+                feat: 0,
+            },
+        };
+
+        tokio_uring::start(async {
+            let result = core
+                .handle_page_fault(&msg, &vma_regions, FaultPolicy::Copy, uffd_fd)
+                .await
+                .unwrap();
+            assert!(matches!(result, PageFaultResult::Copy));
+        });
+
+        cleanup_uffd_region(uffd_fd, addr, mmap_size);
+    }
+
+    #[test]
+    fn test_uffdio_wake() {
+        tokio_uring::start(async {
+            let (uffd_fd, addr, mmap_size) = setup_uffd_region(4096).unwrap();
+
+            let result = uffdio_wake(uffd_fd, addr as u64, 4096).await;
+            assert!(
+                result.is_ok(),
+                "uffdio_wake on registered region failed: {:?}",
+                result.err()
+            );
+
+            let zeropage_result = uffdio_zeropage(uffd_fd, addr as u64, 4096).await;
+            assert!(
+                zeropage_result.is_ok(),
+                "uffdio_zeropage failed: {:?}",
+                zeropage_result.err()
+            );
+
+            let result = uffdio_wake(uffd_fd, addr as u64, 4096).await;
+            assert!(
+                result.is_ok(),
+                "uffdio_wake after zeropage should return Ok (EEXIST): {:?}",
+                result.err()
+            );
+
+            cleanup_uffd_region(uffd_fd, addr, mmap_size);
+        });
+    }
+
+    #[test]
+    fn test_uffdio_wake_invalid_fd() {
+        tokio_uring::start(async {
+            let result = uffdio_wake(-1, 0x1000, 4096).await;
+            assert!(result.is_err());
+        });
+    }
+}

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -49,8 +49,12 @@ pub mod blob_cache;
 pub mod block_device;
 #[cfg(all(target_os = "linux", feature = "block-nbd"))]
 pub mod block_nbd;
+#[cfg(all(target_os = "linux", feature = "block-uffd"))]
+pub mod block_uffd;
 #[cfg(target_os = "linux")]
 mod fs_cache;
+#[cfg(all(target_os = "linux", feature = "block-uffd"))]
+pub mod uffd_proto;
 
 #[cfg(target_os = "linux")]
 pub use fs_cache::FsCacheHandler;

--- a/service/src/uffd_proto.rs
+++ b/service/src/uffd_proto.rs
@@ -1,0 +1,326 @@
+// Copyright (C) 2026 Ant Group. All rights reserved.
+//
+// SPDX-License-Identifier: (Apache-2.0)
+
+//! Protocol definitions for UFFD communication.
+
+use serde::{Deserialize, Serialize};
+use serde_repr::{Deserialize_repr, Serialize_repr};
+
+/// UFFD protocol version
+pub const UFFD_PROTOCOL_VERSION: u32 = 1;
+
+/// Message type enum for UFFD protocol
+#[derive(Debug, Clone, Copy, Default, Serialize_repr, Deserialize_repr, PartialEq, Eq)]
+#[repr(u8)]
+pub enum MessageType {
+    #[default]
+    Handshake = 0,
+    PageFault = 1,
+    Stat = 2,
+    StatResp = 3,
+}
+
+/// Fault handling policy for UFFD
+#[derive(Debug, Clone, Copy, Default, Serialize_repr, Deserialize_repr, PartialEq, Eq)]
+#[repr(u8)]
+pub enum FaultPolicy {
+    /// Zero-copy mode: send fd to client, let client do mmap
+    #[default]
+    Zerocopy = 0,
+    /// Copy mode: use UFFDIO_COPY to copy data directly
+    Copy = 1,
+}
+
+/// VMA region information for userfaultfd registration (JSON format)
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct VmaRegion {
+    pub base_host_virt_addr: u64,
+    pub size: usize,
+    pub offset: u64,
+    pub page_size: usize,
+    #[serde(default)]
+    pub page_size_kib: usize,
+    #[serde(default = "default_prot")]
+    pub prot: i32,
+    #[serde(default = "default_flags")]
+    pub flags: i32,
+}
+
+fn default_prot() -> i32 {
+    libc::PROT_READ
+}
+
+fn default_flags() -> i32 {
+    libc::MAP_PRIVATE | libc::MAP_FIXED
+}
+
+impl VmaRegion {
+    /// Create a new VmaRegion with default prot and flags.
+    #[allow(dead_code)]
+    pub fn new(base_host_virt_addr: u64, size: usize, offset: u64, page_size: usize) -> Self {
+        Self {
+            base_host_virt_addr,
+            size,
+            offset,
+            page_size,
+            page_size_kib: 0,
+            prot: libc::PROT_READ,
+            flags: libc::MAP_PRIVATE | libc::MAP_FIXED,
+        }
+    }
+}
+
+/// Handshake request (Client -> Server)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HandshakeRequest {
+    #[serde(default)]
+    pub r#type: MessageType,
+    pub regions: Vec<VmaRegion>,
+    #[serde(default)]
+    pub policy: FaultPolicy,
+    /// Enable pre-fault in zerocopy mode (default: false)
+    #[serde(default)]
+    pub enable_prefault: bool,
+}
+
+/// Page fault response (Server -> Client)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PageFaultResponse {
+    pub r#type: MessageType,
+    pub ranges: Vec<BlobRange>,
+}
+
+/// Blob range information for page fault response
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BlobRange {
+    pub len: usize,
+    pub blob_offset: u64,
+    pub block_offset: u64,
+}
+
+/// Stat request (Client -> Server)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StatRequest {
+    pub r#type: MessageType,
+}
+
+impl StatRequest {
+    pub fn new() -> Self {
+        Self {
+            r#type: MessageType::Stat,
+        }
+    }
+}
+
+impl Default for StatRequest {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Stat response (Server -> Client)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct StatResponse {
+    pub r#type: MessageType,
+    pub size: u64,
+    pub block_size: u32,
+    pub flags: u32,
+    pub version: u32,
+}
+
+impl StatResponse {
+    pub fn new(size: u64, block_size: u32, flags: u32, version: u32) -> Self {
+        Self {
+            r#type: MessageType::StatResp,
+            size,
+            block_size,
+            flags,
+            version,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_message_type_default() {
+        let msg_type: MessageType = Default::default();
+        assert_eq!(msg_type, MessageType::Handshake);
+    }
+
+    #[test]
+    fn test_message_type_serialize() {
+        let msg_type = MessageType::Handshake;
+        let json = serde_json::to_string(&msg_type).unwrap();
+        assert_eq!(json, "0");
+
+        let msg_type = MessageType::PageFault;
+        let json = serde_json::to_string(&msg_type).unwrap();
+        assert_eq!(json, "1");
+
+        let msg_type = MessageType::Stat;
+        let json = serde_json::to_string(&msg_type).unwrap();
+        assert_eq!(json, "2");
+
+        let msg_type = MessageType::StatResp;
+        let json = serde_json::to_string(&msg_type).unwrap();
+        assert_eq!(json, "3");
+    }
+
+    #[test]
+    fn test_message_type_deserialize() {
+        let msg_type: MessageType = serde_json::from_str("0").unwrap();
+        assert_eq!(msg_type, MessageType::Handshake);
+
+        let msg_type: MessageType = serde_json::from_str("1").unwrap();
+        assert_eq!(msg_type, MessageType::PageFault);
+
+        let msg_type: MessageType = serde_json::from_str("2").unwrap();
+        assert_eq!(msg_type, MessageType::Stat);
+
+        let msg_type: MessageType = serde_json::from_str("3").unwrap();
+        assert_eq!(msg_type, MessageType::StatResp);
+    }
+
+    #[test]
+    fn test_fault_policy_default() {
+        let policy: FaultPolicy = Default::default();
+        assert_eq!(policy, FaultPolicy::Zerocopy);
+    }
+
+    #[test]
+    fn test_vma_region_new() {
+        let region = VmaRegion::new(0x1000, 0x2000, 0x100, 0x1000);
+        assert_eq!(region.base_host_virt_addr, 0x1000);
+        assert_eq!(region.size, 0x2000);
+        assert_eq!(region.offset, 0x100);
+        assert_eq!(region.page_size, 0x1000);
+        assert_eq!(region.prot, libc::PROT_READ);
+        assert_eq!(region.flags, libc::MAP_PRIVATE | libc::MAP_FIXED);
+    }
+
+    #[test]
+    fn test_vma_region_serialize() {
+        let region = VmaRegion {
+            base_host_virt_addr: 0x1000,
+            size: 0x2000,
+            offset: 0x100,
+            page_size: 0x1000,
+            page_size_kib: 0,
+            prot: libc::PROT_READ,
+            flags: libc::MAP_PRIVATE | libc::MAP_FIXED,
+        };
+
+        let json = serde_json::to_string(&region).unwrap();
+        let region2: VmaRegion = serde_json::from_str(&json).unwrap();
+        assert_eq!(region.base_host_virt_addr, region2.base_host_virt_addr);
+        assert_eq!(region.size, region2.size);
+        assert_eq!(region.offset, region2.offset);
+        assert_eq!(region.page_size, region2.page_size);
+    }
+
+    #[test]
+    fn test_vma_region_default_prot_flags() {
+        let json = r#"{"base_host_virt_addr":4096,"size":8192,"offset":256,"page_size":4096}"#;
+        let region: VmaRegion = serde_json::from_str(json).unwrap();
+        assert_eq!(region.prot, libc::PROT_READ);
+        assert_eq!(region.flags, libc::MAP_PRIVATE | libc::MAP_FIXED);
+    }
+
+    #[test]
+    fn test_handshake_request() {
+        let region = VmaRegion::new(0x1000, 0x2000, 0x100, 0x1000);
+
+        let request = HandshakeRequest {
+            r#type: MessageType::Handshake,
+            regions: vec![region],
+            policy: FaultPolicy::default(),
+            enable_prefault: false,
+        };
+
+        let json = serde_json::to_string(&request).unwrap();
+        let request2: HandshakeRequest = serde_json::from_str(&json).unwrap();
+        assert_eq!(request2.r#type, MessageType::Handshake);
+        assert_eq!(request2.regions.len(), 1);
+        assert_eq!(request2.regions[0].page_size, 0x1000);
+        assert!(!request2.enable_prefault);
+    }
+
+    #[test]
+    fn test_handshake_request_default_type() {
+        let json = r#"{"regions":[{"base_host_virt_addr":4096,"size":8192,"offset":256,"page_size":4096}]}"#;
+        let request: HandshakeRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(request.r#type, MessageType::Handshake);
+        assert_eq!(request.regions[0].page_size, 4096);
+    }
+
+    #[test]
+    fn test_blob_range() {
+        let range = BlobRange {
+            len: 0x1000,
+            blob_offset: 0x100,
+            block_offset: 0x200,
+        };
+
+        let json = serde_json::to_string(&range).unwrap();
+        let range2: BlobRange = serde_json::from_str(&json).unwrap();
+        assert_eq!(range.len, range2.len);
+        assert_eq!(range.blob_offset, range2.blob_offset);
+        assert_eq!(range.block_offset, range2.block_offset);
+    }
+
+    #[test]
+    fn test_page_fault_response() {
+        let response = PageFaultResponse {
+            r#type: MessageType::PageFault,
+            ranges: vec![BlobRange {
+                len: 0x1000,
+                blob_offset: 0x100,
+                block_offset: 0x200,
+            }],
+        };
+
+        let json = serde_json::to_string(&response).unwrap();
+        let response2: PageFaultResponse = serde_json::from_str(&json).unwrap();
+        assert_eq!(response2.r#type, MessageType::PageFault);
+        assert_eq!(response2.ranges.len(), 1);
+    }
+
+    #[test]
+    fn test_stat_response() {
+        let response = StatResponse::new(1024 * 1024 * 100, 4096, 0, 1);
+        assert_eq!(response.r#type, MessageType::StatResp);
+        assert_eq!(response.size, 1024 * 1024 * 100);
+        assert_eq!(response.block_size, 4096);
+        assert_eq!(response.flags, 0);
+        assert_eq!(response.version, 1);
+
+        let json = serde_json::to_string(&response).unwrap();
+        let response2: StatResponse = serde_json::from_str(&json).unwrap();
+        assert_eq!(response2.size, response.size);
+        assert_eq!(response2.block_size, response.block_size);
+    }
+
+    #[test]
+    fn test_fault_policy_serialize() {
+        let policy = FaultPolicy::Zerocopy;
+        let json = serde_json::to_string(&policy).unwrap();
+        assert_eq!(json, "0");
+
+        let policy = FaultPolicy::Copy;
+        let json = serde_json::to_string(&policy).unwrap();
+        assert_eq!(json, "1");
+    }
+
+    #[test]
+    fn test_fault_policy_deserialize() {
+        let policy: FaultPolicy = serde_json::from_str("0").unwrap();
+        assert_eq!(policy, FaultPolicy::Zerocopy);
+
+        let policy: FaultPolicy = serde_json::from_str("1").unwrap();
+        assert_eq!(policy, FaultPolicy::Copy);
+    }
+}

--- a/smoke/tests/tool/nydusd.go
+++ b/smoke/tests/tool/nydusd.go
@@ -17,6 +17,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
 	"text/template"
 	"time"
@@ -89,6 +90,9 @@ type NydusdConfig struct {
 	OvlUpperDir string
 	OvlWorkDir  string
 	Writable    bool
+	// UFFD config.
+	UffdSockPath string
+	LocalFsDir   string
 }
 
 type Nydusd struct {
@@ -264,6 +268,65 @@ func NewNydusd(conf NydusdConfig) (*Nydusd, error) {
 	}
 
 	return nydusd, nil
+}
+
+// NewNydusdUffd creates a Nydusd instance for uffd subcommand mode.
+// The uffd mode uses --bootstrap and --localfs-dir instead of a config template.
+func NewNydusdUffd(conf NydusdConfig) (*Nydusd, error) {
+	args := []string{
+		"uffd",
+		"--sock", conf.UffdSockPath,
+		"--bootstrap", conf.BootstrapPath,
+		"--localfs-dir", conf.LocalFsDir,
+		"--log-level", "info",
+		"--threads", "4",
+		"--rlimit-nofile", "0",
+	}
+	if len(conf.APISockPath) > 0 {
+		args = append(args, "--apisock", conf.APISockPath)
+	}
+
+	logrus.Infof("command: %s %s", conf.NydusdPath, strings.Join(args, " "))
+	cmd := exec.Command(conf.NydusdPath, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	transport := &http.Transport{
+		MaxIdleConns:          10,
+		IdleConnTimeout:       10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+		DialContext: func(ctx context.Context, _, _ string) (net.Conn, error) {
+			dialer := &net.Dialer{
+				Timeout:   5 * time.Second,
+				KeepAlive: 5 * time.Second,
+			}
+			return dialer.DialContext(ctx, "unix", conf.APISockPath)
+		},
+	}
+
+	client := &http.Client{
+		Timeout:   30 * time.Second,
+		Transport: transport,
+	}
+
+	nydusd := &Nydusd{
+		client:       client,
+		cmd:          cmd,
+		NydusdConfig: conf,
+	}
+
+	return nydusd, nil
+}
+
+// Shutdown stops a non-FUSE daemon (uffd, nbd) by sending SIGTERM.
+func (nydusd *Nydusd) Shutdown() error {
+	if nydusd.cmd != nil && nydusd.cmd.Process != nil {
+		_ = nydusd.cmd.Process.Signal(syscall.SIGTERM)
+	}
+	if nydusd.waitCh == nil {
+		return nil
+	}
+	return nydusd.waitForExit(10 * time.Second)
 }
 
 func NewNydusdWithOverlay(conf NydusdConfig) (*Nydusd, error) {

--- a/smoke/tests/tool/uffd_client.go
+++ b/smoke/tests/tool/uffd_client.go
@@ -1,0 +1,543 @@
+// Copyright 2026 Nydus Developers. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package tool
+
+import (
+	"encoding/binary"
+	"encoding/json"
+	"fmt"
+	"net"
+	"os/exec"
+	"runtime"
+	"sync"
+	"syscall"
+	"time"
+	"unsafe"
+)
+
+// UFFD protocol constants (matching service/src/uffd_proto.rs).
+const (
+	msgTypeHandshake = 0
+	msgTypePageFault = 1
+	msgTypeStat      = 2
+	msgTypeStatResp  = 3
+
+	PolicyZerocopy = 0
+	PolicyCopy     = 1
+
+	// userfaultfd syscall numbers.
+	sysUserfaultfdAMD64 = 323
+	sysUserfaultfdARM64 = 282
+
+	// UFFDIO ioctl numbers.
+	uffdioAPI      = 0xc018aa3f
+	uffdioRegister = 0xc020aa00
+	uffdioWake     = 0x8010aa02
+
+	uffdioRegisterModeMissing = 1
+
+	uffdAPI = 0xaa
+
+	// EROFS superblock magic.
+	erofsMagicOffset = 1024
+	erofsMagic       = 0xE0F5E1E2
+)
+
+// Protocol message types.
+
+type vmaRegion struct {
+	BaseHostVirtAddr uint64 `json:"base_host_virt_addr"`
+	Size             uint64 `json:"size"`
+	Offset           uint64 `json:"offset"`
+	PageSize         uint64 `json:"page_size"`
+	PageSizeKib      uint64 `json:"page_size_kib,omitempty"`
+	Prot             int32  `json:"prot,omitempty"`
+	Flags            int32  `json:"flags,omitempty"`
+}
+
+type handshakeRequest struct {
+	Type           int         `json:"type"`
+	Regions        []vmaRegion `json:"regions"`
+	Policy         int         `json:"policy"`
+	EnablePrefault bool        `json:"enable_prefault"`
+}
+
+type blobRange struct {
+	Len         uint64 `json:"len"`
+	BlobOffset  uint64 `json:"blob_offset"`
+	BlockOffset uint64 `json:"block_offset"`
+}
+
+type pageFaultResponse struct {
+	Type   int         `json:"type"`
+	Ranges []blobRange `json:"ranges"`
+}
+
+type statRequest struct {
+	Type int `json:"type"`
+}
+
+type statResponse struct {
+	Type      int    `json:"type"`
+	Size      uint64 `json:"size"`
+	BlockSize uint32 `json:"block_size"`
+	Flags     uint32 `json:"flags"`
+	Version   uint32 `json:"version"`
+}
+
+// UffdClient implements the UFFD block device protocol for testing.
+type UffdClient struct {
+	conn       *net.UnixConn
+	uffdFd     int
+	memSlice   []byte // mmap'd region (for syscall.Munmap)
+	deviceSize uint64
+	blockSize  uint32
+	policy     int
+	region     vmaRegion
+	workerWg   sync.WaitGroup
+	workerDone chan struct{}
+	closed     bool
+	mu         sync.Mutex
+}
+
+// sysUserfaultfd returns the syscall number for the current architecture.
+func sysUserfaultfd() uintptr {
+	switch runtime.GOARCH {
+	case "amd64":
+		return sysUserfaultfdAMD64
+	case "arm64":
+		return sysUserfaultfdARM64
+	default:
+		return sysUserfaultfdAMD64 // fallback
+	}
+}
+
+// createUserfaultfd creates a userfaultfd file descriptor.
+func createUserfaultfd() (int, error) {
+	fd, _, errno := syscall.Syscall(sysUserfaultfd(), syscall.O_CLOEXEC|syscall.O_NONBLOCK, 0, 0)
+	if errno != 0 {
+		return -1, fmt.Errorf("userfaultfd: %w", errno)
+	}
+
+	// UFFDIO_API handshake.
+	var api struct {
+		API      uint64
+		Features uint64
+		Ioctls   uint64
+	}
+	api.API = uffdAPI
+
+	_, _, errno = syscall.Syscall(syscall.SYS_IOCTL, fd, uffdioAPI, uintptr(unsafe.Pointer(&api)))
+	if errno != 0 {
+		syscall.Close(int(fd))
+		return -1, fmt.Errorf("UFFDIO_API: %w", errno)
+	}
+
+	return int(fd), nil
+}
+
+// uffdRegister registers a memory range with userfaultfd.
+func uffdRegister(fd int, addr uintptr, len uint64) error {
+	var reg struct {
+		Start  uint64
+		Len    uint64
+		Mode   uint64
+		Ioctls uint64
+	}
+	reg.Start = uint64(addr)
+	reg.Len = len
+	reg.Mode = uffdioRegisterModeMissing
+
+	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, uintptr(fd), uffdioRegister, uintptr(unsafe.Pointer(&reg)))
+	if errno != 0 {
+		return fmt.Errorf("UFFDIO_REGISTER: %w", errno)
+	}
+	return nil
+}
+
+// uffdWake wakes threads blocked on page faults in the given range.
+func uffdWake(fd int, addr uintptr, len uint64) error {
+	var rng struct {
+		Start uint64
+		Len   uint64
+	}
+	rng.Start = uint64(addr)
+	rng.Len = len
+
+	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, uintptr(fd), uffdioWake, uintptr(unsafe.Pointer(&rng)))
+	if errno != 0 {
+		// EEXIST means page already mapped — not a fatal error.
+		if errno == syscall.EEXIST {
+			return nil
+		}
+		return fmt.Errorf("UFFDIO_WAKE: %w", errno)
+	}
+	return nil
+}
+
+// sendWithFd sends data with file descriptors via SCM_RIGHTS.
+func sendWithFd(conn *net.UnixConn, data []byte, fds []int) error {
+	oob := syscall.UnixRights(fds...)
+	_, _, err := conn.WriteMsgUnix(data, oob, nil)
+	return err
+}
+
+// recvWithFd receives data and file descriptors via SCM_RIGHTS.
+func recvWithFd(conn *net.UnixConn, buf []byte) (int, []int, error) {
+	oobBuf := make([]byte, 4096)
+	n, oobn, _, _, err := conn.ReadMsgUnix(buf, oobBuf)
+	if err != nil {
+		return n, nil, err
+	}
+
+	var fds []int
+	if oobn > 0 {
+		msgs, err := syscall.ParseSocketControlMessage(oobBuf[:oobn])
+		if err != nil {
+			return n, nil, fmt.Errorf("parse socket control message: %w", err)
+		}
+		for _, msg := range msgs {
+			parsedFds, err := syscall.ParseUnixRights(&msg)
+			if err != nil {
+				return n, nil, fmt.Errorf("parse unix rights: %w", err)
+			}
+			fds = append(fds, parsedFds...)
+		}
+	}
+
+	return n, fds, nil
+}
+
+// NewUffdClient connects to the UFFD service and queries device size.
+func NewUffdClient(sockPath string) (*UffdClient, error) {
+	conn, err := net.DialUnix("unix", nil, &net.UnixAddr{Name: sockPath, Net: "unix"})
+	if err != nil {
+		return nil, fmt.Errorf("connect to %s: %w", sockPath, err)
+	}
+
+	c := &UffdClient{
+		conn:       conn,
+		uffdFd:     -1,
+		workerDone: make(chan struct{}),
+	}
+
+	// Send Stat request.
+	req := statRequest{Type: msgTypeStat}
+	data, err := json.Marshal(req)
+	if err != nil {
+		c.Close()
+		return nil, fmt.Errorf("marshal stat request: %w", err)
+	}
+	if err := sendWithFd(conn, data, nil); err != nil {
+		c.Close()
+		return nil, fmt.Errorf("send stat request: %w", err)
+	}
+
+	// Receive Stat response.
+	buf := make([]byte, 4096)
+	n, _, err := recvWithFd(conn, buf)
+	if err != nil {
+		c.Close()
+		return nil, fmt.Errorf("recv stat response: %w", err)
+	}
+
+	var resp statResponse
+	if err := json.Unmarshal(buf[:n], &resp); err != nil {
+		c.Close()
+		return nil, fmt.Errorf("unmarshal stat response: %w", err)
+	}
+	if resp.Type != msgTypeStatResp {
+		c.Close()
+		return nil, fmt.Errorf("unexpected stat response type %d", resp.Type)
+	}
+
+	c.deviceSize = resp.Size
+	c.blockSize = resp.BlockSize
+
+	return c, nil
+}
+
+// DeviceSize returns the block device size reported by the server.
+func (c *UffdClient) DeviceSize() uint64 {
+	return c.deviceSize
+}
+
+// BlockSize returns the block size reported by the server.
+func (c *UffdClient) BlockSize() uint32 {
+	return c.blockSize
+}
+
+// Handshake creates a userfaultfd, mmaps a region, registers it,
+// and sends the handshake request with the uffd fd via SCM_RIGHTS.
+func (c *UffdClient) Handshake(policy int, enablePrefault bool) error {
+	if c.memSlice != nil {
+		return fmt.Errorf("already handshaked")
+	}
+
+	// Create userfaultfd.
+	uffdFd, err := createUserfaultfd()
+	if err != nil {
+		return fmt.Errorf("create userfaultfd: %w", err)
+	}
+	c.uffdFd = uffdFd
+
+	// mmap anonymous region (2MB-aligned for huge page support).
+	pageSize := uint64(4096)
+	align := uint64(2 * 1024 * 1024) // 2MB
+	mmapSize := (c.deviceSize + align - 1) / align * align
+	if mmapSize == 0 {
+		mmapSize = align
+	}
+
+	addr, _, errno := syscall.Syscall6(
+		syscall.SYS_MMAP,
+		0,
+		uintptr(mmapSize),
+		syscall.PROT_READ|syscall.PROT_WRITE,
+		syscall.MAP_PRIVATE|syscall.MAP_ANONYMOUS,
+		^uintptr(0), // fd: -1
+		0,
+	)
+	if errno != 0 {
+		syscall.Close(uffdFd)
+		c.uffdFd = -1
+		return fmt.Errorf("mmap: %w", errno)
+	}
+	c.memSlice = unsafe.Slice((*byte)(unsafe.Pointer(addr)), mmapSize) //nolint:govet
+
+	// Register with userfaultfd.
+	if err := uffdRegister(uffdFd, addr, mmapSize); err != nil {
+		_ = syscall.Munmap(c.memSlice)
+		_ = syscall.Close(uffdFd)
+		c.memSlice = nil
+		c.uffdFd = -1
+		return fmt.Errorf("uffd register: %w", err)
+	}
+
+	// Send handshake request with uffd fd.
+	c.policy = policy
+	c.region = vmaRegion{
+		BaseHostVirtAddr: uint64(addr),
+		Size:             c.deviceSize,
+		Offset:           0,
+		PageSize:         pageSize,
+		Prot:             syscall.PROT_READ,
+		Flags:            syscall.MAP_PRIVATE | syscall.MAP_FIXED,
+	}
+
+	req := handshakeRequest{
+		Type:           msgTypeHandshake,
+		Regions:        []vmaRegion{c.region},
+		Policy:         policy,
+		EnablePrefault: enablePrefault,
+	}
+	data, err := json.Marshal(req)
+	if err != nil {
+		return fmt.Errorf("marshal handshake: %w", err)
+	}
+
+	if err := sendWithFd(c.conn, data, []int{uffdFd}); err != nil {
+		return fmt.Errorf("send handshake: %w", err)
+	}
+
+	// For zerocopy mode, start the worker goroutine.
+	if policy == PolicyZerocopy {
+		c.workerWg.Add(1)
+		go c.zerocopyWorker()
+	}
+
+	return nil
+}
+
+// zerocopyWorker receives PageFaultResponse messages and mmaps blob fds.
+func (c *UffdClient) zerocopyWorker() {
+	defer c.workerWg.Done()
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	buf := make([]byte, 4096)
+	for {
+		select {
+		case <-c.workerDone:
+			return
+		default:
+		}
+
+		// No deadline — block until data arrives.
+		c.conn.SetReadDeadline(time.Time{})
+		n, fds, err := recvWithFd(c.conn, buf)
+		if err != nil {
+			if isTemporaryError(err) {
+				continue
+			}
+			// Connection closed or error — stop worker.
+			return
+		}
+		if n == 0 {
+			return
+		}
+
+		// Parse the response.
+		var resp pageFaultResponse
+		if err := json.Unmarshal(buf[:n], &resp); err != nil {
+			closeFds(fds)
+			continue
+		}
+
+		if resp.Type != msgTypePageFault {
+			closeFds(fds)
+			continue
+		}
+
+		if len(fds) != len(resp.Ranges) {
+			closeFds(fds)
+			continue
+		}
+
+		// Process each range: mmap blob fd at the correct address.
+		for i, r := range resp.Ranges {
+			fd := fds[i]
+			targetAddr := c.region.BaseHostVirtAddr + (r.BlockOffset - c.region.Offset)
+
+			mapped, _, _ := syscall.Syscall6(
+				syscall.SYS_MMAP,
+				uintptr(targetAddr),
+				uintptr(r.Len),
+				uintptr(c.region.Prot),
+				uintptr(c.region.Flags)|syscall.MAP_SHARED,
+				uintptr(fd),
+				uintptr(r.BlobOffset),
+			)
+			if mapped == ^uintptr(0) { // MAP_FAILED
+				// mmap failed — close fd and continue.
+				syscall.Close(fd)
+				continue
+			}
+
+			// mmap succeeded — close the original fd (mmap duplicated it).
+			syscall.Close(fd)
+
+			// Wake any threads blocked on page faults in this range.
+			uffdWake(c.uffdFd, uintptr(targetAddr), r.Len)
+		}
+	}
+}
+
+// ReadAt reads data from the UFFD-backed memory at the given offset.
+// This triggers page faults which are resolved by the server.
+func (c *UffdClient) ReadAt(offset, length int64) ([]byte, error) {
+	if c.memSlice == nil {
+		return nil, fmt.Errorf("not handshaked")
+	}
+	if offset < 0 || offset+length > int64(c.deviceSize) {
+		return nil, fmt.Errorf("read out of bounds: offset=%d length=%d deviceSize=%d", offset, length, c.deviceSize)
+	}
+
+	// Read from the mmap'd region. This triggers page faults resolved by the server.
+	data := make([]byte, length)
+	copy(data, c.memSlice[offset:offset+length])
+	return data, nil
+}
+
+// Close cleans up all resources.
+func (c *UffdClient) Close() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.closed {
+		return
+	}
+	c.closed = true
+
+	// Signal worker to stop.
+	if c.workerDone != nil {
+		select {
+		case <-c.workerDone:
+		default:
+			close(c.workerDone)
+		}
+	}
+
+	// Close the socket (will cause worker to exit if still running).
+	if c.conn != nil {
+		c.conn.Close()
+	}
+
+	// Wait for worker to finish.
+	c.workerWg.Wait()
+
+	// Unmap memory.
+	if c.memSlice != nil {
+		syscall.Munmap(c.memSlice)
+		c.memSlice = nil
+	}
+
+	// Close userfaultfd.
+	if c.uffdFd >= 0 {
+		syscall.Close(c.uffdFd)
+		c.uffdFd = -1
+	}
+}
+
+// VerifyErofsMagic checks that the EROFS superblock magic is present at offset 1024.
+func (c *UffdClient) VerifyErofsMagic() error {
+	data, err := c.ReadAt(erofsMagicOffset, 4)
+	if err != nil {
+		return fmt.Errorf("read erofs magic: %w", err)
+	}
+	magic := binary.LittleEndian.Uint32(data)
+	if magic != erofsMagic {
+		return fmt.Errorf("erofs magic mismatch: got 0x%08x, want 0x%08x", magic, erofsMagic)
+	}
+	return nil
+}
+
+// VerifyNonZero reads data at the given offset and checks it's not all zeros.
+func (c *UffdClient) VerifyNonZero(offset, length int64) error {
+	data, err := c.ReadAt(offset, length)
+	if err != nil {
+		return fmt.Errorf("read at offset %d: %w", offset, err)
+	}
+	allZero := true
+	for _, b := range data {
+		if b != 0 {
+			allZero = false
+			break
+		}
+	}
+	if allZero {
+		return fmt.Errorf("data at offset %d is all zeros (expected non-zero data)", offset)
+	}
+	return nil
+}
+
+// closeFds closes all file descriptors in the slice.
+func closeFds(fds []int) {
+	for _, fd := range fds {
+		syscall.Close(fd)
+	}
+}
+
+// isTemporaryError returns true if the error is a temporary network error.
+func isTemporaryError(err error) bool {
+	if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+		return true
+	}
+	return false
+}
+
+// ExportDiskImage uses nydus-image to export the RAFS image to a raw disk file.
+// Returns the path to the exported file.
+func ExportDiskImage(builderPath, bootstrapPath, localfsDir, outputPath string) error {
+	cmd := fmt.Sprintf("%s export --block --bootstrap %s --localfs-dir %s --output %s",
+		builderPath, bootstrapPath, localfsDir, outputPath)
+	out, err := exec.Command("sh", "-c", cmd).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("nydus-image export failed: %w\n%s", err, string(out))
+	}
+	return nil
+}

--- a/smoke/tests/uffd_test.go
+++ b/smoke/tests/uffd_test.go
@@ -1,0 +1,370 @@
+// Copyright 2026 Nydus Developers. All rights reserved.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+package tests
+
+import (
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/BraveY/snapshotter-converter/converter"
+	"github.com/containerd/log"
+	"github.com/dragonflyoss/nydus/smoke/tests/texture"
+	"github.com/dragonflyoss/nydus/smoke/tests/tool"
+	"github.com/dragonflyoss/nydus/smoke/tests/tool/test"
+	"github.com/stretchr/testify/require"
+)
+
+type UffdTestSuite struct {
+	T *testing.T
+}
+
+// buildLayer creates a RAFS v6 layer using MakeThinLowerLayer + Pack + MergeLayers.
+// MakeThinLowerLayer is used instead of MakeLowerLayer because the latter
+// creates special files (char/block devices, FIFO) via mknod which requires root.
+func (s *UffdTestSuite) buildLayer(t *testing.T, ctx *tool.Context) {
+	packOption := converter.PackOption{
+		BuilderPath: ctx.Binary.Builder,
+		Compressor:  ctx.Build.Compressor,
+		FsVersion:   ctx.Build.FSVersion,
+		ChunkSize:   ctx.Build.ChunkSize,
+	}
+
+	lowerLayer := texture.MakeThinLowerLayer(t, filepath.Join(ctx.Env.WorkDir, "source"))
+	digest := lowerLayer.Pack(t, packOption, ctx.Env.BlobDir)
+
+	mergeOption := converter.MergeOption{
+		BuilderPath: ctx.Binary.Builder,
+	}
+	_, bootstrap := tool.MergeLayers(t, *ctx, mergeOption, []converter.Layer{
+		{Digest: digest},
+	})
+
+	ctx.Env.BootstrapPath = bootstrap
+}
+
+// TestUffdDaemonLifecycle verifies that nydusd starts in uffd mode,
+// reaches RUNNING state, and shuts down cleanly.
+func (s *UffdTestSuite) TestUffdDaemonLifecycle(t *testing.T) {
+	ctx := tool.DefaultContext(t)
+	ctx.PrepareWorkDir(t)
+	defer ctx.Destroy(t)
+
+	s.buildLayer(t, ctx)
+
+	uffdSockPath := filepath.Join(ctx.Env.WorkDir, "uffd.sock")
+	apiSockPath := filepath.Join(ctx.Env.WorkDir, "api.sock")
+
+	nydusd, err := tool.NewNydusdUffd(tool.NydusdConfig{
+		NydusdPath:    ctx.Binary.Nydusd,
+		BootstrapPath: ctx.Env.BootstrapPath,
+		LocalFsDir:    ctx.Env.BlobDir,
+		UffdSockPath:  uffdSockPath,
+		APISockPath:   apiSockPath,
+	})
+	require.NoError(t, err)
+
+	// Start daemon
+	_, err = nydusd.Run()
+	require.NoError(t, err)
+	defer func() {
+		if err := nydusd.Shutdown(); err != nil {
+			log.L.WithError(err).Errorf("shutdown uffd daemon")
+		}
+	}()
+
+	// Wait for RUNNING state via API
+	err = nydusd.WaitStatus("RUNNING")
+	require.NoError(t, err)
+
+	// Verify the uffd socket was created
+	_, err = os.Stat(uffdSockPath)
+	require.NoError(t, err)
+}
+
+// TestUffdDaemonRestart verifies that the uffd daemon can be restarted
+// after shutdown and a new instance can listen on the same socket path.
+func (s *UffdTestSuite) TestUffdDaemonRestart(t *testing.T) {
+	ctx := tool.DefaultContext(t)
+	ctx.PrepareWorkDir(t)
+	defer ctx.Destroy(t)
+
+	s.buildLayer(t, ctx)
+
+	uffdSockPath := filepath.Join(ctx.Env.WorkDir, "uffd.sock")
+	apiSockPath := filepath.Join(ctx.Env.WorkDir, "api.sock")
+
+	// First start
+	nydusd, err := tool.NewNydusdUffd(tool.NydusdConfig{
+		NydusdPath:    ctx.Binary.Nydusd,
+		BootstrapPath: ctx.Env.BootstrapPath,
+		LocalFsDir:    ctx.Env.BlobDir,
+		UffdSockPath:  uffdSockPath,
+		APISockPath:   apiSockPath,
+	})
+	require.NoError(t, err)
+
+	_, err = nydusd.Run()
+	require.NoError(t, err)
+
+	err = nydusd.WaitStatus("RUNNING")
+	require.NoError(t, err)
+
+	_, err = os.Stat(uffdSockPath)
+	require.NoError(t, err)
+
+	// Shutdown
+	err = nydusd.Shutdown()
+	require.NoError(t, err)
+
+	// Clean up the socket file left by the previous instance.
+	// nydusd does not unlink the socket on exit, so the new instance
+	// would get "address already in use" if we don't remove it.
+	os.Remove(uffdSockPath)
+
+	// Second start on the same socket path
+	nydusd2, err := tool.NewNydusdUffd(tool.NydusdConfig{
+		NydusdPath:    ctx.Binary.Nydusd,
+		BootstrapPath: ctx.Env.BootstrapPath,
+		LocalFsDir:    ctx.Env.BlobDir,
+		UffdSockPath:  uffdSockPath,
+		APISockPath:   apiSockPath,
+	})
+	require.NoError(t, err)
+
+	_, err = nydusd2.Run()
+	require.NoError(t, err)
+	defer func() {
+		if err := nydusd2.Shutdown(); err != nil {
+			log.L.WithError(err).Errorf("shutdown uffd daemon (second instance)")
+		}
+	}()
+
+	err = nydusd2.WaitStatus("RUNNING")
+	require.NoError(t, err)
+
+	_, err = os.Stat(uffdSockPath)
+	require.NoError(t, err)
+}
+
+// TestUffdDaemonMissingBootstrap verifies that nydusd uffd fails gracefully
+// when started without a valid bootstrap file.
+func (s *UffdTestSuite) TestUffdDaemonMissingBootstrap(t *testing.T) {
+	ctx := tool.DefaultContext(t)
+	ctx.PrepareWorkDir(t)
+	defer ctx.Destroy(t)
+
+	uffdSockPath := filepath.Join(ctx.Env.WorkDir, "uffd.sock")
+	apiSockPath := filepath.Join(ctx.Env.WorkDir, "api.sock")
+
+	nydusd, err := tool.NewNydusdUffd(tool.NydusdConfig{
+		NydusdPath:    ctx.Binary.Nydusd,
+		BootstrapPath: "/nonexistent/bootstrap.boot",
+		LocalFsDir:    ctx.Env.BlobDir,
+		UffdSockPath:  uffdSockPath,
+		APISockPath:   apiSockPath,
+	})
+	require.NoError(t, err)
+
+	_, err = nydusd.Run()
+	require.NoError(t, err)
+
+	// Should NOT reach RUNNING state with invalid bootstrap
+	err = nydusd.WaitStatus("RUNNING")
+	require.Error(t, err, "nydusd should not reach RUNNING state with missing bootstrap")
+
+	_ = nydusd.Shutdown()
+}
+
+// TestUffdZerocopyDataVerification connects a UFFD client in zerocopy mode,
+// triggers page faults by reading from the block device, and verifies the data.
+func (s *UffdTestSuite) TestUffdZerocopyDataVerification(t *testing.T) {
+	ctx := tool.DefaultContext(t)
+	ctx.PrepareWorkDir(t)
+	defer ctx.Destroy(t)
+
+	s.buildLayer(t, ctx)
+
+	// Export disk image for verification reference.
+	diskPath := filepath.Join(ctx.Env.WorkDir, "disk.raw")
+	err := tool.ExportDiskImage(ctx.Binary.Builder, ctx.Env.BootstrapPath, ctx.Env.BlobDir, diskPath)
+	if err != nil {
+		t.Logf("export disk image failed (will use EROFS magic check only): %v", err)
+		diskPath = ""
+	}
+
+	uffdSockPath := filepath.Join(ctx.Env.WorkDir, "uffd.sock")
+	apiSockPath := filepath.Join(ctx.Env.WorkDir, "api.sock")
+
+	nydusd, err := tool.NewNydusdUffd(tool.NydusdConfig{
+		NydusdPath:    ctx.Binary.Nydusd,
+		BootstrapPath: ctx.Env.BootstrapPath,
+		LocalFsDir:    ctx.Env.BlobDir,
+		UffdSockPath:  uffdSockPath,
+		APISockPath:   apiSockPath,
+	})
+	require.NoError(t, err)
+
+	_, err = nydusd.Run()
+	require.NoError(t, err)
+	defer func() {
+		if err := nydusd.Shutdown(); err != nil {
+			log.L.WithError(err).Errorf("shutdown uffd daemon")
+		}
+	}()
+
+	err = nydusd.WaitStatus("RUNNING")
+	require.NoError(t, err)
+
+	// Connect UFFD client in zerocopy mode.
+	client, err := tool.NewUffdClient(uffdSockPath)
+	require.NoError(t, err, "failed to connect UFFD client")
+	defer client.Close()
+
+	t.Logf("UFFD client connected, device size: %d bytes, block size: %d", client.DeviceSize(), client.BlockSize())
+	require.Greater(t, client.DeviceSize(), uint64(0), "device size should be positive")
+
+	err = client.Handshake(tool.PolicyZerocopy, false)
+	require.NoError(t, err, "handshake failed")
+
+	// Allow time for the worker to start processing.
+	time.Sleep(100 * time.Millisecond)
+
+	// Verify EROFS superblock magic at offset 1024.
+	err = client.VerifyErofsMagic()
+	require.NoError(t, err, "EROFS magic verification failed")
+
+	// Verify data at multiple offsets.
+	s.verifyDataAtOffsets(t, client, diskPath)
+}
+
+// TestUffdCopyDataVerification connects a UFFD client in copy mode,
+// triggers page faults by reading from the block device, and verifies the data.
+func (s *UffdTestSuite) TestUffdCopyDataVerification(t *testing.T) {
+	ctx := tool.DefaultContext(t)
+	ctx.PrepareWorkDir(t)
+	defer ctx.Destroy(t)
+
+	s.buildLayer(t, ctx)
+
+	// Export disk image for verification reference.
+	diskPath := filepath.Join(ctx.Env.WorkDir, "disk.raw")
+	err := tool.ExportDiskImage(ctx.Binary.Builder, ctx.Env.BootstrapPath, ctx.Env.BlobDir, diskPath)
+	if err != nil {
+		t.Logf("export disk image failed (will use EROFS magic check only): %v", err)
+		diskPath = ""
+	}
+
+	uffdSockPath := filepath.Join(ctx.Env.WorkDir, "uffd.sock")
+	apiSockPath := filepath.Join(ctx.Env.WorkDir, "api.sock")
+
+	nydusd, err := tool.NewNydusdUffd(tool.NydusdConfig{
+		NydusdPath:    ctx.Binary.Nydusd,
+		BootstrapPath: ctx.Env.BootstrapPath,
+		LocalFsDir:    ctx.Env.BlobDir,
+		UffdSockPath:  uffdSockPath,
+		APISockPath:   apiSockPath,
+	})
+	require.NoError(t, err)
+
+	_, err = nydusd.Run()
+	require.NoError(t, err)
+	defer func() {
+		if err := nydusd.Shutdown(); err != nil {
+			log.L.WithError(err).Errorf("shutdown uffd daemon")
+		}
+	}()
+
+	err = nydusd.WaitStatus("RUNNING")
+	require.NoError(t, err)
+
+	// Connect UFFD client in copy mode.
+	client, err := tool.NewUffdClient(uffdSockPath)
+	require.NoError(t, err, "failed to connect UFFD client")
+	defer client.Close()
+
+	t.Logf("UFFD client connected, device size: %d bytes, block size: %d", client.DeviceSize(), client.BlockSize())
+	require.Greater(t, client.DeviceSize(), uint64(0), "device size should be positive")
+
+	err = client.Handshake(tool.PolicyCopy, false)
+	require.NoError(t, err, "handshake failed")
+
+	// Verify EROFS superblock magic at offset 1024.
+	err = client.VerifyErofsMagic()
+	require.NoError(t, err, "EROFS magic verification failed")
+
+	// Verify data at multiple offsets.
+	s.verifyDataAtOffsets(t, client, diskPath)
+}
+
+// verifyDataAtOffsets reads data at several offsets and verifies correctness.
+// If diskPath is non-empty, compares against the exported disk image.
+// Otherwise, checks that data blocks are non-zero.
+func (s *UffdTestSuite) verifyDataAtOffsets(t *testing.T, client *tool.UffdClient, diskPath string) {
+	deviceSize := client.DeviceSize()
+	readLen := int64(4096) // one block
+
+	// Generate test offsets: start, several interior points, near end.
+	offsets := []int64{0}
+	step := deviceSize / 8
+	for i := uint64(1); i < 8; i++ {
+		off := int64(i * step)
+		off = off / 4096 * 4096 // align to page boundary
+		if off+readLen <= int64(deviceSize) {
+			offsets = append(offsets, off)
+		}
+	}
+	// Near the end.
+	if deviceSize > 4096 {
+		tail := int64((deviceSize-4096)/4096) * 4096
+		found := false
+		for _, o := range offsets {
+			if o == tail {
+				found = true
+				break
+			}
+		}
+		if !found && tail+readLen <= int64(deviceSize) {
+			offsets = append(offsets, tail)
+		}
+	}
+
+	// Read the exported disk image for comparison (if available).
+	var diskData []byte
+	if diskPath != "" {
+		diskFile, err := os.ReadFile(diskPath)
+		if err != nil {
+			t.Logf("could not read disk image: %v (using non-zero check only)", err)
+		} else {
+			diskData = diskFile
+		}
+	}
+
+	for _, offset := range offsets {
+		data, err := client.ReadAt(offset, readLen)
+		require.NoError(t, err, "ReadAt offset=%d failed", offset)
+
+		if diskData != nil && offset+readLen <= int64(len(diskData)) {
+			// Compare against exported disk image.
+			expected := diskData[offset : offset+readLen]
+			require.Equal(t, expected, data, "data mismatch at offset %d", offset)
+		} else {
+			// Verify the EROFS superblock block is non-zero (contains magic + metadata).
+			if offset == 0 {
+				magic := binary.LittleEndian.Uint32(data[1024:1028])
+				require.Equal(t, uint32(0xE0F5E1E2), magic, "EROFS magic not found at offset 0+1024")
+			}
+			// For other offsets, just verify data is accessible (no error).
+		}
+
+		t.Logf("  offset 0x%x: verified %d bytes", offset, len(data))
+	}
+}
+
+func TestUffd(t *testing.T) {
+	test.Run(t, &UffdTestSuite{T: t})
+}

--- a/src/bin/nydusd/main.rs
+++ b/src/bin/nydusd/main.rs
@@ -297,6 +297,8 @@ fn prepare_commandline_options() -> Command {
     let cmdline = append_virtiofs_subcmd_options(cmdline);
     #[cfg(feature = "block-nbd")]
     let cmdline = self::nbd::append_nbd_subcmd_options(cmdline);
+    #[cfg(feature = "block-uffd")]
+    let cmdline = self::uffd::append_uffd_subcmd_options(cmdline);
     append_singleton_subcmd_options(cmdline)
 }
 
@@ -727,6 +729,179 @@ mod nbd {
     }
 }
 
+#[cfg(feature = "block-uffd")]
+mod uffd {
+    use super::*;
+    use nydus_api::BlobCacheEntry;
+    use nydus_service::block_uffd::create_uffd_daemon;
+    use std::str::FromStr;
+
+    pub(super) fn append_uffd_subcmd_options(cmd: Command) -> Command {
+        let subcmd = Command::new("uffd")
+            .about("Export a RAFS v6 image as a block device through userfaultfd (Experiment)");
+        let subcmd = subcmd
+            .arg(
+                Arg::new("sock")
+                    .long("sock")
+                    .short('S')
+                    .help("Path to the UFFD service socket")
+                    .required(true),
+            )
+            .arg(
+                Arg::new("bootstrap")
+                    .long("bootstrap")
+                    .short('B')
+                    .help("Path to the RAFS filesystem metadata file")
+                    .required(false),
+            )
+            .arg(
+                Arg::new("config")
+                    .long("config")
+                    .short('C')
+                    .help("Path to the configuration file")
+                    .required(false),
+            )
+            .arg(
+                Arg::new("localfs-dir")
+                    .long("localfs-dir")
+                    .requires("bootstrap")
+                    .short('D')
+                    .help(
+                        "Path to the `localfs` working directory, which also enables the `localfs` storage backend"
+                    )
+                    .conflicts_with("config"),
+            )
+            .arg(
+                Arg::new("threads")
+                    .long("threads")
+                    .default_value("4")
+                    .help("Number of worker threads to serve UFFD requests")
+                    .value_parser(thread_validator)
+                    .required(false),
+            );
+        cmd.subcommand(subcmd)
+    }
+
+    pub(super) fn process_uffd_service(
+        args: SubCmdArgs,
+        bti: BuildTimeInfo,
+        _apisock: Option<&str>,
+    ) -> Result<()> {
+        let mut entry = if let Some(v) = args.value_of("config") {
+            // Config file takes precedence
+            let mut cfg = ConfigV2::from_file(v)?;
+            if let Ok(auth) = std::env::var("IMAGE_PULL_AUTH") {
+                cfg.update_registry_auth_info(&Some(auth));
+            }
+
+            let backend = cfg.backend.clone().ok_or_else(|| {
+                Error::new(ErrorKind::InvalidInput, "missing backend in ConfigV2")
+            })?;
+            let cache = cfg
+                .cache
+                .clone()
+                .ok_or_else(|| Error::new(ErrorKind::InvalidInput, "missing cache in ConfigV2"))?;
+            let bootstrap = args
+                .value_of("bootstrap")
+                .map(|s| s.to_string())
+                .ok_or_else(|| {
+                    Error::new(
+                        ErrorKind::InvalidInput,
+                        "option `-B/--bootstrap` is required with `--config`",
+                    )
+                })?;
+            let entry_json = serde_json::json!({
+                "type": "bootstrap",
+                "id": "disk-default",
+                "domain_id": "block-uffd",
+                "config_v2": {
+                    "version": cfg.version,
+                    "id": cfg.id,
+                    "backend": backend,
+                    "external_backends": cfg.external_backends,
+                    "cache": cache,
+                    "metadata_path": bootstrap
+                }
+            });
+            serde_json::from_value(entry_json)?
+        } else if let Some(bootstrap) = args.value_of("bootstrap") {
+            let dir = args
+                .value_of("localfs-dir")
+                .ok_or_else(|| einval!("option `-D/--localfs-dir` is required by `--bootstrap`"))?;
+            let config = r#"
+            {
+                "type": "bootstrap",
+                "id": "disk-default",
+                "domain_id": "block-uffd",
+                "config_v2": {
+                    "version": 2,
+                    "id": "block-uffd-factory",
+                    "backend": {
+                        "type": "localfs",
+                        "localfs": {
+                            "dir": "LOCAL_FS_DIR"
+                        }
+                    },
+                    "cache": {
+                        "type": "filecache",
+                        "filecache": {
+                            "work_dir": "LOCAL_FS_DIR"
+                        }
+                    },
+                    "metadata_path": "META_FILE_PATH"
+                }
+            }"#;
+            let config = config
+                .replace("LOCAL_FS_DIR", dir)
+                .replace("META_FILE_PATH", bootstrap);
+            BlobCacheEntry::from_str(&config)?
+        } else {
+            return Err(einval!(
+                "both option `-C/--config` and `-B/--bootstrap` are missing"
+            ));
+        };
+        if !entry.prepare_configuration_info() {
+            return Err(einval!(
+                "invalid blob cache entry configuration information"
+            ));
+        }
+        if !entry.validate() {
+            return Err(einval!(
+                "invalid blob cache entry configuration information"
+            ));
+        }
+
+        // Safe to unwrap because `sock` is mandatory option.
+        let sock = args.value_of("sock").unwrap().to_string();
+        let id = args.value_of("id").map(|id| id.to_string());
+        let supervisor = args.value_of("supervisor").map(|s| s.to_string());
+        let threads: u32 = args
+            .value_of("threads")
+            .map(|n| n.parse().unwrap_or(1))
+            .unwrap_or(1);
+
+        let daemon = create_uffd_daemon(
+            sock,
+            threads,
+            entry,
+            bti,
+            id,
+            supervisor,
+            DAEMON_CONTROLLER.alloc_waker(),
+        )
+        .inspect(|_| {
+            info!("UFFD daemon started!");
+        })
+        .map_err(|e| {
+            error!("Failed in starting UFFD daemon: {}", e);
+            e
+        })?;
+        DAEMON_CONTROLLER.set_daemon(daemon);
+
+        Ok(())
+    }
+}
+
 extern "C" fn sig_exit(_sig: std::os::raw::c_int) {
     DAEMON_CONTROLLER.notify_shutdown();
 }
@@ -790,6 +965,13 @@ fn main() -> Result<()> {
             let subargs = args.subcommand_matches("nbd").unwrap();
             let subargs = SubCmdArgs::new(&args, subargs);
             self::nbd::process_nbd_service(subargs, bti, apisock)?;
+        }
+        #[cfg(feature = "block-uffd")]
+        Some("uffd") => {
+            // Safe to unwrap because the subcommand is `uffd`.
+            let subargs = args.subcommand_matches("uffd").unwrap();
+            let subargs = SubCmdArgs::new(&args, subargs);
+            self::uffd::process_uffd_service(subargs, bti, apisock)?;
         }
         _ => {
             let subargs = SubCmdArgs::new(&args, &args);


### PR DESCRIPTION
## Overview

  Introduce a uffd-based block device service for RAFSv6 images, designed as a backend for VMM
  virtio-pmem with DAX mount inside the guest VM.

  Key benefits:
  - **Native file performance**: with the pre-fault mechanism, already-downloaded data is proactively
  mapped, delivering local file access performance while preserving on-demand fetching
  - **Zero-copy memory sharing**: blob fds are passed to the client via SCM_RIGHTS for direct mmap,
  enabling host-guest page cache sharing through virtio-pmem DAX
  - **Cross-VM deduplication**: multiple VMs share the same host page cache at blob level, keeping memory
   usage flat as VM density grows

  The service communicates over a Unix domain socket using a JSON + fd passing protocol (Firecracker
  compatible).

  ## Related Issues

  N/A

  ## Change Details

  **Commit 1: service: run DataBlob::async_read in spawn_blocking**

  Fix panic when backend is registry by running blocking fetch in `spawn_blocking`.

  **Commit 2: service: add fetch_ranges() to BlockDevice for zero-copy I/O**

 Expose blob fds and add `fetch_ranges()` to `BlockDevice` for zero-copy data path.

  **Commit 3: service: add uffd service to export RAFSv6 images as block devices**

  Implement UffdService which uses userfaultfd to handle page faults for RAFSv6 block device
  images. Key features:
  - **Zerocopy mode**: send blob fds to client for direct mmap
  - **Copy mode**: `UFFDIO_COPY` data into client address space
  - **Pre-fault**: proactively push ready ranges on handshake
  - **Stateless** support reconnection across server restarts

  **Commit 4: nydusd: add subcommand uffd to export nydus images as block devices**

  Wire up the `uffd` subcommand in nydusd, accepting bootstrap path, blob cache config, Unix domain
  socket path, and worker thread count as arguments.

  ## Test Results

  E2E tests run on a Linux machine with a real RAFSv6 image (~8GB, 3 data blobs + 1 meta blob):
  - Zerocopy mode: passed (19 page fault tests + 4 mmap verifications)
  - Zerocopy + pre-fault: passed (with `/proc/maps` mapping verification)
  - Copy mode: passed
  - Reconnect test: passed (client survives server restart)

  ## Change Type
  - [ ] Bug Fix
  - [x] Feature Addition
  - [ ] Documentation Update
  - [ ] Code Refactoring
  - [ ] Performance Improvement
  - [ ] Other (please describe)

  ## Self-Checklist
  - [x] I have run a code style check and addressed any warnings/errors.
  - [x] I have added appropriate comments to my code (if applicable).
  - [ ] I have updated the documentation (if applicable).
  - [x] I have written appropriate unit tests.