### PR TITLE
[nydusd] Support custom TLS CA 

### DIFF
--- a/api/src/config.rs
+++ b/api/src/config.rs
@@ -611,14 +611,6 @@ pub struct RegistryConfig {
     /// Paths to PEM-encoded CA certificate files to trust in addition to the system CA store.
     #[serde(default)]
     pub ca_cert_files: Vec<String>,
-    /// Path to a PEM-encoded client certificate file for mTLS authentication.
-    /// Must be used together with `client_key_file`.
-    #[serde(default)]
-    pub client_cert_file: Option<String>,
-    /// Path to a PEM-encoded private key file for mTLS authentication.
-    /// Must be used together with `client_cert_file`.
-    #[serde(default)]
-    pub client_key_file: Option<String>,
     /// Drop the read request once http request timeout, in seconds.
     #[serde(default = "default_http_timeout")]
     pub timeout: u32,

--- a/api/src/config.rs
+++ b/api/src/config.rs
@@ -1703,6 +1703,7 @@ mod tests {
         let config: OssConfig = serde_json::from_str(content).unwrap();
         assert_eq!(config.scheme, "https");
         assert!(!config.skip_verify);
+        assert!(config.ca_cert_files.is_empty());
         assert_eq!(config.timeout, 5);
         assert_eq!(config.connect_timeout, 5);
     }
@@ -1720,6 +1721,7 @@ mod tests {
         let config: OssConfig = serde_json::from_str(content).unwrap();
         assert_eq!(config.scheme, "https");
         assert!(!config.skip_verify);
+        assert!(config.ca_cert_files.is_empty());
         assert_eq!(config.timeout, 5);
         assert_eq!(config.connect_timeout, 5);
     }
@@ -1733,11 +1735,15 @@ mod tests {
 	    "repo": "test/repo",
 	    "auth": "base64_encoded_auth",
 	    "registry_token": "bearer_token",
-	    "blob_redirected_host": "blob_redirected_host"
+	    "blob_redirected_host": "blob_redirected_host",
+        "ca_cert_files": ["/etc/ssl/certs/my-ca.pem","/etc/ssl/certs/my-ca2.pem"]
         }"#;
         let config: RegistryConfig = serde_json::from_str(content).unwrap();
         assert_eq!(config.scheme, "http");
         assert!(config.skip_verify);
+        assert_eq!(config.ca_cert_files.len(), 2);
+        assert_eq!(config.ca_cert_files[0], "/etc/ssl/certs/my-ca.pem");
+        assert_eq!(config.ca_cert_files[1], "/etc/ssl/certs/my-ca2.pem");
     }
 
     #[test]

