### PR TITLE
[nydusify] Override source imageRef fetched from containerd

### DIFF
--- a/contrib/nydusify/cmd/nydusify.go
+++ b/contrib/nydusify/cmd/nydusify.go
@@ -1445,10 +1445,10 @@ func main() {
 					EnvVars:  []string{"TARGET"},
 				},
 				&cli.StringFlag{
-					Name:     "source",
+					Name:     "source-image-ref",
 					Required: false,
 					Usage:    "Override the source nydus image reference (useful when containerd uses hosts.toml remapping)",
-					EnvVars:  []string{"SOURCE"},
+					EnvVars:  []string{"SOURCE_IMAGE_REF"},
 				},
 				&cli.BoolFlag{
 					Name:     "source-insecure",
@@ -1505,7 +1505,7 @@ func main() {
 					ContainerdAddress: c.String("containerd-address"),
 					Namespace:         c.String("namespace"),
 					ContainerID:       c.String("container"),
-					SourceRef:         c.String("source"),
+					SourceImageRef:    c.String("source-image-ref"),
 					TargetRef:         c.String("target"),
 					SourceInsecure:    c.Bool("source-insecure"),
 					TargetInsecure:    c.Bool("target-insecure"),

--- a/contrib/nydusify/cmd/nydusify.go
+++ b/contrib/nydusify/cmd/nydusify.go
@@ -1444,6 +1444,12 @@ func main() {
 					Usage:    "Target nydus image reference",
 					EnvVars:  []string{"TARGET"},
 				},
+				&cli.StringFlag{
+					Name:     "source",
+					Required: false,
+					Usage:    "Override the source nydus image reference (useful when containerd uses hosts.toml remapping)",
+					EnvVars:  []string{"SOURCE"},
+				},
 				&cli.BoolFlag{
 					Name:     "source-insecure",
 					Required: false,
@@ -1499,6 +1505,7 @@ func main() {
 					ContainerdAddress: c.String("containerd-address"),
 					Namespace:         c.String("namespace"),
 					ContainerID:       c.String("container"),
+					SourceRef:         c.String("source"),
 					TargetRef:         c.String("target"),
 					SourceInsecure:    c.Bool("source-insecure"),
 					TargetInsecure:    c.Bool("target-insecure"),

--- a/contrib/nydusify/pkg/committer/commiter.go
+++ b/contrib/nydusify/pkg/committer/commiter.go
@@ -46,6 +46,7 @@ type Opt struct {
 	Namespace         string
 
 	ContainerID    string
+	SourceRef      string
 	SourceInsecure bool
 	TargetRef      string
 	TargetInsecure bool
@@ -104,6 +105,9 @@ func (cm *Committer) Commit(ctx context.Context, opt Opt) error {
 	}
 
 	originalSourceRef := inspect.Image
+	if opt.SourceRef != "" {
+		originalSourceRef = opt.SourceRef
+	}
 
 	logrus.Infof("pulling base bootstrap")
 	start := time.Now()

--- a/contrib/nydusify/pkg/committer/commiter.go
+++ b/contrib/nydusify/pkg/committer/commiter.go
@@ -46,7 +46,7 @@ type Opt struct {
 	Namespace         string
 
 	ContainerID    string
-	SourceRef      string
+	SourceImageRef string
 	SourceInsecure bool
 	TargetRef      string
 	TargetInsecure bool
@@ -105,8 +105,8 @@ func (cm *Committer) Commit(ctx context.Context, opt Opt) error {
 	}
 
 	originalSourceRef := inspect.Image
-	if opt.SourceRef != "" {
-		originalSourceRef = opt.SourceRef
+	if opt.SourceImageRef != "" {
+		originalSourceRef = opt.SourceImageRef
 	}
 
 	logrus.Infof("pulling base bootstrap")


### PR DESCRIPTION
## Overview
In case containerd has some hosts.toml specific configuration, the imageRef of the containerId can be different to the actual url to fetch the image. 

This PR allow to override the imageRef fetched from containerd

## Change Type
_Please select the type of change your pull request relates to:_
- [ ] Bug Fix
- [X] Feature Addition
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe)

## Self-Checklist
_Before submitting a pull request, please ensure you have completed the following:_
- [ ] I have run a code style check and addressed any warnings/errors.
- [ ] I have added appropriate comments to my code (if applicable).
- [ ] I have updated the documentation (if applicable).
- [ ] I have written appropriate unit tests.