### PR TITLE
perf(fanotify): drop fanotify marks from fully-ready blobs

### DIFF
--- a/nydus/src/fanotify/core.rs
+++ b/nydus/src/fanotify/core.rs
@@ -20,18 +20,33 @@
 //! (they need a real image / kernel).
 
 use std::collections::HashMap;
+use std::ffi::CString;
 use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
+use std::os::unix::ffi::OsStrExt;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
+use tracing::{debug, warn};
 
 use crate::{BlobID, Config, NydusAccessor};
 
-use super::event::{PreContentEvent, Range};
+use super::event::{PreContentEvent, Range, FAN_PRE_ACCESS};
 
 /// EROFS block size as u64 — reuses the canonical constant from the accessor.
 const BLOCK_SIZE: u64 = crate::metadata::EROFS_BLOCK_SIZE as u64;
+
+/// `fanotify_init(2)` flag: close-on-exec on the group descriptor.
+pub(crate) const FAN_CLOEXEC: u32 = 0x0000_0001;
+/// `fanotify_init(2)` flag: non-blocking reads on the group descriptor.
+pub(crate) const FAN_NONBLOCK: u32 = 0x0000_0002;
+/// `fanotify_init(2)` class: pre-content permission events (Linux 6.15+).
+pub(crate) const FAN_CLASS_PRE_CONTENT: u32 = 0x0000_0008;
+/// `fanotify_mark(2)` flag: add a mark.
+pub(crate) const FAN_MARK_ADD: u32 = 0x0000_0001;
+/// `fanotify_mark(2)` flag: remove a mark instead of adding one.
+pub(crate) const FAN_MARK_REMOVE: u32 = 0x0000_0002;
 
 /// What to answer the kernel with for one event.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -113,6 +128,13 @@ pub struct FanotifyCore {
     devices: Vec<BlobDevice>,
     /// `(dev, ino)` → index into `devices` for O(1) event-fd lookup.
     device_index: HashMap<(u64, u64), usize>,
+    /// `BlobID` → index into `devices` for O(1) slot lookup by blob identity.
+    blob_slot: HashMap<BlobID, usize>,
+    /// Per-device-slot sticky flag: true once the fanotify mark has been removed
+    /// (or was never added because the blob was already fully ready at startup).
+    /// Prevents redundant `fully_ready` probes and duplicate `FAN_MARK_REMOVE`
+    /// syscalls across concurrent fetch workers.
+    unmarked: Vec<AtomicBool>,
 }
 
 impl FanotifyCore {
@@ -138,6 +160,7 @@ impl FanotifyCore {
 
         let mut devices = Vec::with_capacity(entries.len());
         let mut device_index = HashMap::with_capacity(entries.len());
+        let mut blob_slot = HashMap::with_capacity(entries.len());
         for (slot, b) in entries.into_iter().enumerate() {
             let expected_index = u16::try_from(slot + 1)
                 .context("blob device table has more slots than the EROFS index space")?;
@@ -161,6 +184,7 @@ impl FanotifyCore {
             let (dev, ino) = cache_identity(&b.cache_path, b.cache_size).with_context(|| {
                 format!("failed to validate blob device {}", b.cache_path.display())
             })?;
+            blob_slot.insert(b.id, slot);
             devices.push(BlobDevice {
                 index: b.index,
                 id: b.id,
@@ -170,10 +194,14 @@ impl FanotifyCore {
             });
             device_index.insert((dev, ino), slot);
         }
+
+        let unmarked: Vec<AtomicBool> = devices.iter().map(|_| AtomicBool::new(false)).collect();
         Ok(Self {
             accessor,
             devices,
             device_index,
+            blob_slot,
+            unmarked,
         })
     }
 
@@ -223,6 +251,90 @@ impl FanotifyCore {
                 e.context(format!("failed to fetch blob range [{offset}, +{count})")),
             )
         })
+    }
+
+    /// Record that the mark for device `slot` was never added (the blob was
+    /// already fully ready at startup), so `try_unmark` skips it at runtime.
+    pub fn mark_unmarked(&self, slot: usize) {
+        if let Some(flag) = self.unmarked.get(slot) {
+            flag.store(true, Ordering::Release);
+        }
+    }
+
+    /// Remove the fanotify mark on a blob whose groupmap is fully ready.
+    ///
+    /// Called from fetch worker threads after a successful fetch. The per-slot
+    /// [`AtomicBool`] ensures the readiness probe and the `FAN_MARK_REMOVE`
+    /// syscall execute at most once per blob across all concurrent workers.
+    /// Returns `true` if this call won the per-slot CAS and attempted
+    /// `FAN_MARK_REMOVE`; the syscall itself may still fail (logged), in
+    /// which case the latched flag prevents any retry.
+    ///
+    /// # Safety (syscall)
+    ///
+    /// `fan_fd` must be a live fanotify group descriptor. `fanotify_mark` is
+    /// thread-safe; concurrent calls with `FAN_MARK_REMOVE` on the same path
+    /// are harmless (the loser gets `ENOENT`).
+    pub fn try_unmark(&self, fan_fd: RawFd, id: &BlobID) -> bool {
+        let Some(&slot) = self.blob_slot.get(id) else {
+            return false;
+        };
+        // Fast path: the mark was already removed by an earlier successful
+        // unmark, or was never added because the blob was fully ready at
+        // startup.
+        if self.unmarked[slot].load(Ordering::Acquire) {
+            return false;
+        }
+        // O(1) probe: single atomic load on the groupmap's shared ALL_READY flag.
+        if !self.accessor.blob.fully_ready(id).unwrap_or(false) {
+            return false;
+        }
+        // Claim the unmark: exactly one thread wins the CAS.
+        if self.unmarked[slot]
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_err()
+        {
+            return false;
+        }
+        let path = match CString::new(self.devices[slot].cache_path.as_os_str().as_bytes()) {
+            Ok(p) => p,
+            Err(_) => return false, // interior NUL: cannot happen for real paths
+        };
+        let ret = unsafe {
+            libc::fanotify_mark(
+                fan_fd,
+                FAN_MARK_REMOVE,
+                FAN_PRE_ACCESS,
+                libc::AT_FDCWD,
+                path.as_ptr(),
+            )
+        };
+        if ret < 0 {
+            let err = std::io::Error::last_os_error();
+            if err.raw_os_error() == Some(libc::ENOENT) {
+                // Benign: the mark was already removed (e.g. by another path).
+                debug!(
+                    "fanotify: FAN_MARK_REMOVE for slot {} ({}): already gone (ENOENT)",
+                    self.devices[slot].index,
+                    self.devices[slot].cache_path.display()
+                );
+            } else {
+                // Unexpected, but not fatal.
+                warn!(
+                    "fanotify: FAN_MARK_REMOVE for slot {} ({}) failed: {err}",
+                    self.devices[slot].index,
+                    self.devices[slot].cache_path.display()
+                );
+            }
+        } else {
+            debug!(
+                "fanotify: unmarked fully-ready blob {} (slot {}) at {}",
+                id,
+                self.devices[slot].index,
+                self.devices[slot].cache_path.display()
+            );
+        }
+        true
     }
 }
 

