### PR TITLE
fix(builder): preserve chunkdict source blob metadata

### DIFF
--- a/builder/src/chunkdict_generator.rs
+++ b/builder/src/chunkdict_generator.rs
@@ -23,11 +23,9 @@ use anyhow::{Ok, Result};
 use nydus_rafs::metadata::chunk::ChunkWrapper;
 use nydus_rafs::metadata::inode::InodeWrapper;
 use nydus_rafs::metadata::layout::RafsXAttrs;
-use nydus_storage::meta::BlobChunkInfoV1Ondisk;
 use nydus_utils::compress::Algorithm;
 use nydus_utils::digest::{DigestHasher, RafsDigest};
 
-use std::mem::size_of;
 use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::Arc;
@@ -43,13 +41,16 @@ pub struct ChunkdictChunkInfo {
     pub chunk_uncompressed_size: u32,
     pub chunk_compressed_offset: u64,
     pub chunk_uncompressed_offset: u64,
+    pub chunk_index: u32,
 }
 
 pub struct ChunkdictBlobInfo {
     pub blob_id: String,
+    pub blob_chunk_count: u32,
     pub blob_compressed_size: u64,
     pub blob_uncompressed_size: u64,
     pub blob_compressor: String,
+    pub blob_meta_ci_compressor: String,
     pub blob_meta_ci_compressed_size: u64,
     pub blob_meta_ci_uncompressed_size: u64,
     pub blob_meta_ci_offset: u64,
@@ -69,7 +70,6 @@ impl Generator {
     ) -> Result<BuildOutput> {
         // Validate and remove chunks whose belonged blob sizes are smaller than a block.
         let mut chunkdict_chunks = chunkdict_chunks_origin.to_vec();
-        Self::sort_chunks(&mut chunkdict_chunks);
         Self::validate_and_remove_chunks(ctx, &mut chunkdict_chunks);
         // Build root tree.
         let mut tree = Self::build_root_tree(ctx)?;
@@ -134,19 +134,6 @@ impl Generator {
 
         // Retain only chunks with chunk_blob_id that has a total uncompressed size > v6_block_size.
         chunkdict.retain(|chunk| !small_chunks.contains(&chunk.chunk_blob_id));
-    }
-
-    fn sort_chunks(chunkdict: &mut [ChunkdictChunkInfo]) {
-        chunkdict.sort_by(|a, b| {
-            a.chunk_blob_id
-                .cmp(&b.chunk_blob_id)
-                .then_with(|| a.chunk_compressed_offset.cmp(&b.chunk_compressed_offset))
-                .then_with(|| {
-                    a.chunk_uncompressed_offset
-                        .cmp(&b.chunk_uncompressed_offset)
-                })
-                .then_with(|| a.chunk_digest.cmp(&b.chunk_digest))
-        });
     }
 
     /// Build the root tree.
@@ -251,26 +238,14 @@ impl Generator {
             file_offset += chunk_info.chunk_uncompressed_size as u64;
             let mut chunk = ChunkWrapper::new(ctx.fs_version);
 
-            // Update blob context.
-            let (blob_index, blob_ctx) =
-                blob_mgr.get_or_cerate_blob_for_chunkdict(ctx, &chunk_info.chunk_blob_id)?;
-            let chunk_uncompressed_size = chunk_info.chunk_uncompressed_size;
-            let pre_d_offset = blob_ctx.current_uncompressed_offset;
-            blob_ctx.uncompressed_blob_size = pre_d_offset + chunk_uncompressed_size as u64;
-            blob_ctx.current_uncompressed_offset += chunk_uncompressed_size as u64;
-
-            blob_ctx.blob_meta_header.set_ci_uncompressed_size(
-                blob_ctx.blob_meta_header.ci_uncompressed_size()
-                    + size_of::<BlobChunkInfoV1Ondisk>() as u64,
-            );
-            blob_ctx.blob_meta_header.set_ci_compressed_size(
-                blob_ctx.blob_meta_header.ci_uncompressed_size()
-                    + size_of::<BlobChunkInfoV1Ondisk>() as u64,
-            );
             let chunkdict_blob_info = chunkdict_blobs
                 .iter()
                 .find(|blob| blob.blob_id == chunk_info.chunk_blob_id)
                 .unwrap();
+            let (blob_index, blob_ctx) =
+                blob_mgr.get_or_cerate_blob_for_chunkdict(ctx, &chunk_info.chunk_blob_id)?;
+            blob_ctx.compressed_blob_size = chunkdict_blob_info.blob_compressed_size;
+            blob_ctx.uncompressed_blob_size = chunkdict_blob_info.blob_uncompressed_size;
             blob_ctx.blob_compressor =
                 Algorithm::from_str(chunkdict_blob_info.blob_compressor.as_str())?;
             blob_ctx
@@ -282,10 +257,14 @@ impl Generator {
             blob_ctx
                 .blob_meta_header
                 .set_ci_compressed_offset(chunkdict_blob_info.blob_meta_ci_offset);
-            blob_ctx.blob_meta_header.set_ci_compressor(Algorithm::Zstd);
+            blob_ctx
+                .blob_meta_header
+                .set_ci_compressor(Algorithm::from_str(
+                    chunkdict_blob_info.blob_meta_ci_compressor.as_str(),
+                )?);
 
-            // Update chunk context.
-            let chunk_index = blob_ctx.alloc_chunk_index()?;
+            blob_ctx.chunk_count = chunkdict_blob_info.blob_chunk_count;
+            let chunk_index = chunk_info.chunk_index;
             chunk.set_blob_index(blob_index);
             chunk.set_index(chunk_index);
             chunk.set_file_offset(cur_file_offset);
@@ -324,6 +303,7 @@ mod tests {
             chunk_uncompressed_size: size,
             chunk_compressed_offset: 0,
             chunk_uncompressed_offset: 0,
+            chunk_index: 0,
         }
     }
 

--- a/src/bin/nydus-image/deduplicate.rs
+++ b/src/bin/nydus-image/deduplicate.rs
@@ -253,9 +253,11 @@ impl Deduplicate<SqliteDatabase> {
             self.db
                 .insert_blob(&ChunkdictBlobInfo {
                     blob_id: blob.blob_id().to_string(),
+                    blob_chunk_count: blob.chunk_count(),
                     blob_compressed_size: blob.compressed_size(),
                     blob_uncompressed_size: blob.uncompressed_size(),
                     blob_compressor: blob.compressor().to_string(),
+                    blob_meta_ci_compressor: blob.meta_ci_compressor().to_string(),
                     blob_meta_ci_compressed_size: blob.meta_ci_compressed_size(),
                     blob_meta_ci_uncompressed_size: blob.meta_ci_uncompressed_size(),
                     blob_meta_ci_offset: blob.meta_ci_offset(),
@@ -288,6 +290,7 @@ impl Deduplicate<SqliteDatabase> {
                         chunk_uncompressed_size: chunk.inner.uncompressed_size(),
                         chunk_compressed_offset: chunk.inner.compressed_offset(),
                         chunk_uncompressed_offset: chunk.inner.uncompressed_offset(),
+                        chunk_index: chunk.inner.index(),
                     })
                     .context("Failed to insert chunk")?;
             }
@@ -442,6 +445,7 @@ impl Algorithm<SqliteDatabase> {
                 chunk_uncompressed_offset: all_chunks[i].chunk_uncompressed_offset,
                 chunk_compressed_size: all_chunks[i].chunk_compressed_size,
                 chunk_uncompressed_size: all_chunks[i].chunk_uncompressed_size,
+                chunk_index: all_chunks[i].chunk_index,
             };
             if smoothed_data[i] > threshold {
                 chunkdict.push(chunk);
@@ -971,7 +975,7 @@ impl ChunkTable {
         let mut stmt: rusqlite::Statement<'_> = conn_guard
             .prepare(
                 "SELECT id, image_reference, version, chunk_blob_id, chunk_digest,chunk_crc32, chunk_compressed_size,
-                chunk_uncompressed_size, chunk_compressed_offset, chunk_uncompressed_offset from chunk
+                chunk_uncompressed_size, chunk_compressed_offset, chunk_uncompressed_offset, chunk_index from chunk
                 WHERE chunk_blob_id = ?1
                 ORDER BY id LIMIT ?2 OFFSET ?3",
             )?;
@@ -986,6 +990,7 @@ impl ChunkTable {
                 chunk_uncompressed_size: row.get(7)?,
                 chunk_compressed_offset: row.get(8)?,
                 chunk_uncompressed_offset: row.get(9)?,
+                chunk_index: row.get(10)?,
             })
         })?;
         let mut chunks = Vec::new();
@@ -1084,7 +1089,8 @@ impl Table<ChunkdictChunkInfo, DatabaseError> for ChunkTable {
                     chunk_compressed_size  INT,
                     chunk_uncompressed_size  INT,
                     chunk_compressed_offset  INT,
-                    chunk_uncompressed_offset  INT
+                    chunk_uncompressed_offset  INT,
+                    chunk_index               INT
                 )",
                 [],
             )
@@ -1106,9 +1112,10 @@ impl Table<ChunkdictChunkInfo, DatabaseError> for ChunkTable {
                     chunk_compressed_size,
                     chunk_uncompressed_size,
                     chunk_compressed_offset,
-                    chunk_uncompressed_offset
+                    chunk_uncompressed_offset,
+                    chunk_index
                 )
-                VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9);
+                VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10);
                 ",
                 rusqlite::params![
                     chunk.image_reference,
@@ -1120,6 +1127,7 @@ impl Table<ChunkdictChunkInfo, DatabaseError> for ChunkTable {
                     chunk.chunk_uncompressed_size,
                     chunk.chunk_compressed_offset,
                     chunk.chunk_uncompressed_offset,
+                    chunk.chunk_index,
                 ],
             )
             .map_err(DatabaseError::SqliteError)?;
