### PR TITLE
kernel-patches: adapt fscache ondemand IO patch for newer kernel

### DIFF
--- a/contrib/kernel-patches/0002-cachefiles-convert-cachefiles_page_copy-to-use-filem.patch
+++ b/contrib/kernel-patches/0002-cachefiles-convert-cachefiles_page_copy-to-use-filem.patch
@@ -1,0 +1,98 @@
+From 8cded62556a98153a07dacc34198c4e5553e1a12 Mon Sep 17 00:00:00 2001
+From: Wenwu Hou <hwenwur@gmail.com>
+Date: Tue, 7 Jul 2026 17:31:27 +0800
+Subject: [PATCH 2/2] cachefiles: convert cachefiles_page_copy() to use
+ filemap_get_folios_contig()
+
+find_get_pages_contig() was removed in commit 48658d8509d2 ("filemap:
+remove find_get_pages_contig()"). Replace it with
+filemap_get_folios_contig().
+
+No functional change intended.
+
+Signed-off-by: Wenwu Hou <hwenwur@gmail.com>
+---
+ fs/cachefiles/io.c | 36 ++++++++++++++++++------------------
+ 1 file changed, 18 insertions(+), 18 deletions(-)
+
+diff --git a/fs/cachefiles/io.c b/fs/cachefiles/io.c
+index 1e4db487a517..7e7439117a3e 100644
+--- a/fs/cachefiles/io.c
++++ b/fs/cachefiles/io.c
+@@ -71,44 +71,46 @@ static void cachefiles_read_complete(struct kiocb *iocb, long ret)
+ 
+ static void cachefiles_page_copy(struct cachefiles_kiocb *ki, struct iov_iter *iter)
+ {
+-	struct address_space *mapping =  ki->iocb.ki_filp->f_mapping;
++	struct address_space *mapping = ki->iocb.ki_filp->f_mapping;
+ 	struct kiocb *iocb = &ki->iocb;
+ 	loff_t isize = i_size_read(mapping->host);
+ 	loff_t end = min_t(loff_t, isize, iocb->ki_pos + iov_iter_count(iter));
+-	struct pagevec pv;
++	struct folio_batch fbatch;
+ 	pgoff_t index;
+ 	unsigned int i;
+ 	bool writably_mapped;
+ 	int error = 0;
+ 
++	folio_batch_init(&fbatch);
++
+ 	while (iocb->ki_pos < end && !error) {
+ 		index = iocb->ki_pos >> PAGE_SHIFT;
+-		pv.nr = find_get_pages_contig(mapping, index, PAGEVEC_SIZE, pv.pages);
+-
+-		if (pv.nr == 0)
++		if (!filemap_get_folios_contig(mapping, &index,
++					       (end - 1) >> PAGE_SHIFT, &fbatch))
+ 			break;
+ 
+ 		writably_mapped = mapping_writably_mapped(mapping);
+ 
+-		for (i = 0; i < pv.nr; i++) {
+-			struct page *page = pv.pages[i];
+-			unsigned int offset = iocb->ki_pos & ~PAGE_MASK;
+-			unsigned int bytes = min_t(loff_t, end - iocb->ki_pos,
+-						   PAGE_SIZE - offset);
+-			unsigned int copied;
++		for (i = 0; i < folio_batch_count(&fbatch); i++) {
++			struct folio *folio = fbatch.folios[i];
++			size_t fsize = folio_size(folio);
++			size_t offset = iocb->ki_pos & (fsize - 1);
++			size_t bytes = min_t(loff_t, end - iocb->ki_pos,
++					     fsize - offset);
++			size_t copied;
+ 
+-			if (page->index * PAGE_SIZE >= end)
++			if (end < folio_pos(folio))
+ 				break;
+ 
+-			if (!PageUptodate(page)) {
++			if (!folio_test_uptodate(folio)) {
+ 				error = -EFAULT;
+ 				break;
+ 			}
+ 
+ 			if (writably_mapped)
+-				flush_dcache_page(page);
++				flush_dcache_folio(folio);
+ 
+-			copied = copy_page_to_iter(page, offset, bytes, iter);
++			copied = copy_folio_to_iter(folio, offset, bytes, iter);
+ 
+ 			iocb->ki_pos += copied;
+ 			if (copied < bytes) {
+@@ -117,10 +119,8 @@ static void cachefiles_page_copy(struct cachefiles_kiocb *ki, struct iov_iter *i
+ 			}
+ 		}
+ 
+-		for (i = 0; i < pv.nr; i++)
+-			put_page(pv.pages[i]);
++		folio_batch_release(&fbatch);
+ 	}
+-
+ }
+ 
+ /*
+-- 
+2.43.0
+


### PR DESCRIPTION
find_get_pages_contig() was removed in newer kernels https://github.com/torvalds/linux/commit/48658d8509d2 . Add a follow-up patch converting cachefiles_page_copy() to use filemap_get_folios_contig() instead, so the on-demand IO optimization keeps building on recent kernels.
