### PR TITLE
fix: avoid logger deadlock on broken error channel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1299,15 +1299,14 @@ dependencies = [
 
 [[package]]
 name = "flexi_logger"
-version = "0.25.6"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84075a94fd76ea9b7a0d2c257444ae30356e58fdac6cd0fe68af33f5279981ae"
+checksum = "f248c29a6d4bc5d065c9e9068d858761a0dcd796759f7801cc14db35db23abd8"
 dependencies = [
  "chrono",
  "flate2",
  "glob",
  "is-terminal",
- "lazy_static",
  "log",
  "nu-ansi-term",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ path = "src/lib.rs"
 [dependencies]
 anyhow = "1"
 clap = { version = "4.0.18", features = ["derive", "cargo"] }
-flexi_logger = { version = "0.25", features = ["compress"] }
+flexi_logger = { version = "0.28.0", features = ["compress"] }
 fuse-backend-rs = { workspace = true }
 hex = "0.4.3"
 hyper = { version = "1.8.1", features = ["client"] }

--- a/src/logger.rs
+++ b/src/logger.rs
@@ -145,6 +145,7 @@ pub fn setup_logging(
             .map_err(|_e| enosys!())?
             .log_to_file(spec)
             .append()
+            .panic_if_error_channel_is_broken(false)
             .format(opt_format);
 
         // Set log rotation
@@ -167,6 +168,7 @@ pub fn setup_logging(
         // can't change log level to a higher level than what is passed to `flexi_logger`.
         Logger::try_with_env_or_str("trace")
             .map_err(|_e| enosys!())?
+            .panic_if_error_channel_is_broken(false)
             .format(colored_opt_format)
             .start()
             .map_err(|e| eother!(e))?;


### PR DESCRIPTION
## Overview
This bumps `flexi_logger` to `0.28.0` and tells it not to panic when its own error output channel is broken.

That is the path hit in #1958. When cache/log/stdout/stderr are on a full filesystem, a secondary logger error can make `nydusd` stop answering the daemon API.

## Related Issues
Fixes #1958

## Change Details
- Bump `flexi_logger` from `0.25.6` to `0.28.0`.
- Call `.panic_if_error_channel_is_broken(false)` in both nydusd logger setup paths.

## Test Results
- `cargo fmt --check`
- `cargo check --locked -p nydus-rs`
- `cargo test -p nydus-rs logger::tests`
- I also reran the ENOSPC repro from #1958:
  - put blob cache, log file, stdout, and stderr on the same 512 MiB ext4 filesystem
  - filled it to 100%
  - read a real file from the mounted image
  - `/api/v1/daemon` still returned while the filesystem was full
  - `/api/v1/daemon` also returned after space was freed

## Change Type
- [x] Bug Fix
- [ ] Feature Addition
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe)

## Self-Checklist
- [x] I have run a code style check and addressed any warnings/errors.
- [x] I have added appropriate comments to my code (if applicable).
- [x] I have updated the documentation (if applicable).
- [x] I have written appropriate unit tests.