@@ -1156,7 +1164,7 @@ impl Table<ChunkdictChunkInfo, DatabaseError> for ChunkTable {
         let mut stmt: rusqlite::Statement<'_> = conn_guard
             .prepare(
                 "SELECT id, image_reference, version, chunk_blob_id, chunk_digest,chunk_crc32, chunk_compressed_size,
-                chunk_uncompressed_size, chunk_compressed_offset, chunk_uncompressed_offset from chunk
+                chunk_uncompressed_size, chunk_compressed_offset, chunk_uncompressed_offset, chunk_index from chunk
                 ORDER BY id LIMIT ?1 OFFSET ?2",
             )?;
         let chunk_iterator = stmt.query_map(params![limit, offset], |row| {
@@ -1170,6 +1178,7 @@ impl Table<ChunkdictChunkInfo, DatabaseError> for ChunkTable {
                 chunk_uncompressed_size: row.get(7)?,
                 chunk_compressed_offset: row.get(8)?,
                 chunk_uncompressed_offset: row.get(9)?,
+                chunk_index: row.get(10)?,
             })
         })?;
         let mut chunks = Vec::new();
@@ -1206,7 +1215,7 @@ impl BlobTable {
             .lock()
             .map_err(|e| DatabaseError::PoisonError(e.to_string()))?;
         let mut stmt = conn_guard.prepare(
-            "SELECT blob_id, blob_compressed_size, blob_uncompressed_size, blob_compressor, blob_meta_ci_compressed_size, blob_meta_ci_uncompressed_size, blob_meta_ci_offset FROM blob WHERE blob_id = ?1",
+            "SELECT blob_id, blob_compressed_size, blob_uncompressed_size, blob_compressor, blob_meta_ci_compressor, blob_meta_ci_compressed_size, blob_meta_ci_uncompressed_size, blob_meta_ci_offset, blob_chunk_count FROM blob WHERE blob_id = ?1",
         )?;
         let mut blob_iterator = stmt.query_map([blob_id], |row| {
             Ok(ChunkdictBlobInfo {
@@ -1214,9 +1223,11 @@ impl BlobTable {
                 blob_compressed_size: row.get(1)?,
                 blob_uncompressed_size: row.get(2)?,
                 blob_compressor: row.get(3)?,
-                blob_meta_ci_compressed_size: row.get(4)?,
-                blob_meta_ci_uncompressed_size: row.get(5)?,
-                blob_meta_ci_offset: row.get(6)?,
+                blob_meta_ci_compressor: row.get(4)?,
+                blob_meta_ci_compressed_size: row.get(5)?,
+                blob_meta_ci_uncompressed_size: row.get(6)?,
+                blob_meta_ci_offset: row.get(7)?,
+                blob_chunk_count: row.get(8)?,
             })
         })?;
 
@@ -1251,9 +1262,11 @@ impl Table<ChunkdictBlobInfo, DatabaseError> for BlobTable {
                     blob_compressed_size                INT,
                     blob_uncompressed_size              INT,
                     blob_compressor                     TEXT,
+                    blob_meta_ci_compressor             TEXT,
                     blob_meta_ci_compressed_size        INT,
                     blob_meta_ci_uncompressed_size      INT,
-                    blob_meta_ci_offset                 INT
+                    blob_meta_ci_offset                 INT,
+                    blob_chunk_count                    INT
                 )",
                 [],
             )
@@ -1271,20 +1284,24 @@ impl Table<ChunkdictBlobInfo, DatabaseError> for BlobTable {
                     blob_compressed_size,
                     blob_uncompressed_size,
                     blob_compressor,
+                    blob_meta_ci_compressor,
                     blob_meta_ci_compressed_size,
                     blob_meta_ci_uncompressed_size,
-                    blob_meta_ci_offset
+                    blob_meta_ci_offset,
+                    blob_chunk_count
                 )
-                VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7);
+                VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9);
                 ",
                 rusqlite::params![
                     blob.blob_id,
                     blob.blob_compressed_size,
                     blob.blob_uncompressed_size,
                     blob.blob_compressor,
+                    blob.blob_meta_ci_compressor,
                     blob.blob_meta_ci_compressed_size,
                     blob.blob_meta_ci_uncompressed_size,
                     blob.blob_meta_ci_offset,
+                    blob.blob_chunk_count,
                 ],
             )
             .map_err(DatabaseError::SqliteError)?;
