### PR TITLE
fix(upgrade): handle full UDS state transfers

### DIFF
--- a/upgrade/src/backend/unix_domain_socket.rs
+++ b/upgrade/src/backend/unix_domain_socket.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::{
+    io::{Read, Write},
     os::{fd::RawFd, unix::net::UnixStream},
     path::PathBuf,
 };
@@ -23,31 +24,47 @@ impl UdsStorageBackend {
 
 const MAX_STATE_DATA_LENGTH: usize = 1024 * 32;
 
+fn write_remaining<W: Write>(writer: &mut W, data: &[u8], sent: usize) -> std::io::Result<()> {
+    if sent < data.len() {
+        writer.write_all(&data[sent..])?;
+    }
+
+    Ok(())
+}
+
+fn read_remaining<R: Read>(reader: &mut R, data: &mut Vec<u8>) -> std::io::Result<()> {
+    reader.read_to_end(data)?;
+    Ok(())
+}
+
 impl StorageBackend for UdsStorageBackend {
     fn save(&mut self, fds: &[RawFd], data: &[u8]) -> Result<usize> {
         if fds.is_empty() {
             return Err(StorageBackendErr::NoEnoughFds);
         }
 
-        let socket =
+        let mut socket =
             UnixStream::connect(&self.socket_path).map_err(StorageBackendErr::CreateUnixStream)?;
         let len = socket
             .send_with_fd(data, fds)
             .map_err(StorageBackendErr::SendFd)?;
+        write_remaining(&mut socket, data, len).map_err(StorageBackendErr::SendFd)?;
 
-        Ok(len)
+        Ok(data.len())
     }
 
     fn restore(&mut self) -> Result<(Vec<RawFd>, Vec<u8>)> {
         let mut data = vec![0u8; MAX_STATE_DATA_LENGTH];
         let mut fds = vec![0i32; 16];
-        let socket =
+        let mut socket =
             UnixStream::connect(&self.socket_path).map_err(StorageBackendErr::CreateUnixStream)?;
-        let (_, fds_cnt) = socket
+        let (bytes_read, fds_cnt) = socket
             .recv_with_fd(data.as_mut_slice(), fds.as_mut_slice())
             .map_err(StorageBackendErr::RecvFd)?;
+        data.truncate(bytes_read);
+        read_remaining(&mut socket, &mut data).map_err(StorageBackendErr::RecvFd)?;
 
-        if fds.is_empty() {
+        if fds_cnt == 0 {
             return Err(StorageBackendErr::NoEnoughFds);
         }
         fds.truncate(fds_cnt);
@@ -57,7 +74,7 @@ impl StorageBackend for UdsStorageBackend {
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
+    use std::{io::Cursor, path::PathBuf};
 
     use super::*;
 
@@ -95,5 +112,30 @@ mod tests {
             result,
             Err(StorageBackendErr::CreateUnixStream(_))
         ));
+    }
+
+    #[test]
+    fn test_write_remaining_writes_unsent_suffix() {
+        let mut writer = Vec::new();
+        write_remaining(&mut writer, b"abcdef", 3).unwrap();
+        assert_eq!(writer, b"def");
+    }
+
+    #[test]
+    fn test_write_remaining_is_noop_when_all_bytes_were_sent() {
+        let mut writer = Vec::new();
+        write_remaining(&mut writer, b"abcdef", 6).unwrap();
+        assert!(writer.is_empty());
+    }
+
+    #[test]
+    fn test_read_remaining_appends_rest_of_stream() {
+        let mut reader = Cursor::new(b"def".to_vec());
+        let mut data = b"abc\0\0".to_vec();
+        data.truncate(3);
+
+        read_remaining(&mut reader, &mut data).unwrap();
+
+        assert_eq!(data, b"abcdef");
     }
 }


### PR DESCRIPTION
## Overview
UDS restore was only taking the first `recv_with_fd()` chunk, so larger state data could be cut off. Keep reading the rest after the fd arrives, and send any bytes left by `send_with_fd()`.

## Related Issues
Fixes #1975 