### PR TITLE
fusedev: fix remount invalidation for nested mountpoints

### DIFF
--- a/service/src/fs_service.rs
+++ b/service/src/fs_service.rs
@@ -187,9 +187,11 @@ pub trait FsService: Send + Sync {
         if self.is_fuse() {
             if let Some(rafs) = fs.deref().as_any().downcast_ref::<Rafs>() {
                 let root_ino = rafs.get_root_inode().unwrap();
+                let (mountpoint_parent_ino, mountpoint_name) =
+                    mountpoint_invalidation_target(self.get_vfs(), &cmd.mountpoint)?;
                 self.walk_and_notify_invalidation(
-                    ROOT_ID,
-                    cmd.mountpoint.trim_start_matches('/'),
+                    mountpoint_parent_ino,
+                    mountpoint_name,
                     root_ino,
                     fs_idx,
                 )?;
@@ -248,6 +250,27 @@ pub trait FsService: Send + Sync {
     }
     /// Cast `self` to trait object of [Any] to support object downcast.
     fn as_any(&self) -> &dyn Any;
+}
+
+fn mountpoint_invalidation_target<'a>(vfs: &Vfs, mountpoint: &'a str) -> Result<(u64, &'a str)> {
+    if mountpoint == "/" {
+        // Keep root mountpoint invalidation compatible with the previous behavior.
+        // Path::file_name() does not produce a basename for "/".
+        return Ok((ROOT_ID, mountpoint.trim_start_matches('/')));
+    }
+
+    let name = Path::new(mountpoint)
+        .file_name()
+        .and_then(|name| name.to_str())
+        .ok_or_else(|| {
+            Error::InvalidArguments(format!("invalid mountpoint basename {mountpoint}"))
+        })?;
+    let root_pseudofs = vfs.get_root_pseudofs();
+    let mountpoint_ino = root_pseudofs.path_walk(mountpoint)?;
+    let ino = mountpoint_ino.ok_or(Error::NotFound)?;
+    let parent_ino = root_pseudofs.get_parent_inode(ino).ok_or(Error::NotFound)?;
+
+    Ok((parent_ino, name))
 }
 
 /// Validate prefetch file list from user input.
@@ -440,6 +463,57 @@ mod tests {
             "relative/path".to_string(),
         ]))
         .is_err());
+    }
+
+    #[test]
+    fn it_should_resolve_root_mountpoint_invalidation_target() {
+        let vfs = Vfs::default();
+        let (parent_ino, name) = mountpoint_invalidation_target(&vfs, "/").unwrap();
+
+        assert_eq!(parent_ino, ROOT_ID);
+        assert_eq!(name, "");
+    }
+
+    #[test]
+    fn it_should_resolve_nested_mountpoint_invalidation_target() {
+        let vfs = Vfs::default();
+        let root_pseudofs = vfs.get_root_pseudofs();
+        root_pseudofs.mount("/a/b/c").unwrap();
+
+        let (parent_ino, name) = mountpoint_invalidation_target(&vfs, "/a/b/c").unwrap();
+        let expected_parent_ino = root_pseudofs.path_walk("/a/b").unwrap().unwrap();
+
+        assert_eq!(parent_ino, expected_parent_ino);
+        assert_eq!(name, "c");
+    }
+
+    #[test]
+    fn it_should_fail_to_resolve_missing_mountpoint_invalidation_target() {
+        let vfs = Vfs::default();
+
+        let err = mountpoint_invalidation_target(&vfs, "/a/b/c").unwrap_err();
+        assert_eq!(
+            std::mem::discriminant(&err),
+            std::mem::discriminant(&Error::NotFound)
+        );
+    }
+
+    #[test]
+    fn it_should_fail_to_resolve_relative_mountpoint_invalidation_target() {
+        let vfs = Vfs::default();
+
+        assert!(mountpoint_invalidation_target(&vfs, "a/b/c").is_err());
+    }
+
+    #[test]
+    fn it_should_reject_invalid_mountpoint_invalidation_basename() {
+        let vfs = Vfs::default();
+
+        let err = mountpoint_invalidation_target(&vfs, "/..").unwrap_err();
+        assert_eq!(
+            std::mem::discriminant(&err),
+            std::mem::discriminant(&Error::InvalidArguments(String::new()))
+        );
     }
 
     #[test]

