### PR TITLE
chore(ci): bump actions for Node.js 24 and fix containerd config compat

### DIFF
--- a/.github/workflows/e2e-dragonfly.yml
+++ b/.github/workflows/e2e-dragonfly.yml
@@ -56,7 +56,7 @@ jobs:
     steps:
       - name: Cache Dragonfly binaries
         id: cache-dragonfly
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: /tmp/dragonfly-bin
           key: dragonfly-${{ env.DRAGONFLY_VERSION }}-client-${{ env.CLIENT_VERSION }}-linux-amd64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,10 +35,10 @@ jobs:
       shell: bash
     - name: Set up Docker Buildx
       if: matrix.arch == 'riscv64'
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
     - name: Build and push Docker image
       if: matrix.arch == 'riscv64'
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@v7
       with:
         context: .
         file: ./.github/workflows/Dockerfile.cross

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -85,10 +85,10 @@ jobs:
       shell: bash
     - name: Set up Docker Buildx
       if: matrix.arch == 'riscv64'
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
     - name: Build and push Docker image
       if: matrix.arch == 'riscv64'
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@v7
       with:
         context: .
         file: ./.github/workflows/Dockerfile.cross
@@ -160,9 +160,8 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v6
-    - name: Docker Cache
-      uses: jpribyl/action-docker-layer-caching@v0.1.0
-      continue-on-error: true
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v4
     - name: Download Nydus
       uses: actions/download-artifact@v7
       with:

--- a/misc/performance/containerd_config.toml
+++ b/misc/performance/containerd_config.toml
@@ -1,4 +1,4 @@
-version = 4
+version = 3
 root = "/var/lib/containerd"
 state = "/run/containerd"
 oom_score = 0


### PR DESCRIPTION
-  Upgrade GitHub Actions that rely on Node.js 20 before the forced
-  Downgrade `containerd_config.toml` from `version = 4` to `version = 3` to fix `takeover-test` failures: CI runners ship with containerd v2.2.4 which does not support config version 4. Will revert once runners are upgraded.