### PR TITLE
builder: avoid coalescing hard-linked symlinks

### DIFF
--- a/builder/src/core/bootstrap.rs
+++ b/builder/src/core/bootstrap.rs
@@ -38,14 +38,7 @@ impl Bootstrap {
         root_node.index = index;
         root_node.inode.set_ino(index);
         ctx.prefetch.insert(&self.tree.node, root_node.deref());
-        bootstrap_ctx.inode_map.insert(
-            (
-                root_node.layer_idx,
-                root_node.info.src_ino,
-                root_node.info.src_dev,
-            ),
-            vec![self.tree.node.clone()],
-        );
+        bootstrap_ctx.inode_count += 1;
         drop(root_node);
 
         Self::build_rafs(ctx, bootstrap_ctx, &mut self.tree)?;
@@ -122,39 +115,45 @@ impl Bootstrap {
                 child_node.inode.set_parent(parent_ino);
             }
 
-            // Handle hardlink.
-            // All hardlink nodes' ino and nlink should be the same.
-            // We need to find hardlink node index list in the layer where the node is located
-            // because the real_ino may be different among different layers,
             let mut v6_hardlink_offset: Option<u64> = None;
-            let key = (
-                child_node.layer_idx,
-                child_node.info.src_ino,
-                child_node.info.src_dev,
-            );
-            if let Some(indexes) = bootstrap_ctx.inode_map.get_mut(&key) {
-                let nlink = indexes.len() as u32 + 1;
-                // Update nlink for previous hardlink inodes
-                for n in indexes.iter() {
-                    n.borrow_mut().inode.set_nlink(nlink);
-                }
+            if child_node.is_reg() {
+                // Only regular files are represented as hardlinks in RAFS. The source inode may
+                // be different among layers, so layer index is part of the hardlink cache key.
+                let key = (
+                    child_node.layer_idx,
+                    child_node.info.src_ino,
+                    child_node.info.src_dev,
+                );
+                if let Some(indexes) = bootstrap_ctx.inode_map.get_mut(&key) {
+                    let nlink = indexes.len() as u32 + 1;
+                    // Update nlink for previous hardlink inodes.
+                    for n in indexes.iter() {
+                        n.borrow_mut().inode.set_nlink(nlink);
+                    }
 
-                let (first_ino, first_offset) = {
-                    let first_node = indexes[0].borrow_mut();
-                    (first_node.inode.ino(), first_node.v6_offset)
-                };
-                // set offset for rafs v6 hardlinks
-                v6_hardlink_offset = Some(first_offset);
-                child_node.inode.set_nlink(nlink);
-                child_node.inode.set_ino(first_ino);
-                indexes.push(child.node.clone());
+                    let (first_ino, first_offset) = {
+                        let first_node = indexes[0].borrow_mut();
+                        (first_node.inode.ino(), first_node.v6_offset)
+                    };
+                    // Set offset for RAFS v6 hardlinks.
+                    v6_hardlink_offset = Some(first_offset);
+                    child_node.inode.set_nlink(nlink);
+                    child_node.inode.set_ino(first_ino);
+                    indexes.push(child.node.clone());
+                } else {
+                    child_node.inode.set_ino(index);
+                    child_node.inode.set_nlink(1);
+                    bootstrap_ctx
+                        .inode_map
+                        .insert(key, vec![child.node.clone()]);
+                    bootstrap_ctx.inode_count += 1;
+                }
             } else {
+                // RAFS doesn't model hardlinks for non-regular files. Assign a distinct inode
+                // even when two source entries (for example symlinks) share an inode.
                 child_node.inode.set_ino(index);
                 child_node.inode.set_nlink(1);
-                // Store inode real ino
-                bootstrap_ctx
-                    .inode_map
-                    .insert(key, vec![child.node.clone()]);
+                bootstrap_ctx.inode_count += 1;
             }
 
             // update bootstrap_ctx.offset for rafs v6 non-dir nodes.

--- a/builder/src/core/context.rs
+++ b/builder/src/core/context.rs
@@ -1220,8 +1220,11 @@ impl BlobManager {
 pub struct BootstrapContext {
     /// This build has a parent bootstrap.
     pub layered: bool,
-    /// Cache node index for hardlinks, HashMap<(layer_index, real_inode, dev), Vec<TreeNode>>.
+    /// Cache node indexes for regular-file hardlinks,
+    /// HashMap<(layer_index, real_inode, dev), Vec<TreeNode>>.
     pub(crate) inode_map: HashMap<(u16, Inode, u64), Vec<TreeNode>>,
+    /// Number of unique inodes in the generated filesystem.
+    pub(crate) inode_count: u64,
     /// Current position to write in f_bootstrap
     pub(crate) offset: u64,
     pub(crate) writer: Box<dyn RafsIoWrite>,
@@ -1243,6 +1246,7 @@ impl BootstrapContext {
         Ok(Self {
             layered,
             inode_map: HashMap::new(),
+            inode_count: 0,
             next_ino: 1,
             offset: EROFS_BLOCK_SIZE_4096,
             writer,

--- a/builder/src/core/v5.rs
+++ b/builder/src/core/v5.rs
@@ -174,7 +174,7 @@ impl Bootstrap {
 
         // Set super block
         let mut super_block = RafsV5SuperBlock::new();
-        let inodes_count = bootstrap_ctx.inode_map.len() as u64;
+        let inodes_count = bootstrap_ctx.inode_count;
         super_block.set_inodes_count(inodes_count);
         super_block.set_inode_table_offset(super_block_size as u64);
         super_block.set_inode_table_entries(inode_table_entries);

--- a/builder/src/directory.rs
+++ b/builder/src/directory.rs
@@ -268,7 +268,61 @@ impl Builder for DirectoryBuilder {
 
 #[cfg(test)]
 mod tests {
+    use std::fs;
+    use std::os::unix::fs::symlink;
+    use std::path::Path;
+
+    use nydus_rafs::metadata::RafsVersion;
+    use vmm_sys_util::tempdir::TempDir;
+
     use super::*;
+    use crate::{Bootstrap, BootstrapContext};
+
+    fn inode_fields(tree: &Tree, path: &str) -> (u64, u64, u32) {
+        let node = tree.get_node(Path::new(path)).unwrap().borrow_mut_node();
+        (node.inode.ino(), node.inode.parent(), node.inode.nlink())
+    }
+
+    #[test]
+    fn test_v5_hardlinked_symlink_is_not_coalesced() {
+        let source = TempDir::new().unwrap();
+        let nested = source.as_path().join("b");
+        fs::create_dir(&nested).unwrap();
+
+        let symlink_path = source.as_path().join("a");
+        symlink("target", &symlink_path).unwrap();
+        fs::hard_link(&symlink_path, nested.join("a")).unwrap();
+
+        let regular_path = source.as_path().join("c");
+        fs::write(&regular_path, b"data").unwrap();
+        fs::hard_link(&regular_path, nested.join("c")).unwrap();
+
+        let mut ctx = BuildContext {
+            fs_version: RafsVersion::V5,
+            source_path: source.as_path().to_path_buf(),
+            ..Default::default()
+        };
+        let (tree, _) = DirectoryBuilder::new().build_tree(&mut ctx, 0).unwrap();
+        let mut bootstrap_ctx = BootstrapContext::new(None, false).unwrap();
+        let mut bootstrap = Bootstrap::new(tree).unwrap();
+        bootstrap.build(&mut ctx, &mut bootstrap_ctx).unwrap();
+
+        let (symlink_ino, _, symlink_nlink) = inode_fields(&bootstrap.tree, "/a");
+        let (nested_symlink_ino, nested_symlink_parent, nested_symlink_nlink) =
+            inode_fields(&bootstrap.tree, "/b/a");
+        assert_ne!(symlink_ino, nested_symlink_ino);
+        assert_eq!(symlink_nlink, 1);
+        assert_eq!(nested_symlink_nlink, 1);
+        assert!(nested_symlink_parent < nested_symlink_ino);
+
+        let (regular_ino, _, regular_nlink) = inode_fields(&bootstrap.tree, "/c");
+        let (nested_regular_ino, _, nested_regular_nlink) = inode_fields(&bootstrap.tree, "/b/c");
+        assert_eq!(regular_ino, nested_regular_ino);
+        assert_eq!(regular_nlink, 2);
+        assert_eq!(nested_regular_nlink, 2);
+        assert_eq!(bootstrap_ctx.inode_map.len(), 1);
+        assert_eq!(bootstrap_ctx.inode_count, 5);
+    }
 
     #[test]
     fn test_directory_builder_new() {


### PR DESCRIPTION
Directory builds used the source inode and device to coalesce all file types. Hard-linked symlinks under different directories could therefore reuse an inode lower than the parent inode, causing RAFS v5 bootstrap validation and merge to fail.

Limit hardlink coalescing to regular files and track the number of generated inodes separately. Add regression coverage for hard-linked symlinks while verifying that regular-file hardlinks remain coalesced.

## Overview
Fix RAFS v5 bootstrap validation failures caused by coalescing hard-linked symbolic links into the same RAFS inode.

When two symlink directory entries share the same source inode but are located under different parent directories, the builder may reuse a child inode number that is lower than its parent inode. Since RAFS only treats regular files with nlink > 1 as hardlinks, the symlink is validated as a normal child and fails with invalid parent inode.

## Related Issues
Fix #1983 

## Change Details
1. Limit source-inode based hardlink coalescing to regular files.
2. Assign a distinct RAFS inode with nlink=1 to each non-regular directory entry, including hard-linked symlinks.
3. Add inode_count to track the actual number of generated filesystem inodes independently from the regular-file hardlink cache.
4. Use the generated inode count in the RAFS v5 superblock.
5. Add a regression test covering both hard-linked symlinks and regular-file hardlinks.

## Test Results
_If you have any relevant screenshots or videos that can help illustrate your changes, please add them here._

## Change Type
_Please select the type of change your pull request relates to:_
- [x] Bug Fix
- [ ] Feature Addition
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe)

## Self-Checklist
_Before submitting a pull request, please ensure you have completed the following:_
- [x] I have run a code style check and addressed any warnings/errors.
- [x] I have added appropriate comments to my code (if applicable).
- [x] I have updated the documentation (if applicable).
- [x] I have written appropriate unit tests.