--- a/api/src/config.rs
+++ b/api/src/config.rs
@@ -577,6 +577,9 @@ pub struct HttpProxyConfig {
     /// Skip SSL certificate validation for HTTPS scheme.
     #[serde(default)]
     pub skip_verify: bool,
+    /// Paths to PEM-encoded CA certificate files to trust in addition to the system CA store.
+    #[serde(default)]
+    pub ca_cert_files: Vec<String>,
     /// Drop the read request once http request timeout, in seconds.
     #[serde(default = "default_http_timeout")]
     pub timeout: u32,

--- a/api/src/config.rs
+++ b/api/src/config.rs
@@ -504,6 +504,9 @@ pub struct OssConfig {
     /// Skip SSL certificate validation for HTTPS scheme.
     #[serde(default)]
     pub skip_verify: bool,
+    /// Paths to PEM-encoded CA certificate files to trust in addition to the system CA store.
+    #[serde(default)]
+    pub ca_cert_files: Vec<String>,
     /// Drop the read request once http request timeout, in seconds.
     #[serde(default = "default_http_timeout")]
     pub timeout: u32,
@@ -545,6 +548,9 @@ pub struct S3Config {
     /// Skip SSL certificate validation for HTTPS scheme.
     #[serde(default)]
     pub skip_verify: bool,
+    /// Paths to PEM-encoded CA certificate files to trust in addition to the system CA store.
+    #[serde(default)]
+    pub ca_cert_files: Vec<String>,
     /// Drop the read request once http request timeout, in seconds.
     #[serde(default = "default_http_timeout")]
     pub timeout: u32,
@@ -602,6 +608,17 @@ pub struct RegistryConfig {
     /// When true, also allows automatic HTTPS-to-HTTP fallback on TLS errors.
     #[serde(default)]
     pub skip_verify: bool,
+    /// Paths to PEM-encoded CA certificate files to trust in addition to the system CA store.
+    #[serde(default)]
+    pub ca_cert_files: Vec<String>,
+    /// Path to a PEM-encoded client certificate file for mTLS authentication.
+    /// Must be used together with `client_key_file`.
+    #[serde(default)]
+    pub client_cert_file: Option<String>,
+    /// Path to a PEM-encoded private key file for mTLS authentication.
+    /// Must be used together with `client_cert_file`.
+    #[serde(default)]
+    pub client_key_file: Option<String>,
     /// Drop the read request once http request timeout, in seconds.
     #[serde(default = "default_http_timeout")]
     pub timeout: u32,

--- a/docs/nydusd.md
+++ b/docs/nydusd.md
@@ -260,6 +260,15 @@ Document located at: https://github.com/adamqqqplay/nydus-localdisk/blob/master/
         // Skip SSL certificate validation for HTTPS scheme.
         // When true, also allows automatic HTTPS-to-HTTP fallback on TLS errors.
         "skip_verify": false,
+        // Paths to PEM-encoded CA certificate files to trust in addition to the system CA store, optional.
+        // Useful when the registry uses a private or self-signed CA.
+        "ca_cert_files": ["/etc/ssl/certs/my-ca.pem"],
+        // Path to a PEM-encoded client certificate file for mTLS authentication, optional.
+        // Must be used together with `client_key_file`.
+        "client_cert_file": "/etc/ssl/certs/client.pem",
+        // Path to a PEM-encoded private key file for mTLS authentication, optional.
+        // Must be used together with `client_cert_file`.
+        "client_key_file": "/etc/ssl/private/client-key.pem",
         // Use format `$namespace/$repo` (no image tag)
         "repo": "test/repo",
         // Username and password for auth

--- a/docs/nydusd.md
+++ b/docs/nydusd.md
@@ -263,12 +263,6 @@ Document located at: https://github.com/adamqqqplay/nydus-localdisk/blob/master/
         // Paths to PEM-encoded CA certificate files to trust in addition to the system CA store, optional.
         // Useful when the registry uses a private or self-signed CA.
         "ca_cert_files": ["/etc/ssl/certs/my-ca.pem"],
-        // Path to a PEM-encoded client certificate file for mTLS authentication, optional.
-        // Must be used together with `client_key_file`.
-        "client_cert_file": "/etc/ssl/certs/client.pem",
-        // Path to a PEM-encoded private key file for mTLS authentication, optional.
-        // Must be used together with `client_cert_file`.
-        "client_key_file": "/etc/ssl/private/client-key.pem",
         // Use format `$namespace/$repo` (no image tag)
         "repo": "test/repo",
         // Username and password for auth

--- a/misc/configs/nydusd-blob-cache-entry-configuration-v2.toml
+++ b/misc/configs/nydusd-blob-cache-entry-configuration-v2.toml
@@ -31,6 +31,9 @@ access_key_id = "my_access_key_id"
 access_key_secret = "my_access_key_secret"
 # Skip SSL certificate validation for HTTPS scheme.
 skip_verify = true
+# Paths to PEM-encoded CA certificate files to trust in addition to the system CA store, optional.
+# Useful when the endpoint uses a private or self-signed CA.
+# ca_cert_files = ["/etc/ssl/certs/my-ca.pem"]
 # Drop the read request once http request timeout, in seconds.
 timeout = 10
 # Drop the read request once http connection timeout, in seconds.
@@ -62,6 +65,15 @@ auth = "base64_encoded"
 # Skip SSL certificate validation for HTTPS scheme.
 # When true, also allows automatic HTTPS-to-HTTP fallback on TLS errors.
 skip_verify = true
+# Paths to PEM-encoded CA certificate files to trust in addition to the system CA store, optional.
+# Useful when the registry uses a private or self-signed CA.
+# ca_cert_files = ["/etc/ssl/certs/my-ca.pem"]
+# Path to a PEM-encoded client certificate file for mTLS authentication, optional.
+# Must be used together with client_key_file.
+# client_cert_file = "/etc/ssl/certs/client.pem"
+# Path to a PEM-encoded private key file for mTLS authentication, optional.
+# Must be used together with client_cert_file.
+# client_key_file = "/etc/ssl/private/client-key.pem"
 # Drop the read request once http request timeout, in seconds.
 timeout = 10
 # Drop the read request once http connection timeout, in seconds.

--- a/misc/configs/nydusd-blob-cache-entry-configuration-v2.toml
+++ b/misc/configs/nydusd-blob-cache-entry-configuration-v2.toml
@@ -68,12 +68,6 @@ skip_verify = true
 # Paths to PEM-encoded CA certificate files to trust in addition to the system CA store, optional.
 # Useful when the registry uses a private or self-signed CA.
 # ca_cert_files = ["/etc/ssl/certs/my-ca.pem"]
-# Path to a PEM-encoded client certificate file for mTLS authentication, optional.
-# Must be used together with client_key_file.
-# client_cert_file = "/etc/ssl/certs/client.pem"
-# Path to a PEM-encoded private key file for mTLS authentication, optional.
-# Must be used together with client_cert_file.
-# client_key_file = "/etc/ssl/private/client-key.pem"
 # Drop the read request once http request timeout, in seconds.
 timeout = 10
 # Drop the read request once http connection timeout, in seconds.

--- a/misc/configs/nydusd-blob-cache-entry.toml
+++ b/misc/configs/nydusd-blob-cache-entry.toml
@@ -36,6 +36,9 @@ access_key_id = "my_access_key_id"
 access_key_secret = "my_access_key_secret"
 # Skip SSL certificate validation for HTTPS scheme.
 skip_verify = true
+# Paths to PEM-encoded CA certificate files to trust in addition to the system CA store, optional.
+# Useful when the endpoint uses a private or self-signed CA.
+# ca_cert_files = ["/etc/ssl/certs/my-ca.pem"]
 # Drop the read request once http request timeout, in seconds.
 timeout = 10
 # Drop the read request once http connection timeout, in seconds.
@@ -67,6 +70,15 @@ auth = "base64_encoded"
 # Skip SSL certificate validation for HTTPS scheme.
 # When true, also allows automatic HTTPS-to-HTTP fallback on TLS errors.
 skip_verify = true
+# Paths to PEM-encoded CA certificate files to trust in addition to the system CA store, optional.
+# Useful when the registry uses a private or self-signed CA.
+# ca_cert_files = ["/etc/ssl/certs/my-ca.pem"]
+# Path to a PEM-encoded client certificate file for mTLS authentication, optional.
+# Must be used together with client_key_file.
+# client_cert_file = "/etc/ssl/certs/client.pem"
+# Path to a PEM-encoded private key file for mTLS authentication, optional.
+# Must be used together with client_cert_file.
+# client_key_file = "/etc/ssl/private/client-key.pem"
 # Drop the read request once http request timeout, in seconds.
 timeout = 10
 # Drop the read request once http connection timeout, in seconds.

--- a/misc/configs/nydusd-blob-cache-entry.toml
+++ b/misc/configs/nydusd-blob-cache-entry.toml
@@ -73,12 +73,6 @@ skip_verify = true
 # Paths to PEM-encoded CA certificate files to trust in addition to the system CA store, optional.
 # Useful when the registry uses a private or self-signed CA.
 # ca_cert_files = ["/etc/ssl/certs/my-ca.pem"]
-# Path to a PEM-encoded client certificate file for mTLS authentication, optional.
-# Must be used together with client_key_file.
-# client_cert_file = "/etc/ssl/certs/client.pem"
-# Path to a PEM-encoded private key file for mTLS authentication, optional.
-# Must be used together with client_cert_file.
-# client_key_file = "/etc/ssl/private/client-key.pem"
 # Drop the read request once http request timeout, in seconds.
 timeout = 10
 # Drop the read request once http connection timeout, in seconds.

--- a/misc/configs/nydusd-config-v2.toml
+++ b/misc/configs/nydusd-config-v2.toml
@@ -66,12 +66,6 @@ skip_verify = true
 # Paths to PEM-encoded CA certificate files to trust in addition to the system CA store, optional.
 # Useful when the registry uses a private or self-signed CA.
 # ca_cert_files = ["/etc/ssl/certs/my-ca.pem"]
-# Path to a PEM-encoded client certificate file for mTLS authentication, optional.
-# Must be used together with client_key_file.
-# client_cert_file = "/etc/ssl/certs/client.pem"
-# Path to a PEM-encoded private key file for mTLS authentication, optional.
-# Must be used together with client_cert_file.
-# client_key_file = "/etc/ssl/private/client-key.pem"
 # Drop the read request once http request timeout, in seconds.
 timeout = 10
 # Drop the read request once http connection timeout, in seconds.

--- a/misc/configs/nydusd-config-v2.toml
+++ b/misc/configs/nydusd-config-v2.toml
@@ -29,6 +29,9 @@ access_key_id = "my_access_key_id"
 access_key_secret = "my_access_key_secret"
 # Skip SSL certificate validation for HTTPS scheme.
 skip_verify = true
+# Paths to PEM-encoded CA certificate files to trust in addition to the system CA store, optional.
+# Useful when the endpoint uses a private or self-signed CA.
+# ca_cert_files = ["/etc/ssl/certs/my-ca.pem"]
 # Drop the read request once http request timeout, in seconds.
 timeout = 10
 # Drop the read request once http connection timeout, in seconds.
@@ -60,6 +63,15 @@ auth = "base64_encoded"
 # Skip SSL certificate validation for HTTPS scheme.
 # When true, also allows automatic HTTPS-to-HTTP fallback on TLS errors.
 skip_verify = true
+# Paths to PEM-encoded CA certificate files to trust in addition to the system CA store, optional.
+# Useful when the registry uses a private or self-signed CA.
+# ca_cert_files = ["/etc/ssl/certs/my-ca.pem"]
+# Path to a PEM-encoded client certificate file for mTLS authentication, optional.
+# Must be used together with client_key_file.
+# client_cert_file = "/etc/ssl/certs/client.pem"
+# Path to a PEM-encoded private key file for mTLS authentication, optional.
+# Must be used together with client_cert_file.
+# client_key_file = "/etc/ssl/private/client-key.pem"
 # Drop the read request once http request timeout, in seconds.
 timeout = 10
 # Drop the read request once http connection timeout, in seconds.

--- a/misc/configs/nydusd-config.json
+++ b/misc/configs/nydusd-config.json
@@ -5,7 +5,11 @@
       "config": {
         "timeout": 5,
         "connect_timeout": 5,
-        "retry_limit": 2
+        "retry_limit": 2,
+        "skip_verify": false,
+        "ca_cert_files": ["/etc/ssl/certs/my-ca.pem"],
+        "client_cert_file": "/etc/ssl/certs/client.pem",
+        "client_key_file": "/etc/ssl/private/client-key.pem"
       }
     },
     "cache": {

--- a/misc/configs/nydusd-config.json
+++ b/misc/configs/nydusd-config.json
@@ -7,9 +7,7 @@
         "connect_timeout": 5,
         "retry_limit": 2,
         "skip_verify": false,
-        "ca_cert_files": ["/etc/ssl/certs/my-ca.pem"],
-        "client_cert_file": "/etc/ssl/certs/client.pem",
-        "client_key_file": "/etc/ssl/private/client-key.pem"
+        "ca_cert_files": ["/etc/ssl/certs/my-ca.pem"]
       }
     },
     "cache": {

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -28,7 +28,6 @@ nix = "0.24"
 reqwest = { version = "0.12.28", features = [
     "blocking",
     "json",
-    "native-tls",
 ], optional = true }
 rusqlite = { version = "0.30", features = ["bundled"], optional = true }
 r2d2 = { version = "0.8", optional = true }

--- a/storage/Cargo.toml
+++ b/storage/Cargo.toml
@@ -28,6 +28,7 @@ nix = "0.24"
 reqwest = { version = "0.12.28", features = [
     "blocking",
     "json",
+    "native-tls",
 ], optional = true }
 rusqlite = { version = "0.30", features = ["bundled"], optional = true }
 r2d2 = { version = "0.8", optional = true }

--- a/storage/src/backend/connection.rs
+++ b/storage/src/backend/connection.rs
@@ -132,7 +132,7 @@ impl From<HttpProxyConfig> for ConnectionConfig {
             timeout: c.timeout,
             connect_timeout: c.connect_timeout,
             retry_limit: c.retry_limit,
-            ca_cert_files: Vec::new(),
+            ca_cert_files: c.ca_cert_files,
         }
     }
 }

--- a/storage/src/backend/connection.rs
+++ b/storage/src/backend/connection.rs
@@ -502,8 +502,8 @@ impl Connection {
         {
             let cert_pem = std::fs::read(cert_file).map_err(|e| einval!(e))?;
             let key_pem = std::fs::read(key_file).map_err(|e| einval!(e))?;
-            let identity = reqwest::Identity::from_pkcs8_pem(&cert_pem, &key_pem)
-                .map_err(|e| einval!(e))?;
+            let identity =
+                reqwest::Identity::from_pkcs8_pem(&cert_pem, &key_pem).map_err(|e| einval!(e))?;
             cb = cb.identity(identity);
         }
 

--- a/storage/src/backend/connection.rs
+++ b/storage/src/backend/connection.rs
@@ -70,10 +70,6 @@ pub(crate) struct ConnectionConfig {
     pub retry_limit: u8,
     /// Paths to PEM-encoded CA certificate files to trust in addition to the system CA store.
     pub ca_cert_files: Vec<String>,
-    /// Path to a PEM-encoded client certificate file for mTLS authentication.
-    pub client_cert_file: Option<String>,
-    /// Path to a PEM-encoded private key file for mTLS authentication.
-    pub client_key_file: Option<String>,
 }
 
 impl Default for ConnectionConfig {
@@ -85,8 +81,6 @@ impl Default for ConnectionConfig {
             connect_timeout: 5,
             retry_limit: 0,
             ca_cert_files: Vec::new(),
-            client_cert_file: None,
-            client_key_file: None,
         }
     }
 }
@@ -100,8 +94,6 @@ impl From<OssConfig> for ConnectionConfig {
             connect_timeout: c.connect_timeout,
             retry_limit: c.retry_limit,
             ca_cert_files: c.ca_cert_files,
-            client_cert_file: None,
-            client_key_file: None,
         }
     }
 }
