### PR TITLE
ci: pin nerdctl to v2.2.2 to fix smoke test failure

### DIFF
--- a/docs/containerd-env-setup.md
+++ b/docs/containerd-env-setup.md
@@ -149,6 +149,16 @@ For version 3 containerd config format:
     discard_unpacked_layers = false
 ```
 
+For version 4 containerd config format:
+
+```toml
+[plugins]
+  [plugins.'io.containerd.cri.v1.images']
+    snapshotter = 'nydus'
+    disable_snapshot_annotations = false
+    discard_unpacked_layers = false
+```
+
 Then restart containerd, e.g.:
 
 ```bash

--- a/misc/performance/containerd_config.toml
+++ b/misc/performance/containerd_config.toml
@@ -1,4 +1,4 @@
-version = 2
+version = 4
 root = "/var/lib/containerd"
 state = "/run/containerd"
 oom_score = 0
@@ -11,7 +11,13 @@ oom_score = 0
   disable_snapshot_annotations = false
   discard_unpacked_layers = false
 
+[[plugins."io.containerd.transfer.v1.local".unpack_config]]
+  platform = "linux"
+  snapshotter = "nydus"
+
 [proxy_plugins]
   [proxy_plugins.nydus]
       type = "snapshot"
       address = "/run/containerd-nydus/containerd-nydus-grpc.sock"
+      [proxy_plugins.nydus.exports]
+        enable_remote_snapshot_annotations = "true"


### PR DESCRIPTION
## Overview
 Fix `TestTakeover/TestAPIHotUpgrade` smoke test failure by pinning nerdctl to v2.2.2.

## Related Issues
 Related  https://github.com/containerd/nerdctl/pull/4583

## Change Details
Since nerdctl v2.3.x, when connected to containerd >= 2.0.0, the image pull logic switches from the legacy `client.Pull()` to the `client.Transfer()` API , which requires `unpack_config` configured in containerd. There is no runtime flag to force the legacy `client.Pull()` path in v2.3.x.([`SupportsFullTransferService`](https://github.com/containerd/nerdctl/blob/bffd4f8e84fd12ccf59435d7e5b84effb2269bd0/pkg/imgutil/imgutil.go#L139))

The script `misc/prepare.sh` pulls the latest nerdctl version by default. After the upgrade, the smoke test failed with the error: `unable to initialize unpacker: no unpack platforms defined: invalid argument` 
([`CI failure`](https://github.com/dragonflyoss/nydus/actions/runs/26429679160/job/77806864813))                                                            
                                                                                                                                                                       
When testing with nerdctl v2.3.x + containerd 2.x, adding these containerd config entries has been verified to resolve the issue and enable normal operation：                                                                                                                                                     
  ```toml                                                                                                                                                              
  [[plugins.'io.containerd.transfer.v1.local'.unpack_config]]                                                                                                          
      platform = "linux/amd64"                                                                                                                                         
      snapshotter = "nydus"                                                                                                                                            
                                                                                                                                                                       
  [proxy_plugins.nydus]                                                                                                                                                
      type = "snapshot"                                                                                                                                                
      address = "/run/containerd-nydus/containerd-nydus-grpc.sock"                                                                                                     
      [proxy_plugins.nydus.exports]                                                                                                                                    
          enable_remote_snapshot_annotations = "true"
  ```
## Test Results
_If you have any relevant screenshots or videos that can help illustrate your changes, please add them here._

## Change Type
_Please select the type of change your pull request relates to:_
- [x] Bug Fix
- [ ] Feature Addition
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe)

## Self-Checklist
_Before submitting a pull request, please ensure you have completed the following:_
- [ ] I have run a code style check and addressed any warnings/errors.
- [ ] I have added appropriate comments to my code (if applicable).
- [ ] I have updated the documentation (if applicable).
- [ ] I have written appropriate unit tests.