--- a/nydus/src/fanotify/service.rs
+++ b/nydus/src/fanotify/service.rs
@@ -15,7 +15,7 @@ use std::io;
 use std::os::fd::{AsRawFd, FromRawFd, OwnedFd, RawFd};
 use std::os::unix::ffi::OsStrExt;
 use std::sync::mpsc::{self, TryRecvError};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, Weak};
 use std::thread;
 
 use anyhow::{anyhow, Context, Result};
@@ -25,16 +25,10 @@ use crate::BlobID;
 
 use super::core::{
     align_fetch_range, decide, fd_identity, Decision, DenyReason, FanotifyCore, FetchError,
-    Response,
+    Response, FAN_CLASS_PRE_CONTENT, FAN_CLOEXEC, FAN_MARK_ADD, FAN_NONBLOCK,
 };
-use super::event::{EventIter, PreContentEvent};
+use super::event::{EventIter, PreContentEvent, FAN_PRE_ACCESS};
 use super::response::{FdResponseWriter, PendingPermission, ResponseWriter};
-
-const FAN_CLOEXEC: u32 = 0x0000_0001;
-const FAN_NONBLOCK: u32 = 0x0000_0002;
-const FAN_CLASS_PRE_CONTENT: u32 = 0x0000_0008;
-const FAN_MARK_ADD: u32 = 0x0000_0001;
-const FAN_PRE_ACCESS: u64 = 0x0010_0000;
 
 // 256 KiB holds ~5400 minimum-size events per read(2)
 // (24-byte fanotify_event_metadata + 24-byte RANGE record).
@@ -261,11 +255,14 @@ impl FanotifyService {
         }
         let fan = unsafe { OwnedFd::from_raw_fd(fan_fd) };
 
