### PR TITLE
nydusify: read chunkdict blobs from local content store

### DIFF
--- a/contrib/nydusify/pkg/chunkdict/generator/generator.go
+++ b/contrib/nydusify/pkg/chunkdict/generator/generator.go
@@ -314,39 +314,22 @@ func pushBlobFromBackend(
 				blobDigest := digest.Digest("sha256:" + blobID)
 
 				var blobSize int64
-				var rc io.ReadCloser
 
 				if bkd != nil {
-					rc, err = bkd.Reader(blobID)
-					if err != nil {
-						return errors.Wrap(err, "get blob reader")
-					}
 					blobSize, err = bkd.Size(blobID)
 					if err != nil {
 						return errors.Wrap(err, "get blob size")
 					}
 				} else {
-					imageDesc, err := generator.sourcesParser[0].Remote.Resolve(ctx)
-					if err != nil {
-						if strings.Contains(err.Error(), "x509: certificate signed by unknown authority") {
-							logrus.Warningln("try to enable \"--source-insecure\" / \"--target-insecure\" option")
-						}
-						return errors.Wrap(err, "resolve image")
-					}
-					rc, err = generator.sourcesParser[0].Remote.Pull(ctx, *imageDesc, true)
-					if err != nil {
-						return errors.Wrap(err, "get blob reader")
-					}
 					blobInfo, err := pvd.ContentStore().Info(ctx, blobDigest)
 					if err != nil {
 						return errors.Wrap(err, "get info from content store")
 					}
 					blobSize = blobInfo.Size
 				}
-				defer rc.Close()
 
 				blobSizeStr := humanize.Bytes(uint64(blobSize))
-				logrus.WithField("digest", blobDigest).WithField("size", blobSizeStr).Infof("pushing blob from backend")
+				logrus.WithField("digest", blobDigest).WithField("size", blobSizeStr).Infof("pushing blob")
 
 				blobDescs[idx] = ocispec.Descriptor{
 					Digest:    blobDigest,
@@ -356,6 +339,7 @@ func pushBlobFromBackend(
 						converter.LayerAnnotationNydusBlob: "true",
 					},
 				}
+
 				writer, err := getPushWriter(ctx, pvd, blobDescs[idx], generator.Opt)
 				if err != nil {
 					if errdefs.NeedsRetryWithHTTP(err) {
@@ -366,15 +350,36 @@ func pushBlobFromBackend(
 						return errors.Wrap(err, "get push writer")
 					}
 				}
-				if writer != nil {
-					defer writer.Close()
-					return content.Copy(ctx, writer, rc, blobSize, blobDigest)
+
+				if writer == nil {
+					logrus.WithField("digest", blobDigest).WithField("size", blobSizeStr).Infof("blob already exists, skip push")
+					return nil
 				}
+				defer writer.Close()
 
-				logrus.WithField("digest", blobDigest).WithField("size", blobSizeStr).Infof("pushed blob from backend")
+				var rc io.ReadCloser
+				if bkd != nil {
+					rc, err = bkd.Reader(blobID)
+					if err != nil {
+						return errors.Wrap(err, "get blob reader")
+					}
+				} else {
+					ra, err := pvd.ContentStore().ReaderAt(ctx, blobDescs[idx])
+					if err != nil {
+						return errors.Wrap(err, "get blob reader from content store")
+					}
 
-				return nil
+					rc = struct {
+						io.Reader
+						io.Closer
+					}{
+						Reader: io.NewSectionReader(ra, 0, blobSize),
+						Closer: ra,
+					}
+				}
+				defer rc.Close()
 
+				return content.Copy(ctx, writer, rc, blobSize, blobDigest)
 			})
 		}(idx)
 	}


### PR DESCRIPTION
## Overview
When running `nydusify chunkdict generate` with multiple Nydus source images, the chunk dictionary can be generated successfully, but the push stage may fail with:

