### PR TITLE
fix: some improvements for v3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2865,7 +2865,6 @@ dependencies = [
  "crc32c",
  "dragonfly-client-request",
  "futures",
- "hickory-resolver",
  "libc",
  "memmap2",
  "nydus",

--- a/nydus-accessor/Cargo.toml
+++ b/nydus-accessor/Cargo.toml
@@ -15,7 +15,6 @@ default = []
 # Container image registry backend (OCI distribution).
 backend-registry = [
   "dep:reqwest",
-  "dep:hickory-resolver",
   "dep:url",
   "dep:arc-swap",
   "dep:once_cell",
@@ -36,7 +35,6 @@ bitflags = "2"
 crc32c = "0.6"
 dragonfly-client-request = { version = "=1.4.0", optional = true }
 futures = { version = "0.3", optional = true }
-hickory-resolver = { version = "0.25", optional = true }
 libc = "0.2"
 memmap2 = "0.9"
 once_cell = { version = "1", optional = true }

--- a/nydus-accessor/src/lib.rs
+++ b/nydus-accessor/src/lib.rs
@@ -24,7 +24,8 @@ pub use accessor::{
 };
 pub use config::Config;
 pub use metadata::{
-    BlobMeta, BlobMetaChunk, BlobMetaGroup, BlobMetaHeader, BLOB_META_HEADER_SIZE, BLOB_META_MAGIC,
+    is_rafs_v7_bootstrap, BlobMeta, BlobMetaChunk, BlobMetaGroup, BlobMetaHeader,
+    BLOB_META_HEADER_SIZE, BLOB_META_MAGIC, EROFS_FEATURE_COMPAT_RAFS_V6,
 };
 pub use metrics::trace::{TraceDocument, TracePattern, TraceRecorder, TRACE_DOCUMENT_VERSION};
 pub use metrics::MetricsSnapshot;

--- a/nydus-accessor/src/metadata/mod.rs
+++ b/nydus-accessor/src/metadata/mod.rs
@@ -35,6 +35,11 @@ pub const EROFS_SLOTSIZE: u32 = 1 << EROFS_ISLOTBITS;
 // Feature flags.
 pub const EROFS_FEATURE_COMPAT_SB_CHKSUM: u32 = 0x0000_0001;
 pub const EROFS_FEATURE_COMPAT_MTIME: u32 = 0x0000_0002;
+/// RAFS v6 marker: RAFS v6 bootstraps embed a private extension superblock
+/// and always set this compat bit; pure-EROFS nydus (rafs v7) bootstraps
+/// never do. This crate does not read RAFS v6 images — the bit exists only
+/// so the two formats can be told apart (see [`is_rafs_v7_bootstrap`]).
+pub const EROFS_FEATURE_COMPAT_RAFS_V6: u32 = 0x4000_0000;
 pub const EROFS_FEATURE_INCOMPAT_CHUNKED_FILE: u32 = 0x0000_0004;
 pub const EROFS_FEATURE_INCOMPAT_DEVICE_TABLE: u32 = 0x0000_0008;
 /// 48-bit block addressing: the kernel interprets the `*_hi` halves of chunk

--- a/nydus-accessor/src/metadata/superblock.rs
+++ b/nydus-accessor/src/metadata/superblock.rs
@@ -1,5 +1,8 @@
 use super::*;
+use std::fs::File;
+use std::io::{self, Read, Seek, SeekFrom};
 use std::mem;
+use std::path::Path;
 
 /// EROFS superblock — 128 bytes, `#[repr(C, packed)]`.
 #[repr(C, packed)]
@@ -111,5 +114,108 @@ impl ErofsSuperblock {
 
     pub fn devt_slotoff(&self) -> u16 {
         get_u16(&self.devt_slotoff)
+    }
+}
+
+/// Check whether `path` is a rafs v7 (pure EROFS) bootstrap.
+///
+/// Reads the EROFS superblock at [`EROFS_SUPER_OFFSET`] and requires:
+/// - the EROFS magic,
+/// - only incompat features this crate implements (standard EROFS contract),
+/// - the [`EROFS_FEATURE_COMPAT_RAFS_V6`] marker bit to be absent.
+///
+/// Returns `Ok(false)` for RAFS v6 bootstraps (which always carry the marker
+/// bit) and an error for files that are not readable EROFS images at all, so
+/// callers can route `nydus://` paths to the right backend by content instead
+/// of by URI scheme.
+pub fn is_rafs_v7_bootstrap(path: &Path) -> io::Result<bool> {
+    let mut file = File::open(path)?;
+    file.seek(SeekFrom::Start(EROFS_SUPER_OFFSET))?;
+    let mut buf = [0u8; EROFS_SB_BASE_SIZE];
+    file.read_exact(&mut buf)?;
+    // Safety: ErofsSuperblock is #[repr(C, packed)], exactly
+    // EROFS_SB_BASE_SIZE bytes, and valid for any bit pattern.
+    let sb: &ErofsSuperblock = unsafe { &*(buf.as_ptr() as *const ErofsSuperblock) };
+
+    if sb.magic() != EROFS_SUPER_MAGIC_V1 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("bad EROFS magic: 0x{:08X}", sb.magic()),
+        ));
+    }
+    const SUPPORTED_INCOMPAT: u32 = EROFS_FEATURE_INCOMPAT_CHUNKED_FILE
+        | EROFS_FEATURE_INCOMPAT_DEVICE_TABLE
+        | EROFS_FEATURE_INCOMPAT_48BIT;
+    let unknown = sb.feature_incompat() & !SUPPORTED_INCOMPAT;
+    if unknown != 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!("unsupported EROFS incompat features: {unknown:#x}"),
+        ));
+    }
+    Ok(sb.feature_compat() & EROFS_FEATURE_COMPAT_RAFS_V6 == 0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn write_bootstrap(
+        feature_compat: u32,
+        feature_incompat: u32,
+        magic: Option<u32>,
+    ) -> tempfile::NamedTempFile {
+        let mut sb = ErofsSuperblock::new(
+            feature_compat,
+            feature_incompat,
+            0,
+            0,
+            0,
+            1,
+            1,
+            0,
+            0,
+            &[0u8; 16],
+        );
+        if let Some(m) = magic {
+            set_u32(&mut sb.magic, m);
+        }
+        let mut file = tempfile::NamedTempFile::new().unwrap();
+        file.write_all(&[0u8; EROFS_SUPER_OFFSET as usize]).unwrap();
+        file.write_all(sb.as_bytes()).unwrap();
+        file.flush().unwrap();
+        file
+    }
+
+    #[test]
+    fn test_is_rafs_v7_bootstrap() {
+        // Pure EROFS with standard bits only: rafs v7.
+        let v7 = write_bootstrap(
+            EROFS_FEATURE_COMPAT_SB_CHKSUM,
+            EROFS_FEATURE_INCOMPAT_CHUNKED_FILE | EROFS_FEATURE_INCOMPAT_DEVICE_TABLE,
+            None,
+        );
+        assert!(is_rafs_v7_bootstrap(v7.path()).unwrap());
+
+        // RAFS v6 marker bit present: not v7.
+        let v6 = write_bootstrap(
+            EROFS_FEATURE_COMPAT_RAFS_V6,
+            EROFS_FEATURE_INCOMPAT_CHUNKED_FILE | EROFS_FEATURE_INCOMPAT_DEVICE_TABLE,
+            None,
+        );
+        assert!(!is_rafs_v7_bootstrap(v6.path()).unwrap());
+
+        // Bad magic: error.
+        let bad = write_bootstrap(0, 0, Some(0xDEAD_BEEF));
+        assert!(is_rafs_v7_bootstrap(bad.path()).is_err());
+
+        // Unknown incompat bit: error.
+        let unknown = write_bootstrap(0, 0x8000_0000, None);
+        assert!(is_rafs_v7_bootstrap(unknown.path()).is_err());
+
+        // Truncated file (no superblock): error.
+        let empty = tempfile::NamedTempFile::new().unwrap();
+        assert!(is_rafs_v7_bootstrap(empty.path()).is_err());
     }
 }