@@ -1315,7 +1332,7 @@ impl Table<ChunkdictBlobInfo, DatabaseError> for BlobTable {
             .lock()
             .map_err(|e| DatabaseError::PoisonError(e.to_string()))?;
         let mut stmt: rusqlite::Statement<'_> = conn_guard.prepare(
-            "SELECT blob_id, blob_compressed_size, blob_uncompressed_size, blob_compressor, blob_meta_ci_compressed_size, blob_meta_ci_uncompressed_size, blob_meta_ci_offset from blob
+            "SELECT blob_id, blob_compressed_size, blob_uncompressed_size, blob_compressor, blob_meta_ci_compressor, blob_meta_ci_compressed_size, blob_meta_ci_uncompressed_size, blob_meta_ci_offset, blob_chunk_count from blob
                 ORDER BY id LIMIT ?1 OFFSET ?2",
         )?;
         let blob_iterator = stmt.query_map(params![limit, offset], |row| {
@@ -1324,9 +1341,11 @@ impl Table<ChunkdictBlobInfo, DatabaseError> for BlobTable {
                 blob_compressed_size: row.get(1)?,
                 blob_uncompressed_size: row.get(2)?,
                 blob_compressor: row.get(3)?,
-                blob_meta_ci_compressed_size: row.get(4)?,
-                blob_meta_ci_uncompressed_size: row.get(5)?,
-                blob_meta_ci_offset: row.get(6)?,
+                blob_meta_ci_compressor: row.get(4)?,
+                blob_meta_ci_compressed_size: row.get(5)?,
+                blob_meta_ci_uncompressed_size: row.get(6)?,
+                blob_meta_ci_offset: row.get(7)?,
+                blob_chunk_count: row.get(8)?,
             })
         })?;
         let mut blobs = Vec::new();