```text
peipei@node82:~/expri/chunk_dict/nydus_static$ sudo ./nydusify chunkdict generate --sources \
  59.77.8.68:80/nydus/tensorflow:2.21.0-gpu_none_1M_nydus,59.77.8.68:80/nydus/tensorflow:2.20.0-gpu_none_1M_nydus,59.77.8.68:80/nydus/tensorflow:2.19.0-gpu_none_1M_nydus \
  --target 59.77.8.68:80/chunkdict/tensorflow:nydus_1M_chunkdict \
  -nydus-image ./nydus-image \
  --source-insecure --target-insecure
INFO[2026-05-25T09:55:58Z] fetch failed                                  error="failed to do request: Head \"https://59.77.8.68:80/v2/nydus/tensorflow/manifests/2.21.0-gpu_none_1M_nydus\": http: server gave HTTP response to HTTPS client" host="59.77.8.68:80"
INFO[2026-05-25T09:55:59Z] Pulling Nydus bootstrap to output/59.77.8.68:80:nydus:tensorflow:2.21.0-gpu_none_1M_nydus/nydus_bootstrap 
INFO[2026-05-25T09:56:00Z] Pulling Nydus bootstrap to output/59.77.8.68:80:nydus:tensorflow:2.20.0-gpu_none_1M_nydus/nydus_bootstrap 
INFO[2026-05-25T09:56:00Z] Pulling Nydus bootstrap to output/59.77.8.68:80:nydus:tensorflow:2.19.0-gpu_none_1M_nydus/nydus_bootstrap 
INFO[2026-05-25T09:56:01Z] Invoking 'nydus-image chunkdict generate' command 
Warning: Blob with id '3de85651c5150bbd4eeece0fe9c21dcbcc3fd093886141357aeb69151eab2f59' is smaller than 4096 bytes.
Warning: Blob with id '4eb094ea711099d084cd0103019fade9adfd87c5920dcc7670aa9c76d234b936' is smaller than 4096 bytes.
Warning: Blob with id '0e107ae5d055453ba1d8e1668f1e937632331cca32e3bda036067bcc6c3b3ddd' is smaller than 4096 bytes.
Warning: Blob with id 'f7fc4d65ac587bbc9baa6cf61e84df09a2eb15e61a32c5238189bbb07e73bb73' is smaller than 4096 bytes.
Warning: Blob with id '545212f107ffa03e37540bbaec187c493bb2b36855437e9c46826a1be1489bc8' is smaller than 4096 bytes.
Warning: Blob with id '3db0b4190eb3e9284edaed0d9d49270b37704d24d0e064f7332715b427dc1c2d' is smaller than 4096 bytes.
Warning: Blob with id 'ad9ee260eb889f0fa168bda8bcd49a237d90e580e22417202f29a7740d794d4a' is smaller than 4096 bytes.
Warning: Blob with id '9824c5c998058e95297587b4a227e82fc9dc863458e163e8fa7d020af1abff74' is smaller than 4096 bytes.
INFO[2026-05-25T10:08:35Z] Successfully generate image chunk dictionary 
INFO[2026-05-25T10:08:35Z] pulling source image from 59.77.8.68:80/nydus/tensorflow:2.21.0-gpu_none_1M_nydus 
INFO[2026-05-25T10:08:35Z] fetch failed                                  error="failed to do request: Head \"https://59.77.8.68:80/v2/nydus/tensorflow/manifests/2.21.0-gpu_none_1M_nydus\": http: server gave HTTP response to HTTPS client" host="59.77.8.68:80"
INFO[2026-05-25T10:08:35Z] pulling source image from 59.77.8.68:80/nydus/tensorflow:2.21.0-gpu_none_1M_nydus 
INFO[2026-05-25T10:09:43Z] pulling source image from 59.77.8.68:80/nydus/tensorflow:2.20.0-gpu_none_1M_nydus 
INFO[2026-05-25T10:10:49Z] pulling source image from 59.77.8.68:80/nydus/tensorflow:2.19.0-gpu_none_1M_nydus 
INFO[2026-05-25T10:11:58Z] pulled source image 59.77.8.68:80/nydus/tensorflow:2.21.0-gpu_none_1M_nydus 
INFO[2026-05-25T10:11:58Z] pushing blob from backend                     digest="sha256:0be2eb734b4227901a66dab897dd8b1c642117f7830286ba99980b8364cb43e0" size="42 kB"
INFO[2026-05-25T10:11:58Z] pushing blob from backend                     digest="sha256:744ed9fe549fcfea418445b61f34cbad4984508e00124ab748f8d5a3d72d91ed" size="4.9 GB"
INFO[2026-05-25T10:11:58Z] pushing blob from backend                     digest="sha256:87d02766c12b182b306ad1cc7751497d064e49ccb9fa9d3c4ec124691110a090" size="78 MB"
INFO[2026-05-25T10:11:58Z] pushing blob from backend                     digest="sha256:6bdb4f92e488004539d50bc1a833c54dfc990257b4c4d1ede0670f8fed5efc38" size="155 MB"
INFO[2026-05-25T10:11:58Z] pushing blob from backend                     digest="sha256:3888f9572e1a996a258fe8134dcd972a05c57be4a038dc1539366dcf06d465a1" size="2.1 GB"
INFO[2026-05-25T10:11:58Z] pushed blob from backend                      digest="sha256:87d02766c12b182b306ad1cc7751497d064e49ccb9fa9d3c4ec124691110a090" size="78 MB"
INFO[2026-05-25T10:11:58Z] pushed blob from backend                      digest="sha256:0be2eb734b4227901a66dab897dd8b1c642117f7830286ba99980b8364cb43e0" size="42 kB"
INFO[2026-05-25T10:11:58Z] pushed blob from backend                      digest="sha256:6bdb4f92e488004539d50bc1a833c54dfc990257b4c4d1ede0670f8fed5efc38" size="155 MB"
INFO[2026-05-25T10:11:58Z] pushed blob from backend                      digest="sha256:744ed9fe549fcfea418445b61f34cbad4984508e00124ab748f8d5a3d72d91ed" size="4.9 GB"
INFO[2026-05-25T10:11:58Z] pushed blob from backend                      digest="sha256:3888f9572e1a996a258fe8134dcd972a05c57be4a038dc1539366dcf06d465a1" size="2.1 GB"
INFO[2026-05-25T10:11:58Z] fetch failed                                  error="failed to do request: Head \"http://59.77.8.68:80/v2/nydus/tensorflow/manifests/2.21.0-gpu_none_1M_nydus\": failed to read expected number of bytes: unexpected EOF" host="59.77.8.68:80"
INFO[2026-05-25T10:11:58Z] fetch failed                                  error="failed to do request: Head \"http://59.77.8.68:80/v2/nydus/tensorflow/manifests/2.21.0-gpu_none_1M_nydus\": failed to read expected number of bytes: unexpected EOF" host="59.77.8.68:80"
INFO[2026-05-25T10:11:58Z] fetch failed                                  error="failed to do request: Head \"http://59.77.8.68:80/v2/nydus/tensorflow/manifests/2.21.0-gpu_none_1M_nydus\": failed to read expected number of bytes: unexpected EOF" host="59.77.8.68:80"
FATA[2026-05-25T10:11:58Z] push image manifests: get resolver: push blobs: failed to read expected number of bytes: unexpected EOF 
```
The root cause is in the no-backend path of `pushBlobFromBackend`.

