### PR TITLE
feat(nydusify): use offline pattern file for optimize

### DIFF
--- a/docs/nydus.md
+++ b/docs/nydus.md
@@ -1793,13 +1793,13 @@ with the failing rule and offending path in the error.
 
 ### nydusify optimize
 
-`nydusify optimize --apiserver <addr> --source <nydus-ref> --target <nydus-ref> [OPTIONS]`
+`nydusify optimize --pattern <path> --source <nydus-ref> --target <nydus-ref> [OPTIONS]`
 
-Publishes an optimized copy of a nydus image from a live access trace:
+Publishes an optimized copy of a nydus image from a recorded access pattern:
 
 1. Pull `--source` (must be a nydus image) and extract its bootstrap layer
 	(`image.boot` plus the per-layer blob metas, which seed the cache dir).
-2. Run `nydus optimize` against the bootstrap with `--apiserver`, using a
+2. Run `nydus optimize` against the bootstrap with `--trace-file`, using a
 	registry-backed storage config so source group data is range-read from the
 	source registry on demand.
 3. Assemble the optimized manifest: the original data layers are reused as-is,
@@ -1808,23 +1808,27 @@ Publishes an optimized copy of a nydus image from a live access trace:
 	(including the ondemand one). Config diff ids and history are updated.
 4. Push the result to `--target`.
 
-`--apiserver` points at the apiserver socket of a running `nydusify mount` of
-the source image (`<work-dir>/apiserver.sock`; a bare path or `unix://` form is
-accepted). Mount the image **without** `--prefetch` (the default) so the trace
-records the pure on-demand access pattern, exercise the workload, then run
-optimize while the mount is still up. Mount the optimized image **with**
-`--prefetch` to get the phase-0 redirect warmup. Shared flags (`--builder`,
-`--work-dir`, `--platform`, `--insecure`, `--plain-http`, `--log-level`) behave
-as in `nydusify convert`. No root is required: optimize never extracts OCI
-layers, it only rewrites metadata and appends the ondemand layer.
+`--pattern` is a JSON access-pattern file in the same format served by a
+mount's `GET /trace` endpoint
+(`{"version":1,"patterns":[{"blob_index":1,"group_index":4},...]}`). It can be
+saved from the `/trace` endpoint of a `nydusify mount` apiserver, or exported
+offline from a pmem/accessor mount trace (e.g. a rund sandbox extendedstats
+snapshot). Record the pattern from a mount **without** prefetch so it captures
+the pure on-demand access pattern, exercise the workload, then save the trace.
+Mount the optimized image **with** `--prefetch` to get the phase-0 redirect
+warmup. Shared flags (`--builder`, `--work-dir`, `--platform`, `--insecure`,
+`--plain-http`, `--log-level`) behave as in `nydusify convert`. No root is
+required: optimize never extracts OCI layers, it only rewrites metadata and
+appends the ondemand layer.
 
 Example:
 
 ```bash
 nydusify mount -t localhost:5000/app:nydus -m /mnt/app --work-dir /tmp/mnt &
 # ... run the workload against /mnt/app ...
+curl --unix-socket /tmp/mnt/apiserver.sock http://localhost/trace > /tmp/pattern.json
 nydusify optimize \
-  --apiserver /tmp/mnt/apiserver.sock \
+  --pattern /tmp/pattern.json \
   --source localhost:5000/app:nydus \
   --target localhost:5000/app:nydus-optimized \
   --plain-http

--- a/nydusify/internal/checker/optimize.go
+++ b/nydusify/internal/checker/optimize.go
@@ -15,7 +15,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"strconv"
-	"strings"
 
 	"github.com/containerd/containerd/v2/core/content"
 	"github.com/containerd/errdefs"
@@ -35,11 +34,9 @@ type OptimizeOpt struct {
 	Source string
 	// Target is the optimized nydus image reference to push. Required.
 	Target string
-	// Apiserver is the apiserver address of a running mount of the source
-	// image (e.g. `unix:///path/to/apiserver.sock`, as exposed by `nydusify
-	// mount`); the access patterns are fetched live from its `/trace`
-	// endpoint. Required.
-	Apiserver string
+	// Pattern is the path to a JSON access-pattern file (the same document
+	// served by the `/trace` endpoint). Required.
+	Pattern string
 	// Builder is the nydus binary path (PATH-resolvable). Defaults to "nydus".
 	Builder string
 	// WorkDir is the scratch directory backing the content store and the