--- a/nydus-accessor/src/storage/backend/dns.rs
+++ b/nydus-accessor/src/storage/backend/dns.rs
@@ -1,11 +1,10 @@
-//! DNS resolution for the registry backend, backed by
-//! [hickory-resolver](https://github.com/hickory-dns/hickory-dns).
+//! DNS resolution for the registry backend, backed by the system resolver
+//! (`getaddrinfo`, through [`tokio::net::lookup_host`]).
 //!
-//! Results are cached with their record TTL (failures use a short negative
-//! TTL), and concurrent lookups for the same host are de-duplicated with a
-//! small singleflight built on [`futures::future::Shared`]. This avoids a
-//! thundering herd of identical DNS queries when many blob requests start at
-//! once after mount.
+//! Results are cached and concurrent lookups for the same host are
+//! de-duplicated with a small singleflight built on
+//! [`futures::future::Shared`]. This avoids a thundering herd of identical DNS
+//! queries when many blob requests start at once after mount.
 
 use std::collections::HashMap;
 use std::net::{IpAddr, SocketAddr};
@@ -13,11 +12,11 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use futures::future::{BoxFuture, FutureExt, Shared};
-use hickory_resolver::config::LookupIpStrategy;
-use hickory_resolver::TokioResolver;
-use once_cell::sync::OnceCell;
 use reqwest::dns::{Addrs, Name, Resolve, Resolving};
 use tokio::sync::RwLock;