```go
				if bkd != nil {
					rc, err = bkd.Reader(blobID)
					if err != nil {
						return errors.Wrap(err, "get blob reader")
					}
					blobSize, err = bkd.Size(blobID)
					if err != nil {
						return errors.Wrap(err, "get blob size")
					}
				} else {
					imageDesc, err := generator.sourcesParser[0].Remote.Resolve(ctx)
					if err != nil {
						if strings.Contains(err.Error(), "x509: certificate signed by unknown authority") {
							logrus.Warningln("try to enable \"--source-insecure\" / \"--target-insecure\" option")
						}
						return errors.Wrap(err, "resolve image")
					}
					rc, err = generator.sourcesParser[0].Remote.Pull(ctx, *imageDesc, true)
					if err != nil {
						return errors.Wrap(err, "get blob reader")
					}
					blobInfo, err := pvd.ContentStore().Info(ctx, blobDigest)
					if err != nil {
						return errors.Wrap(err, "get info from content store")
					}
					blobSize = blobInfo.Size
				}
```

`Remote.Resolve()` resolves the source image reference and returns the descriptor of the referenced top-level object, usually the source image manifest or image index.
Therefore, the returned `rc` reads from the resolved source image descriptor.
However, the size and digest passed to `content.Copy()` are from the current chunk blob:
```go
content.Copy(ctx, writer, rc, blobSize, blobDigest)
```
As a result, `content.Copy()` may try to read a large chunk blob from a small manifest reader and fail with `unexpected EOF`.

