### PR TITLE
Fix fleaky ci

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,8 +45,6 @@ jobs:
         push: false
         load: true
         tags: rust-cross-compile-riscv64:latest
-        cache-from: type=gha
-        cache-to: type=gha,mode=max
         build-args: |
           RUST_VERSION=${{ steps.set_toolchain_version.outputs.rust-version }}
     - name: Build nydus-rs Non-RISC-V

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -95,8 +95,6 @@ jobs:
         push: false
         load: true
         tags: rust-cross-compile-riscv64:latest
-        cache-from: type=gha,scope=buildx-riscv64
-        cache-to: type=gha,mode=max,scope=buildx-riscv64
         build-args: |
           RUST_VERSION=${{ steps.set_toolchain_version.outputs.rust-version }}
     - name: Build Nydus Non-RISC-V

--- a/smoke/tests/api_test.go
+++ b/smoke/tests/api_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/BraveY/snapshotter-converter/converter"
 	"github.com/containerd/log"
@@ -185,8 +186,16 @@ func (a *APIV1TestSuite) TestPrefetch(t *testing.T) {
 	err = nydusd.MountByAPI(config)
 	require.NoError(t, err)
 
-	bcm, err := nydusd.GetBlobCacheMetrics("")
-	require.NoError(t, err)
+	// Prefetch runs asynchronously after mount; poll until data arrives.
+	var bcm *tool.BlobCacheMetrics
+	for i := 0; i < 10; i++ {
+		bcm, err = nydusd.GetBlobCacheMetrics("")
+		require.NoError(t, err)
+		if bcm.PrefetchDataAmount > 0 {
+			break
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
 	require.Greater(t, bcm.PrefetchDataAmount, uint64(0))
 
 	_, err = nydusd.GetBlobCacheMetrics("/pseudo_fs_1")

--- a/smoke/tests/cas_test.go
+++ b/smoke/tests/cas_test.go
@@ -62,12 +62,23 @@ func (c *CasTestSuite) testCasTables(t *testing.T, enablePrefetch bool) {
 		require.NoError(t, err)
 		var count int
 		query := fmt.Sprintf("SELECT COUNT(*) FROM %s;", expectedTable)
-		err = db.QueryRow(query).Scan(&count)
-		require.NoError(t, err)
 		if expectedTable == "Blobs" {
+			err = db.QueryRow(query).Scan(&count)
+			require.NoError(t, err)
 			require.Equal(t, 1, count)
 		} else {
-			require.Equal(t, 13, count)
+			// Chunk dedup DB writes may lag behind reads; poll until stable.
+			expected := 13
+			for i := 0; i < 10; i++ {
+				err = db.QueryRow(query).Scan(&count)
+				require.NoError(t, err)
+				if count >= expected {
+					break
+				}
+				time.Sleep(500 * time.Millisecond)
+				_, _ = db.Exec("PRAGMA wal_checkpoint(FULL)")
+			}
+			require.Equal(t, expected, count)
 		}
 	}
 }


### PR DESCRIPTION
Fix three fleaky CI issues:

1. RISC-V Docker cross build cache depends on gha cache that is not stable
2. `TestPrefetch` should poll until data is available
3. `testCasTables` should wait to see more chunks as DB writes are async