### PR TITLE
builder: fix chunkdict chunk ordering

### DIFF
--- a/builder/src/chunkdict_generator.rs
+++ b/builder/src/chunkdict_generator.rs
@@ -25,7 +25,7 @@ use nydus_rafs::metadata::inode::InodeWrapper;
 use nydus_rafs::metadata::layout::RafsXAttrs;
 use nydus_storage::meta::BlobChunkInfoV1Ondisk;
 use nydus_utils::compress::Algorithm;
-use nydus_utils::digest::RafsDigest;
+use nydus_utils::digest::{DigestHasher, RafsDigest};
 
 use std::mem::size_of;
 use std::path::PathBuf;
@@ -69,6 +69,7 @@ impl Generator {
     ) -> Result<BuildOutput> {
         // Validate and remove chunks whose belonged blob sizes are smaller than a block.
         let mut chunkdict_chunks = chunkdict_chunks_origin.to_vec();
+        Self::sort_chunks(&mut chunkdict_chunks);
         Self::validate_and_remove_chunks(ctx, &mut chunkdict_chunks);
         // Build root tree.
         let mut tree = Self::build_root_tree(ctx)?;
@@ -133,6 +134,19 @@ impl Generator {
 
         // Retain only chunks with chunk_blob_id that has a total uncompressed size > v6_block_size.
         chunkdict.retain(|chunk| !small_chunks.contains(&chunk.chunk_blob_id));
+    }
+
+    fn sort_chunks(chunkdict: &mut [ChunkdictChunkInfo]) {
+        chunkdict.sort_by(|a, b| {
+            a.chunk_blob_id
+                .cmp(&b.chunk_blob_id)
+                .then_with(|| a.chunk_compressed_offset.cmp(&b.chunk_compressed_offset))
+                .then_with(|| {
+                    a.chunk_uncompressed_offset
+                        .cmp(&b.chunk_uncompressed_offset)
+                })
+                .then_with(|| a.chunk_digest.cmp(&b.chunk_digest))
+        });
     }
 
     /// Build the root tree.
@@ -208,6 +222,14 @@ impl Generator {
 
         // Update child count.
         node.inode.set_child_count(node.chunks.len() as u32);
+
+        // For RAFS v5, regular inode digest should be the hash of all chunk digests.
+        let mut inode_hasher = RafsDigest::hasher(ctx.digester);
+        for chunk in node.chunks.iter() {
+            inode_hasher.digest_update(chunk.inner.id().as_ref());
+        }
+        node.inode.set_digest(inode_hasher.digest_finalize());
+
         let child = Tree::new(node);
         child
             .borrow_mut_node()

--- a/builder/src/chunkdict_generator.rs
+++ b/builder/src/chunkdict_generator.rs
@@ -25,7 +25,7 @@ use nydus_rafs::metadata::inode::InodeWrapper;
 use nydus_rafs::metadata::layout::RafsXAttrs;
 use nydus_storage::meta::BlobChunkInfoV1Ondisk;
 use nydus_utils::compress::Algorithm;
-use nydus_utils::digest::{DigestHasher, RafsDigest};
+use nydus_utils::digest::RafsDigest;
 
 use std::mem::size_of;
 use std::path::PathBuf;

--- a/builder/src/chunkdict_generator.rs
+++ b/builder/src/chunkdict_generator.rs
@@ -222,14 +222,6 @@ impl Generator {
 
         // Update child count.
         node.inode.set_child_count(node.chunks.len() as u32);
-
-        // For RAFS v5, regular inode digest should be the hash of all chunk digests.
-        let mut inode_hasher = RafsDigest::hasher(ctx.digester);
-        for chunk in node.chunks.iter() {
-            inode_hasher.digest_update(chunk.inner.id().as_ref());
-        }
-        node.inode.set_digest(inode_hasher.digest_finalize());
-
         let child = Tree::new(node);
         child
             .borrow_mut_node()


### PR DESCRIPTION
## Overview
After converting an image with chunkdict, `nydusd` panicked while reading chunk data from the converted image:

```text
[2026-05-31 06:21:09.871028 +00:00] ERROR [/log-panics-2.1.0/src/lib.rs:130] thread 'fuse_server' panicked at 'assertion failed: region.chunks[idx].id() < region.chunks[idx + 1].id()': storage/src/cache/cachedfile.rs:1314
   8: nydus_storage::cache::cachedfile::FileCacheEntry::dispatch_one_range
   9: <nydus_storage::cache::cachedfile::FileCacheEntry as nydus_storage::cache::BlobCache>::read
  10: <nydus_storage::device::BlobDeviceIoVec as fuse_backend_rs::common::file_traits::FileReadWriteVolatile>::read_vectored_at_volatile
  13: nydus_storage::device::BlobDevice::read_to
  14: <nydus_rafs::fs::Rafs as fuse_backend_rs::api::filesystem::sync_io::FileSystem>::read
```

The panic happens when the cache layer merges adjacent chunks for reading:
```rust
assert!(end <= start);
assert!(region.chunks[idx].id() < region.chunks[idx + 1].id());
```
chunks from the same blob may not always be ordered by their physical offsets before the bootstrap is generated.
Before generating the chunkdict bootstrap, sort chunkdict_chunks by their physical order.
This ensures that chunks from the same blob are assigned indexes in the same order as their physical offsets

## Related Issues
_Please link to the relevant issue. For example: `Fix #123` or `Related #456`._

## Change Details
_Please describe your changes in detail:_

## Test Results
_If you have any relevant screenshots or videos that can help illustrate your changes, please add them here._

## Change Type
_Please select the type of change your pull request relates to:_
- [x] Bug Fix
- [ ] Feature Addition
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe)

## Self-Checklist
_Before submitting a pull request, please ensure you have completed the following:_
- [ ] I have run a code style check and addressed any warnings/errors.
- [ ] I have added appropriate comments to my code (if applicable).
- [ ] I have updated the documentation (if applicable).
- [ ] I have written appropriate unit tests.