@@ -1375,9 +1394,11 @@ mod tests {
         blob_table.create()?;
         let blob = ChunkdictBlobInfo {
             blob_id: "BLOB123".to_string(),
+            blob_chunk_count: 16,
             blob_compressed_size: 1024,
             blob_uncompressed_size: 2048,
             blob_compressor: "zstd".to_string(),
+            blob_meta_ci_compressor: "none".to_string(),
             blob_meta_ci_compressed_size: 1024,
             blob_meta_ci_uncompressed_size: 2048,
             blob_meta_ci_offset: 0,
@@ -1389,6 +1410,11 @@ mod tests {
         assert_eq!(blobs[0].blob_compressed_size, blob.blob_compressed_size);
         assert_eq!(blobs[0].blob_uncompressed_size, blob.blob_uncompressed_size);
         assert_eq!(blobs[0].blob_compressor, blob.blob_compressor);
+        assert_eq!(blobs[0].blob_chunk_count, blob.blob_chunk_count);
+        assert_eq!(
+            blobs[0].blob_meta_ci_compressor,
+            blob.blob_meta_ci_compressor
+        );
         assert_eq!(
             blobs[0].blob_meta_ci_compressed_size,
             blob.blob_meta_ci_compressed_size
@@ -1415,6 +1441,7 @@ mod tests {
             chunk_uncompressed_size: 1024,
             chunk_compressed_offset: 0,
             chunk_uncompressed_offset: 0,
+            chunk_index: 7,
         };
         chunk_table.insert(&chunk)?;
         let chunk2 = ChunkdictChunkInfo {
@@ -1427,6 +1454,7 @@ mod tests {
             chunk_uncompressed_size: 1024,
             chunk_compressed_offset: 0,
             chunk_uncompressed_offset: 0,
+            chunk_index: 8,
         };
         chunk_table.insert(&chunk2)?;
         let chunks = chunk_table.list_all()?;
@@ -1448,6 +1476,7 @@ mod tests {
             chunks[0].chunk_uncompressed_offset,
             chunk.chunk_uncompressed_offset
         );
+        assert_eq!(chunks[0].chunk_index, chunk.chunk_index);
 
         let chunks = chunk_table.list_all_by_blob_id(&chunk.chunk_blob_id)?;
         assert_eq!(chunks[0].chunk_blob_id, chunk.chunk_blob_id);
@@ -1463,9 +1492,11 @@ mod tests {
         for i in 0..200 {
             let blob = ChunkdictBlobInfo {
                 blob_id: format!("BLOB{}", i),
+                blob_chunk_count: i as u32,
                 blob_compressed_size: i,
                 blob_uncompressed_size: i * 2,
                 blob_compressor: "zstd".to_string(),
+                blob_meta_ci_compressor: "none".to_string(),
                 blob_meta_ci_compressed_size: i,
                 blob_meta_ci_uncompressed_size: i * 2,
                 blob_meta_ci_offset: i * 3,
@@ -1478,6 +1509,8 @@ mod tests {
         assert_eq!(blobs[0].blob_compressed_size, 100);
         assert_eq!(blobs[0].blob_uncompressed_size, 200);
         assert_eq!(blobs[0].blob_compressor, "zstd");
+        assert_eq!(blobs[0].blob_chunk_count, 100);
+        assert_eq!(blobs[0].blob_meta_ci_compressor, "none");
         assert_eq!(blobs[0].blob_meta_ci_compressed_size, 100);
         assert_eq!(blobs[0].blob_meta_ci_uncompressed_size, 200);
         assert_eq!(blobs[0].blob_meta_ci_offset, 300);
@@ -1500,6 +1533,7 @@ mod tests {
                 chunk_uncompressed_size: i * 2,
                 chunk_compressed_offset: i64 * 3,
                 chunk_uncompressed_offset: i64 * 4,
+                chunk_index: i,
             };
             chunk_table.insert(&chunk)?;
         }
@@ -1513,6 +1547,7 @@ mod tests {
         assert_eq!(chunks[0].chunk_uncompressed_size, 200);
         assert_eq!(chunks[0].chunk_compressed_offset, 300);
         assert_eq!(chunks[0].chunk_uncompressed_offset, 400);
+        assert_eq!(chunks[0].chunk_index, 100);
         Ok(())
     }
 
@@ -1532,6 +1567,7 @@ mod tests {
                 chunk_uncompressed_size: i * 2,
                 chunk_compressed_offset: i64 * 3,
                 chunk_uncompressed_offset: i64 * 4,
+                chunk_index: i,
             };
             all_chunk.push(chunk);
         }
@@ -1545,6 +1581,7 @@ mod tests {
         assert_eq!(chunkdict[0].chunk_uncompressed_size, 198);
         assert_eq!(chunkdict[0].chunk_compressed_offset, 297);
         assert_eq!(chunkdict[0].chunk_uncompressed_offset, 396);
+        assert_eq!(chunkdict[0].chunk_index, 99);
         Ok(())
     }
 
@@ -1565,6 +1602,7 @@ mod tests {
                 chunk_uncompressed_size: i * 2,
                 chunk_compressed_offset: i64 * 3,
                 chunk_uncompressed_offset: i64 * 4,
+                chunk_index: i,
             };
             chunk_table.insert(&chunk)?;
         }
@@ -1595,6 +1633,7 @@ mod tests {
                 chunk_uncompressed_size: 1,
                 chunk_compressed_offset: i64 * 3,
                 chunk_uncompressed_offset: i64 * 4,
+                chunk_index: i,
             };
             all_chunks1.push(chunk);
         }
@@ -1611,6 +1650,7 @@ mod tests {
                 chunk_uncompressed_size: 1,
                 chunk_compressed_offset: i64 * 3,
                 chunk_uncompressed_offset: i64 * 4,
+                chunk_index: i,
             };
             all_chunks2.push(chunk);
         }
@@ -1640,6 +1680,7 @@ mod tests {
                     chunk_uncompressed_size: 1,
                     chunk_compressed_offset: 1,
                     chunk_uncompressed_offset: 1,
+                    chunk_index: j,
                 };
                 all_chunks.push(chunk);
             }
@@ -1671,6 +1712,7 @@ mod tests {
                     chunk_uncompressed_size: 1,
                     chunk_compressed_offset: 1,
                     chunk_uncompressed_offset: 1,
+                    chunk_index: j,
                 };
                 all_chunks.push(chunk);
             }
@@ -1707,6 +1749,7 @@ mod tests {
                     chunk_uncompressed_size: 1,
                     chunk_compressed_offset: 1,
                     chunk_uncompressed_offset: 1,
+                    chunk_index: j,
                 };
                 all_chunks.push(chunk);
             }
@@ -1734,6 +1777,7 @@ mod tests {
                     chunk_uncompressed_size: 1,
                     chunk_compressed_offset: 1,
                     chunk_uncompressed_offset: 1,
+                    chunk_index: j,
                 };
                 all_chunks.push(chunk);
             }