@@ -115,8 +107,6 @@ impl From<S3Config> for ConnectionConfig {
             connect_timeout: c.connect_timeout,
             retry_limit: c.retry_limit,
             ca_cert_files: c.ca_cert_files,
-            client_cert_file: None,
-            client_key_file: None,
         }
     }
 }
@@ -130,8 +120,6 @@ impl From<RegistryConfig> for ConnectionConfig {
             connect_timeout: c.connect_timeout,
             retry_limit: c.retry_limit,
             ca_cert_files: c.ca_cert_files,
-            client_cert_file: c.client_cert_file,
-            client_key_file: c.client_key_file,
         }
     }
 }
@@ -145,8 +133,6 @@ impl From<HttpProxyConfig> for ConnectionConfig {
             connect_timeout: c.connect_timeout,
             retry_limit: c.retry_limit,
             ca_cert_files: Vec::new(),
-            client_cert_file: None,
-            client_key_file: None,
         }
     }
 }
@@ -495,16 +481,6 @@ impl Connection {
             let pem = std::fs::read(ca_cert_file).map_err(|e| einval!(e))?;
             let cert = reqwest::Certificate::from_pem(&pem).map_err(|e| einval!(e))?;
             cb = cb.add_root_certificate(cert);
-        }
-
-        if let (Some(cert_file), Some(key_file)) =
-            (&config.client_cert_file, &config.client_key_file)
-        {
-            let cert_pem = std::fs::read(cert_file).map_err(|e| einval!(e))?;
-            let key_pem = std::fs::read(key_file).map_err(|e| einval!(e))?;
-            let identity =
-                reqwest::Identity::from_pkcs8_pem(&cert_pem, &key_pem).map_err(|e| einval!(e))?;
-            cb = cb.identity(identity);
         }
 
         if !proxy.is_empty() {

--- a/storage/src/backend/connection.rs
+++ b/storage/src/backend/connection.rs
@@ -68,6 +68,12 @@ pub(crate) struct ConnectionConfig {
     pub timeout: u32,
     pub connect_timeout: u32,
     pub retry_limit: u8,
+    /// Paths to PEM-encoded CA certificate files to trust in addition to the system CA store.
+    pub ca_cert_files: Vec<String>,
+    /// Path to a PEM-encoded client certificate file for mTLS authentication.
+    pub client_cert_file: Option<String>,
+    /// Path to a PEM-encoded private key file for mTLS authentication.
+    pub client_key_file: Option<String>,
 }
 
 impl Default for ConnectionConfig {
@@ -78,6 +84,9 @@ impl Default for ConnectionConfig {
             timeout: 5,
             connect_timeout: 5,
             retry_limit: 0,
+            ca_cert_files: Vec::new(),
+            client_cert_file: None,
+            client_key_file: None,
         }
     }
 }
