### PR TITLE
Fix: RAFS v5 chunkdict bootstrap metadata

### DIFF
--- a/builder/src/chunkdict_generator.rs
+++ b/builder/src/chunkdict_generator.rs
@@ -25,7 +25,7 @@ use nydus_rafs::metadata::inode::InodeWrapper;
 use nydus_rafs::metadata::layout::RafsXAttrs;
 use nydus_storage::meta::BlobChunkInfoV1Ondisk;
 use nydus_utils::compress::Algorithm;
-use nydus_utils::digest::RafsDigest;
+use nydus_utils::digest::{DigestHasher, RafsDigest};
 
 use std::mem::size_of;
 use std::path::PathBuf;
@@ -222,6 +222,14 @@ impl Generator {
 
         // Update child count.
         node.inode.set_child_count(node.chunks.len() as u32);
+
+        // For RAFS v5, regular inode digest should be the hash of all chunk digests.
+        let mut inode_hasher = RafsDigest::hasher(ctx.digester);
+        for chunk in node.chunks.iter() {
+            inode_hasher.digest_update(chunk.inner.id().as_ref());
+        }
+        node.inode.set_digest(inode_hasher.digest_finalize());
+
         let child = Tree::new(node);
         child
             .borrow_mut_node()
@@ -237,9 +245,10 @@ impl Generator {
         chunkdict_chunks: &[ChunkdictChunkInfo],
         chunkdict_blobs: &[ChunkdictBlobInfo],
     ) -> Result<()> {
-        for (index, chunk_info) in chunkdict_chunks.iter().enumerate() {
-            let chunk_size: u32 = chunk_info.chunk_compressed_size;
-            let file_offset = index as u64 * chunk_size as u64;
+        let mut file_offset = 0u64;
+        for chunk_info in chunkdict_chunks.iter() {
+            let cur_file_offset = file_offset;
+            file_offset += chunk_info.chunk_uncompressed_size as u64;
             let mut chunk = ChunkWrapper::new(ctx.fs_version);
 
             // Update blob context.
@@ -279,11 +288,15 @@ impl Generator {
             let chunk_index = blob_ctx.alloc_chunk_index()?;
             chunk.set_blob_index(blob_index);
             chunk.set_index(chunk_index);
-            chunk.set_file_offset(file_offset);
+            chunk.set_file_offset(cur_file_offset);
             chunk.set_compressed_size(chunk_info.chunk_compressed_size);
             chunk.set_compressed_offset(chunk_info.chunk_compressed_offset);
             chunk.set_uncompressed_size(chunk_info.chunk_uncompressed_size);
             chunk.set_uncompressed_offset(chunk_info.chunk_uncompressed_offset);
+            chunk.set_compressed(
+                blob_ctx.blob_compressor != Algorithm::None
+                    && chunk_info.chunk_compressed_size != chunk_info.chunk_uncompressed_size,
+            );
             chunk.set_id(RafsDigest::from_string(&chunk_info.chunk_digest));
             chunk.set_crc32(chunk_info.chunk_crc32);
 

--- a/storage/src/cache/filecache/mod.rs
+++ b/storage/src/cache/filecache/mod.rs
@@ -283,9 +283,7 @@ impl FileCacheEntry {
                 return Err(einval!(msg));
             }
             let load_chunk_digest = need_validation || cas_mgr.is_some();
-            let meta = if blob_info.meta_ci_is_valid()
-                || blob_info.has_feature(BlobFeatures::IS_CHUNKDICT_GENERATED)
-            {
+            let meta = if blob_info.meta_ci_is_valid() {
                 let meta = FileCacheMeta::new(
                     blob_file_path,
                     blob_info.clone(),


### PR DESCRIPTION
## Overview
When generating a RAFS v5 chunkdict bootstrap with chunkdict, several fields in the generated chunk metadata are incorrect.

### 1.
The original code calculates the chunkdict file offset with the compressed chunk size:

```rust
for (index, chunk_info) in chunkdict_chunks.iter().enumerate() {
    let chunk_size: u32 = chunk_info.chunk_compressed_size;
    let file_offset = index as u64 * chunk_size as u64;
    ...
    chunk.set_file_offset(file_offset);
}
```

`file_offset` is the logical offset inside the file, so it should be calculated from the uncompressed data size.

### 2.
When generating chunkdict chunk metadata, the original code does not set the `COMPRESSED` flag.

### 3.
The generated chunkdict entry is a regular file in the RAFS v5 bootstrap, but its inode digest is not set.
This breaks RAFS v5 inode digest validation. In `rafs/src/metadata/layout/v5.rs`, `rafsv5_validate_inode()` 

### 4.
The original filecache logic forces chunkdict-generated blobs to load `blob.meta`:

```rust
let meta = if blob_info.meta_ci_is_valid()
    || blob_info.has_feature(BlobFeatures::IS_CHUNKDICT_GENERATED)
{
    ...
}
```

However, RAFS v5 blob table entries do not have valid `meta_ci_*` information for chunkdict blobs.

## Related Issues
_Please link to the relevant issue. For example: `Fix #123` or `Related #456`._

## Change Details
_Please describe your changes in detail:_

## Test Results
_If you have any relevant screenshots or videos that can help illustrate your changes, please add them here._

## Change Type
_Please select the type of change your pull request relates to:_
- [x] Bug Fix
- [ ] Feature Addition
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe)

## Self-Checklist
_Before submitting a pull request, please ensure you have completed the following:_
- [ ] I have run a code style check and addressed any warnings/errors.
- [ ] I have added appropriate comments to my code (if applicable).
- [ ] I have updated the documentation (if applicable).
- [ ] I have written appropriate unit tests.