+
+/// TTL applied to successful lookups; the system resolver reports no record TTL.
+const POSITIVE_CACHE_TTL: Duration = Duration::from_secs(60);
 
 /// TTL applied to failed lookups, to avoid hammering the DNS server.
 const NEGATIVE_CACHE_TTL: Duration = Duration::from_secs(60);
@@ -31,42 +30,22 @@ struct CachedLookup {
 
 type SharedLookup = Shared<BoxFuture<'static, Arc<CachedLookup>>>;
 
+#[derive(Default)]
 struct ResolverState {
-    resolver: TokioResolver,
     cache: RwLock<HashMap<String, Arc<CachedLookup>>>,
     inflight: Mutex<HashMap<String, SharedLookup>>,
 }
 
 /// A `reqwest`-compatible resolver that caches and de-duplicates lookups.
 #[derive(Clone, Default)]
-pub(crate) struct HickoryResolver {
-    // Construction is delayed because there may be no Tokio runtime when the
-    // resolver is created; it is initialized lazily on first use.
-    state: Arc<OnceCell<Arc<ResolverState>>>,
+pub(crate) struct SystemResolver {
+    state: Arc<ResolverState>,
 }
 
-impl HickoryResolver {
-    fn state(&self) -> Result<Arc<ResolverState>, String> {
-        self.state
-            .get_or_try_init(|| {
-                let mut builder =
-                    TokioResolver::builder_tokio().map_err(|e| format!("dns init failed: {e}"))?;
-                builder.options_mut().ip_strategy = LookupIpStrategy::Ipv4thenIpv6;
-                Ok::<_, String>(Arc::new(ResolverState {
-                    resolver: builder.build(),
-                    cache: RwLock::new(HashMap::new()),
-                    inflight: Mutex::new(HashMap::new()),
-                }))
-            })
-            .cloned()
-    }
-}
-
-impl Resolve for HickoryResolver {
+impl Resolve for SystemResolver {
     fn resolve(&self, name: Name) -> Resolving {
-        let this = self.clone();
+        let state = self.state.clone();
         Box::pin(async move {
-            let state = this.state().map_err(|e| -> BoxError { e.into() })?;
             let host = name.as_str().to_string();
             let cached = resolve_cached(state, host).await;
             match &cached.result {
@@ -81,8 +60,6 @@ impl Resolve for HickoryResolver {
         })
     }
 }
-
-type BoxError = Box<dyn std::error::Error + Send + Sync>;
 
 async fn resolve_cached(state: Arc<ResolverState>, host: String) -> Arc<CachedLookup> {
     // Fast path: a still-valid cache entry.
@@ -113,10 +90,10 @@ async fn resolve_cached(state: Arc<ResolverState>, host: String) -> Arc<CachedLo
 }
 
 async fn lookup_and_cache(state: Arc<ResolverState>, host: String) -> Arc<CachedLookup> {
-    let cached = match state.resolver.lookup_ip(host.as_str()).await {
-        Ok(lookup) => Arc::new(CachedLookup {
-            valid_until: lookup.valid_until(),
-            result: Ok(Arc::new(lookup.iter().collect())),
+    let cached = match tokio::net::lookup_host((host.as_str(), 0u16)).await {
+        Ok(addrs) => Arc::new(CachedLookup {
+            valid_until: Instant::now() + POSITIVE_CACHE_TTL,
+            result: Ok(Arc::new(addrs.map(|addr| addr.ip()).collect())),
         }),
         Err(err) => Arc::new(CachedLookup {
             valid_until: Instant::now() + NEGATIVE_CACHE_TTL,
@@ -156,7 +133,7 @@ mod tests {
             .build()
             .unwrap();
         rt.block_on(async {
-            let resolver = HickoryResolver::default();
+            let resolver = SystemResolver::default();
             let name: Name = "localhost".parse().unwrap();
             let addrs = resolver.resolve(name).await.unwrap();
             assert!(addrs.count() > 0);
@@ -171,8 +148,8 @@ mod tests {
             .build()
             .unwrap();
         rt.block_on(async {
-            let resolver = HickoryResolver::default();
-            let state = resolver.state().unwrap();
+            let resolver = SystemResolver::default();
+            let state = resolver.state.clone();
             let _ = resolve_cached(state.clone(), "localhost".to_string()).await;
             assert!(state.cache.read().await.contains_key("localhost"));
             // Second resolution should hit the cache and dedup cleanly.

--- a/nydus-accessor/src/storage/backend/http.rs
+++ b/nydus-accessor/src/storage/backend/http.rs
@@ -16,7 +16,7 @@ use reqwest::redirect::Policy;
 use reqwest::Client;
 use tokio::runtime::Runtime;
 
-use super::dns::HickoryResolver;
+use super::dns::SystemResolver;
 
 /// Shared runtime used for every backend network operation (direct HTTP and,
 /// when enabled, the Dragonfly SDK proxy).
@@ -68,7 +68,7 @@ pub(crate) fn build_client(
         // Backends handle 3xx redirects manually so they can cache the
         // redirected blob-storage URL.
         .redirect(Policy::none())
-        .dns_resolver(Arc::new(HickoryResolver::default()));
+        .dns_resolver(Arc::new(SystemResolver::default()));
 
     builder = match proxy_url {
         Some(url) => {

--- a/nydusify/pkg/converter/pack.go
+++ b/nydusify/pkg/converter/pack.go
@@ -91,6 +91,14 @@ func Pack(ctx context.Context, dest io.Writer, opt PackOption) (io.WriteCloser, 
 			// Unblock the writer side on extraction failure.
 			pr.CloseWithError(err)
 		} else {
+			// The tar reader stops at the end-of-archive marker and does not
+			// consume what follows. Streams written with the traditional
+			// blocking factor (GNU tar pads the archive to a multiple of
+			// 10240 bytes) therefore still hold trailing zero blocks. Drain
+			// them, otherwise closing the pipe here makes the writer side
+			// fail with "io: read/write on closed pipe" even though the
+			// extraction succeeded.
+			_, _ = io.Copy(io.Discard, pr)
 			_ = pr.Close()
 		}
 		pack.extractErr <- err


### PR DESCRIPTION
This pull request introduces several improvements and cleanups to the nydus-accessor project. The main changes are the replacement of the custom DNS resolver with a simpler, system-based resolver, the addition of a utility for distinguishing RAFS v6 and v7 bootstraps, and a fix to the packer to avoid spurious pipe errors. Unused dependencies are also removed.

**DNS Resolver Refactor:**

- Replaced the `HickoryResolver` (which used the `hickory-resolver` crate) with a new `SystemResolver` that uses the system resolver via `tokio::net::lookup_host`, simplifying the implementation and removing the dependency on `hickory-resolver`. The resolver now applies a fixed TTL to positive results since the system resolver does not provide record TTLs. [[1]](diffhunk://#diff-2683bc6c7f99c54c07a3df3cbd82a394d5facfae8d3bfb9b8dd02231bae9ec42L1-R20) [[2]](diffhunk://#diff-2683bc6c7f99c54c07a3df3cbd82a394d5facfae8d3bfb9b8dd02231bae9ec42R33-L69) [[3]](diffhunk://#diff-2683bc6c7f99c54c07a3df3cbd82a394d5facfae8d3bfb9b8dd02231bae9ec42L116-R96) [[4]](diffhunk://#diff-2683bc6c7f99c54c07a3df3cbd82a394d5facfae8d3bfb9b8dd02231bae9ec42L159-R136) [[5]](diffhunk://#diff-2683bc6c7f99c54c07a3df3cbd82a394d5facfae8d3bfb9b8dd02231bae9ec42L174-R152) [[6]](diffhunk://#diff-6472374466204629665a983aef9256e5248c34a9673e5f100ee39f1449d98ff8L19-R19) [[7]](diffhunk://#diff-6472374466204629665a983aef9256e5248c34a9673e5f100ee39f1449d98ff8L71-R71) [[8]](diffhunk://#diff-fc674b236719daa4b489a3ffbc012c37a7a935f544984fc38275dce8bc44f85dL18) [[9]](diffhunk://#diff-fc674b236719daa4b489a3ffbc012c37a7a935f544984fc38275dce8bc44f85dL39)

**RAFS Bootstrap Detection:**

- Added the `is_rafs_v7_bootstrap` function and the `EROFS_FEATURE_COMPAT_RAFS_V6` constant to allow distinguishing between RAFS v6 and v7 (pure EROFS) bootstraps by inspecting the image content, not just the URI scheme. Includes comprehensive documentation and tests. [[1]](diffhunk://#diff-6758e86e54481ced98a499869fb063f8153de7e4c4a9719106dcd279b9b52453L27-R28) [[2]](diffhunk://#diff-dd601bd08c85ee82ec2befe196202ed2beca9183e3d4c6f3764b0c145ffc6d50R38-R42) [[3]](diffhunk://#diff-44626727f2d1d14554d5722f7dbc1db9f3e18241c4fe1b6835f52739097cebd7R2-R5) [[4]](diffhunk://#diff-44626727f2d1d14554d5722f7dbc1db9f3e18241c4fe1b6835f52739097cebd7R119-R221)

**Packer Robustness:**

- Fixed the packer in `nydusify` to drain trailing zero blocks from tar streams after extraction, preventing "io: read/write on closed pipe" errors when closing the writer, especially for archives padded to a multiple of 10240 bytes.

**Dependency Cleanup:**

- Removed the unused `hickory-resolver` dependency from `Cargo.toml` and related code, reducing build complexity and binary size. [[1]](diffhunk://#diff-fc674b236719daa4b489a3ffbc012c37a7a935f544984fc38275dce8bc44f85dL18) [[2]](diffhunk://#diff-fc674b236719daa4b489a3ffbc012c37a7a935f544984fc38275dce8bc44f85dL39)

These changes simplify the codebase, improve reliability, and make image format detection more robust.