### PR TITLE
fix: validate nydusify tar paths before extraction

### DIFF
--- a/contrib/nydusify/pkg/utils/archive_test.go
+++ b/contrib/nydusify/pkg/utils/archive_test.go
@@ -97,6 +97,77 @@ func TestUnpackFromTar(t *testing.T) {
 	assert.Equal(t, string(payload), string(content))
 }
 
+func TestUnpackFromTarRejectsPathTraversal(t *testing.T) {
+	var buffer bytes.Buffer
+	tarWriter := tar.NewWriter(&buffer)
+	payload := []byte("escaped")
+	require.NoError(t, tarWriter.WriteHeader(&tar.Header{
+		Name:     "../escaped.txt",
+		Mode:     0o644,
+		Size:     int64(len(payload)),
+		Typeflag: tar.TypeReg,
+	}))
+	_, err := tarWriter.Write(payload)
+	require.NoError(t, err)
+	require.NoError(t, tarWriter.Close())
+
+	tmpDir := t.TempDir()
+	dstDir := filepath.Join(tmpDir, "untar")
+	err = UnpackFromTar(bytes.NewReader(buffer.Bytes()), dstDir)
+	require.Error(t, err)
+	assert.NoFileExists(t, filepath.Join(tmpDir, "escaped.txt"))
+}
+
+func TestUnpackFromTarCreatesParentDirectories(t *testing.T) {
+	var buffer bytes.Buffer
+	tarWriter := tar.NewWriter(&buffer)
+	payload := []byte("nested file")
+	require.NoError(t, tarWriter.WriteHeader(&tar.Header{
+		Name:     "subdir/file.txt",
+		Mode:     0o644,
+		Size:     int64(len(payload)),
+		Typeflag: tar.TypeReg,
+	}))
+	_, err := tarWriter.Write(payload)
+	require.NoError(t, err)
+	require.NoError(t, tarWriter.Close())
+
+	dstDir := filepath.Join(t.TempDir(), "untar")
+	require.NoError(t, UnpackFromTar(bytes.NewReader(buffer.Bytes()), dstDir))
+
+	content, err := os.ReadFile(filepath.Join(dstDir, "subdir", "file.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, string(payload), string(content))
+}
+
+func TestUnpackFromTarAllowsRootDirectoryEntry(t *testing.T) {
+	var buffer bytes.Buffer
+	tarWriter := tar.NewWriter(&buffer)
+	require.NoError(t, tarWriter.WriteHeader(&tar.Header{
+		Name:     ".",
+		Mode:     0o755,
+		Typeflag: tar.TypeDir,
+	}))
+
+	payload := []byte("ok")
+	require.NoError(t, tarWriter.WriteHeader(&tar.Header{
+		Name:     "./root.txt",
+		Mode:     0o644,
+		Size:     int64(len(payload)),
+		Typeflag: tar.TypeReg,
+	}))
+	_, err := tarWriter.Write(payload)
+	require.NoError(t, err)
+	require.NoError(t, tarWriter.Close())
+
+	dstDir := filepath.Join(t.TempDir(), "untar")
+	require.NoError(t, UnpackFromTar(bytes.NewReader(buffer.Bytes()), dstDir))
+
+	content, err := os.ReadFile(filepath.Join(dstDir, "root.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, string(payload), string(content))
+}
+
 func TestUnpackTargzInvalidStream(t *testing.T) {
 	invalid := io.NopCloser(bytes.NewReader([]byte("not-a-tar-gz")))
 	defer invalid.Close()

--- a/contrib/nydusify/pkg/utils/utils.go
+++ b/contrib/nydusify/pkg/utils/utils.go
@@ -230,6 +230,11 @@ func UnpackFromTar(reader io.Reader, targetDir string) error {
 		return err
 	}
 
+	targetDir, err := filepath.Abs(targetDir)
+	if err != nil {
+		return err
+	}
+
 	tr := tar.NewReader(reader)
 	for {
 		header, err := tr.Next()
@@ -240,7 +245,10 @@ func UnpackFromTar(reader io.Reader, targetDir string) error {
 			return err
 		}
 
-		filePath := filepath.Join(targetDir, header.Name)
+		filePath, err := unpackTarPath(targetDir, header.Name)
+		if err != nil {
+			return err
+		}
 
 		switch header.Typeflag {
 		case tar.TypeDir:
@@ -248,13 +256,19 @@ func UnpackFromTar(reader io.Reader, targetDir string) error {
 				return err
 			}
 		case tar.TypeReg:
+			if err := os.MkdirAll(filepath.Dir(filePath), 0755); err != nil {
+				return err
+			}
 			f, err := os.OpenFile(filePath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, header.FileInfo().Mode())
 			if err != nil {
 				return err
 			}
-			defer f.Close()
 
 			if _, err := io.Copy(f, tr); err != nil {
+				f.Close()
+				return err
+			}
+			if err := f.Close(); err != nil {
 				return err
 			}
 		default:
@@ -262,6 +276,24 @@ func UnpackFromTar(reader io.Reader, targetDir string) error {
 	}
 
 	return nil
+}
+
+func unpackTarPath(targetDir, name string) (string, error) {
+	cleanName := filepath.Clean(name)
+	if filepath.IsAbs(cleanName) {
+		return "", fmt.Errorf("invalid tar path %q", name)
+	}
+
+	path := filepath.Join(targetDir, cleanName)
+	rel, err := filepath.Rel(targetDir, path)
+	if err != nil {
+		return "", err
+	}
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(os.PathSeparator)) {
+		return "", fmt.Errorf("tar path %q escapes target directory", name)
+	}
+
+	return path, nil
 }
 
 func IsEmptyString(str string) bool {


### PR DESCRIPTION
## Overview
Block `UnpackFromTar` from writing outside the target dir, and make nested file entries unpack cleanly. Small patch, but the bug is pretty nasty.

## Related Issues
None found.

## Change Details
Before this change, `UnpackFromTar` joined `targetDir` with `header.Name` directly. A tar entry like `../escaped.txt` could slip out of the destination, and `subdir/file.txt` failed if the parent dir was not already there.

Repro before fix:
1. Build a tar stream with `../escaped.txt` or `subdir/file.txt`.
2. Call `UnpackFromTar(reader, dst)`.
3. `../escaped.txt` escapes `dst`, and `subdir/file.txt` errors on missing parent dirs.

This patch validates tar paths, creates parent dirs for regular files, and keeps valid `.` root entries working.

## Test Results
`go test ./contrib/nydusify/pkg/utils`
`go test ./contrib/nydusify/pkg/...`

## Change Type
- [x] Bug Fix
- [ ] Feature Addition
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe)

## Self-Checklist
- [x] I have run a code style check and addressed any warnings/errors.
- [x] I have added appropriate comments to my code (if applicable).
- [ ] I have updated the documentation (if applicable).
- [x] I have written appropriate unit tests.
