### PR TITLE
fix: correct typos and wrong entry type labels in error messages

### DIFF
--- a/builder/src/core/node.rs
+++ b/builder/src/core/node.rs
@@ -258,7 +258,7 @@ impl Node {
                 }
                 return Ok(0);
             } else {
-                return Err(Error::msg("inode's symblink is invalid."));
+                return Err(Error::msg("inode's symlink is invalid."));
             }
         } else if self.is_special() {
             if self.inode.is_v5() {

--- a/builder/src/stargz.rs
+++ b/builder/src/stargz.rs
@@ -472,7 +472,7 @@ impl StargzBuilder {
                     self.file_chunk_map
                         .insert(path.to_path_buf(), (entry.size, vec![chunk]));
                 } else {
-                    bail!("stargz: file chunk lacks of corresponding head regular file entry");
+                    bail!("stargz: file chunk lacks corresponding head regular file entry");
                 }
 
                 let aligned_chunk_size = if ctx.aligned_chunk {
@@ -539,7 +539,7 @@ impl StargzBuilder {
                     *last_reg_entry = None;
                     Ok(size)
                 } else {
-                    bail!("stargz: tailer chunk lacks of corresponding head chunk");
+                    bail!("stargz: tail chunk lacks corresponding head chunk");
                 }
             } else if entry.chunk_size != ctx.chunk_size as u64 {
                 bail!(

--- a/builder/src/tarball.rs
+++ b/builder/src/tarball.rs
@@ -302,7 +302,7 @@ impl<'a> TarballTreeBuilder<'a> {
             let symlink_link_path = entry
                 .link_name()
                 .context("tarball: failed to get target path for tar symlink entry")?
-                .ok_or_else(|| anyhow!("tarball: failed to get symlink target tor tar entry"))?;
+                .ok_or_else(|| anyhow!("tarball: failed to get symlink target for tar entry"))?;
             let symlink_size = symlink_link_path.as_os_str().byte_size();
             if symlink_size > u16::MAX as usize {
                 bail!("tarball: symlink target from tar entry is too big");
@@ -330,8 +330,8 @@ impl<'a> TarballTreeBuilder<'a> {
         let ino = if entry_type.is_hard_link() {
             let link_path = entry
                 .link_name()
-                .context("tarball: failed to get target path for tar symlink entry")?
-                .ok_or_else(|| anyhow!("tarball: failed to get symlink target tor tar entry"))?;
+                .context("tarball: failed to get target path for tar hardlink entry")?
+                .ok_or_else(|| anyhow!("tarball: failed to get hardlink target for tar entry"))?;
             let link_path = PathBuf::from("/").join(link_path);
             let link_path = link_path.components().as_path();
             let targets = Node::generate_target_vec(link_path);

--- a/rafs/src/metadata/layout/v5.rs
+++ b/rafs/src/metadata/layout/v5.rs
@@ -1398,7 +1398,7 @@ pub(crate) fn rafsv5_align(size: usize) -> usize {
     }
 }
 
-/// Validate inode metadata, include children, chunks and symblink etc.
+/// Validate inode metadata, include children, chunks and symlink etc.
 ///
 /// The default implementation is for rafs v5. The chunk data is not validated here, which will
 /// be validate on fs read.


### PR DESCRIPTION
## Overview

Small set of typo/wording fixes in error messages across `builder/`.

## Related Issues

None.

## Change Details

- `tarball.rs`: `"tor tar entry"` -> `"for tar entry"` (typo, dropped a letter)
- `tarball.rs`: hardlink block used `"symlink entry"` / `"symlink target"` in its error strings - fixed to `"hardlink"`
- `stargz.rs`: `"lacks of"` -> `"lacks"` (grammar) in two messages; `"tailer chunk"` -> `"tail chunk"`
- `node.rs`, `layout/v5.rs`: `"symblink"` -> `"symlink"` (misspelling)

To hit these errors: convert a tarball with a broken symlink or hardlink (missing link_name), or feed a malformed stargz image to `nydus-image create`. The wrong message strings come out and say the wrong entry type.

## Test Results

No functional change, error message text only.

## Change Type

- [x] Bug Fix

## Self-Checklist

- [x] I have run a code style check and addressed any warnings/errors.
- [x] I have added appropriate comments to my code (if applicable).
- [x] I have updated the documentation (if applicable).
- [x] I have written appropriate unit tests.