@@ -1771,6 +1815,7 @@ mod tests {
                 chunk_uncompressed_size: i * 2,
                 chunk_compressed_offset: i64 * 3,
                 chunk_uncompressed_offset: i64 * 4,
+                chunk_index: i,
             };
             all_chunks.push(chunk);
         }


### PR DESCRIPTION
## Overview
The chunkdict generator only creates a new bootstrap, while the referenced blobs still come from the original remote image. The current implementation has the following issues:

1、It recalculates the uncompressed blob size by accumulating chunk sizes and does not correctly restore the compressed blob size. However, RAFS v6 blobs may contain alignment gaps, so the accumulated size may not match the actual source blob size.

2、It hard-codes Zstd as the compression algorithm for the Blob.Meta chunk-info array, which may differ from the algorithm used by the source Blob.Meta.

3、It reallocates chunk indexes. [dragonflyoss/nydus#1949](https://github.com/dragonflyoss/nydus/pull/1949) mitigated this issue by sorting chunks by blob ID and physical offset before generating the bootstrap. However, this only reconstructs chunk indexes indirectly and is not suitable for RAFS v6.

A better approach is to preserve the original Blob and chunk metadata directly, including the compressed and uncompressed blob sizes, the Blob.Meta compression algorithm, the chunk count, and the chunk indexes.

I performed basic validation for both RAFS v5 and v6, including generating a chunkdict, converting an image with the chunkdict, and starting a container from the converted image. All steps completed successfully.



## Related Issues
_Please link to the relevant issue. For example: `Fix #123` or `Related #456`._

## Change Details
_Please describe your changes in detail:_

## Test Results
_If you have any relevant screenshots or videos that can help illustrate your changes, please add them here._

## Change Type
_Please select the type of change your pull request relates to:_
- [x] Bug Fix
- [ ] Feature Addition
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe)

## Self-Checklist
_Before submitting a pull request, please ensure you have completed the following:_
- [ ] I have run a code style check and addressed any warnings/errors.
- [ ] I have added appropriate comments to my code (if applicable).
- [ ] I have updated the documentation (if applicable).
- [ ] I have written appropriate unit tests.