### PR TITLE
nydus-image: fix chunkdict test size calculation

### DIFF
--- a/src/bin/nydus-image/deduplicate.rs
+++ b/src/bin/nydus-image/deduplicate.rs
@@ -807,9 +807,9 @@ impl Algorithm<SqliteDatabase> {
             train_set_size as f64 / 1024_f64 / 1024_f64
         );
 
-        let mut test_set_size = 0;
+        let mut test_set_size: u64 = 0;
         for i in &test {
-            test_set_size += i.chunk_compressed_size;
+            test_set_size += i.chunk_compressed_size as u64;
         }
         info!(
             "Test set size is {}",
@@ -822,12 +822,13 @@ impl Algorithm<SqliteDatabase> {
         let mut threshold = 0.5;
         let max_threshold = 0.8;
 
-        let mut test_total_size: u32 = 0;
-        let mut min_test_size: u32 = u32::MAX;
+        let mut min_test_size: u64 = u64::MAX;
         let mut min_data_dict = HashMap::new();
 
         while threshold <= max_threshold {
+            let mut test_total_size: u64 = 0;
             version_datadict.clear();
+
             for point in data_point.iter_mut() {
                 for single_dictionary in &datadict {
                     for (key, value) in single_dictionary.iter() {
@@ -870,7 +871,7 @@ impl Algorithm<SqliteDatabase> {
                 }
                 for chunk in point.chunk_list.iter() {
                     test_total_size = test_total_size
-                        .checked_add(chunk.chunk_compressed_size)
+                        .checked_add(chunk.chunk_compressed_size as u64)
                         .unwrap_or(test_total_size);
                 }
             }


### PR DESCRIPTION
## Overview
This PR fixes the test set size calculation in `deduplicate_version()`.

Previously, `test_total_size` was declared outside the threshold loop, so the test size from each threshold iteration was accumulated into the next one. Each threshold should be evaluated independently.

This PR also changes `test_total_size`, `min_test_size`, and `test_set_size` to `u64` to avoid overflow when processing large images.

## Related Issues
N/A

## Change Details
Before this PR, `test_total_size` was initialized before the threshold loop:

```rust
let mut test_total_size: u32 = 0;
let mut min_test_size: u32 = u32::MAX;

while threshold <= max_threshold {
    ...
}
```

This caused `test_total_size` to accumulate across threshold iterations.

This PR moves `test_total_size` into the threshold loop:

```rust
let mut min_test_size: u64 = u64::MAX;

while threshold <= max_threshold {
    let mut test_total_size: u64 = 0;
    ...
}
```

It also uses `u64` for test size accounting to avoid `u32` overflow on large images.


## Test Results
```bash
cargo fmt
cargo test test_deduplicate_version
```

## Change Type
_Please select the type of change your pull request relates to:_
- [x] Bug Fix
- [ ] Feature Addition
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe)

## Self-Checklist
_Before submitting a pull request, please ensure you have completed the following:_
- [x] I have run a code style check and addressed any warnings/errors.
- [ ] I have added appropriate comments to my code (if applicable).
- [ ] I have updated the documentation (if applicable).
- [ ] I have written appropriate unit tests.