### PR TITLE
fix: report fscache blob cull completion status

### DIFF
--- a/api/src/http.rs
+++ b/api/src/http.rs
@@ -125,6 +125,10 @@ pub enum ApiRequest {
     DeleteBlobObject(BlobCacheObjectId),
     /// Delete a blob cache file
     DeleteBlobFile(String),
+    /// Cull a blob cache file and optionally retain pending work in the background.
+    CullBlobFile(String, bool),
+    /// List blob culls that are still pending in nydusd.
+    GetPendingBlobCulls,
 }
 
 /// Kinds for daemon related error messages.
@@ -186,6 +190,10 @@ pub enum ApiResponsePayload {
     DaemonInfo(String),
     /// No data is sent on the channel.
     Empty,
+    /// The request has not completed yet.
+    Pending(String),
+    /// JSON map of blob IDs to pending reasons.
+    PendingCulls(String),
     /// Global error events.
     Events(String),
 
@@ -261,6 +269,8 @@ pub enum HttpError {
     DeleteBlobObject(ApiError),
     /// Failed to delete blob file
     DeleteBlobFile(ApiError),
+    /// Failed to cull blob file
+    CullBlobFile(ApiError),
     /// Failed to list existing blob objects
     GetBlobObjects(ApiError),
 }

--- a/api/src/http_endpoint_v2.rs
+++ b/api/src/http_endpoint_v2.rs
@@ -32,6 +32,13 @@ fn convert_to_response<O: FnOnce(ApiError) -> HttpError>(api_resp: ApiResponse, 
             use ApiResponsePayload::*;
             match r {
                 Empty => success_response(None),
+                // dbs-uhttp has no 202 status variant. This dedicated endpoint uses a
+                // structured 200 response for pending while 204 remains the done signal.
+                Pending(reason) => success_response(Some(format!(
+                    r#"{{"status":"pending","reason":{}}}"#,
+                    serde_json::to_string(&reason).expect("serialize cull pending reason")
+                ))),
+                PendingCulls(d) => success_response(Some(d)),
                 DaemonInfo(d) => success_response(Some(d)),
                 BlobObjectList(d) => success_response(Some(d)),
                 _ => panic!("Unexpected response message from API service"),
@@ -40,6 +47,35 @@ fn convert_to_response<O: FnOnce(ApiError) -> HttpError>(api_resp: ApiResponse, 
         Err(e) => {
             let status_code = translate_status_code(&e);
             error_response(op(e), status_code)
+        }
+    }
+}
+
+/// Reclaim a blob from the kernel fscache and report whether it completed.
+pub struct BlobCullHandlerV2 {}
+impl EndpointHandler for BlobCullHandlerV2 {
+    fn handle_request(
+        &self,
+        req: &Request,
+        kicker: &dyn Fn(ApiRequest) -> ApiResponse,
+    ) -> HttpResult {
+        match (req.method(), req.body.as_ref()) {
+            (Method::Delete, None) => {
+                let blob_id = extract_query_part(req, "blob_id")
+                    .filter(|blob_id| !blob_id.is_empty())
+                    .ok_or(HttpError::BadRequest)?;
+                let background = extract_query_part(req, "background")
+                    .map(|value| value.parse::<bool>().map_err(|_| HttpError::BadRequest))
+                    .transpose()?
+                    .unwrap_or(false);
+                let r = kicker(ApiRequest::CullBlobFile(blob_id, background));
+                Ok(convert_to_response(r, HttpError::CullBlobFile))
+            }
+            (Method::Get, None) => {
+                let r = kicker(ApiRequest::GetPendingBlobCulls);
+                Ok(convert_to_response(r, HttpError::CullBlobFile))
+            }
+            _ => Err(HttpError::BadRequest),
         }
     }
 }
@@ -226,6 +262,70 @@ mod tests {
         let handler = BlobObjectListHandlerV2 {};
         let raw = b"POST http://localhost/api/v2/blobs HTTP/1.0\r\n\r\n";
         let req = Request::try_from(raw.as_slice(), None).unwrap();
+        let result = handler.handle_request(&req, &|_| ok_empty());
+        assert!(matches!(result, Err(HttpError::BadRequest)));
+    }
+
+    #[test]
+    fn test_blob_cull_handler_done() {
+        let handler = BlobCullHandlerV2 {};
+        let req = delete_req("http://localhost/api/v2/blobs/cull?blob_id=test_blob");
+        let result = handler
+            .handle_request(&req, &|request| {
+                assert!(matches!(
+                    request,
+                    ApiRequest::CullBlobFile(blob_id, false) if blob_id == "test_blob"
+                ));
+                ok_empty()
+            })
+            .unwrap();
+        assert_eq!(result.status(), dbs_uhttp::StatusCode::NoContent);
+    }
+
+    #[test]
+    fn test_blob_cull_handler_pending() {
+        let handler = BlobCullHandlerV2 {};
+        let req =
+            delete_req("http://localhost/api/v2/blobs/cull?blob_id=test_blob&background=true");
+        let result = handler
+            .handle_request(&req, &|request| {
+                assert!(matches!(
+                    request,
+                    ApiRequest::CullBlobFile(blob_id, true) if blob_id == "test_blob"
+                ));
+                Ok(ApiResponsePayload::Pending("open".to_string()))
+            })
+            .unwrap();
+        assert_eq!(result.status(), dbs_uhttp::StatusCode::OK);
+    }
+
+    #[test]
+    fn test_blob_cull_handler_lists_pending() {
+        let handler = BlobCullHandlerV2 {};
+        let req = get_req("http://localhost/api/v2/blobs/cull");
+        let result = handler
+            .handle_request(&req, &|_| {
+                Ok(ApiResponsePayload::PendingCulls(
+                    r#"{"blob":"open"}"#.to_string(),
+                ))
+            })
+            .unwrap();
+        assert_eq!(result.status(), dbs_uhttp::StatusCode::OK);
+    }
+
+    #[test]
+    fn test_blob_cull_handler_requires_blob_id() {
+        let handler = BlobCullHandlerV2 {};
+        let req = delete_req("http://localhost/api/v2/blobs/cull");
+        let result = handler.handle_request(&req, &|_| ok_empty());
+        assert!(matches!(result, Err(HttpError::BadRequest)));
+    }
+
+    #[test]
+    fn test_blob_cull_handler_rejects_invalid_background() {
+        let handler = BlobCullHandlerV2 {};
+        let req =
+            delete_req("http://localhost/api/v2/blobs/cull?blob_id=test_blob&background=invalid");
         let result = handler.handle_request(&req, &|_| ok_empty());
         assert!(matches!(result, Err(HttpError::BadRequest)));
     }

--- a/api/src/http_handler.rs
+++ b/api/src/http_handler.rs
@@ -27,7 +27,9 @@ use crate::http_endpoint_v1::{
     ConfigHandler, FsBackendInfo, InfoHandler, MetricsFsAccessPatternHandler,
     MetricsFsFilesHandler, MetricsFsGlobalHandler, MetricsFsInflightHandler, HTTP_ROOT_V1,
 };
-use crate::http_endpoint_v2::{BlobObjectListHandlerV2, InfoV2Handler, HTTP_ROOT_V2};
+use crate::http_endpoint_v2::{
+    BlobCullHandlerV2, BlobObjectListHandlerV2, InfoV2Handler, HTTP_ROOT_V2,
+};
 
 const EXIT_TOKEN: Token = Token(usize::MAX);
 const REQUEST_TOKEN: Token = Token(1);
@@ -163,6 +165,7 @@ lazy_static! {
         // Nydus API, v2
         r.routes.insert(endpoint_v2!("/daemon"), Box::new(InfoV2Handler{}));
         r.routes.insert(endpoint_v2!("/blobs"), Box::new(BlobObjectListHandlerV2{}));
+        r.routes.insert(endpoint_v2!("/blobs/cull"), Box::new(BlobCullHandlerV2{}));
 
         r
     };
@@ -355,6 +358,7 @@ mod tests {
     fn test_http_api_routes_v2() {
         assert!(HTTP_ROUTES.routes.contains_key("/api/v2/daemon"));
         assert!(HTTP_ROUTES.routes.contains_key("/api/v2/blobs"));
+        assert!(HTTP_ROUTES.routes.contains_key("/api/v2/blobs/cull"));
     }
 
     #[test]

--- a/service/src/blob_cache.rs
+++ b/service/src/blob_cache.rs
@@ -214,7 +214,7 @@ impl BlobCacheState {
             let scoped_blob_prefix = generate_blob_key(&param.domain_id, &param.blob_id);
 
             match self.id_to_config_map.get(&scoped_blob_prefix) {
-                None => return Err(enoent!("blob_cache: cache entry not found")),
+                None => return Ok(()),
                 Some(BlobConfig::MetaBlob(o)) => {
                     is_meta = true;
                     data_blobs = o.blobs.lock().unwrap().clone();
@@ -240,6 +240,13 @@ impl BlobCacheState {
 
     fn get(&self, key: &str) -> Option<BlobConfig> {
         self.id_to_config_map.get(key).cloned()
+    }
+
+    fn contains_blob_id(&self, blob_id: &str) -> bool {
+        self.id_to_config_map.values().any(|config| match config {
+            BlobConfig::MetaBlob(blob) => blob.blob_id == blob_id,
+            BlobConfig::DataBlob(blob) => blob.blob_info.blob_id() == blob_id,
+        })
     }
 }
 
@@ -308,6 +315,11 @@ impl BlobCacheMgr {
     /// Get configuration information of the cached blob with specified `key`.
     pub fn get_config(&self, key: &str) -> Option<BlobConfig> {
         self.get_state().get(key)
+    }
+
+    /// Check whether a bootstrap or data blob still has a configured reference.
+    pub fn contains_blob_id(&self, blob_id: &str) -> bool {
+        self.get_state().contains_blob_id(blob_id)
     }
 
     #[inline]
@@ -764,6 +776,7 @@ mod tests {
         mgr.add_blob_entry(&entry).unwrap();
         let blob_id = generate_blob_key(&entry.domain_id, &entry.blob_id);
         assert!(mgr.get_config(&blob_id).is_some());
+        assert!(mgr.contains_blob_id(&entry.blob_id));
 
         // add the same entry will trigger an error
         assert!(mgr.add_blob_entry(&entry).is_err());
@@ -774,6 +787,8 @@ mod tests {
             "be7d77eeb719f70884758d1aa800ed0fb09d701aaec469964e9d54325f0d5fef",
         );
         assert!(mgr.get_config(&key).is_some());
+        assert!(mgr
+            .contains_blob_id("be7d77eeb719f70884758d1aa800ed0fb09d701aaec469964e9d54325f0d5fef"));
 
         assert_eq!(mgr.get_state().id_to_config_map.len(), 2);
 
@@ -798,9 +813,17 @@ mod tests {
             blob_id: "rafs-v6-cloned".to_string(),
         })
         .unwrap();
+        // Teardown retries must be idempotent after the first request removed the entry.
+        mgr.remove_blob_entry(&BlobCacheObjectId {
+            domain_id: "domain2".to_string(),
+            blob_id: "rafs-v6-cloned".to_string(),
+        })
+        .unwrap();
         assert_eq!(mgr.get_state().id_to_config_map.len(), 0);
         assert!(mgr.get_config(&blob_id).is_none());
         assert!(mgr.get_config(&blob_id_cloned).is_none());
+        assert!(!mgr
+            .contains_blob_id("be7d77eeb719f70884758d1aa800ed0fb09d701aaec469964e9d54325f0d5fef"));
     }
 
     #[test]

--- a/service/src/daemon.rs
+++ b/service/src/daemon.rs
@@ -8,6 +8,7 @@
 
 use std::any::Any;
 use std::cmp::PartialEq;
+use std::collections::HashMap;
 use std::convert::From;
 use std::fmt::{Display, Formatter};
 use std::ops::Deref;
@@ -25,6 +26,15 @@ use serde::{self, Serialize};
 use crate::fs_service::{FsBackendCollection, FsService};
 use crate::upgrade::UpgradeManager;
 use crate::{BlobCacheMgr, Error, Result};
+
+/// Result of trying to reclaim a blob from the kernel fscache.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum BlobCullResult {
+    /// The cache cookie was reclaimed or is stably absent.
+    Done,
+    /// Reclamation has not completed; background requests remain owned by the cull worker.
+    Pending(String),
+}
 
 /// Nydus daemon working states.
 #[allow(clippy::upper_case_acronyms)]
@@ -189,6 +199,16 @@ pub trait NydusDaemon: DaemonStateMachineSubscriber + Send + Sync {
     /// Delete a blob object managed by the daemon.
     fn delete_blob(&self, _blob_id: String) -> Result<()> {
         Ok(())
+    }
+
+    /// Try to reclaim a blob and report whether it completed synchronously.
+    fn cull_blob(&self, _blob_id: String, _background: bool) -> Result<BlobCullResult> {
+        Err(Error::Unsupported)
+    }
+
+    /// Return cull operations that are still waiting for a lifecycle or cachefiles event.
+    fn pending_culls(&self) -> Result<HashMap<String, String>> {
+        Err(Error::Unsupported)
     }
 }
 

--- a/service/src/fs_cache.rs
+++ b/service/src/fs_cache.rs
@@ -13,7 +13,7 @@
 //! - [FsCacheHandler] reads blob data from the [BlobCacheMgr] and sends back reply messages.
 
 use std::collections::hash_map::Entry::Vacant;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet, VecDeque};
 use std::convert::TryFrom;
 use std::fs::{self, File, OpenOptions};
 use std::io::{copy, Error, ErrorKind, Result, Write};
@@ -23,6 +23,7 @@ use std::path::{Path, PathBuf};
 use std::ptr::read_unaligned;
 use std::string::String;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::mpsc::{channel, Sender};
 use std::sync::{Arc, Barrier, Condvar, Mutex, MutexGuard, RwLock};
 use std::{cmp, env, thread, time};
 
@@ -35,6 +36,7 @@ use nydus_storage::factory::{ASYNC_RUNTIME, BLOB_FACTORY};
 use crate::blob_cache::{
     generate_blob_key, BlobCacheMgr, BlobConfig, DataBlobConfig, MetaBlobConfig,
 };
+use crate::daemon::BlobCullResult;
 
 nix::ioctl_write_int!(fscache_cread, 0x98, 1);
 
@@ -49,6 +51,7 @@ const TOKEN_EVENT_FSCACHE: usize = 2;
 
 const BLOB_CACHE_INIT_RETRY: u8 = 5;
 const BLOB_CACHE_INIT_INTERVAL_MS: u64 = 300;
+const FSCACHE_CULL_RETRY_INTERVAL_MS: u64 = 1000;
 
 /// Command code in requests from fscache driver.
 #[repr(u32)]
@@ -209,6 +212,8 @@ impl TryFrom<&[u8]> for FsCacheMsgRead {
 }
 
 struct FsCacheBootstrap {
+    blob_id: String,
+    volume_key: String,
     bootstrap_file: File,
     cache_file: File,
 }
@@ -217,6 +222,7 @@ struct FsCacheBlobCache {
     cache: Option<Arc<dyn BlobCache>>,
     config: Arc<DataBlobConfig>,
     file: Arc<File>,
+    volume_key: String,
 }
 
 impl FsCacheBlobCache {
@@ -243,6 +249,616 @@ struct FsCacheState {
     blob_cache_mgr: Arc<BlobCacheMgr>,
 }
 
+#[derive(Default)]
+struct FsCacheCullInner {
+    pending: HashSet<String>,
+    pending_reasons: HashMap<String, String>,
+    background_pending: HashSet<String>,
+    // An open object can only become cullable after its CLOSE event. Keep this
+    // state so repeated synchronous callers do not run the same open check.
+    open_pending: HashSet<String>,
+    queued: HashSet<String>,
+    processing: HashSet<String>,
+    queue: VecDeque<String>,
+    waiters: HashMap<String, Vec<Sender<FsCacheCullStatus>>>,
+    unsettled_closes: HashMap<String, HashSet<String>>,
+    stopped: bool,
+}
+
+#[derive(Default)]
+struct FsCacheCullState {
+    inner: Mutex<FsCacheCullInner>,
+    condvar: Condvar,
+    cwd_lock: Mutex<()>,
+}
+
+#[derive(Clone, Debug)]
+enum FsCacheCullStatus {
+    Done,
+    Pending(String),
+    Failed(String),
+}
+
+struct FsCacheCullOps<'a> {
+    file: &'a File,
+    state: &'a Arc<Mutex<FsCacheState>>,
+    cull_state: &'a Arc<FsCacheCullState>,
+    cache_dir: &'a Path,
+}
+
+struct FsCacheCullWorker {
+    file: File,
+    state: Arc<Mutex<FsCacheState>>,
+    cull_state: Arc<FsCacheCullState>,
+    cache_dir: PathBuf,
+}
+
+struct CurrentDirGuard {
+    old: PathBuf,
+}
+
+impl FsCacheCullState {
+    fn enqueue(&self, blob_id: String) {
+        let mut inner = self.inner.lock().unwrap();
+        if inner.stopped {
+            return;
+        }
+
+        inner.pending.insert(blob_id.clone());
+        inner.background_pending.insert(blob_id.clone());
+        let queued = !inner.open_pending.contains(&blob_id)
+            && !inner.processing.contains(&blob_id)
+            && inner.queued.insert(blob_id.clone());
+        if queued {
+            inner.queue.push_back(blob_id);
+            self.condvar.notify_one();
+        }
+    }
+
+    fn request(&self, blob_id: String, background: bool) -> Result<FsCacheCullStatus> {
+        let (tx, rx) = channel();
+        let mut inner = self.inner.lock().unwrap();
+        if inner.stopped {
+            return Err(Error::new(
+                ErrorKind::BrokenPipe,
+                "fscache cull worker stopped",
+            ));
+        }
+
+        if background {
+            inner.background_pending.insert(blob_id.clone());
+        }
+        if inner.open_pending.contains(&blob_id) {
+            return Ok(FsCacheCullStatus::Pending("open".to_string()));
+        }
+        inner.pending.insert(blob_id.clone());
+        inner.waiters.entry(blob_id.clone()).or_default().push(tx);
+        if !inner.processing.contains(&blob_id) {
+            // Synchronous API callers should not wait behind a large legacy GC queue.
+            if inner.queued.contains(&blob_id) {
+                if let Some(index) = inner.queue.iter().position(|queued| queued == &blob_id) {
+                    inner.queue.remove(index);
+                }
+            } else {
+                inner.queued.insert(blob_id.clone());
+            }
+            inner.queue.push_front(blob_id);
+            self.condvar.notify_one();
+        }
+        drop(inner);
+
+        rx.recv()
+            .map_err(|_| Error::new(ErrorKind::BrokenPipe, "fscache cull worker exited"))
+    }
+
+    /// Publish one attempt's result and report whether the worker still owns the pending cull.
+    /// Only requests explicitly marked for background completion remain owned after Pending.
+    fn finish_attempt(&self, blob_id: &str, status: FsCacheCullStatus) -> bool {
+        let mut inner = self.inner.lock().unwrap();
+        inner.processing.remove(blob_id);
+        let waiters = inner.waiters.remove(blob_id).unwrap_or_default();
+        let terminal = matches!(
+            &status,
+            FsCacheCullStatus::Done | FsCacheCullStatus::Failed(_)
+        );
+        let background = inner.background_pending.contains(blob_id);
+        let open_pending = background
+            && matches!(&status, FsCacheCullStatus::Pending(reason) if reason == "open")
+            && !inner.unsettled_closes.contains_key(blob_id);
+        if open_pending {
+            inner.pending.insert(blob_id.to_string());
+            inner.open_pending.insert(blob_id.to_string());
+        }
+        if let FsCacheCullStatus::Pending(reason) = &status {
+            if background {
+                inner
+                    .pending_reasons
+                    .insert(blob_id.to_string(), reason.clone());
+            } else {
+                inner.pending.remove(blob_id);
+                inner.queued.remove(blob_id);
+                inner.open_pending.remove(blob_id);
+                inner.pending_reasons.remove(blob_id);
+            }
+        } else if terminal {
+            inner.pending.remove(blob_id);
+            inner.queued.remove(blob_id);
+            inner.open_pending.remove(blob_id);
+            inner.pending_reasons.remove(blob_id);
+            inner.background_pending.remove(blob_id);
+        }
+        let retry_pending = !terminal && inner.pending.contains(blob_id);
+        self.condvar.notify_all();
+        drop(inner);
+
+        for waiter in waiters {
+            let _ = waiter.send(status.clone());
+        }
+        retry_pending
+    }
+
+    fn record_close(&self, blob_id: &str, volume_key: &str) {
+        let mut inner = self.inner.lock().unwrap();
+        inner.open_pending.remove(blob_id);
+        inner
+            .unsettled_closes
+            .entry(blob_id.to_string())
+            .or_default()
+            .insert(volume_key.to_string());
+
+        if !inner.stopped
+            && inner.pending.contains(blob_id)
+            && inner.queued.insert(blob_id.to_string())
+        {
+            inner.queue.push_back(blob_id.to_string());
+            self.condvar.notify_one();
+        }
+    }
+
+    fn unsettled_close_volumes(&self, blob_id: &str) -> HashSet<String> {
+        self.inner
+            .lock()
+            .unwrap()
+            .unsettled_closes
+            .get(blob_id)
+            .cloned()
+            .unwrap_or_default()
+    }
+
+    fn pending_culls(&self) -> HashMap<String, String> {
+        self.inner.lock().unwrap().pending_reasons.clone()
+    }
+
+    fn resolve_close(&self, blob_id: &str, volume_key: &str) {
+        let mut inner = self.inner.lock().unwrap();
+        let remove_blob = match inner.unsettled_closes.get_mut(blob_id) {
+            Some(volumes) => {
+                volumes.remove(volume_key);
+                volumes.is_empty()
+            }
+            None => false,
+        };
+        if remove_blob {
+            inner.unsettled_closes.remove(blob_id);
+        }
+    }
+
+    fn stop(&self) {
+        let mut inner = self.inner.lock().unwrap();
+        inner.stopped = true;
+        inner.queue.clear();
+        inner.queued.clear();
+        inner.open_pending.clear();
+        inner.pending.clear();
+        inner.pending_reasons.clear();
+        inner.background_pending.clear();
+        let waiters = std::mem::take(&mut inner.waiters);
+        self.condvar.notify_all();
+        drop(inner);
+
+        for (_, blob_waiters) in waiters {
+            for waiter in blob_waiters {
+                let _ = waiter.send(FsCacheCullStatus::Failed(
+                    "fscache cull worker stopped".to_string(),
+                ));
+            }
+        }
+    }
+
+    fn next(&self) -> Option<String> {
+        let mut inner = self.inner.lock().unwrap();
+        loop {
+            while inner.queue.is_empty() && !inner.stopped {
+                inner = self.condvar.wait(inner).unwrap();
+            }
+            if inner.stopped {
+                return None;
+            }
+            if let Some(blob_id) = inner.queue.pop_front() {
+                inner.queued.remove(&blob_id);
+                if inner.pending.contains(&blob_id) {
+                    inner.processing.insert(blob_id.clone());
+                    return Some(blob_id);
+                }
+            }
+        }
+    }
+
+    fn wait_before_retry(&self, blob_id: &str, timeout: time::Duration) -> bool {
+        let mut inner = self.inner.lock().unwrap();
+        if inner.stopped || !inner.pending.contains(blob_id) {
+            return false;
+        }
+
+        if !inner.queued.contains(blob_id) {
+            let (guard, _) = self.condvar.wait_timeout(inner, timeout).unwrap();
+            inner = guard;
+        }
+
+        if inner.stopped || !inner.pending.contains(blob_id) {
+            return false;
+        }
+
+        if !inner.queued.contains(blob_id) {
+            inner.queued.insert(blob_id.to_string());
+            inner.queue.push_back(blob_id.to_string());
+            self.condvar.notify_one();
+        }
+        true
+    }
+}
+
+impl CurrentDirGuard {
+    fn new(dir: &Path) -> Result<Self> {
+        let old = env::current_dir()?;
+        env::set_current_dir(dir)?;
+        Ok(Self { old })
+    }
+}
+
+impl Drop for CurrentDirGuard {
+    fn drop(&mut self) {
+        let _ = env::set_current_dir(&self.old);
+    }
+}
+
+impl<'a> FsCacheCullOps<'a> {
+    fn try_cull_cache_once(&self, blob_id: &str) -> Result<FsCacheCullStatus> {
+        let open = self.blob_is_open(blob_id);
+        if open {
+            // Do not touch cachefiles while nydusd still has the object open. It can only be
+            // rejected as busy and the kernel lookup may be slow; close handling will wake this
+            // pending cull immediately.
+            return Ok(FsCacheCullStatus::Pending("open".to_string()));
+        }
+        if self.blob_is_configured(blob_id) {
+            // Bind publishes blob configuration before cachefiles sends OPEN. Treat that
+            // interval as referenced; otherwise cull can report a stably absent cookie just
+            // before the legitimate OPEN creates it.
+            return Ok(FsCacheCullStatus::Pending("configured".to_string()));
+        }
+        let mut unsettled_volumes = self.cull_state.unsettled_close_volumes(blob_id);
+
+        let children = match fs::read_dir(self.cache_dir) {
+            Ok(children) => children,
+            Err(e) if Self::is_not_found(&e) && unsettled_volumes.is_empty() => {
+                return Ok(FsCacheCullStatus::Done)
+            }
+            Err(e) if Self::is_not_found(&e) => {
+                return Ok(FsCacheCullStatus::Pending(
+                    "awaiting cachefiles commit".to_string(),
+                ))
+            }
+            Err(e) => {
+                return Ok(FsCacheCullStatus::Failed(format!(
+                    "read cache dir {} failed: {}",
+                    self.cache_dir.display(),
+                    e
+                )));
+            }
+        };
+        let mut pending_reason: Option<String> = None;
+
+        // Calculate the blob path in all volumes and try to cull the matching cookies.
+        for child in children {
+            let child = match child {
+                Ok(child) => child,
+                Err(e) => {
+                    return Ok(FsCacheCullStatus::Failed(format!(
+                        "read cache dir entry failed: {}",
+                        e
+                    )));
+                }
+            };
+            let path = child.path();
+            let file_name = match child.file_name().to_str() {
+                Some(n) => n.to_string(),
+                None => {
+                    warn!("failed to get file name of {}", child.path().display());
+                    continue;
+                }
+            };
+            if !path.is_dir() || !file_name.starts_with("Ierofs,") {
+                continue;
+            }
+
+            // Get volume_key from volume dir name, e.g. Ierofs,SharedDomain -> erofs,SharedDomain.
+            let volume_key = &file_name[1..];
+            let (cookie_dir, cookie_name) = Self::generate_cookie_path(&path, volume_key, blob_id);
+            let cookie_path = cookie_dir.join(&cookie_name);
+            if !cookie_path.is_file() {
+                continue;
+            }
+            let cookie_path = cookie_path.display();
+
+            match self.inuse(&cookie_dir, &cookie_name) {
+                Err(e) => {
+                    if Self::is_not_found(&e) {
+                        continue;
+                    }
+                    return Ok(FsCacheCullStatus::Failed(format!(
+                        "inuse {} failed: {}",
+                        cookie_path, e
+                    )));
+                }
+                Ok(true) => {
+                    warn!("blob {} in use, cull pending", cookie_path);
+                    pending_reason.get_or_insert_with(|| "inuse".to_string());
+                }
+                Ok(false) => {
+                    if let Err(e) = self.cull(&cookie_dir, &cookie_name) {
+                        if Self::is_not_found(&e) {
+                            if unsettled_volumes.remove(volume_key) {
+                                self.cull_state.resolve_close(blob_id, volume_key);
+                            }
+                            continue;
+                        }
+                        if e.raw_os_error() == Some(libc::EBUSY) {
+                            pending_reason.get_or_insert_with(|| "cull busy".to_string());
+                            continue;
+                        }
+                        return Ok(FsCacheCullStatus::Failed(format!(
+                            "cull {} failed: {}",
+                            cookie_path, e
+                        )));
+                    } else if unsettled_volumes.remove(volume_key) {
+                        self.cull_state.resolve_close(blob_id, volume_key);
+                    }
+                }
+            }
+        }
+
+        if let Some(reason) = pending_reason {
+            return Ok(FsCacheCullStatus::Pending(reason));
+        }
+
+        if !unsettled_volumes.is_empty() {
+            return Ok(FsCacheCullStatus::Pending(
+                "awaiting cachefiles commit".to_string(),
+            ));
+        }
+
+        Ok(FsCacheCullStatus::Done)
+    }
+
+    fn is_not_found(err: &Error) -> bool {
+        matches!(
+            err.raw_os_error(),
+            Some(e) if e == libc::ENOENT || e == libc::ESTALE
+        )
+    }
+
+    fn blob_is_open(&self, blob_id: &str) -> bool {
+        let state = self.state.lock().unwrap();
+        state
+            .id_to_config_map
+            .values()
+            .any(|config| config.blob_info().blob_id() == blob_id)
+            || state
+                .id_to_object_map
+                .values()
+                .any(|(object, _fd)| match object {
+                    FsCacheObject::Bootstrap(bootstrap) => bootstrap.blob_id.as_str() == blob_id,
+                    FsCacheObject::DataBlob(_blob) => false,
+                })
+    }
+
+    fn blob_is_configured(&self, blob_id: &str) -> bool {
+        self.state
+            .lock()
+            .unwrap()
+            .blob_cache_mgr
+            .contains_blob_id(blob_id)
+    }
+
+    #[inline]
+    fn hash_32(val: u32) -> u32 {
+        val.wrapping_mul(0x61C88647)
+    }
+
+    #[inline]
+    fn rol32(word: u32, shift: i32) -> u32 {
+        word << (shift & 31) | (word >> ((-shift) & 31))
+    }
+
+    #[inline]
+    fn round_up_u32(size: usize) -> usize {
+        size.div_ceil(4) * 4
+    }
+
+    fn fscache_hash(salt: u32, data: &[u8]) -> u32 {
+        assert_eq!(data.len() % 4, 0);
+
+        let mut x = 0;
+        let mut y = salt;
+        let mut buf_le32: [u8; 4] = [0; 4];
+        let n = data.len() / 4;
+
+        for i in 0..n {
+            buf_le32.clone_from_slice(&data[i * 4..i * 4 + 4]);
+            let a = u32::from_ne_bytes(buf_le32).to_le();
+            x ^= a;
+            y ^= x;
+            x = Self::rol32(x, 7);
+            x = x.wrapping_add(y);
+            y = Self::rol32(y, 20);
+            y = y.wrapping_mul(9);
+        }
+        Self::hash_32(y ^ Self::hash_32(x))
+    }
+
+    fn generate_cookie_path(
+        volume_path: &Path,
+        volume_key: &str,
+        cookie_key: &str,
+    ) -> (PathBuf, String) {
+        // Calculate volume hash.
+        let mut volume_hash_key: Vec<u8> =
+            Vec::with_capacity(Self::round_up_u32(volume_key.len() + 2));
+        volume_hash_key.push(volume_key.len() as u8);
+        volume_hash_key.append(&mut volume_key.as_bytes().to_vec());
+        volume_hash_key.resize(volume_hash_key.capacity(), 0);
+        let volume_hash = Self::fscache_hash(0, volume_hash_key.as_slice());
+
+        // Calculate cookie hash.
+        let mut cookie_hash_key: Vec<u8> = Vec::with_capacity(Self::round_up_u32(cookie_key.len()));
+        cookie_hash_key.append(&mut cookie_key.as_bytes().to_vec());
+        cookie_hash_key.resize(cookie_hash_key.capacity(), 0);
+        let dir_hash = Self::fscache_hash(volume_hash, cookie_hash_key.as_slice());
+
+        let dir = format!("@{:02x}", dir_hash as u8);
+        let cookie = format!("D{}", cookie_key);
+        (volume_path.join(dir), cookie)
+    }
+
+    fn write_cachefiles_cmd(&self, cookie_dir: &Path, msg: &str) -> Result<usize> {
+        let _cwd_lock = self.cull_state.cwd_lock.lock().unwrap();
+        let _cwd = CurrentDirGuard::new(cookie_dir)?;
+        let ret = unsafe {
+            libc::write(
+                self.file.as_raw_fd(),
+                msg.as_bytes().as_ptr() as *const libc::c_void,
+                msg.len(),
+            )
+        };
+        if ret < 0 {
+            Err(Error::last_os_error())
+        } else {
+            Ok(ret as usize)
+        }
+    }
+
+    fn inuse(&self, cookie_dir: &Path, cookie_name: &str) -> Result<bool> {
+        let msg = format!("inuse {}", cookie_name);
+        match self.write_cachefiles_cmd(cookie_dir, &msg) {
+            Err(err) => {
+                if err.raw_os_error() == Some(libc::EBUSY) {
+                    Ok(true)
+                } else {
+                    Err(err)
+                }
+            }
+            Ok(n) if n == msg.len() => Ok(false),
+            Ok(_) => Err(Error::new(
+                ErrorKind::WriteZero,
+                "short write to cachefiles device",
+            )),
+        }
+    }
+
+    fn cull(&self, cookie_dir: &Path, cookie_name: &str) -> Result<()> {
+        let msg = format!("cull {}", cookie_name);
+        match self.write_cachefiles_cmd(cookie_dir, &msg) {
+            Ok(n) if n == msg.len() => Ok(()),
+            Ok(_) => Err(Error::new(
+                ErrorKind::WriteZero,
+                "short write to cachefiles device",
+            )),
+            Err(err) => Err(err),
+        }
+    }
+}
+
+impl FsCacheCullWorker {
+    fn start(
+        file: File,
+        state: Arc<Mutex<FsCacheState>>,
+        cull_state: Arc<FsCacheCullState>,
+        cache_dir: PathBuf,
+    ) -> thread::JoinHandle<()> {
+        thread::spawn(move || {
+            Self {
+                file,
+                state,
+                cull_state,
+                cache_dir,
+            }
+            .run()
+        })
+    }
+
+    fn run(self) {
+        if let Err(e) = Self::unshare_fs_struct() {
+            error!("fscache: failed to isolate cull worker: {}", e);
+            self.cull_state.stop();
+            return;
+        }
+
+        while let Some(blob_id) = self.cull_state.next() {
+            let ops = FsCacheCullOps {
+                file: &self.file,
+                state: &self.state,
+                cull_state: &self.cull_state,
+                cache_dir: &self.cache_dir,
+            };
+
+            match ops.try_cull_cache_once(&blob_id) {
+                Ok(status @ FsCacheCullStatus::Done) => {
+                    self.cull_state.finish_attempt(&blob_id, status);
+                }
+                Ok(FsCacheCullStatus::Pending(reason)) => {
+                    let wait_for_lifecycle_event = reason == "open" || reason == "configured";
+                    let retry_pending = self
+                        .cull_state
+                        .finish_attempt(&blob_id, FsCacheCullStatus::Pending(reason));
+                    if !retry_pending {
+                        continue;
+                    }
+                    if wait_for_lifecycle_event {
+                        // The blob is still referenced by an active config or fscache object.
+                        // Retrying on a timer can only observe the same in-memory state. CLOSE
+                        // wakes this legacy asynchronous cull after the reference is removed.
+                        continue;
+                    }
+                    self.cull_state.wait_before_retry(
+                        &blob_id,
+                        time::Duration::from_millis(FSCACHE_CULL_RETRY_INTERVAL_MS),
+                    );
+                }
+                Ok(FsCacheCullStatus::Failed(reason)) => {
+                    warn!("fscache: failed to cull blob {}: {}", blob_id, reason);
+                    self.cull_state
+                        .finish_attempt(&blob_id, FsCacheCullStatus::Failed(reason));
+                }
+                Err(e) => {
+                    self.cull_state
+                        .finish_attempt(&blob_id, FsCacheCullStatus::Failed(e.to_string()));
+                    warn!("fscache: failed to cull blob {}: {}", blob_id, e);
+                }
+            }
+        }
+    }
+
+    fn unshare_fs_struct() -> Result<()> {
+        let ret = unsafe { libc::unshare(libc::CLONE_FS) };
+        if ret != 0 {
+            Err(Error::last_os_error())
+        } else {
+            Ok(())
+        }
+    }
+}
+
 /// Handler to cooperate with Linux fscache driver to manage cached blob objects.
 ///
 /// The `FsCacheHandler` create a communication channel with the Linux fscache driver, configure
@@ -255,7 +871,10 @@ pub struct FsCacheHandler {
     state: Arc<Mutex<FsCacheState>>,
     poller: Mutex<Poll>,
     waker: Arc<Waker>,
+    #[allow(dead_code)]
     cache_dir: PathBuf,
+    cull_state: Arc<FsCacheCullState>,
+    cull_worker: Mutex<Option<thread::JoinHandle<()>>>,
 }
 
 impl FsCacheHandler {
@@ -321,17 +940,28 @@ impl FsCacheHandler {
             id_to_config_map: Default::default(),
             blob_cache_mgr,
         };
+        let state = Arc::new(Mutex::new(state));
         let cache_dir = PathBuf::new().join(dir).join("cache");
+        let cull_state = Arc::new(FsCacheCullState::default());
+        let cull_worker_file = file.try_clone()?;
+        let cull_worker = FsCacheCullWorker::start(
+            cull_worker_file,
+            state.clone(),
+            cull_state.clone(),
+            cache_dir.clone(),
+        );
 
         Ok(FsCacheHandler {
             active: AtomicBool::new(true),
             barrier: Barrier::new(threads + 1),
             threads,
             file,
-            state: Arc::new(Mutex::new(state)),
+            state,
             poller: Mutex::new(poller),
             waker: Arc::new(waker),
             cache_dir,
+            cull_state,
+            cull_worker: Mutex::new(Some(cull_worker)),
         })
     }
 
@@ -347,6 +977,12 @@ impl FsCacheHandler {
             error!("fscache: failed to signal worker thread to exit, {}", e);
         }
         self.barrier.wait();
+        self.cull_state.stop();
+        if let Some(worker) = self.cull_worker.lock().unwrap().take() {
+            if worker.join().is_err() {
+                warn!("fscache: cull worker panicked");
+            }
+        }
     }
 
     /// Run the event loop to handle all requests from kernel fscache driver.
@@ -478,6 +1114,7 @@ impl FsCacheHandler {
                 cache: None,
                 config: config.clone(),
                 file: Arc::new(unsafe { File::from_raw_fd(msg.fd as RawFd) }),
+                volume_key: msg.volume_key.clone(),
             }));
             e.insert((FsCacheObject::DataBlob(fsblob.clone()), msg.fd));
             state.id_to_config_map.insert(hdr.object_id, config.clone());
@@ -614,6 +1251,8 @@ impl FsCacheHandler {
                     Ok(md) => {
                         let cache_file = unsafe { File::from_raw_fd(msg.fd as RawFd) };
                         let bootstrap = Arc::new(FsCacheBootstrap {
+                            blob_id: config.blob_id().to_string(),
+                            volume_key: msg.volume_key.clone(),
                             bootstrap_file: f,
                             cache_file,
                         });
@@ -657,28 +1296,38 @@ impl FsCacheHandler {
 
     fn handle_close_request(&self, hdr: &FsCacheMsgHeader) {
         let mut state = self.get_state();
-
-        if let Some((FsCacheObject::DataBlob(fsblob), _)) =
-            state.id_to_object_map.remove(&hdr.object_id)
-        {
-            // Safe to unwrap() because `id_to_config_map` and `id_to_object_map` is kept
-            // in consistence.
-            let config = state.id_to_config_map.remove(&hdr.object_id).unwrap();
-            let factory_config = config.config_v2();
-            let guard = fsblob.read().unwrap();
-            match guard.get_blob_cache() {
-                Some(blob) => {
-                    if let Ok(cache_cfg) = factory_config.get_cache_config() {
-                        if cache_cfg.prefetch.enable {
-                            let _ = blob.stop_prefetch();
+        let closed_blob = match state.id_to_object_map.remove(&hdr.object_id) {
+            Some((FsCacheObject::DataBlob(fsblob), _)) => {
+                // Safe to unwrap because the config and object maps are kept consistent.
+                let config = state.id_to_config_map.remove(&hdr.object_id).unwrap();
+                let blob_id = config.blob_info().blob_id().to_string();
+                let factory_config = config.config_v2();
+                let guard = fsblob.read().unwrap();
+                match guard.get_blob_cache() {
+                    Some(blob) => {
+                        if let Ok(cache_cfg) = factory_config.get_cache_config() {
+                            if cache_cfg.prefetch.enable {
+                                let _ = blob.stop_prefetch();
+                            }
                         }
+                        let id = blob.blob_id().to_string();
+                        drop(blob);
+                        BLOB_FACTORY.gc(Some((factory_config, &id)));
                     }
-                    let id = blob.blob_id().to_string();
-                    drop(blob);
-                    BLOB_FACTORY.gc(Some((factory_config, &id)));
+                    _ => warn!("fscache: blob object not ready {}", hdr.object_id),
                 }
-                _ => warn!("fscache: blob object not ready {}", hdr.object_id),
+                Some((blob_id, fsblob.read().unwrap().volume_key.clone()))
             }
+            Some((FsCacheObject::Bootstrap(bootstrap), _)) => {
+                Some((bootstrap.blob_id.clone(), bootstrap.volume_key.clone()))
+            }
+            None => None,
+        };
+
+        // Publish the close settle window before releasing the object-state lock. A cull
+        // attempt cannot observe the object as closed without also seeing this marker.
+        if let Some((blob_id, volume_key)) = closed_blob.as_ref() {
+            self.cull_state.record_close(blob_id, volume_key);
         }
     }
 
@@ -756,166 +1405,56 @@ impl FsCacheHandler {
         }
     }
 
-    /// Reclaim unused facache objects.
+    /// Queue an unused fscache object for reclamation.
     pub fn cull_cache(&self, blob_id: String) -> Result<()> {
-        let children = fs::read_dir(self.cache_dir.clone())?;
-        let mut res = true;
-        // This is safe, because only api server which is a single thread server will call this func,
-        // and no other func will change cwd.
-        let cwd_old = env::current_dir()?;
+        self.cull_state.enqueue(blob_id);
+        Ok(())
+    }
 
-        info!("try to cull blob {}", blob_id);
-
-        // calc blob path in all volumes then try to cull them
-        for child in children {
-            let child = child?;
-            let path = child.path();
-            let file_name = match child.file_name().to_str() {
-                Some(n) => n.to_string(),
-                None => {
-                    warn!("failed to get file name of {}", child.path().display());
-                    continue;
-                }
-            };
-            if !path.is_dir() || !file_name.starts_with("Ierofs,") {
-                continue;
-            }
-
-            // get volume_key form volume dir name e.g. Ierofs,SharedDomain
-            let volume_key = &file_name[1..];
-            let (cookie_dir, cookie_name) = self.generate_cookie_path(&path, volume_key, &blob_id);
-            let cookie_path = cookie_dir.join(&cookie_name);
-            if !cookie_path.is_file() {
-                continue;
-            }
-            let cookie_path = cookie_path.display();
-
-            match self.inuse(&cookie_dir, &cookie_name) {
-                Err(e) => {
-                    warn!("blob {} call inuse err {}, cull failed!", cookie_path, e);
-                    res = false;
-                }
-                Ok(true) => {
-                    warn!("blob {} in use, skip!", cookie_path);
-                    res = false;
-                }
-                Ok(false) => {
-                    if let Err(e) = self.cull(&cookie_dir, &cookie_name) {
-                        warn!("blob {} call cull err {}, cull failed!", cookie_path, e);
-                        res = false;
-                    }
-                }
-            }
-        }
-
-        env::set_current_dir(cwd_old)?;
-        if res {
-            Ok(())
-        } else {
-            Err(eother!("failed to cull blob objects from fscache"))
+    /// Try one cull attempt and wait until the dedicated cull worker reports its result.
+    pub fn cull_cache_status(&self, blob_id: String, background: bool) -> Result<BlobCullResult> {
+        match self.cull_state.request(blob_id, background)? {
+            FsCacheCullStatus::Done => Ok(BlobCullResult::Done),
+            FsCacheCullStatus::Pending(reason) => Ok(BlobCullResult::Pending(reason)),
+            FsCacheCullStatus::Failed(reason) => Err(Error::other(reason)),
         }
     }
 
+    pub fn pending_culls(&self) -> HashMap<String, String> {
+        self.cull_state.pending_culls()
+    }
+
+    #[cfg(test)]
     #[inline]
     fn hash_32(&self, val: u32) -> u32 {
-        val * 0x61C88647
+        FsCacheCullOps::hash_32(val)
     }
 
+    #[cfg(test)]
     #[inline]
     fn rol32(&self, word: u32, shift: i32) -> u32 {
-        word << (shift & 31) | (word >> ((-shift) & 31))
+        FsCacheCullOps::rol32(word, shift)
     }
 
+    #[cfg(test)]
     #[inline]
     fn round_up_u32(&self, size: usize) -> usize {
-        size.div_ceil(4) * 4
+        FsCacheCullOps::round_up_u32(size)
     }
 
-    //address from kernel fscache_hash()
+    #[cfg(test)]
     fn fscache_hash(&self, salt: u32, data: &[u8]) -> u32 {
-        assert_eq!(data.len() % 4, 0);
-
-        let mut x = 0;
-        let mut y = salt;
-        let mut buf_le32: [u8; 4] = [0; 4];
-        let n = data.len() / 4;
-
-        for i in 0..n {
-            buf_le32.clone_from_slice(&data[i * 4..i * 4 + 4]);
-            let a = u32::from_ne_bytes(buf_le32).to_le();
-            x ^= a;
-            y ^= x;
-            x = self.rol32(x, 7);
-            x += y;
-            y = self.rol32(y, 20);
-            y *= 9;
-        }
-        self.hash_32(y ^ self.hash_32(x))
+        FsCacheCullOps::fscache_hash(salt, data)
     }
 
+    #[cfg(test)]
     fn generate_cookie_path(
         &self,
         volume_path: &Path,
         volume_key: &str,
         cookie_key: &str,
     ) -> (PathBuf, String) {
-        //calc volume hash
-        let mut volume_hash_key: Vec<u8> =
-            Vec::with_capacity(self.round_up_u32(volume_key.len() + 2));
-        volume_hash_key.push(volume_key.len() as u8);
-        volume_hash_key.append(&mut volume_key.as_bytes().to_vec());
-        volume_hash_key.resize(volume_hash_key.capacity(), 0);
-        let volume_hash = self.fscache_hash(0, volume_hash_key.as_slice());
-
-        //calc cookie hash
-        let mut cookie_hash_key: Vec<u8> = Vec::with_capacity(self.round_up_u32(cookie_key.len()));
-        cookie_hash_key.append(&mut cookie_key.as_bytes().to_vec());
-        cookie_hash_key.resize(cookie_hash_key.capacity(), 0);
-        let dir_hash = self.fscache_hash(volume_hash, cookie_hash_key.as_slice());
-
-        let dir = format!("@{:02x}", dir_hash as u8);
-        let cookie = format!("D{}", cookie_key);
-        (volume_path.join(dir), cookie)
-    }
-
-    fn inuse(&self, cookie_dir: &Path, cookie_name: &str) -> Result<bool> {
-        env::set_current_dir(cookie_dir)?;
-        let msg = format!("inuse {}", cookie_name);
-        let ret = unsafe {
-            libc::write(
-                self.file.as_raw_fd(),
-                msg.as_bytes().as_ptr() as *const libc::c_void,
-                msg.len(),
-            )
-        };
-        if ret < 0 {
-            let err = Error::last_os_error();
-            if let Some(e) = err.raw_os_error() {
-                if e == libc::EBUSY {
-                    return Ok(true);
-                }
-            }
-            Err(err)
-        } else {
-            Ok(false)
-        }
-    }
-
-    fn cull(&self, cookie_dir: &Path, cookie_name: &str) -> Result<()> {
-        env::set_current_dir(cookie_dir)?;
-        let msg = format!("cull {}", cookie_name);
-        let ret = unsafe {
-            libc::write(
-                self.file.as_raw_fd(),
-                msg.as_bytes().as_ptr() as *const libc::c_void,
-                msg.len(),
-            )
-        };
-        if ret as usize != msg.len() {
-            Err(Error::last_os_error())
-        } else {
-            Ok(())
-        }
+        FsCacheCullOps::generate_cookie_path(volume_path, volume_key, cookie_key)
     }
 
     #[inline]
@@ -973,6 +1512,7 @@ mod tests {
         let poller = Poll::new().unwrap();
         let waker = Arc::new(Waker::new(poller.registry(), Token(TOKEN_EVENT_WAKER)).unwrap());
         let file = File::create(cache_dir.join("cachefiles")).unwrap();
+        let cull_state = Arc::new(FsCacheCullState::default());
 
         FsCacheHandler {
             active: AtomicBool::new(true),
@@ -986,6 +1526,8 @@ mod tests {
             poller: Mutex::new(poller),
             waker,
             cache_dir,
+            cull_state,
+            cull_worker: Mutex::new(None),
         }
     }
 
@@ -995,6 +1537,225 @@ mod tests {
         assert_eq!(FsCacheOpCode::try_from(1).unwrap(), FsCacheOpCode::Close);
         assert_eq!(FsCacheOpCode::try_from(2).unwrap(), FsCacheOpCode::Read);
         FsCacheOpCode::try_from(3).unwrap_err();
+    }
+
+    #[test]
+    fn test_cull_close_remains_unsettled_until_resolved() {
+        let state = FsCacheCullState::default();
+        state.record_close("blob", "erofs,domain");
+
+        assert_eq!(
+            state.unsettled_close_volumes("blob"),
+            HashSet::from(["erofs,domain".to_string()])
+        );
+        state.resolve_close("blob", "erofs,domain");
+        assert!(state.unsettled_close_volumes("blob").is_empty());
+    }
+
+    #[test]
+    fn test_cull_request_receives_attempt_status() {
+        let state = Arc::new(FsCacheCullState::default());
+        let worker_state = state.clone();
+        let worker = thread::spawn(move || {
+            let blob_id = worker_state.next().unwrap();
+            assert_eq!(blob_id, "blob");
+            worker_state.finish_attempt(&blob_id, FsCacheCullStatus::Done);
+        });
+
+        assert!(matches!(
+            state.request("blob".to_string(), false),
+            Ok(FsCacheCullStatus::Done)
+        ));
+        worker.join().unwrap();
+    }
+
+    #[test]
+    fn test_background_pending_cull_remains_owned_by_worker() {
+        let state = Arc::new(FsCacheCullState::default());
+        let request_state = state.clone();
+        let requester = thread::spawn(move || request_state.request("blob".to_string(), true));
+
+        let blob_id = state.next().unwrap();
+        assert_eq!(blob_id, "blob");
+        // CLOSE may queue another attempt while the synchronous attempt is still processing.
+        state.record_close(&blob_id, "erofs,domain");
+        assert!(state.finish_attempt(
+            &blob_id,
+            FsCacheCullStatus::Pending("awaiting cachefiles commit".to_string())
+        ));
+        assert!(matches!(
+            requester.join().unwrap(),
+            Ok(FsCacheCullStatus::Pending(_))
+        ));
+
+        assert_eq!(
+            state.pending_culls().get(&blob_id).map(String::as_str),
+            Some("awaiting cachefiles commit")
+        );
+
+        // The CLOSE queued while the first attempt was running remains owned by the worker.
+        assert_eq!(state.next().as_deref(), Some("blob"));
+        state.finish_attempt("blob", FsCacheCullStatus::Done);
+
+        let inner = state.inner.lock().unwrap();
+        assert!(!inner.pending.contains(&blob_id));
+        assert!(!inner.queued.contains(&blob_id));
+        assert!(!inner.processing.contains(&blob_id));
+        assert!(inner.queue.is_empty());
+        assert!(inner.pending_reasons.is_empty());
+    }
+
+    #[test]
+    fn test_foreground_pending_cull_releases_worker_ownership() {
+        let state = Arc::new(FsCacheCullState::default());
+        let request_state = state.clone();
+        let requester = thread::spawn(move || request_state.request("blob".to_string(), false));
+
+        let blob_id = state.next().unwrap();
+        assert_eq!(blob_id, "blob");
+        assert!(!state.finish_attempt(
+            &blob_id,
+            FsCacheCullStatus::Pending("awaiting cachefiles commit".to_string())
+        ));
+        assert!(matches!(
+            requester.join().unwrap(),
+            Ok(FsCacheCullStatus::Pending(_))
+        ));
+
+        let inner = state.inner.lock().unwrap();
+        assert!(!inner.pending.contains(&blob_id));
+        assert!(!inner.queued.contains(&blob_id));
+        assert!(!inner.processing.contains(&blob_id));
+        assert!(inner.pending_reasons.is_empty());
+        assert!(inner.background_pending.is_empty());
+    }
+
+    #[test]
+    fn test_open_pending_cull_is_coalesced_until_close() {
+        let state = Arc::new(FsCacheCullState::default());
+        let request_state = state.clone();
+        let requester = thread::spawn(move || request_state.request("blob".to_string(), true));
+
+        let blob_id = state.next().unwrap();
+        assert_eq!(blob_id, "blob");
+        assert!(state.finish_attempt(&blob_id, FsCacheCullStatus::Pending("open".to_string())));
+        assert!(matches!(
+            requester.join().unwrap(),
+            Ok(FsCacheCullStatus::Pending(reason)) if reason == "open"
+        ));
+
+        // A second synchronous caller observes the existing lifecycle wait and does not
+        // schedule another cull attempt.
+        assert!(matches!(
+            state.request("blob".to_string(), true),
+            Ok(FsCacheCullStatus::Pending(reason)) if reason == "open"
+        ));
+        assert_eq!(
+            state.pending_culls().get("blob").map(String::as_str),
+            Some("open")
+        );
+
+        // CLOSE is the lifecycle event that makes the blob worth trying again.
+        state.record_close("blob", "erofs,domain");
+        assert_eq!(state.next().as_deref(), Some("blob"));
+        state.finish_attempt("blob", FsCacheCullStatus::Done);
+        assert!(state.pending_culls().is_empty());
+    }
+
+    #[test]
+    fn test_cull_stably_absent_cookie_is_done() {
+        let cache_dir = TempDir::new().unwrap();
+        let mut handler = create_test_handler();
+        handler.cache_dir = cache_dir.as_path().to_path_buf();
+        let ops = FsCacheCullOps {
+            file: &handler.file,
+            state: &handler.state,
+            cull_state: &handler.cull_state,
+            cache_dir: &handler.cache_dir,
+        };
+
+        assert!(matches!(
+            ops.try_cull_cache_once("absent-blob"),
+            Ok(FsCacheCullStatus::Done)
+        ));
+    }
+
+    #[test]
+    fn test_cull_post_close_absence_is_pending() {
+        let cache_dir = TempDir::new().unwrap();
+        let volume_key = "erofs,domain";
+        fs::create_dir(cache_dir.as_path().join(format!("I{}", volume_key))).unwrap();
+        let mut handler = create_test_handler();
+        handler.cache_dir = cache_dir.as_path().to_path_buf();
+        handler.cull_state.record_close("blob", volume_key);
+        let ops = FsCacheCullOps {
+            file: &handler.file,
+            state: &handler.state,
+            cull_state: &handler.cull_state,
+            cache_dir: &handler.cache_dir,
+        };
+
+        assert!(matches!(
+            ops.try_cull_cache_once("blob"),
+            Ok(FsCacheCullStatus::Pending(reason))
+                if reason == "awaiting cachefiles commit"
+        ));
+        assert_eq!(
+            handler.cull_state.unsettled_close_volumes("blob"),
+            HashSet::from([volume_key.to_string()])
+        );
+    }
+
+    #[test]
+    fn test_cull_success_resolves_post_close_volume() {
+        let cache_dir = TempDir::new().unwrap();
+        let volume_key = "erofs,domain";
+        let volume_path = cache_dir.as_path().join(format!("I{}", volume_key));
+        fs::create_dir(&volume_path).unwrap();
+        let (cookie_dir, cookie_name) =
+            FsCacheCullOps::generate_cookie_path(&volume_path, volume_key, "blob");
+        fs::create_dir(&cookie_dir).unwrap();
+
+        let mut handler = create_test_handler();
+        handler.cache_dir = cache_dir.as_path().to_path_buf();
+        handler.cull_state.record_close("blob", volume_key);
+        let ops = FsCacheCullOps {
+            file: &handler.file,
+            state: &handler.state,
+            cull_state: &handler.cull_state,
+            cache_dir: &handler.cache_dir,
+        };
+
+        assert!(matches!(
+            ops.try_cull_cache_once("blob"),
+            Ok(FsCacheCullStatus::Pending(reason))
+                if reason == "awaiting cachefiles commit"
+        ));
+        File::create(cookie_dir.join(cookie_name)).unwrap();
+        assert!(matches!(
+            ops.try_cull_cache_once("blob"),
+            Ok(FsCacheCullStatus::Done)
+        ));
+        assert!(handler
+            .cull_state
+            .unsettled_close_volumes("blob")
+            .is_empty());
+    }
+
+    #[test]
+    fn test_close_requeues_open_cull_after_unsettled_close_is_recorded() {
+        let state = FsCacheCullState::default();
+        state.enqueue("blob".to_string());
+        assert_eq!(state.next().as_deref(), Some("blob"));
+
+        // CLOSE may race after an attempt observed open=true but before it publishes Pending.
+        state.record_close("blob", "volume");
+        state.finish_attempt("blob", FsCacheCullStatus::Pending("open".to_string()));
+        assert_eq!(state.next().as_deref(), Some("blob"));
+        assert_eq!(
+            state.unsettled_close_volumes("blob"),
+            HashSet::from(["volume".to_string()])
+        );
     }
 
     #[test]

--- a/service/src/singleton.rs
+++ b/service/src/singleton.rs
@@ -19,8 +19,8 @@ use nydus_api::config::BlobCacheList;
 use nydus_api::BuildTimeInfo;
 
 use crate::daemon::{
-    DaemonState, DaemonStateMachineContext, DaemonStateMachineInput, DaemonStateMachineSubscriber,
-    NydusDaemon,
+    BlobCullResult, DaemonState, DaemonStateMachineContext, DaemonStateMachineInput,
+    DaemonStateMachineSubscriber, NydusDaemon,
 };
 use crate::fs_service::FsService;
 #[cfg(target_os = "linux")]
@@ -236,6 +236,28 @@ impl NydusDaemon for ServiceController {
                 return fscache
                     .cull_cache(_blob_id)
                     .map_err(|e| Error::StartService(format!("{}", e)));
+            }
+        }
+        Err(Error::Unsupported)
+    }
+
+    fn cull_blob(&self, _blob_id: String, _background: bool) -> Result<BlobCullResult> {
+        #[cfg(target_os = "linux")]
+        if self.fscache_enabled.load(Ordering::Acquire) {
+            if let Some(fscache) = self.fscache.lock().unwrap().clone() {
+                return fscache
+                    .cull_cache_status(_blob_id, _background)
+                    .map_err(|e| Error::StartService(format!("{}", e)));
+            }
+        }
+        Err(Error::Unsupported)
+    }
+
+    fn pending_culls(&self) -> Result<std::collections::HashMap<String, String>> {
+        #[cfg(target_os = "linux")]
+        if self.fscache_enabled.load(Ordering::Acquire) {
+            if let Some(fscache) = self.fscache.lock().unwrap().clone() {
+                return Ok(fscache.pending_culls());
             }
         }
         Err(Error::Unsupported)

--- a/src/bin/nydusd/api_server_glue.rs
+++ b/src/bin/nydusd/api_server_glue.rs
@@ -15,7 +15,7 @@ use mio::Waker;
 use nix::sys::signal::{kill, SIGTERM};
 use nix::unistd::Pid;
 
-use nydus::daemon::NydusDaemon;
+use nydus::daemon::{BlobCullResult, NydusDaemon};
 use nydus::{FsBackendMountCmd, FsBackendType, FsBackendUmountCmd, FsService};
 use nydus_api::{
     start_http_thread, ApiError, ApiMountCmd, ApiRequest, ApiResponse, ApiResponsePayload,
@@ -68,6 +68,10 @@ impl ApiServer {
             ApiRequest::CreateBlobObject(entry) => self.create_blob_cache_entry(&entry),
             ApiRequest::DeleteBlobObject(param) => self.remove_blob_cache_entry(&param),
             ApiRequest::DeleteBlobFile(blob_id) => self.blob_cache_gc(blob_id),
+            ApiRequest::CullBlobFile(blob_id, background) => {
+                self.blob_cache_cull(blob_id, background)
+            }
+            ApiRequest::GetPendingBlobCulls => self.pending_blob_culls(),
         };
 
         self.respond(resp);
@@ -319,6 +323,26 @@ impl ApiServer {
             .delete_blob(blob_id)
             .map_err(|e| ApiError::DaemonAbnormal(e.into()))
             .map(|_| ApiResponsePayload::Empty)
+    }
+
+    fn blob_cache_cull(&self, blob_id: String, background: bool) -> ApiResponse {
+        self.get_daemon_object()?
+            .cull_blob(blob_id, background)
+            .map_err(|e| ApiError::DaemonAbnormal(e.into()))
+            .map(|result| match result {
+                BlobCullResult::Done => ApiResponsePayload::Empty,
+                BlobCullResult::Pending(reason) => ApiResponsePayload::Pending(reason),
+            })
+    }
+
+    fn pending_blob_culls(&self) -> ApiResponse {
+        let pending = self
+            .get_daemon_object()?
+            .pending_culls()
+            .map_err(|e| ApiError::DaemonAbnormal(e.into()))?;
+        let body = serde_json::to_string(&pending)
+            .map_err(|e| ApiError::DaemonAbnormal(DaemonErrorKind::Serde(e)))?;
+        Ok(ApiResponsePayload::PendingCulls(body))
     }
 
     fn do_start(&self) -> ApiResponse {


### PR DESCRIPTION
## Overview
Run cachefiles cull requests on a dedicated worker and expose whether reclamation finished or needs another attempt.

Keep configured and open blobs out of cull, and track CLOSE events by fscache volume until cachefiles commits the cookie. A missing cookie after CLOSE is therefore reported as pending instead of done.

Wake asynchronous culls when references close, while leaving retry ownership with synchronous callers. Treat already-removed cache entries as idempotent and keep the cull worker's filesystem state isolated from the daemon.

Add API and fscache tests for done and pending responses, cull ordering, close and cachefiles commit handling, and retry ownership.

Related: [Nydus-Snapshotter: fix: retry fscache blob cull until cachefiles completes#787](https://github.com/containerd/nydus-snapshotter/pull/787)

## Change Type
_Please select the type of change your pull request relates to:_
- [x] Bug Fix
- [ ] Feature Addition
- [ ] Documentation Update
- [ ] Code Refactoring
- [x] Performance Improvement
- [ ] Other (please describe)