@@ -77,12 +74,8 @@ func NewOptimizer(opt OptimizeOpt) (*Optimizer, error) {
 	if opt.Target == "" {
 		return nil, errors.New("target must be provided")
 	}
-	if opt.Apiserver == "" {
-		return nil, errors.New("apiserver must be provided")
-	}
-	// Accept a bare socket path for convenience; nydus expects unix://.
-	if !strings.HasPrefix(opt.Apiserver, "unix://") {
-		opt.Apiserver = "unix://" + opt.Apiserver
+	if opt.Pattern == "" {
+		return nil, errors.New("pattern must be provided")
 	}
 	if opt.PlatformMC == nil {
 		opt.PlatformMC = platforms.Default()
@@ -217,12 +210,12 @@ func (o *Optimizer) Optimize(ctx context.Context) error {
 func (o *Optimizer) runNydusOptimize(ctx context.Context, parentBootstrap, bootstrap, blobDir, configPath string) (string, error) {
 	args := []string{
 		"optimize",
-		"--apiserver", o.opt.Apiserver,
 		"--parent-bootstrap", parentBootstrap,
 		"--bootstrap", bootstrap,
 		"--blob-dir", blobDir,
 		"--config", configPath,
 		"--log-level", nydusLogLevel(o.opt.LogLevel),
+		"--trace-file", o.opt.Pattern,
 	}
 	cmd := exec.CommandContext(ctx, builderBinary(o.opt.Builder), args...)
 	var output bytes.Buffer
@@ -282,21 +275,33 @@ func commitBlobFile(ctx context.Context, cs content.Store, path string) (*ocispe
 // The image config diff ids and history are updated accordingly.
 func (o *Optimizer) writeOptimizedImage(ctx context.Context, cs content.Store, img *Image, ondemandDesc, bootstrapDesc ocispec.Descriptor) (*ocispec.Descriptor, error) {
 	layers := make([]ocispec.Descriptor, 0, len(img.Manifest.Layers)+1)
-	for _, layer := range img.Manifest.Layers {
+	diffIDs := make([]digest.Digest, 0, len(img.Manifest.Layers)+2)
+	for i, layer := range img.Manifest.Layers {
 		if converter.IsNydusBootstrap(layer) {
 			continue
 		}
 		layers = append(layers, layer)
+		if uncompressed := layer.Annotations[converter.LayerAnnotationUncompressed]; uncompressed != "" {
+			diffIDs = append(diffIDs, digest.Digest(uncompressed))
+		} else if i < len(img.Config.RootFS.DiffIDs) {
+			// Data layers from other builders may lack the uncompressed
+			// annotation; keep the original diff id from the source config
+			// (manifest layers and config diff ids are index-aligned).
+			diffIDs = append(diffIDs, img.Config.RootFS.DiffIDs[i])
+		} else {
+			return nil, errors.Errorf("cannot determine diff id for layer %s", layer.Digest)
+		}
+	}
+	for _, l := range []ocispec.Descriptor{ondemandDesc, bootstrapDesc} {
+		uncompressed := l.Annotations[converter.LayerAnnotationUncompressed]
+		if uncompressed == "" {
+			return nil, errors.Errorf("missing uncompressed annotation on appended layer %s", l.Digest)
+		}
+		diffIDs = append(diffIDs, digest.Digest(uncompressed))
 	}
 	layers = append(layers, ondemandDesc, bootstrapDesc)
 
 	config := img.Config
-	diffIDs := make([]digest.Digest, 0, len(layers))
-	for _, l := range layers {
-		if uncompressed := l.Annotations[converter.LayerAnnotationUncompressed]; uncompressed != "" {
-			diffIDs = append(diffIDs, digest.Digest(uncompressed))
-		}
-	}
 	config.RootFS.DiffIDs = diffIDs
 	config.History = append(config.History, ocispec.History{
 		CreatedBy: "Nydus Optimizer",

--- a/nydusify/internal/checker/optimize_test.go
+++ b/nydusify/internal/checker/optimize_test.go
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026. Nydus Developers. All rights reserved.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package checker
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestNewOptimizerPatternValidation(t *testing.T) {
+	base := OptimizeOpt{Source: "localhost:5000/src:v3", Target: "localhost:5000/dst:v3"}
+
+	// Pattern missing.
+	if _, err := NewOptimizer(base); err == nil ||
+		!strings.Contains(err.Error(), "pattern must be provided") {
+		t.Fatalf("expected missing-pattern error, got %v", err)
+	}
+
+	// Pattern provided.
+	withPattern := base
+	withPattern.Pattern = "/tmp/pattern.json"
+	o, err := NewOptimizer(withPattern)
+	if err != nil {
+		t.Fatalf("pattern should be accepted: %v", err)
+	}
+	if o.opt.Pattern != "/tmp/pattern.json" {
+		t.Fatalf("unexpected opt normalization: %+v", o.opt)
+	}
+}

--- a/nydusify/main.go
+++ b/nydusify/main.go
@@ -574,8 +574,8 @@ func optimizeCommand() *cli.Command {
 		Usage: "Build an ondemand blob from a /trace access pattern and push an optimized nydus image",
 		Flags: []cli.Flag{
 			&cli.StringFlag{
-				Name:     "apiserver",
-				Usage:    "apiserver address of a running mount of the source image (e.g. unix:///path/to/apiserver.sock); access patterns are fetched from its /trace endpoint",
+				Name:     "pattern",
+				Usage:    "path to a JSON access-pattern file (same format as the /trace endpoint)",
 				Required: true,
 			},
 			&cli.StringFlag{
@@ -665,7 +665,7 @@ func runOptimize(c *cli.Context) error {
 	opt, err := checker.NewOptimizer(checker.OptimizeOpt{
 		Source:          c.String("source"),
 		Target:          c.String("target"),
-		Apiserver:       c.String("apiserver"),
+		Pattern:         c.String("pattern"),
 		Builder:         c.String("builder"),
 		WorkDir:         workDir,
 		SourceInsecure:  c.Bool("source-insecure"),

--- a/tests/integration/e2e_test.go
+++ b/tests/integration/e2e_test.go
@@ -988,9 +988,9 @@ func verifyBlobCacheArtifacts(t *testing.T, cacheDir string, blobs ...string) {
 //  1. docker build/push a source OCI image, convert it with `nydusify
 //     convert`, and validate it with `nydusify check`.
 //  2. Mount the nydus image WITHOUT prefetch, replay a read workload, and
-//     verify the baseline metrics show on-demand backend reads. While the
-//     mount is live, run `nydusify optimize --apiserver` to build the
-//     ondemand (redirect) blob from the recorded /trace pattern and push the
+//     verify the baseline metrics show on-demand backend reads. Save the
+//     recorded /trace pattern to a file and run `nydusify optimize
+//     --pattern` to build the ondemand (redirect) blob from it and push the
 //     optimized image.
 //  3. Mount the optimized image WITH prefetch on a cold cache, wait for
 //     prefetch to quiesce, replay the same workload, and verify:
@@ -1066,14 +1066,14 @@ func TestNydusifyOptimizeE2E(t *testing.T) {
 		require.Zero(t, metricValue(metrics, "cache_redirect_fill_group"))
 		require.Zero(t, metricValue(metrics, "cache_fill_group"),
 			"baseline mount must not prefetch")
-		traceCount = fetchTraceCount(t, socket)
+		traceCount = saveTrace(t, socket, filepath.Join(tmpDir, "pattern.json"))
 		require.Greater(t, traceCount, 1, "trace must cover multiple groups")
 		t.Logf("baseline: ondemand_reads=%v trace_groups=%d",
 			metricValue(metrics, "backend_ondemand_read_count"), traceCount)
 
-		t.Log("Optimizing against the live mount apiserver...")
+		t.Log("Optimizing with the saved trace pattern...")
 		runNydusifyCommand(t, nydusifyBin, nydusBin, "optimize",
-			"--apiserver", socket,
+			"--pattern", filepath.Join(tmpDir, "pattern.json"),
 			"--source", nydusRef,
 			"--target", optRef,
 			"--work-dir", filepath.Join(tmpDir, "optimize"))

--- a/tests/integration/optimize_util.go
+++ b/tests/integration/optimize_util.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"os"
@@ -193,9 +194,10 @@ func waitPrefetchQuiesce(t *testing.T, socketPath string) {
 	}, 60*time.Second, 300*time.Millisecond, "prefetch did not quiesce within 60s")
 }
 
-// fetchTraceCount GETs the /trace endpoint from the mount's apiserver socket
-// and returns the number of recorded (blob, group) access patterns.
-func fetchTraceCount(t *testing.T, socketPath string) int {
+// saveTrace GETs the /trace endpoint from the mount's apiserver socket, saves
+// the raw JSON access-pattern document to path, and returns the number of
+// recorded (blob, group) access patterns.
+func saveTrace(t *testing.T, socketPath, path string) int {
 	t.Helper()
 
 	client := &http.Client{
@@ -212,6 +214,10 @@ func fetchTraceCount(t *testing.T, socketPath string) int {
 	defer func() { _ = resp.Body.Close() }()
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 
+	raw, err := io.ReadAll(resp.Body)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path, raw, 0644))
+
 	var doc struct {
 		Version  uint32 `json:"version"`
 		Patterns []struct {
@@ -219,7 +225,7 @@ func fetchTraceCount(t *testing.T, socketPath string) int {
 			GroupIndex uint32 `json:"group_index"`
 		} `json:"patterns"`
 	}
-	require.NoError(t, json.NewDecoder(resp.Body).Decode(&doc))
+	require.NoError(t, json.Unmarshal(raw, &doc))
 	require.EqualValues(t, 1, doc.Version, "unexpected trace document version")
 	return len(doc.Patterns)
 }


### PR DESCRIPTION
Replace the live `--apiserver` /trace source of `nydusify optimize` with a required `--pattern` flag that takes an offline JSON access-pattern file (the same document served by the /trace endpoint), e.g. exported from a rund sandbox via extendedstats.

Also fix the optimized image config: writeOptimizedImage dropped the diff ids of data layers lacking the containerd.io/uncompressed annotation (e.g. layers produced by buildkit), yielding a config with 2 diff ids against a 54-layer manifest and failing pulls with "number of layers and diffIDs don't match". Keep the source config diff id for such layers (manifest layers and config diff ids are index-aligned) and error out when an appended layer misses the annotation.

## Overview
_Please briefly describe the changes your pull request makes._

## Related Issues
_Please link to the relevant issue. For example: `Fix #123` or `Related #456`._

## Change Details
_Please describe your changes in detail:_

## Test Results
_If you have any relevant screenshots or videos that can help illustrate your changes, please add them here._

## Change Type
_Please select the type of change your pull request relates to:_
- [ ] Bug Fix
- [x] Feature Addition
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe)

## Self-Checklist
_Before submitting a pull request, please ensure you have completed the following:_
- [ ] I have run a code style check and addressed any warnings/errors.
- [ ] I have added appropriate comments to my code (if applicable).
- [x] I have updated the documentation (if applicable).
- [ ] I have written appropriate unit tests.