### PR TITLE
feat(nydusify): support multiple mixed sources in convert

### DIFF
--- a/docs/nydus.md
+++ b/docs/nydus.md
@@ -1542,8 +1542,9 @@ artifacts and are not directly consumable as plain EROFS external devices.
 
 `nydus` operates on local directories, blobs and bootstraps. `nydusify` is the
 Go orchestrator that wraps `nydus` to operate on whole OCI images in a registry:
-it pulls an OCI image, converts every layer into a nydus image, pushes the
-result, and can validate that the converted image is faithful to its source.
+it pulls one or more sources (OCI images and/or local directories), converts
+them into a nydus image, pushes the result, and can validate that the converted
+image is faithful to its source.
 
 `nydusify` lives in `nydusify/` as its own Go module
 (`github.com/dragonflyoss/nydus/nydusify`) and shells out to the `nydus`
@@ -1554,11 +1555,12 @@ binary for the actual filesystem work (`nydus build`, `nydus merge`,
         nydusify convert                         nydusify check
         -----------------                         ---------------
   registry --pull--> content store          registry --pull--> content store
+  and/or local directory sources                         |
+              |                              manifest / bootstrap / filesystem
+   per layer / per dir: nydus build                      rules
               |                                          |
-   per-layer: nydus build                    manifest / bootstrap / filesystem
-              |                                          rules
-   index hook: nydus merge                              |
-              |                                      pass / fail
+   all blobs: nydus merge                            pass / fail
+              |
   registry <--push-- nydus image
 ```
 
@@ -1589,7 +1591,8 @@ nydus image (OCI manifest, os.features: ["nydus.remoteimage.v1"])
 |--------------------------------------------------------------------|
 | layer 0     nydus blob layer   ...nydus.blob.v1   <- OCI layer 0   |
 | layer 1     nydus blob layer   ...nydus.blob.v1   <- OCI layer 1   |
-|  ...        (one full blob per source OCI layer)                   |
+|  ...        (one full blob per source OCI layer                    |
+|             or per local directory source)                         |
 | layer N     bootstrap layer    gzip tar { image/image.boot }       |
 |             = merged overlaid bootstrap referencing layers 0..N-1  |
 +--------------------------------------------------------------------+
@@ -1617,7 +1620,7 @@ pull/push:
 
 | `nydusify` | Underlying `nydus` subcommands | Registry |
 | --- | --- | --- |
-| `convert` | `nydus build` (per OCI layer) + `nydus merge` (index hook) | pull source, push target |
+| `convert` | `nydus build` (per OCI layer / per directory source) + `nydus merge` (all blobs) | pull sources, push target |
 | `check` | `nydus check` (bootstrap rule) + `nydus fuse` (filesystem rule) | pull source and/or target |
 
 The `--builder` flag selects which `nydus` binary is invoked for all of the
@@ -1625,12 +1628,22 @@ above, so `nydusify` and `nydus` versions can be pinned together.
 
 ### convert
 
-`nydusify convert --source <oci-ref> --target <nydus-ref> [OPTIONS]`
+`nydusify convert --source <oci-ref|dir> [--source <oci-ref|dir> ...] --target <nydus-ref> [OPTIONS]`
 
-Pulls the source OCI image into a local content store, converts it, and pushes
-the resulting nydus image to the target reference.
+Converts one or more sources into a nydus image and pushes it to the target
+reference. A source is either an OCI image reference (pulled into a local
+content store) or a local directory path (built directly with `nydus build`).
 
-Pipeline:
+With a single image source, the classic whole-image conversion runs (all
+platforms by default). With a single directory source, a one-layer nydus image
+is built from the directory tree. When `--source` is repeated, the sources are
+stacked in order (first is lowest) into **one** nydus image: every directory
+contributes one blob layer, every image contributes its layers as blob layers
+(existing nydus blob layers are reused as-is and a pre-merged bootstrap is
+dropped), and a single `nydus merge` over all blobs produces the one bootstrap
+layer covering the whole stack.
+
+Pipeline (single image source):
 
 1. Pull `--source` into a scratch content store
    (`internal/remote`, backed by containerd's local content store).
@@ -1645,11 +1658,24 @@ Pipeline:
 4. Push the rewritten manifest and all new layers to `--target`
    (`internal/remote`).
 
+Pipeline (multiple and/or directory sources, `internal/converter/multi.go`):
+
+1. Pull each image source; directory sources are used in place.
+2. Per source, produce nydus blob layers: `nydus build` on each directory,
+   per-layer conversion for OCI image layers, pass-through for layers that are
+   already nydus blobs.
+3. Stage all blobs (in stacking order) and run a single `nydus merge` to
+   produce one bootstrap layer for the whole stack.
+4. Assemble the manifest (`[blobs..., bootstrap]`) and config. The runtime
+   config (env, cmd, entrypoint, ...) is inherited from the uppermost image
+   source when present; otherwise a minimal config is synthesized. Push to
+   `--target`.
+
 Flags:
 
 | Flag | Default | Description |
 | --- | --- | --- |
-| `--source`, `-s` | required | Source OCI image reference. |
+| `--source`, `-s` | required | Source OCI image reference or local directory path. Repeatable; multiple sources are stacked in order (lower to upper) into one image. |
 | `--target`, `-t` | required | Target nydus image reference to push. |
 | `--builder` | `nydus` | Path to the `nydus` binary (PATH-resolvable). |
 | `--work-dir` | temp dir | Scratch directory; a temp dir is created and removed when omitted. |
@@ -1657,26 +1683,47 @@ Flags:
 | `--compress-size` | `4194304` | Blob meta group uncompressed size in bytes; a power of two, at least 1 MiB and at least `--chunk-size`. |
 | `--compressor` | `zstd` | Chunk data compressor: `none` or `zstd`. |
 | `--platform` | all | Convert only the given platform (e.g. `linux/amd64`). |
+| `--append-in-bootstrap` | empty | Local file paths to bundle into the bootstrap layer tar alongside `image.boot`; files inside a directory source are excluded from that source's blob data region. |
 | `--insecure` | `false` | Skip TLS verification for the registry. |
 | `--plain-http` | `false` | Use plain HTTP to talk to the registry. |
 | `--log-level` | `info` | `trace`, `debug`, `info`, `warn`, `error`. Forwarded to the `nydus build`/`merge` subprocesses. |
 
 Notes:
 
-- Converting an image requires **root privileges**. Layer extraction must
-  preserve original uid/gid, setuid/setgid/sticky bits, xattrs and device/fifo
-  nodes; these operations fail without root, and `nydusify` treats such
-  failures as fatal rather than silently producing a corrupted image.
+- Converting an **OCI image** source requires **root privileges**. Layer
+  extraction must preserve original uid/gid, setuid/setgid/sticky bits, xattrs
+  and device/fifo nodes; these operations fail without root, and `nydusify`
+  treats such failures as fatal rather than silently producing a corrupted
+  image. Directory sources and already-nydus image sources do not need root.
+- Multiple sources are merged into one single-platform manifest, so image
+  sources are resolved against exactly one platform: `--platform`, or the host
+  platform when omitted.
 - Image references are normalized like a container runtime: a bare name such as
   `mariadb` expands to `docker.io/library/mariadb:latest`, and a tagless
   reference defaults to `:latest`.
 
-Example:
+Examples:
 
 ```bash
+# Whole-image conversion (requires root).
 sudo nydusify convert \
   --source docker.io/library/mariadb:latest \
   --target localhost:5000/mariadb-nydus \
+  --plain-http
+
+# One-layer image from a local directory.
+nydusify convert \
+  --source ./models/llama \
+  --target localhost:5000/llama-nydus \
+  --plain-http
+
+# Stack a nydus base image and two directories into one image:
+# three blob layers plus one merged bootstrap layer.
+nydusify convert \
+  --source localhost:5000/base-nydus \
+  --source ./layer-data \
+  --source ./layer-config \
+  --target localhost:5000/app-nydus \
   --plain-http
 ```
 

--- a/nydusify/internal/converter/convert.go
+++ b/nydusify/internal/converter/convert.go
@@ -75,6 +75,13 @@ func Convert(ctx context.Context, cs content.Store, srcDesc ocispec.Descriptor, 
 		converter.ConvertHooks{PostConvertHook: hookFn},
 	)
 
+	// A source that is already (partly) a nydus image carries blob layers
+	// whose diff ids cannot be computed by decompression; label them upfront
+	// so images.GetDiffID takes the fast path.
+	if err := labelNydusBlobDiffIDs(ctx, cs, srcDesc, platformMC); err != nil {
+		return nil, errors.Wrap(err, "label nydus blob diff ids")
+	}
+
 	newDesc, err := indexConvertFn(ctx, cs, srcDesc)
 	if err != nil {
 		return nil, errors.Wrap(err, "convert image")

--- a/nydusify/internal/converter/local.go
+++ b/nydusify/internal/converter/local.go
@@ -8,7 +8,6 @@ package converter
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"os"
 	"path/filepath"
@@ -19,7 +18,6 @@ import (
 	"github.com/containerd/platforms"
 	pkgconv "github.com/dragonflyoss/nydus/nydusify/pkg/converter"
 	digest "github.com/opencontainers/go-digest"
-	"github.com/opencontainers/image-spec/specs-go"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/pkg/errors"
 )
@@ -46,142 +44,21 @@ type LocalDirOption struct {
 // (as entries under "image/"). If any of those files reside inside SourceDir,
 // they are passed as --exclude flags to `nydus build` so their data does not
 // also end up in the blob data region.
+//
+// It is a thin wrapper around ConvertMultiSource with a single directory
+// source.
 func ConvertLocalDir(ctx context.Context, cs content.Store, opt LocalDirOption) (*ocispec.Descriptor, error) {
-	if opt.Compressor == "" {
-		opt.Compressor = "zstd"
-	}
-	if opt.ChunkSize == 0 {
-		opt.ChunkSize = 1 << 20
-	}
-	if opt.CompressSize == 0 {
-		opt.CompressSize = 1 << 20
-	}
-
-	appendFiles, err := validateAndReadAppendFiles(opt.AppendInBootstrap)
-	if err != nil {
-		return nil, err
-	}
-
-	buildDir, err := os.MkdirTemp(opt.WorkDir, "local-build-")
-	if err != nil {
-		return nil, errors.Wrap(err, "create build scratch dir")
-	}
-	defer func() { _ = os.RemoveAll(buildDir) }()
-
-	// Pass the append file paths as --exclude flags to `nydus build`.
-	// The Rust side resolves each path against the source directory and
-	// canonicalizes it, so files outside the source are simply ignored.
-	excludes := opt.AppendInBootstrap
-
-	// Step 1: Run nydus build to produce the full blob.
-	blobPath := filepath.Join(buildDir, "blob.nydus")
-	if err := runNydusBuild(ctx, BuildOption{
-		BuilderPath:  opt.BuilderPath,
-		SourceDir:    opt.SourceDir,
-		BlobPath:     blobPath,
-		ChunkSize:    opt.ChunkSize,
-		CompressSize: opt.CompressSize,
-		Compressor:   opt.Compressor,
-		LogLevel:     opt.LogLevel,
-		Excludes:     excludes,
-	}); err != nil {
-		return nil, err
-	}
-
-	// Step 2: Ingest the blob into the content store.
-	blobDesc, err := ingestBlobFile(ctx, cs, blobPath)
-	if err != nil {
-		return nil, errors.Wrap(err, "ingest blob")
-	}
-
-	// Step 3: Stage blob metadata for merge and extract blob.meta.
-	mergeDir, err := os.MkdirTemp(opt.WorkDir, "local-merge-")
-	if err != nil {
-		return nil, errors.Wrap(err, "create merge scratch dir")
-	}
-	defer func() { _ = os.RemoveAll(mergeDir) }()
-
-	stagedPath, err := stageNydusMetadataFromFile(blobPath, blobDesc.Digest, mergeDir)
-	if err != nil {
-		return nil, errors.Wrap(err, "stage blob for merge")
-	}
-
-	blobMetaData, err := extractBlobMetaFromFile(blobPath)
-	if err != nil {
-		return nil, errors.Wrap(err, "extract blob meta")
-	}
-	blobMetas := []BlobMetaFile{{
-		Name: blobDesc.Digest.Encoded() + ".blob.meta",
-		Data: blobMetaData,
-	}}
-
-	// Step 4: Run nydus merge (single layer) to produce the bootstrap.
-	bootstrapPath := filepath.Join(mergeDir, "bootstrap")
-	if err := runNydusMerge(ctx, MergeBuildOption{
-		BuilderPath:   opt.BuilderPath,
-		SourcePaths:   []string{stagedPath},
-		BootstrapPath: bootstrapPath,
-		LogLevel:      opt.LogLevel,
-	}); err != nil {
-		return nil, err
-	}
-
-	// Step 5: Pack bootstrap layer with blob.meta and appended files.
-	bootstrapData, err := os.ReadFile(bootstrapPath)
-	if err != nil {
-		return nil, errors.Wrap(err, "read bootstrap")
-	}
-
-	bootstrapDesc, err := WriteBootstrapLayer(ctx, cs, bootstrapData, blobMetas, appendFiles)
-	if err != nil {
-		return nil, errors.Wrap(err, "write bootstrap layer")
-	}
-
-	// Step 6: Build OCI image config.
-	config := ocispec.Image{
-		Platform: platforms.DefaultSpec(),
-		RootFS: ocispec.RootFS{
-			Type: "layers",
-			DiffIDs: []digest.Digest{
-				blobDesc.Digest,
-				digest.Digest(bootstrapDesc.Annotations[LayerAnnotationUncompressed]),
-			},
-		},
-		History: []ocispec.History{
-			{CreatedBy: "Nydus Build", Comment: "Nydus Data Layer"},
-			{CreatedBy: "Nydus Converter", Comment: "Nydus Bootstrap Layer"},
-		},
-	}
-
-	configDesc, err := writeJSON(ctx, cs, config, ocispec.Descriptor{MediaType: ocispec.MediaTypeImageConfig}, nil)
-	if err != nil {
-		return nil, errors.Wrap(err, "write image config")
-	}
-	configDesc.MediaType = ocispec.MediaTypeImageConfig
-
-	// Step 7: Build OCI manifest.
-	layers := []ocispec.Descriptor{blobDesc, *bootstrapDesc}
-
-	labels := map[string]string{
-		"containerd.io/gc.ref.content.config": configDesc.Digest.String(),
-	}
-	for idx, l := range layers {
-		labels[fmt.Sprintf("containerd.io/gc.ref.content.l.%d", idx)] = l.Digest.String()
-	}
-
-	manifest := ocispec.Manifest{
-		Versioned: specs.Versioned{SchemaVersion: 2},
-		MediaType: ocispec.MediaTypeImageManifest,
-		Config:    *configDesc,
-		Layers:    layers,
-	}
-
-	manifestDesc, err := writeJSON(ctx, cs, manifest, ocispec.Descriptor{MediaType: ocispec.MediaTypeImageManifest}, labels)
-	if err != nil {
-		return nil, errors.Wrap(err, "write manifest")
-	}
-
-	return manifestDesc, nil
+	return ConvertMultiSource(ctx, cs, MultiSourceOption{
+		BuilderPath:       opt.BuilderPath,
+		WorkDir:           opt.WorkDir,
+		ChunkSize:         opt.ChunkSize,
+		CompressSize:      opt.CompressSize,
+		Compressor:        opt.Compressor,
+		LogLevel:          opt.LogLevel,
+		Platform:          platforms.DefaultSpec(),
+		Sources:           []Source{{Dir: opt.SourceDir}},
+		AppendInBootstrap: opt.AppendInBootstrap,
+	})
 }
 
 // validateAndReadAppendFiles validates the list of file paths and reads their

--- a/nydusify/internal/converter/multi.go
+++ b/nydusify/internal/converter/multi.go
@@ -1,0 +1,438 @@
+/*
+ * Copyright (c) 2026. Nydus Developers. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package converter
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/containerd/containerd/v2/core/content"
+	"github.com/containerd/containerd/v2/core/images"
+	"github.com/containerd/containerd/v2/core/images/converter"
+	"github.com/containerd/errdefs"
+	"github.com/containerd/platforms"
+	digest "github.com/opencontainers/go-digest"
+	"github.com/opencontainers/image-spec/specs-go"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/pkg/errors"
+)
+
+// Source describes one input of a multi-source conversion. Exactly one of the
+// fields must be set.
+type Source struct {
+	// Dir is a local directory path to build into a nydus blob layer.
+	Dir string
+	// Image is the root descriptor (already pulled into the content store) of
+	// an OCI or nydus image whose layers become nydus blob layers.
+	Image *ocispec.Descriptor
+}
+
+// MultiSourceOption configures a multi-source -> nydus image conversion. The
+// sources are stacked in order (first is lowest) and merged into a single
+// bootstrap layer.
+type MultiSourceOption struct {
+	// BuilderPath is the nydus binary path (PATH-resolvable). Defaults to "nydus".
+	BuilderPath string
+	// WorkDir is a scratch directory for builds, staging and merging.
+	WorkDir string
+	// ChunkSize is the nydus file chunk size in bytes.
+	ChunkSize uint32
+	// CompressSize is the nydus group uncompressed size in bytes.
+	CompressSize uint32
+	// Compressor is the chunk data compressor ("none" or "zstd").
+	Compressor string
+	// LogLevel is forwarded to the `nydus` subprocesses.
+	LogLevel string
+	// Platform is the single platform the output manifest targets. Image
+	// sources are resolved against it; directory sources are built as-is.
+	Platform ocispec.Platform
+	// Sources are the conversion inputs in stacking order (lower to upper).
+	Sources []Source
+	// AppendInBootstrap lists local files to bundle into the bootstrap layer
+	// tar alongside image.boot. Files residing inside a directory source are
+	// excluded from that source's blob data region.
+	AppendInBootstrap []string
+}
+
+// ConvertMultiSource converts a mixed list of sources (local directories and
+// OCI/nydus images) into a single nydus image manifest: one nydus blob layer
+// per directory / per image layer, plus one merged bootstrap layer. The
+// converted content is written into cs, ready for pushing to a registry.
+//
+// The image runtime config (env, entrypoint, ...) is inherited from the last
+// (uppermost) image source when present; otherwise a minimal config is
+// synthesized.
+func ConvertMultiSource(ctx context.Context, cs content.Store, opt MultiSourceOption) (*ocispec.Descriptor, error) {
+	if opt.Compressor == "" {
+		opt.Compressor = "zstd"
+	}
+	if opt.ChunkSize == 0 {
+		opt.ChunkSize = 1 << 20
+	}
+	if opt.CompressSize == 0 {
+		opt.CompressSize = 1 << 20
+	}
+	if opt.Platform.OS == "" {
+		opt.Platform = platforms.DefaultSpec()
+	}
+	if len(opt.Sources) == 0 {
+		return nil, errors.New("no sources given")
+	}
+
+	appendFiles, err := validateAndReadAppendFiles(opt.AppendInBootstrap)
+	if err != nil {
+		return nil, err
+	}
+
+	mergeDir, err := os.MkdirTemp(opt.WorkDir, "multi-merge-")
+	if err != nil {
+		return nil, errors.Wrap(err, "create merge scratch dir")
+	}
+	defer func() { _ = os.RemoveAll(mergeDir) }()
+
+	var (
+		blobDescs   []ocispec.Descriptor
+		stagedPaths []string
+		blobMetas   []BlobMetaFile
+		baseConfig  json.RawMessage
+	)
+
+	for i, src := range opt.Sources {
+		switch {
+		case src.Dir != "" && src.Image == nil:
+			desc, staged, meta, err := buildDirBlob(ctx, cs, opt, src.Dir, mergeDir)
+			if err != nil {
+				return nil, errors.Wrapf(err, "convert directory source %q", src.Dir)
+			}
+			blobDescs = append(blobDescs, desc)
+			stagedPaths = append(stagedPaths, staged)
+			blobMetas = append(blobMetas, meta)
+		case src.Image != nil && src.Dir == "":
+			descs, config, err := convertImageSource(ctx, cs, opt, *src.Image)
+			if err != nil {
+				return nil, errors.Wrapf(err, "convert image source %d", i)
+			}
+			for _, desc := range descs {
+				staged, err := stageNydusMetadata(ctx, cs, desc, mergeDir)
+				if err != nil {
+					return nil, errors.Wrapf(err, "stage blob %s", desc.Digest)
+				}
+				meta, err := extractBlobMeta(ctx, cs, desc)
+				if err != nil {
+					return nil, errors.Wrapf(err, "extract blob meta %s", desc.Digest)
+				}
+				blobDescs = append(blobDescs, desc)
+				stagedPaths = append(stagedPaths, staged)
+				blobMetas = append(blobMetas, BlobMetaFile{
+					Name: desc.Digest.Encoded() + ".blob.meta",
+					Data: meta,
+				})
+			}
+			baseConfig = config
+		default:
+			return nil, errors.Errorf("source %d: exactly one of Dir or Image must be set", i)
+		}
+	}
+	if len(blobDescs) == 0 {
+		return nil, errors.New("sources produced no nydus blob layers")
+	}
+
+	// Merge all staged blobs (in stacking order) into a single bootstrap.
+	bootstrapPath := filepath.Join(mergeDir, "bootstrap")
+	if err := runNydusMerge(ctx, MergeBuildOption{
+		BuilderPath:   opt.BuilderPath,
+		SourcePaths:   stagedPaths,
+		BootstrapPath: bootstrapPath,
+		LogLevel:      opt.LogLevel,
+	}); err != nil {
+		return nil, err
+	}
+
+	bootstrapData, err := os.ReadFile(bootstrapPath)
+	if err != nil {
+		return nil, errors.Wrap(err, "read bootstrap")
+	}
+	bootstrapDesc, err := WriteBootstrapLayer(ctx, cs, bootstrapData, blobMetas, appendFiles)
+	if err != nil {
+		return nil, errors.Wrap(err, "write bootstrap layer")
+	}
+
+	// Assemble the final layer list, diff ids and history.
+	layers := make([]ocispec.Descriptor, 0, len(blobDescs)+1)
+	layers = append(layers, blobDescs...)
+	layers = append(layers, *bootstrapDesc)
+
+	diffIDs := make([]digest.Digest, 0, len(layers))
+	history := make([]ocispec.History, 0, len(layers))
+	for _, l := range layers[:len(layers)-1] {
+		diffIDs = append(diffIDs, digest.Digest(l.Annotations[LayerAnnotationUncompressed]))
+		history = append(history, ocispec.History{
+			CreatedBy: "Nydus Build", Comment: "Nydus Data Layer",
+		})
+	}
+	diffIDs = append(diffIDs, digest.Digest(bootstrapDesc.Annotations[LayerAnnotationUncompressed]))
+	history = append(history, ocispec.History{
+		CreatedBy: "Nydus Converter", Comment: "Nydus Bootstrap Layer",
+	})
+
+	configJSON, err := buildImageConfig(baseConfig, opt.Platform, diffIDs, history)
+	if err != nil {
+		return nil, errors.Wrap(err, "build image config")
+	}
+	configDesc, err := writeJSON(ctx, cs, configJSON, ocispec.Descriptor{MediaType: ocispec.MediaTypeImageConfig}, nil)
+	if err != nil {
+		return nil, errors.Wrap(err, "write image config")
+	}
+	configDesc.MediaType = ocispec.MediaTypeImageConfig
+
+	labels := map[string]string{
+		"containerd.io/gc.ref.content.config": configDesc.Digest.String(),
+	}
+	for idx, l := range layers {
+		labels[fmt.Sprintf("containerd.io/gc.ref.content.l.%d", idx)] = l.Digest.String()
+	}
+
+	manifest := ocispec.Manifest{
+		Versioned: specs.Versioned{SchemaVersion: 2},
+		MediaType: ocispec.MediaTypeImageManifest,
+		Config:    *configDesc,
+		Layers:    layers,
+	}
+	manifestDesc, err := writeJSON(ctx, cs, manifest, ocispec.Descriptor{MediaType: ocispec.MediaTypeImageManifest}, labels)
+	if err != nil {
+		return nil, errors.Wrap(err, "write manifest")
+	}
+	return manifestDesc, nil
+}
+
+// buildDirBlob runs `nydus build` on dir, ingests the resulting full blob into
+// the content store, stages its metadata into mergeDir for `nydus merge`, and
+// extracts its blob meta artifact.
+func buildDirBlob(ctx context.Context, cs content.Store, opt MultiSourceOption, dir, mergeDir string) (ocispec.Descriptor, string, BlobMetaFile, error) {
+	buildDir, err := os.MkdirTemp(opt.WorkDir, "local-build-")
+	if err != nil {
+		return ocispec.Descriptor{}, "", BlobMetaFile{}, errors.Wrap(err, "create build scratch dir")
+	}
+	defer func() { _ = os.RemoveAll(buildDir) }()
+
+	// Pass the append file paths as --exclude flags to `nydus build`. The
+	// Rust side resolves each path against the source directory and
+	// canonicalizes it, so files outside the source are simply ignored.
+	blobPath := filepath.Join(buildDir, "blob.nydus")
+	if err := runNydusBuild(ctx, BuildOption{
+		BuilderPath:  opt.BuilderPath,
+		SourceDir:    dir,
+		BlobPath:     blobPath,
+		ChunkSize:    opt.ChunkSize,
+		CompressSize: opt.CompressSize,
+		Compressor:   opt.Compressor,
+		LogLevel:     opt.LogLevel,
+		Excludes:     opt.AppendInBootstrap,
+	}); err != nil {
+		return ocispec.Descriptor{}, "", BlobMetaFile{}, err
+	}
+
+	blobDesc, err := ingestBlobFile(ctx, cs, blobPath)
+	if err != nil {
+		return ocispec.Descriptor{}, "", BlobMetaFile{}, errors.Wrap(err, "ingest blob")
+	}
+
+	stagedPath, err := stageNydusMetadataFromFile(blobPath, blobDesc.Digest, mergeDir)
+	if err != nil {
+		return ocispec.Descriptor{}, "", BlobMetaFile{}, errors.Wrap(err, "stage blob for merge")
+	}
+
+	metaData, err := extractBlobMetaFromFile(blobPath)
+	if err != nil {
+		return ocispec.Descriptor{}, "", BlobMetaFile{}, errors.Wrap(err, "extract blob meta")
+	}
+
+	return blobDesc, stagedPath, BlobMetaFile{
+		Name: blobDesc.Digest.Encoded() + ".blob.meta",
+		Data: metaData,
+	}, nil
+}
+
+// convertImageSource converts every OCI layer of the image rooted at srcDesc
+// into a nydus blob layer (layers already in nydus format are reused as-is,
+// and an existing bootstrap layer is dropped), then returns the blob layer
+// descriptors in stacking order together with the image's raw config JSON.
+func convertImageSource(ctx context.Context, cs content.Store, opt MultiSourceOption, srcDesc ocispec.Descriptor) ([]ocispec.Descriptor, json.RawMessage, error) {
+	platformMC := platforms.Only(opt.Platform)
+
+	layerFn := LayerConvertFunc(PackOption{
+		BuilderPath:  opt.BuilderPath,
+		WorkDir:      opt.WorkDir,
+		ChunkSize:    opt.ChunkSize,
+		CompressSize: opt.CompressSize,
+		Compressor:   opt.Compressor,
+		LogLevel:     opt.LogLevel,
+	})
+	// Convert layers only: no post-convert hook, so no per-image bootstrap
+	// merge happens here. The caller merges the blobs of all sources at once.
+	convertFn := converter.IndexConvertFuncWithHook(layerFn, true, platformMC, converter.ConvertHooks{})
+
+	if err := labelNydusBlobDiffIDs(ctx, cs, srcDesc, platformMC); err != nil {
+		return nil, nil, errors.Wrap(err, "label nydus blob diff ids")
+	}
+
+	newDesc, err := convertFn(ctx, cs, srcDesc)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "convert image layers")
+	}
+	if newDesc == nil {
+		// Nothing was modified (e.g. the source is already a nydus image).
+		newDesc = &srcDesc
+	}
+
+	manifestDesc, err := resolveManifestDesc(ctx, cs, *newDesc, platformMC)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var manifest ocispec.Manifest
+	if _, err := readJSON(ctx, cs, &manifest, manifestDesc); err != nil {
+		return nil, nil, errors.Wrap(err, "read manifest json")
+	}
+
+	blobs := make([]ocispec.Descriptor, 0, len(manifest.Layers))
+	for _, layer := range manifest.Layers {
+		if IsNydusBootstrap(layer) {
+			// A pre-merged bootstrap of an existing nydus image is dropped;
+			// a fresh bootstrap covering all sources is generated instead.
+			continue
+		}
+		if !IsNydusBlob(layer) {
+			return nil, nil, errors.Errorf("unsupported layer %s (%s) in image source", layer.Digest, layer.MediaType)
+		}
+		blobs = append(blobs, layer)
+	}
+
+	var config json.RawMessage
+	if _, err := readJSON(ctx, cs, &config, manifest.Config); err != nil {
+		return nil, nil, errors.Wrap(err, "read image config")
+	}
+	return blobs, config, nil
+}
+
+// buildImageConfig produces the final OCI image config JSON. When base is
+// non-nil, only its `rootfs` and `history` fields are replaced so every other
+// field (in particular the runtime config) is preserved byte-for-byte;
+// otherwise a minimal config is synthesized.
+func buildImageConfig(base json.RawMessage, platform ocispec.Platform, diffIDs []digest.Digest, history []ocispec.History) (json.RawMessage, error) {
+	if base == nil {
+		return json.Marshal(ocispec.Image{
+			Platform: platform,
+			RootFS: ocispec.RootFS{
+				Type:    "layers",
+				DiffIDs: diffIDs,
+			},
+			History: history,
+		})
+	}
+
+	var rawConfig map[string]json.RawMessage
+	if err := json.Unmarshal(base, &rawConfig); err != nil {
+		return nil, errors.Wrap(err, "unmarshal image config")
+	}
+
+	rootFSRaw, err := json.Marshal(ocispec.RootFS{Type: "layers", DiffIDs: diffIDs})
+	if err != nil {
+		return nil, errors.Wrap(err, "marshal image config rootfs")
+	}
+	rawConfig["rootfs"] = rootFSRaw
+
+	historyRaw, err := json.Marshal(history)
+	if err != nil {
+		return nil, errors.Wrap(err, "marshal image config history")
+	}
+	rawConfig["history"] = historyRaw
+
+	return json.Marshal(rawConfig)
+}
+
+// labelNydusBlobDiffIDs sets the containerd.io/uncompressed content-store
+// label on every nydus blob layer referenced by rootDesc (taken from the layer
+// annotation of the same name). A nydus full blob is uncompressed at the layer
+// level but starts with compressed chunk data, so without the label
+// images.GetDiffID would try to decompress the blob and fail with "magic
+// number mismatch". With the label it takes the fast path.
+func labelNydusBlobDiffIDs(ctx context.Context, cs content.Store, rootDesc ocispec.Descriptor, platformMC platforms.MatchComparer) error {
+	var manifestDescs []ocispec.Descriptor
+	switch {
+	case images.IsManifestType(rootDesc.MediaType):
+		manifestDescs = []ocispec.Descriptor{rootDesc}
+	case images.IsIndexType(rootDesc.MediaType):
+		var index ocispec.Index
+		if _, err := readJSON(ctx, cs, &index, rootDesc); err != nil {
+			return errors.Wrap(err, "read index json")
+		}
+		for _, m := range index.Manifests {
+			if m.Platform == nil || platformMC.Match(*m.Platform) {
+				manifestDescs = append(manifestDescs, m)
+			}
+		}
+	default:
+		return nil
+	}
+
+	for _, manifestDesc := range manifestDescs {
+		var manifest ocispec.Manifest
+		if _, err := readJSON(ctx, cs, &manifest, manifestDesc); err != nil {
+			return errors.Wrap(err, "read manifest json")
+		}
+		for _, layer := range manifest.Layers {
+			uncompressed := layer.Annotations[LayerAnnotationUncompressed]
+			if !IsNydusBlob(layer) || uncompressed == "" {
+				continue
+			}
+			info, err := cs.Info(ctx, layer.Digest)
+			if err != nil {
+				if errdefs.IsNotFound(err) {
+					continue
+				}
+				return errors.Wrapf(err, "stat blob %s", layer.Digest)
+			}
+			if info.Labels[LayerAnnotationUncompressed] == uncompressed {
+				continue
+			}
+			if info.Labels == nil {
+				info.Labels = map[string]string{}
+			}
+			info.Labels[LayerAnnotationUncompressed] = uncompressed
+			if _, err := cs.Update(ctx, info, "labels"); err != nil {
+				return errors.Wrapf(err, "label blob %s", layer.Digest)
+			}
+		}
+	}
+	return nil
+}
+
+// resolveManifestDesc returns the platform-specific manifest descriptor,
+// selecting from an index when rootDesc is multi-platform.
+func resolveManifestDesc(ctx context.Context, cs content.Store, rootDesc ocispec.Descriptor, platformMC platforms.MatchComparer) (ocispec.Descriptor, error) {
+	if images.IsManifestType(rootDesc.MediaType) {
+		return rootDesc, nil
+	}
+	if !images.IsIndexType(rootDesc.MediaType) {
+		return ocispec.Descriptor{}, errors.Errorf("unsupported root media type %q", rootDesc.MediaType)
+	}
+
+	var index ocispec.Index
+	if _, err := readJSON(ctx, cs, &index, rootDesc); err != nil {
+		return ocispec.Descriptor{}, errors.Wrap(err, "read index json")
+	}
+	for _, m := range index.Manifests {
+		if m.Platform == nil || platformMC.Match(*m.Platform) {
+			return m, nil
+		}
+	}
+	return ocispec.Descriptor{}, errors.New("no manifest matches the requested platform")
+}

--- a/nydusify/main.go
+++ b/nydusify/main.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"encoding/json"
 	"os"
+	"strings"
 
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/containerd/v2/core/images"
@@ -47,10 +48,10 @@ func convertCommand() *cli.Command {
 		Name:  "convert",
 		Usage: "Pull an OCI image, convert it to a nydus image, and push the result",
 		Flags: []cli.Flag{
-			&cli.StringFlag{
+			&cli.StringSliceFlag{
 				Name:     "source",
 				Aliases:  []string{"s"},
-				Usage:    "source OCI image reference (e.g. registry/repo:tag) or local directory path",
+				Usage:    "source OCI image reference (e.g. registry/repo:tag) or local directory path; can be repeated to stack multiple sources (lower to upper) into one nydus image with a single merged bootstrap",
 				Required: true,
 			},
 			&cli.StringFlag{
@@ -124,26 +125,33 @@ func runConvert(c *cli.Context) error {
 
 	ctx := log.WithLogger(context.Background(), log.L)
 
-	source := c.String("source")
+	sources := c.StringSlice("source")
+	source := sources[0]
 	target := c.String("target")
 	appendFiles := c.StringSlice("append-in-bootstrap")
+	multiSource := len(sources) > 1
 
 	// Detect whether --source is a local directory (instead of an OCI image
 	// reference). When the source is a directory, we use ConvertLocalDir
 	// which builds a single-layer nydus image directly from the directory
 	// tree, excluding any --append-in-bootstrap files that reside inside it.
-	isLocalDir := false
-	if info, err := os.Stat(source); err == nil && info.IsDir() {
-		isLocalDir = true
-	}
+	isLocalDir := isDir(source)
 
+	platform := platforms.DefaultSpec()
 	platformMC := platforms.All
 	if p := c.String("platform"); p != "" {
 		parsed, err := platforms.Parse(p)
 		if err != nil {
 			return errors.Wrapf(err, "invalid platform %q", p)
 		}
+		platform = parsed
 		platformMC = platforms.Only(parsed)
+	} else if multiSource {
+		// Multiple sources are merged into one single-platform manifest, so
+		// image sources must be resolved to exactly one platform. Default to
+		// the host platform when --platform is not given.
+		logrus.Infof("multiple sources: defaulting to platform %s", platforms.Format(platform))
+		platformMC = platforms.Only(platform)
 	}
 
 	// Prepare a scratch work directory.
@@ -185,7 +193,37 @@ func runConvert(c *cli.Context) error {
 
 	var newDesc *ocispec.Descriptor
 
-	if isLocalDir {
+	if multiSource {
+		srcs := make([]converter.Source, 0, len(sources))
+		for _, s := range sources {
+			if isDir(s) {
+				srcs = append(srcs, converter.Source{Dir: s})
+				continue
+			}
+			logrus.Infof("pulling source image %s", s)
+			desc, err := provider.Pull(ctx, s, remote.PullAll, remote.Source)
+			if err != nil {
+				return errors.Wrapf(err, "pull %q", s)
+			}
+			srcs = append(srcs, converter.Source{Image: &desc})
+		}
+
+		logrus.Infof("converting %d sources to nydus format", len(srcs))
+		newDesc, err = converter.ConvertMultiSource(ctx, provider.ContentStore(), converter.MultiSourceOption{
+			BuilderPath:       c.String("builder"),
+			WorkDir:           scratchDir,
+			ChunkSize:         uint32(c.Uint("chunk-size")),
+			CompressSize:      uint32(c.Uint("compress-size")),
+			Compressor:        c.String("compressor"),
+			LogLevel:          c.String("log-level"),
+			Platform:          platform,
+			Sources:           srcs,
+			AppendInBootstrap: appendFiles,
+		})
+		if err != nil {
+			return errors.Wrap(err, "convert multiple sources")
+		}
+	} else if isLocalDir {
 		logrus.Infof("converting local directory %s to nydus format", source)
 		newDesc, err = converter.ConvertLocalDir(ctx, provider.ContentStore(), converter.LocalDirOption{
 			BuilderPath:       c.String("builder"),
@@ -239,8 +277,15 @@ func runConvert(c *cli.Context) error {
 		return errors.Wrapf(err, "push %q", target)
 	}
 
-	logrus.Infof("done: %s -> %s (%s)", source, target, newDesc.Digest)
+	logrus.Infof("done: %s -> %s (%s)", strings.Join(sources, ", "), target, newDesc.Digest)
 	return nil
+}
+
+// isDir reports whether path exists and is a local directory (as opposed to
+// an OCI image reference).
+func isDir(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && info.IsDir()
 }
 
 // totalLayerSize resolves rootDesc (a manifest or a multi-platform index) for


### PR DESCRIPTION
Allow `nydusify convert --source` to be repeated so multiple sources - local directories and OCI/nydus image references, in stacking order (lower to upper) - are converted into one nydus image: one nydus blob layer per directory / per image layer, plus a single merged bootstrap layer, then pushed to the target.

- Add ConvertMultiSource: builds directory sources via `nydus build`, converts image source layers (reusing existing nydus blob layers and dropping pre-merged bootstraps), stages all blobs and runs a single `nydus merge`. The runtime config is inherited from the uppermost image source when present.
- Rewrite ConvertLocalDir as a thin single-directory wrapper around ConvertMultiSource, removing the duplicated pipeline.
- Multiple sources are resolved against a single platform (--platform or the host platform by default).
- Fix a latent bug: pulled nydus blob layers lack the containerd.io/uncompressed content-store label, so images.GetDiffID tried to decompress them and failed with "magic number mismatch". Label them upfront from the layer annotation in both the single-image and multi-source paths.

Verified end to end against a local registry: two-directory convert/push, nydus-image + directory mixed convert/push, and FUSE mount with all files from every source readable.

## Overview
_Please briefly describe the changes your pull request makes._

## Related Issues
_Please link to the relevant issue. For example: `Fix #123` or `Related #456`._

## Change Details
_Please describe your changes in detail:_

## Test Results
_If you have any relevant screenshots or videos that can help illustrate your changes, please add them here._

## Change Type
_Please select the type of change your pull request relates to:_
- [ ] Bug Fix
- [x] Feature Addition
- [x] Documentation Update
- [ ] Code Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe)

## Self-Checklist
_Before submitting a pull request, please ensure you have completed the following:_
- [ ] I have run a code style check and addressed any warnings/errors.
- [ ] I have added appropriate comments to my code (if applicable).
- [ ] I have updated the documentation (if applicable).
- [ ] I have written appropriate unit tests.