During chunkdict generation, source image layers are pulled into the local content store in the push stage. Therefore, when no backend is configured, it may be more appropriate to read the current chunk blob directly from the local content store.

This can also avoid build failures caused by reading blobs from a fixed source image repository when chunk blobs come from different source image repositories.

This change updates the no-backend path to open the current chunk blob from the local content store and then push it to the target registry. 

After this change, the generated chunkdict image can be pushed successfully：
```text
peipei@node82:~/expri/chunk_dict/nydus_static$ sudo ./nydusify chunkdict generate --sources   59.77.8.68:80/nydus/tensorflow:2.21.0-gpu_none_1M_nydus,59.77.8.68:80/nydus/tensorflow:2.20.0-gpu_none_1M_nydus,59.77.8.68:80/nydus/tensorflow:2.19.0-gpu_none_1M_nydus   --target 59.77.8.68:80/chunkdict/tensorflow:nydus_1M_chunkdict   -nydus-image ./nydus-image   --source-insecure --target-insecure
INFO[2026-05-25T13:46:29Z] fetch failed                                  error="failed to do request: Head \"https://59.77.8.68:80/v2/nydus/tensorflow/manifests/2.21.0-gpu_none_1M_nydus\": http: server gave HTTP response to HTTPS client" host="59.77.8.68:80"
INFO[2026-05-25T13:46:30Z] Pulling Nydus bootstrap to output/59.77.8.68:80:nydus:tensorflow:2.21.0-gpu_none_1M_nydus/nydus_bootstrap 
INFO[2026-05-25T13:46:30Z] Pulling Nydus bootstrap to output/59.77.8.68:80:nydus:tensorflow:2.20.0-gpu_none_1M_nydus/nydus_bootstrap 
INFO[2026-05-25T13:46:31Z] Pulling Nydus bootstrap to output/59.77.8.68:80:nydus:tensorflow:2.19.0-gpu_none_1M_nydus/nydus_bootstrap 
INFO[2026-05-25T13:46:31Z] Invoking 'nydus-image chunkdict generate' command 
Warning: Blob with id '9824c5c998058e95297587b4a227e82fc9dc863458e163e8fa7d020af1abff74' is smaller than 4096 bytes.
Warning: Blob with id 'ad9ee260eb889f0fa168bda8bcd49a237d90e580e22417202f29a7740d794d4a' is smaller than 4096 bytes.
Warning: Blob with id '545212f107ffa03e37540bbaec187c493bb2b36855437e9c46826a1be1489bc8' is smaller than 4096 bytes.
Warning: Blob with id 'f7fc4d65ac587bbc9baa6cf61e84df09a2eb15e61a32c5238189bbb07e73bb73' is smaller than 4096 bytes.
Warning: Blob with id '3db0b4190eb3e9284edaed0d9d49270b37704d24d0e064f7332715b427dc1c2d' is smaller than 4096 bytes.
Warning: Blob with id '4eb094ea711099d084cd0103019fade9adfd87c5920dcc7670aa9c76d234b936' is smaller than 4096 bytes.
Warning: Blob with id '3de85651c5150bbd4eeece0fe9c21dcbcc3fd093886141357aeb69151eab2f59' is smaller than 4096 bytes.
Warning: Blob with id '0e107ae5d055453ba1d8e1668f1e937632331cca32e3bda036067bcc6c3b3ddd' is smaller than 4096 bytes.
INFO[2026-05-25T13:57:35Z] Successfully generate image chunk dictionary 
INFO[2026-05-25T13:57:35Z] pulling source image from 59.77.8.68:80/nydus/tensorflow:2.21.0-gpu_none_1M_nydus 
INFO[2026-05-25T13:57:35Z] fetch failed                                  error="failed to do request: Head \"https://59.77.8.68:80/v2/nydus/tensorflow/manifests/2.21.0-gpu_none_1M_nydus\": http: server gave HTTP response to HTTPS client" host="59.77.8.68:80"
INFO[2026-05-25T13:57:35Z] pulling source image from 59.77.8.68:80/nydus/tensorflow:2.21.0-gpu_none_1M_nydus 
INFO[2026-05-25T13:58:43Z] pulling source image from 59.77.8.68:80/nydus/tensorflow:2.20.0-gpu_none_1M_nydus 
INFO[2026-05-25T13:59:49Z] pulling source image from 59.77.8.68:80/nydus/tensorflow:2.19.0-gpu_none_1M_nydus 
INFO[2026-05-25T14:01:08Z] pulled source image 59.77.8.68:80/nydus/tensorflow:2.21.0-gpu_none_1M_nydus 
INFO[2026-05-25T14:01:08Z] pushing blob                                  digest="sha256:0be2eb734b4227901a66dab897dd8b1c642117f7830286ba99980b8364cb43e0" size="42 kB"
INFO[2026-05-25T14:01:08Z] pushing blob                                  digest="sha256:3888f9572e1a996a258fe8134dcd972a05c57be4a038dc1539366dcf06d465a1" size="2.1 GB"
INFO[2026-05-25T14:01:08Z] pushing blob                                  digest="sha256:08ec5b87450cfc7872210dea2a858df5dfe4eb6a87f717864b01b28c48eb0f48" size="104 MB"
INFO[2026-05-25T14:01:08Z] pushing blob                                  digest="sha256:8e1a200f11714a45e44b0bf05feb3c4abcefc8962498417e21d6d62439c533ec" size="10 MB"
INFO[2026-05-25T14:01:08Z] pushing blob                                  digest="sha256:6bdb4f92e488004539d50bc1a833c54dfc990257b4c4d1ede0670f8fed5efc38" size="155 MB"
INFO[2026-05-25T14:01:08Z] pushing blob                                  digest="sha256:db0480e89107947a22897fc12c67244beb24f035060fb962cb9d1450c919d76e" size="199 MB"
INFO[2026-05-25T14:01:08Z] pushing blob                                  digest="sha256:744ed9fe549fcfea418445b61f34cbad4984508e00124ab748f8d5a3d72d91ed" size="4.9 GB"
INFO[2026-05-25T14:01:12Z] pushing blob                                  digest="sha256:87d02766c12b182b306ad1cc7751497d064e49ccb9fa9d3c4ec124691110a090" size="78 MB"
INFO[2026-05-25T14:02:18Z] pushing target image to 59.77.8.68:80/chunkdict/tensorflow:nydus_1M_chunkdict 
```

## Related Issues
_Please link to the relevant issue. For example: `Fix #123` or `Related #456`._

## Change Details
_Please describe your changes in detail:_

## Test Results
_If you have any relevant screenshots or videos that can help illustrate your changes, please add them here._

## Change Type
_Please select the type of change your pull request relates to:_
- [x] Bug Fix
- [ ] Feature Addition
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe)

## Self-Checklist
_Before submitting a pull request, please ensure you have completed the following:_
- [ ] I have run a code style check and addressed any warnings/errors.
- [ ] I have added appropriate comments to my code (if applicable).
- [ ] I have updated the documentation (if applicable).
- [ ] I have written appropriate unit tests.