-        for device in core.devices() {
+        for (slot, device) in core.devices().iter().enumerate() {
             if core
                 .range_ready(&device.id, 0, device.cache_size)
                 .unwrap_or(false)
             {
+                // Record that this slot's mark was never added, so runtime
+                // `try_unmark` probes skip it entirely.
+                core.mark_unmarked(slot);
                 debug!(
                     "fanotify: skip marking fully-ready blob {} (slot {})",
                     device.id, device.index
@@ -333,6 +330,7 @@ fn serve(
     pool: Arc<FetchPool>,
 ) -> Result<()> {
     let fan_raw = fan_fd.as_raw_fd();
+    let fan_weak = Arc::downgrade(fan_fd);
     let epfd = epoll_create().context("epoll_create1")?;
 
     let writer: Arc<dyn ResponseWriter> = Arc::new(FdResponseWriter::new(fan_fd.clone()));
@@ -364,6 +362,7 @@ fn serve(
     coordinate(
         epfd.as_raw_fd(),
         fan_raw,
+        &fan_weak,
         core,
         &writer,
         &pool,
@@ -382,6 +381,7 @@ fn serve(
 fn coordinate(
     epfd: RawFd,
     fan_fd: RawFd,
+    fan_weak: &Weak<OwnedFd>,
     core: &Arc<FanotifyCore>,
     writer: &Arc<dyn ResponseWriter>,
     pool: &FetchPool,
@@ -398,6 +398,7 @@ fn coordinate(
     let outcome = event_loop(
         epfd,
         fan_fd,
+        fan_weak,
         core,
         writer,
         pool,
@@ -432,6 +433,7 @@ fn coordinate(
 fn event_loop(
     epfd: RawFd,
     fan_fd: RawFd,
+    fan_weak: &Weak<OwnedFd>,
     core: &Arc<FanotifyCore>,
     writer: &Arc<dyn ResponseWriter>,
     pool: &FetchPool,
@@ -483,6 +485,7 @@ fn event_loop(
                 match read_events(fan_fd, &mut buffer) {
                     Ok(0) => {} // EAGAIN: no events
                     Ok(n) => admit_batch(
+                        fan_weak,
                         core,
                         writer,
                         pool,
@@ -550,6 +553,7 @@ fn drain_completions(
 
 #[allow(clippy::too_many_arguments)]
 fn admit_batch(
+    fan_weak: &Weak<OwnedFd>,
     core: &Arc<FanotifyCore>,
     writer: &Arc<dyn ResponseWriter>,
     pool: &FetchPool,
@@ -600,6 +604,7 @@ fn admit_batch(
         };
 
         admit_event(
+            fan_weak,
             core,
             writer,
             pool,
@@ -617,6 +622,7 @@ fn admit_batch(
 
 #[allow(clippy::too_many_arguments)]
 fn admit_event(
+    fan_weak: &Weak<OwnedFd>,
     core: &Arc<FanotifyCore>,
     writer: &Arc<dyn ResponseWriter>,
     pool: &FetchPool,
@@ -677,6 +683,9 @@ fn admit_event(
                 offset, count, device.id
             );
             respond(&mut permission, Response::Allow)?;
+            if let Some(fd_arc) = fan_weak.upgrade() {
+                core.try_unmark(fd_arc.as_raw_fd(), &device.id);
+            }
             return Ok(());
         }
         Ok(false) => {}
@@ -712,10 +721,22 @@ fn admit_event(
     let cache_size = device.cache_size;
     let core = Arc::clone(core);
     let sink = Arc::clone(sink);
+
+    let fan_weak = fan_weak.clone();
     pool.execute(move || {
         let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             core.fetch(&id, cache_size, offset, count)
         }));
+        // After a successful fetch, check whether this was the last group of
+        // the blob. If the groupmap's sticky ALL_READY flag is now set, remove
+        // the fanotify mark so the kernel stops generating events for this
+        // file entirely — subsequent reads hit the page cache without any
+        // daemon involvement.
+        if matches!(&result, Ok(Ok(()))) {
+            if let Some(fd_arc) = fan_weak.upgrade() {
+                core.try_unmark(fd_arc.as_raw_fd(), &id);
+            }
+        }
         let result = match result {
             Ok(fetch_result) => CompletionResult::Fetch(fetch_result),
             Err(_) => CompletionResult::Panicked,


### PR DESCRIPTION
## Overview
Once a blob's groupmap latches its sticky ALL_READY flag, the fanotify mark on its cache file has no further purpose: every subsequent read is already cache-resident. Remove the mark so the kernel stops generating FAN_PRE_ACCESS events for that file entirely, and warmed reads go straight to the page cache with zero daemon involvement.

## Related Issues
_Please link to the relevant issue. For example: `Fix #123` or `Related #456`._

## Change Details
_Please describe your changes in detail:_

## Test Results
_If you have any relevant screenshots or videos that can help illustrate your changes, please add them here._

## Change Type
_Please select the type of change your pull request relates to:_
- [ ] Bug Fix
- [ ] Feature Addition
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe)

## Self-Checklist
_Before submitting a pull request, please ensure you have completed the following:_
- [ ] I have run a code style check and addressed any warnings/errors.
- [ ] I have added appropriate comments to my code (if applicable).
- [ ] I have updated the documentation (if applicable).
- [ ] I have written appropriate unit tests.