@@ -90,6 +99,9 @@ impl From<OssConfig> for ConnectionConfig {
             timeout: c.timeout,
             connect_timeout: c.connect_timeout,
             retry_limit: c.retry_limit,
+            ca_cert_files: c.ca_cert_files,
+            client_cert_file: None,
+            client_key_file: None,
         }
     }
 }
@@ -102,6 +114,9 @@ impl From<S3Config> for ConnectionConfig {
             timeout: c.timeout,
             connect_timeout: c.connect_timeout,
             retry_limit: c.retry_limit,
+            ca_cert_files: c.ca_cert_files,
+            client_cert_file: None,
+            client_key_file: None,
         }
     }
 }
@@ -114,6 +129,9 @@ impl From<RegistryConfig> for ConnectionConfig {
             timeout: c.timeout,
             connect_timeout: c.connect_timeout,
             retry_limit: c.retry_limit,
+            ca_cert_files: c.ca_cert_files,
+            client_cert_file: c.client_cert_file,
+            client_key_file: c.client_key_file,
         }
     }
 }
@@ -126,6 +144,9 @@ impl From<HttpProxyConfig> for ConnectionConfig {
             timeout: c.timeout,
             connect_timeout: c.connect_timeout,
             retry_limit: c.retry_limit,
+            ca_cert_files: Vec::new(),
+            client_cert_file: None,
+            client_key_file: None,
         }
     }
 }