--- a/smoke/tests/api_test.go
+++ b/smoke/tests/api_test.go
@@ -264,6 +264,88 @@ func (a *APIV1TestSuite) TestSubMountCache(t *testing.T) {
 	}
 }
 
+func (a *APIV1TestSuite) TestNestedMountpointStatAfterRemount(t *testing.T) {
+	ctx := tool.DefaultContext(t)
+
+	ctx.PrepareWorkDir(t)
+	defer ctx.Destroy(t)
+
+	config := tool.NydusdConfig{
+		NydusdPath:  ctx.Binary.Nydusd,
+		MountPath:   ctx.Env.MountDir,
+		APISockPath: filepath.Join(ctx.Env.WorkDir, "nydusd-api.sock"),
+		ConfigPath:  filepath.Join(ctx.Env.WorkDir, "nydusd-config.fusedev.json"),
+	}
+
+	nydusd, err := tool.NewNydusd(config)
+	require.NoError(t, err)
+
+	err = nydusd.Mount()
+	require.NoError(t, err)
+
+	nestedMountpoint := "/a/b/c"
+	nestedMountHostPath := filepath.Join(ctx.Env.MountDir, "a/b/c")
+	nestedMounted := false
+	defer func() {
+		if nestedMounted {
+			if err := nydusd.UmountByAPI(nestedMountpoint); err != nil {
+				log.L.WithError(err).Errorf("umount nested mountpoint %s", nestedMountpoint)
+			}
+		}
+		if err := nydusd.Umount(); err != nil {
+			log.L.WithError(err).Errorf("umount")
+		}
+	}()
+
+	layer := tool.NewLayer(t, filepath.Join(ctx.Env.WorkDir, "nested-rootfs"))
+	layer.CreateFile(t, "file-1", []byte("file-1"))
+	layer.CreateDir(t, "dir-1")
+	layer.CreateFile(t, "dir-1/file-1", []byte("dir-1/file-1"))
+	bootstrap := a.buildLayer(t, ctx, layer)
+
+	childConfig := config
+	childConfig.BootstrapPath = bootstrap
+	childConfig.MountPath = nestedMountpoint
+	childConfig.BackendType = "localfs"
+	childConfig.BackendConfig = fmt.Sprintf(`{"dir": "%s"}`, ctx.Env.BlobDir)
+	childConfig.BlobCacheDir = ctx.Env.CacheDir
+	childConfig.CacheType = ctx.Runtime.CacheType
+	childConfig.CacheCompressed = ctx.Runtime.CacheCompressed
+	childConfig.RafsMode = ctx.Runtime.RafsMode
+	childConfig.EnablePrefetch = ctx.Runtime.EnablePrefetch
+	childConfig.DigestValidate = false
+	childConfig.AmplifyIO = ctx.Runtime.AmplifyIO
+
+	t.Logf("mount nested RAFS backend at %s", nestedMountpoint)
+	err = nydusd.MountByAPI(childConfig)
+	require.NoError(t, err)
+	nestedMounted = true
+
+	t.Logf("stat nested mountpoint after first mount: %s", nestedMountHostPath)
+	_, err = os.Stat(nestedMountHostPath)
+	require.NoError(t, err)
+	nydusd.VerifyByPath(t, layer.FileTree, nestedMountpoint)
+
+	t.Logf("unmount nested mountpoint %s", nestedMountpoint)
+	err = nydusd.UmountByAPI(nestedMountpoint)
+	require.NoError(t, err)
+	nestedMounted = false
+
+	t.Logf("remount nested RAFS backend at %s", nestedMountpoint)
+	err = nydusd.MountByAPI(childConfig)
+	require.NoError(t, err)
+	nestedMounted = true
+
+	t.Logf("stat nested mountpoint immediately after remount without reading parent directory: %s", nestedMountHostPath)
+	_, err = os.Stat(nestedMountHostPath)
+	require.NoError(t, err)
+	nydusd.VerifyByPath(t, layer.FileTree, nestedMountpoint)
+
+	err = nydusd.UmountByAPI(nestedMountpoint)
+	require.NoError(t, err)
+	nestedMounted = false
+}
+
 func (a *APIV1TestSuite) TestMount(t *testing.T) {
 
 	ctx := tool.DefaultContext(t)


### PR DESCRIPTION
## Overview

Fix FUSE cache invalidation when unmounting a RAFS backend mounted at a subdirectory path.

Before this change, `FsService::umount()` invalidated the mountpoint root entry by passing `ROOT_ID` and the full mountpoint path to `notify_inval_entry()`. For a mountpoint such as `/a/b/c`, this produced an invalidation request equivalent to `(ROOT_ID, "a/b/c")`. FUSE entry invalidation expects a direct `parent/name` pair, so the remounted path could remain stale and `stat(<mountpoint>)` could return `ENOENT` until the parent directory was read.

## Related Issues

Fix #1928 

## Change Details

For non-root mountpoints, this PR resolves the mountpoint pseudo inode, finds its direct parent inode, and passes the mountpoint basename to `walk_and_notify_invalidation()`. This makes the entry invalidation target match the FUSE `parent/name` semantics.

For the root mountpoint `/`, this PR keeps the previous behavior by using `ROOT_ID` and an empty entry name. This avoids changing the existing `/` mount/unmount behavior while fixing subdirectory mountpoints.

## Test Results

Code checks:

```text
$ cargo fmt --check --package nydus-service
$ cargo check -p nydus-service
```

Workspace unit tests were also run with host-environment-dependent cases skipped on the validation host:

```text
Starting 832 tests across 13 binaries (5 tests skipped)
Summary [  23.696s] 832 tests run: 832 passed, 5 skipped
```

The skipped cases depend on host capabilities or system configuration that were not available in that environment; all executed unit tests passed.

Added a smoke test for the nested mountpoint remount case, then ran it against both the old invalidation target and the fixed build:

```text
Bad build (old invalidation target):
mount nested RAFS backend at /a/b/c
stat nested mountpoint after first mount: <workdir>/mnt/a/b/c
unmount nested mountpoint /a/b/c
remount nested RAFS backend at /a/b/c
stat nested mountpoint immediately after remount without reading parent directory: <workdir>/mnt/a/b/c
Error: Received unexpected error:
  stat <workdir>/mnt/a/b/c: no such file or directory
--- FAIL: TestAPI/TestNestedMountpointStatAfterRemount

Fixed build (direct parent/name invalidation):
mount nested RAFS backend at /a/b/c
stat nested mountpoint after first mount: <workdir>/mnt/a/b/c
unmount nested mountpoint /a/b/c
remount nested RAFS backend at /a/b/c
stat nested mountpoint immediately after remount without reading parent directory: <workdir>/mnt/a/b/c
--- PASS: TestAPI/TestNestedMountpointStatAfterRemount
PASS
```

The bad build was produced by temporarily reverting the invalidation target back to `ROOT_ID + full mountpoint path`. With that behavior, the same smoke test reproduces the remount failure. With this PR applied, the test passes by directly statting `/a/b/c` after remount without reading the parent directory first.

Regression validation for the root mountpoint `/`:

```text
old v2.4.1:
  mount / unmount / exit via the HTTP API all returned 204

fixed build:
  mount / unmount / exit via the HTTP API all returned 204
```

The patched build did not produce `invalid mountpoint basename /`, and root mountpoint behavior remained unchanged.

## Change Type

- [x] Bug Fix
- [ ] Feature Addition
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe)

## Self-Checklist

- [x] I have run a code style check and addressed any warnings/errors.
- [x] I have added appropriate comments to my code (if applicable).
- [x] I have updated the documentation (if applicable).
- [x] I have written appropriate unit tests.
