### PR TITLE
fix: support relative registry redirects

### DIFF
--- a/storage/src/backend/registry.rs
+++ b/storage/src/backend/registry.rs
@@ -913,8 +913,11 @@ impl RegistryReader {
             // Handle redirect request and cache redirect url
             if need_redirect {
                 if let Some(location) = resp.headers().get("location") {
-                    let location = location.to_str().unwrap();
-                    let mut location = Url::parse(location)
+                    let location = location.to_str().map_err(|e| {
+                        RegistryError::Common(format!("invalid Location header: {}", e))
+                    })?;
+                    let mut location = Url::parse(&url)
+                        .and_then(|base| base.join(location))
                         .map_err(|e| RegistryError::Url(location.to_string(), e))?;
                     // Note: Some P2P proxy server supports only scheme specified origin blob server,
                     // so we need change scheme to `blob_url_scheme` here


### PR DESCRIPTION
## Overview
Resolve relative redirect URLs when fetching blobs from registries. GCP Artifact Registry returns relative Location headers (e.g. `/artifacts-downloads/...`) on blob redirects, which caused nydusd to fail with `RelativeUrlWithoutBase`.

## Related Issues
N/A

## Change Details
In `_try_read`, the redirect Location header was parsed with `Url::parse()`, which requires an absolute URL. Relative redirect URLs fail. The fix constructs a base URL from the registry's scheme and host fields and uses Url::join() to resolve the `Location` header against it.

`join()` handles both cases: absolute URLs are returned as-is (the base is ignored), and relative URLs are resolved against the base origin.

## Test Results
N/A

## Change Type
- [x] Bug Fix
- [ ] Feature Addition
- [ ] Documentation Update
- [ ] Code Refactoring
- [ ] Performance Improvement
- [ ] Other (please describe)

## Self-Checklist
- [x] I have run a code style check and addressed any warnings/errors.
- [ ] I have added appropriate comments to my code (if applicable).
- [ ] I have updated the documentation (if applicable).
- [ ] I have written appropriate unit tests.