### PR TITLE
fix: avoid panics on invalid inspect request arguments

### DIFF
--- a/src/bin/nydus-image/inspect.rs
+++ b/src/bin/nydus-image/inspect.rs
@@ -704,7 +704,10 @@ impl Executor {
             ("blobs", None) => inspector.cmd_list_blobs(),
             ("prefetch", None) => inspector.cmd_list_prefetch(),
             ("chunk", Some(argument)) => {
-                let offset: u64 = argument.parse().unwrap();
+                let offset: u64 = argument.parse().map_err(|_| {
+                    println!("Wrong OFFSET is specified. Is it a valid u64 value?");
+                    ExecuteError::ArgumentParse
+                })?;
                 inspector.cmd_show_chunk(offset)
             }
             ("icheck", Some(argument)) => {
@@ -759,6 +762,7 @@ impl Prompt {
                 Err(ExecuteError::Exit) => break,
                 Err(ExecuteError::IllegalCommand) => continue,
                 Err(ExecuteError::HelpCommand) => continue,
+                Err(ExecuteError::ArgumentParse) => continue,
                 Err(ExecuteError::ExecError(e)) => {
                     println!("Failed to execute command, {:?}", e);
                     continue;

--- a/src/bin/nydus-image/main.rs
+++ b/src/bin/nydus-image/main.rs
@@ -1827,7 +1827,7 @@ impl Command {
             })?;
 
         if let Some(c) = cmd {
-            let o = inspect::Executor::execute(&mut inspector, c.to_string()).unwrap();
+            let o = Self::execute_inspect_request(&mut inspector, c)?;
             serde_json::to_writer(std::io::stdout(), &o)
                 .unwrap_or_else(|e| error!("Failed to serialize result, {:?}", e));
         } else {
@@ -1835,6 +1835,28 @@ impl Command {
         }
 
         Ok(())
+    }
+
+    fn execute_inspect_request(
+        inspector: &mut inspect::RafsInspector,
+        request: &str,
+    ) -> Result<Option<serde_json::Value>> {
+        match inspect::Executor::execute(inspector, request.to_string()) {
+            Ok(output) => Ok(output),
+            Err(inspect::ExecuteError::ExecError(e)) => {
+                Err(e).context(format!("failed to execute inspect request `{request}`"))
+            }
+            Err(inspect::ExecuteError::ArgumentParse) => {
+                bail!("invalid arguments in inspect request `{request}`")
+            }
+            Err(inspect::ExecuteError::IllegalCommand) => {
+                bail!("unsupported inspect request `{request}`")
+            }
+            Err(inspect::ExecuteError::HelpCommand) => {
+                bail!("help is not supported in inspect request mode")
+            }
+            Err(inspect::ExecuteError::Exit) => Ok(None),
+        }
     }
 
     fn stat(matches: &ArgMatches) -> Result<()> {
@@ -2315,9 +2337,37 @@ impl Command {
 
 #[cfg(test)]
 mod tests {
+    use std::{path::PathBuf, sync::Arc};
+
     use super::Command;
+    use nydus_api::ConfigV2;
+
     #[test]
     fn test_ensure_file() {
         Command::ensure_file("/dev/stdin").unwrap();
+    }
+
+    #[test]
+    fn test_execute_inspect_request_rejects_invalid_chunk_offset() {
+        let bootstrap =
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/texture/bootstrap/rafs-v5.boot");
+        let mut inspector =
+            super::inspect::RafsInspector::new(&bootstrap, true, Arc::new(ConfigV2::default()))
+                .unwrap();
+
+        let err = Command::execute_inspect_request(&mut inspector, "chunk abc").unwrap_err();
+        assert!(err.to_string().contains("invalid arguments"));
+    }
+
+    #[test]
+    fn test_execute_inspect_request_rejects_invalid_inode() {
+        let bootstrap =
+            PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/texture/bootstrap/rafs-v5.boot");
+        let mut inspector =
+            super::inspect::RafsInspector::new(&bootstrap, true, Arc::new(ConfigV2::default()))
+                .unwrap();
+
+        let err = Command::execute_inspect_request(&mut inspector, "icheck abc").unwrap_err();
+        assert!(err.to_string().contains("invalid arguments"));
     }
 }


### PR DESCRIPTION
## Overview
`nydus-image inspect --request` can still panic on bad args. Easy to hit with a typo, pretty meh.

## Related Issues
Related #705

## Change Details
Parse `chunk OFFSET` like `icheck INODE`, return normal errors in request mode, and add regression tests. Tiny fix, keeps valid requests working the same.

## Test Results
`cargo test -q --bin nydus-image`

Repro before:
`cargo run -q --bin nydus-image -- inspect tests/texture/bootstrap/rafs-v5.boot --request 'chunk abc'`
`cargo run -q --bin nydus-image -- inspect tests/texture/bootstrap/rafs-v5.boot --request 'icheck abc'`

Before: panic
Now: `Error: invalid arguments in inspect request 'chunk abc'`
Now: `Error: invalid arguments in inspect request 'icheck abc'`

Valid request check:
`cargo run -q --bin nydus-image -- inspect tests/texture/bootstrap/rafs-v5.boot --request 'stats'`

## Change Type
- [x] Bug Fix
- [ ] Feature Addition
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe)

## Self-Checklist
- [x] I have run a code style check and addressed any warnings/errors.
- [x] I have added appropriate comments to my code (if applicable).
- [x] I have updated the documentation (if applicable).
- [x] I have written appropriate unit tests.
