### PR TITLE
fix(nydusify): guard against empty mount slice in Manager.Inspect

### DIFF
--- a/contrib/nydusify/pkg/committer/manager.go
+++ b/contrib/nydusify/pkg/committer/manager.go
@@ -113,6 +113,9 @@ func (m *Manager) Inspect(ctx context.Context, containerID string) (*InspectResu
 	if err != nil {
 		return nil, errors.Wrapf(err, "get snapshot mount")
 	}
+	if len(mount) == 0 {
+		return nil, errors.Errorf("no mounts returned for snapshot %q", containerInfo.SnapshotKey)
+	}
 	lowerDirs, upperDir, err := parseMountOptions(mount[0].Options)
 	if err != nil {
 		return nil, errors.Wrapf(err, "parse snapshot mount options")

--- a/contrib/nydusify/pkg/committer/manager_test.go
+++ b/contrib/nydusify/pkg/committer/manager_test.go
@@ -258,6 +258,37 @@ func TestManagerErrorPaths(t *testing.T) {
 	require.ErrorContains(t, err, "get snapshot mount")
 }
 
+func TestInspectEmptyMounts(t *testing.T) {
+	specBytes, err := json.Marshal(runtimespec.Spec{})
+	require.NoError(t, err)
+
+	client := &containerdclient.Client{}
+	patches := patchClientNewSeq([]gomonkey.OutputCell{
+		{Values: []interface{}{client, nil}},
+	})
+	defer patches.Reset()
+
+	loadPatches := patchLoadContainerSeq(client, []gomonkey.OutputCell{
+		{Values: []interface{}{&mockContainer{
+			image: &mockImage{name: "test-image"},
+			task:  &mockTask{pid: 100},
+			info: containers.Container{
+				Spec:        &anypb.Any{TypeUrl: "test", Value: specBytes},
+				SnapshotKey: "snap-key",
+			},
+		}, nil}},
+	})
+	defer loadPatches.Reset()
+
+	snapshotPatches := patchSnapshotService(client, &mockSnapshotter{
+		mounts: []mount.Mount{},
+	})
+	defer snapshotPatches.Reset()
+
+	_, err = (&Manager{address: "test"}).Inspect(context.Background(), "id")
+	require.ErrorContains(t, err, "no mounts returned for snapshot")
+}
+
 func TestInspectParseMountOptionsPaths(t *testing.T) {
 	specBytes, err := json.Marshal(runtimespec.Spec{Mounts: []runtimespec.Mount{{Destination: "/dst", Source: "/src"}}})
 	require.NoError(t, err)


### PR DESCRIPTION
## Overview

`Manager.Inspect` calls `snapshot.Mounts()` and immediately indexes `mount[0]` with no bounds check. If the snapshotter returns an empty slice (no error), it panics with index out of range.

## Related Issues

N/A

## Change Details

Added a `len(mount) == 0` guard right after the nil-error check that returns a clear error with the snapshot key instead of crashing. Also added `TestInspectEmptyMounts` which mocks the snapshotter returning zero mounts to cover this path.

How to hit it: configure `Manager.Inspect` against a container whose nydus snapshot got garbage-collected or is otherwise missing from the snapshotter, `Mounts()` returns `([], nil)`, and you get a panic.

## Test Results

```
=== RUN   TestInspectEmptyMounts
--- PASS: TestInspectEmptyMounts (0.00s)
```

All existing tests still pass.

## Change Type

- [x] Bug Fix

## Self-Checklist

- [x] I have run a code style check and addressed any warnings/errors.
- [x] I have written appropriate unit tests.