### PR TITLE
fix: use canonical release URL and correct typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ In the future, `zstd::chunked` can work in this way as well.
 
 ### Run Nydus Service
 
-Using the key features of nydus as native in your project without preparing and invoking `nydusd` deliberately, [nydus-service](./service/README.md) helps to reuse the core services of nyuds.
+Using the key features of nydus as native in your project without preparing and invoking `nydusd` deliberately, [nydus-service](./service/README.md) helps to reuse the core services of nydus.
 
 ## Documentation
 

--- a/docs/docker-env-setup.md
+++ b/docs/docker-env-setup.md
@@ -23,11 +23,11 @@ sudo wget -O /etc/nydus/nydusd-config.fusedev.json https://raw.githubusercontent
 sudo wget -O /etc/nydus/config.toml https://raw.githubusercontent.com/containerd/nydus-snapshotter/"$TAG"/misc/snapshotter/config.toml
 ```
 
-3. Download nydus image service release tarball from [the release page](https://github.com/dragonflyoss/image-service/releases). 
+3. Download nydus image service release tarball from [the release page](https://github.com/dragonflyoss/nydus/releases). 
 ```shell
 # Get the latest version. If this version does not work for you, you can try v2.1.4
 TAG=`curl -s https://api.github.com/repos/dragonflyoss/nydus/releases/latest | grep tag_name | cut -f4 -d "\""`
-wget https://github.com/dragonflyoss/image-service/releases/download/"$TAG"/nydus-static-"$TAG"-linux-amd64.tgz
+wget https://github.com/dragonflyoss/nydus/releases/download/"$TAG"/nydus-static-"$TAG"-linux-amd64.tgz
 tar -xzvf nydus-static-"$TAG"-linux-amd64.tgz
 sudo cp -r nydus-static/* /usr/local/bin
 sudo chmod -R 755 /usr/local/bin/nydus*

--- a/service/src/lib.rs
+++ b/service/src/lib.rs
@@ -90,7 +90,7 @@ pub enum Error {
     #[error("failed to start service, {0}")]
     StartService(String),
     /// Input event to stat-machine is not expected.
-    #[error("unexpect state machine transition event `{0:?}`")]
+    #[error("unexpected state machine transition event `{0:?}`")]
     UnexpectedEvent(crate::daemon::DaemonStateMachineInput),
     #[error("failed to wait daemon, {0}")]
     WaitDaemon(#[source] io::Error),


### PR DESCRIPTION
## Overview
Clean up a stale Docker setup release URL and fix 2 small typos.

## Related Issues
Related #1633

## Change Details
`docs/docker-env-setup.md` fetches the latest tag from `dragonflyoss/nydus`, but the download example still points at `dragonflyoss/image-service`.
That old URL still works today via a `301` redirect, but it's stale and kinda confusing when you follow the doc step by step.
This switches the doc to the canonical `dragonflyoss/nydus/releases` path.
Also fixes `nyuds` in `README.md` and `unexpect` in a service error message.

## Test Results
Repro:
1. `TAG=$(curl -fsSL https://api.github.com/repos/dragonflyoss/nydus/releases/latest | jq -r .tag_name)`
2. `curl -o /dev/null -s -w '%{http_code} %{redirect_url}\n' https://github.com/dragonflyoss/image-service/releases/download/$TAG/nydus-static-$TAG-linux-amd64.tgz`
3. The old doc URL returns `301` to `https://github.com/dragonflyoss/nydus/releases/download/$TAG/...`
4. `cargo test -q -p nydus-service --lib daemon_error_kind`

## Change Type
- [x] Bug Fix
- [x] Documentation Update
- [ ] Feature Addition
- [ ] Code Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe)

## Self-Checklist
- [x] I have run a code style check and addressed any warnings/errors.
- [ ] I have added appropriate comments to my code (if applicable).
- [x] I have updated the documentation (if applicable).
- [ ] I have written appropriate unit tests.