@@ -468,6 +489,22 @@ impl Connection {
 
         if config.skip_verify {
             cb = cb.danger_accept_invalid_certs(true);
+        }
+
+        for ca_cert_file in &config.ca_cert_files {
+            let pem = std::fs::read(ca_cert_file).map_err(|e| einval!(e))?;
+            let cert = reqwest::Certificate::from_pem(&pem).map_err(|e| einval!(e))?;
+            cb = cb.add_root_certificate(cert);
+        }
+
+        if let (Some(cert_file), Some(key_file)) =
+            (&config.client_cert_file, &config.client_key_file)
+        {
+            let cert_pem = std::fs::read(cert_file).map_err(|e| einval!(e))?;
+            let key_pem = std::fs::read(key_file).map_err(|e| einval!(e))?;
+            let identity = reqwest::Identity::from_pkcs8_pem(&cert_pem, &key_pem)
+                .map_err(|e| einval!(e))?;
+            cb = cb.identity(identity);
         }
 
         if !proxy.is_empty() {

--- a/storage/src/backend/connection.rs
+++ b/storage/src/backend/connection.rs
@@ -611,5 +611,6 @@ mod tests {
         assert!(config.proxy.fallback);
         assert_eq!(config.proxy.ping_url, "");
         assert_eq!(config.proxy.url, "");
+        assert!(config.ca_cert_files.is_empty());
     }
 }


### PR DESCRIPTION
## Overview

Add new TLS configuration options to backends:
* ca_cert_files — a list of paths to PEM-encoded CA certificate files to trust in addition to the system CA store. Supported by all three backends.                                                                   

```toml                                                                                                                                                                                                                    
  # Registry OSS / S3 backend  : CA trust store 
  [backend.registry]                                                                                                                                                                                                 
  ca_cert_files    = ["/etc/ssl/certs/ca1.pem", "/etc/ssl/certs/ca2.pem"]                                                                                                                                                                                                                   
``` 

## Related Issues
Partial implementation of #1924 . See this [comment](https://github.com/dragonflyoss/nydus/issues/1924#issuecomment-4251037432) for the reason of the partial implementation

## Change Details


## Test Results

Context : 
* registry is in TLS with a certificate that is not trusted in the system CAs 
* /etc/containerd/certs.d/externalname.myregistry.com/hosts.toml is like 
```toml
server = "https://externalname.myregistry.com"

[host."https://myinternalname:5050"]
  capabilities = ["pull", "resolve", "push"]
  ca = ["/etc/containerd/certs.d/externalname.myregistry.com/ca.pem"]
```

Scenario from the main branch : 
* Nydusd and nydus snapshotter are without patchs 

* State with a pod requesting an Image 
  * Errors on nydusd on TLS certificate unknown 
  * Pod blocked at the pull image step

Scenario : 

* Nydus snapshotter has the patch https://github.com/containerd/nydus-snapshotter/pull/745 
* Config of nydusd in /var/lib/containerd/io.containerd.snapshotter.v1.nydus/config/<id>/config.json contains : 
```
{
  "device": {
    "id": "/id",
    "backend": {
      "type": "registry",
      "config": {
        [...]
        "ca_cert_files": [
          "/etc/containerd/certs.d/checkpoints.node.datadoghq.com/apiservice-ca.pem"
        ],
       }
     }
}
```
* State with a pod requesting an Image 
  * Nydusd properly download the files from the registry
  * Pod is Running

## Change Type
_Please select the type of change your pull request relates to:_
- [ ] Bug Fix
- [X] Feature Addition
- [X] Documentation Update
- [ ] Code Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe)

## Self-Checklist
_Before submitting a pull request, please ensure you have completed the following:_
- [x] I have run a code style check and addressed any warnings/errors.
- [x] I have added appropriate comments to my code (if applicable).
- [X] I have updated the documentation (if applicable).
- [ ] I have written appropriate unit tests.